### PR TITLE
v3.07.00: Portfolio Visibility Overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.07.00] - 2026-02-07
+
+### Increment 6 — Confidence Styling + Summary Cards Refresh
+
+#### Added
+
+- **Retail/Gain-Loss confidence styling**: Retail and Gain/Loss columns now visually differentiate estimated values (melt fallback — italic, 65% opacity) from confirmed values (manual retail — bold). Estimated gains carry the same muted styling so users can see at a glance which items have researched retail prices vs spot-derived estimates
+- **"All Metals" summary card**: New combined totals card showing portfolio-wide Items, Weight, Purchase Price, Melt Value, Retail Value, and Gain/Loss. Previously the JS calculated these but the HTML card was missing — totals silently failed to display
+- **Avg Cost/oz metric**: Each metal card and the combined card now show average purchase cost per troy ounce (total purchase / total weight). Key stacker metric for evaluating cost basis across a position
+- **Gain/Loss "bottom line" emphasis**: The Gain/Loss row in each summary card now has a top separator, bolder label, and larger font to visually anchor it as the portfolio's bottom line
+
+#### Changed
+
+- Removed inline asterisk `*` indicator from Retail column in favor of CSS class-based confidence styling (`retail-confirmed`, `retail-estimated`, `gainloss-estimated`)
+- Removed orphaned `.about-badge-static` CSS class
+
 ## [3.06.02] - 2026-02-07
 
 ### Patch — eBay Search Split (Buy vs Sold)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.07.00] - 2026-02-07
 
-### Increment 6 — Confidence Styling + Summary Cards Refresh
+### Increment 6 — Portfolio Visibility Overhaul
 
 #### Added
 
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"All Metals" summary card**: New combined totals card showing portfolio-wide Items, Weight, Purchase Price, Melt Value, Retail Value, and Gain/Loss. Previously the JS calculated these but the HTML card was missing — totals silently failed to display
 - **Avg Cost/oz metric**: Each metal card and the combined card now show average purchase cost per troy ounce (total purchase / total weight). Key stacker metric for evaluating cost basis across a position
 - **Gain/Loss "bottom line" emphasis**: The Gain/Loss row in each summary card now has a top separator, bolder label, and larger font to visually anchor it as the portfolio's bottom line
+- **Metal detail modal: full portfolio breakdown**: Clicking a metal card header now shows Purchase, Melt, Retail, and Gain/Loss per type and per purchase location in a compact 2x2 grid layout. Previously only showed purchase price as a single value. Chart tooltips also show the full quartet
 
 #### Changed
 
 - Removed inline asterisk `*` indicator from Retail column in favor of CSS class-based confidence styling (`retail-confirmed`, `retail-estimated`, `gainloss-estimated`)
 - Removed orphaned `.about-badge-static` CSS class
+- Metal detail breakdown rows restructured: header (name + count/weight) + 2x2 financial grid replaces the old stacked single-value layout
 
 ## [3.06.02] - 2026-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Avg Cost/oz metric**: Each metal card and the combined card now show average purchase cost per troy ounce (total purchase / total weight). Key stacker metric for evaluating cost basis across a position
 - **Gain/Loss "bottom line" emphasis**: The Gain/Loss row in each summary card now has a top separator, bolder label, and larger font to visually anchor it as the portfolio's bottom line
 - **Metal detail modal: full portfolio breakdown**: Clicking a metal card header now shows Purchase, Melt, Retail, and Gain/Loss per type and per purchase location in a compact 2x2 grid layout. Previously only showed purchase price as a single value. Chart tooltips also show the full quartet
+- **All Metals breakdown modal**: Clicking the "All Metals" card header opens a portfolio-wide breakdown — left panel shows by-metal allocation (Silver, Gold, Platinum, Palladium) with full financial grid, right panel shows by-location across all metals. Pie charts and tooltips included
 
 #### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,10 +112,9 @@ These items focus on visual polish and usability improvements that require no ba
 - **Table CSS hardening** — audit responsive breakpoints, test mobile layout, ensure all 14 columns degrade gracefully
 - ~~**Summary cards visual refresh**~~ — **DONE (v3.07.00)**: Added "All Metals" combined totals card, Avg Cost/oz metric per metal and combined, Gain/Loss "bottom line" emphasis with separator and larger font
 - **Spot price manual input UX** — improve the experience for manually entering spot prices when API is unavailable
-- **Metal stats modal overhaul** — enhance the per-metal detail modals (opened by clicking a metal stats card) with full portfolio breakdown:
-  - **Breakdown tables**: replace single "total value" column with the full quartet — Purchase Cost, Melt Value, Est. Retail, Gain/Loss — for each category row (type, name, etc.)
+- ~~**Metal stats modal overhaul**~~ — **DONE (v3.07.00)**: Breakdown rows now show full Purchase/Melt/Retail/Gain-Loss in a 2x2 grid. Chart tooltips show all 4 values. Remaining future work:
   - **Pie chart toggle**: add a toggle or tab bar letting users switch the pie chart between Purchase / Melt / Retail / Gain-Loss views, so the chart slices reflect whichever value set the user cares about
-  - **Library audit**: evaluate whether Chart.js (already integrated) is sufficient for these richer visualizations, or whether a more dashboard-oriented library offers better interactivity (tooltips, drill-down, responsive legends). Candidates: Chart.js (current), ApexCharts, Tabler.io (full UI kit). Preference is to stay with Chart.js if it handles the use case cleanly to avoid adding a framework dependency
+  - **Library audit**: evaluate whether Chart.js (already integrated) is sufficient for these richer visualizations, or whether a more dashboard-oriented library offers better interactivity (tooltips, drill-down, responsive legends)
 - **Chart.js dashboard improvements** — add spot price trend visualization, portfolio value over time
 - **Custom tagging system** — replace the removed `isCollectable` boolean with a flexible tagging system (e.g., "IRA", "stack", "numismatic", "gift")
 - ~~**Dead CSS cleanup pass**~~ — **DONE (v3.06.01)**: Removed ~125 lines of orphaned `.collectable-*` selectors and unused icon utility classes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ Project direction and planned work for the StakTrakr precious metals inventory t
 ## Next Session (Priority)
 
 - ~~**BUG: Table dates off by one day**~~ — **DONE (Increment 4)**: `formatDisplayDate()` now parses the `YYYY-MM-DD` string directly via `split('-')` — no `Date` constructor, no timezone ambiguity
-- **About modal overhaul** — update GitHub repository URLs to match new location, review and clean up the version/changelog display process, ensure all links are functional and information is current
+- ~~**About modal overhaul**~~ — **DONE (v3.06.01)**: Rewrote description with project links, added badge-style links (site/GitHub/community/MIT License) with dynamic domain-aware site URL, removed duplicated privacy notice from version modal
 - **Full UI review walkthrough** — hands-on walk-through of the entire application UI after Increments 1 and 2, cataloging visual issues, layout inconsistencies, and UX friction before proceeding with further feature work
 - ~~**Fix spot price change indicator**~~ — **DONE (Increment 3)**: `updateSpotCardColor()` now compares against the most recent API/manual entry with a *different* price, so direction arrows persist across page refreshes instead of always resetting to orange
 - ~~**Numista API key storage broken**~~ — **DONE (Increment 4)**: Removed non-functional AES-256-GCM encryption (`CryptoUtils` class), simplified to base64 encoding matching the metals API key pattern. Added `catalog_api_config` to `ALLOWED_STORAGE_KEYS` so the key persists across page loads. Removed password field from settings UI
@@ -90,9 +90,9 @@ These items focus on visual polish and usability improvements that require no ba
 - **Notes column removal** ~~+ N# column restoration + hover tooltip~~ — ~~remove~~ **DONE (Increment 5)**: Notes icon column removed from table (15 → 14 columns with new duplicate column). Notes remain in the add/edit modal. Remaining: re-add N# column, add row hover tooltip for notes content
   - **N# column behavior**: clicking the N# value **filters the table** to show all items sharing that catalog number (same pattern as metal/type filter links). A small external-link icon next to the N# opens the Numista catalog page in the existing iframe modal (same icon pattern as purchase location external links). This replaces the previous standalone "N# grouping view" idea — grouping is now just a filter click away
   - Items without a N# show "—" in the column (no filter link, no icon)
-- **Retail column UX bundle** — ship together as one increment:
+- **Retail column UX bundle**:
   - **Inline retail editing**: add pencil icon to the Retail column (mirroring the existing Name column inline edit) so users can click to set/update retail price without opening the full edit modal. Gain/Loss should recalculate immediately on save
-  - **Confidence styling**: visually differentiate manual vs auto-computed retail prices. Auto (melt fallback): muted/gray + italic to signal "estimated". Manual (user-set): standard weight + color to signal "confirmed". Carry styling through to Gain/Loss column so estimated gains are also visually distinct from confirmed ones
+  - ~~**Confidence styling**~~ — **DONE (v3.07.00)**: Retail and Gain/Loss columns now visually differentiate estimated (melt fallback — italic, muted) vs confirmed (manual retail — bold). Removed asterisk indicator in favor of CSS classes
 - ~~**Duplicate item button**~~ — **DONE (Increment 5)**: Copy icon in action column opens `#itemModal` in add mode pre-filled from source item. Date defaults to today, qty resets to 1, serial clears
 - ~~**Fraction input for weight field**~~ — **DONE (Increment 5)**: `parseFraction()` in `js/utils.js` handles `1/1000`, `1 1/2`, and plain decimals. Weight input changed to `type="text"` with `inputmode="decimal"`
 - **Numista integration — Sync & Search** (prerequisite: fix Numista API client above):
@@ -110,7 +110,7 @@ These items focus on visual polish and usability improvements that require no ba
   - **Scope**: `css/styles.css` theme sections (`[data-theme="light"]`, `[data-theme="sepia"]`), sticky column rules, table row/hover rules
 - ~~**eBay search icon redesign**~~ — **DONE (v3.06.01 + v3.06.02)**: Replaced emoji-in-red-circle with clean 12px SVG magnifying glass using `currentColor`. Split into two search functions: Purchase column → active listings (buy), Retail column → sold listings (price research)
 - **Table CSS hardening** — audit responsive breakpoints, test mobile layout, ensure all 14 columns degrade gracefully
-- **Summary cards visual refresh** — update card layout to better surface the portfolio model (total purchase cost, total melt value, total retail, net gain/loss)
+- ~~**Summary cards visual refresh**~~ — **DONE (v3.07.00)**: Added "All Metals" combined totals card, Avg Cost/oz metric per metal and combined, Gain/Loss "bottom line" emphasis with separator and larger font
 - **Spot price manual input UX** — improve the experience for manually entering spot prices when API is unavailable
 - **Metal stats modal overhaul** — enhance the per-metal detail modals (opened by clicking a metal stats card) with full portfolio breakdown:
   - **Breakdown tables**: replace single "total value" column with the full quartet — Purchase Cost, Melt Value, Est. Retail, Gain/Loss — for each category row (type, name, etc.)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1724,8 +1724,27 @@ input[type="submit"] {
 .palladium .total-title {
   border-bottom: 4px solid var(--palladium);
 }
-/* Metal-specific colors */
-/* (removed empty duplicate metal-specific rules) */
+
+/* All Metals combined card — uses primary accent */
+.total-card-all .total-title {
+  border-bottom: 4px solid var(--primary);
+}
+
+/* Gain/Loss bottom-line emphasis — the "bottom line" of each card */
+.total-item-bottom-line {
+  border-bottom: none;
+  border-top: 2px solid var(--border);
+  margin-top: 0.25rem;
+  padding-top: 0.5rem;
+}
+.total-item-bottom-line .total-label {
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+.total-item-bottom-line .total-value {
+  font-weight: 700;
+  font-size: 1rem;
+}
 
 /* =============================================================================
    TABLES - Main inventory table with interactive features
@@ -4672,6 +4691,19 @@ th {
 
 .ebay-price-link:hover .ebay-search-svg {
   color: var(--text-primary);
+}
+
+/* Retail/Gain-Loss confidence styling — estimated (melt fallback) vs confirmed (manual) */
+.retail-estimated {
+  font-style: italic;
+  opacity: 0.65;
+}
+.retail-confirmed {
+  font-weight: 600;
+}
+.gainloss-estimated {
+  font-style: italic;
+  opacity: 0.65;
 }
 
 /* Responsive catalog link with improved mobile experience */

--- a/css/styles.css
+++ b/css/styles.css
@@ -3003,9 +3003,6 @@ a.about-badge:hover {
 }
 
 .breakdown-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: var(--spacing-sm) 0;
   border-bottom: 1px dashed var(--border);
 }
@@ -3014,30 +3011,56 @@ a.about-badge:hover {
   border-bottom: none;
 }
 
-.breakdown-label {
-  font-weight: 500;
-  color: var(--text-primary);
+.breakdown-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.25rem;
 }
 
-.breakdown-values {
-  text-align: right;
+.breakdown-label {
+  font-weight: 600;
+  color: var(--text-primary);
   font-size: 0.875rem;
 }
 
-.breakdown-count {
+.breakdown-meta {
   color: var(--text-muted);
+  font-size: 0.75rem;
   font-weight: 500;
 }
 
-.breakdown-weight {
-  color: var(--primary);
-  font-weight: 600;
+/* 2x2 financial grid for breakdown rows */
+.breakdown-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.125rem 0.75rem;
+  font-size: 0.8rem;
 }
 
-.breakdown-value {
-  color: var(--success);
-  font-weight: 600;
+.breakdown-cell {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.1rem 0;
 }
+
+.breakdown-cell-label {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 0.75rem;
+}
+
+.breakdown-cell-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdown-purchase .breakdown-cell-value { color: var(--text-primary); }
+.breakdown-melt .breakdown-cell-value { color: var(--primary); }
+.breakdown-retail .breakdown-cell-value { color: var(--text-secondary); }
+.breakdown-gain .breakdown-cell-value { color: var(--success); }
+.breakdown-loss .breakdown-cell-value { color: var(--danger); }
 
 .chart-canvas-container {
   position: relative;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **Portfolio visibility overhaul (v3.07.00)**: Confidence styling for Retail/Gain-Loss (estimated vs confirmed), new "All Metals" totals card with Avg Cost/oz, metal detail modal now shows full Purchase/Melt/Retail/Gain-Loss breakdown per type and location in a compact 2x2 grid
+- **Portfolio visibility overhaul (v3.07.00)**: Confidence styling for Retail/Gain-Loss (estimated vs confirmed), new "All Metals" totals card with Avg Cost/oz and clickable breakdown modal showing by-metal and by-location allocation, metal detail modals now show full Purchase/Melt/Retail/Gain-Loss breakdown per type and location in a compact 2x2 grid
 - **eBay search split (v3.06.02)**: Purchase column search icon now opens active eBay listings (what's for sale), Retail column search icon opens sold listings (what items actually sold for) — research buying price and resale value from the right columns
 - **CSS cleanup & icon polish (v3.06.01)**: Removed 125+ lines of dead CSS, replaced eBay emoji icon with clean SVG, overhauled About modal with project links and MIT License
 - **Rebrand to StakTrakr (v3.06.00)**: New canonical brand with multi-domain auto-branding — `staktrakr.com`, `stackrtrackr.com`, and `stackertrackr.com` each display their own brand name automatically

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **Confidence styling + summary refresh (v3.07.00)**: Retail and Gain/Loss columns now show italic/muted for estimated values (melt fallback) vs bold for confirmed (manual retail). New "All Metals" totals card, Avg Cost/oz per metal, and Gain/Loss bottom-line emphasis in summary cards
+- **Portfolio visibility overhaul (v3.07.00)**: Confidence styling for Retail/Gain-Loss (estimated vs confirmed), new "All Metals" totals card with Avg Cost/oz, metal detail modal now shows full Purchase/Melt/Retail/Gain-Loss breakdown per type and location in a compact 2x2 grid
 - **eBay search split (v3.06.02)**: Purchase column search icon now opens active eBay listings (what's for sale), Retail column search icon opens sold listings (what items actually sold for) — research buying price and resale value from the right columns
 - **CSS cleanup & icon polish (v3.06.01)**: Removed 125+ lines of dead CSS, replaced eBay emoji icon with clean SVG, overhauled About modal with project links and MIT License
 - **Rebrand to StakTrakr (v3.06.00)**: New canonical brand with multi-domain auto-branding — `staktrakr.com`, `stackrtrackr.com`, and `stackertrackr.com` each display their own brand name automatically

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Confidence styling + summary refresh (v3.07.00)**: Retail and Gain/Loss columns now show italic/muted for estimated values (melt fallback) vs bold for confirmed (manual retail). New "All Metals" totals card, Avg Cost/oz per metal, and Gain/Loss bottom-line emphasis in summary cards
 - **eBay search split (v3.06.02)**: Purchase column search icon now opens active eBay listings (what's for sale), Retail column search icon opens sold listings (what items actually sold for) — research buying price and resale value from the right columns
 - **CSS cleanup & icon polish (v3.06.01)**: Removed 125+ lines of dead CSS, replaced eBay emoji icon with clean SVG, overhauled About modal with project links and MIT License
 - **Rebrand to StakTrakr (v3.06.00)**: New canonical brand with multi-domain auto-branding — `staktrakr.com`, `stackrtrackr.com`, and `stackertrackr.com` each display their own brand name automatically

--- a/index.html
+++ b/index.html
@@ -772,6 +772,10 @@
                 <span class="total-label">Weight (oz):</span>
                 <span class="total-value" id="totalWeightSilver">0.00</span>
               </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzSilver">$0.00</span>
+              </div>
             </div>
             <div class="total-group">
               <div class="total-item">
@@ -786,7 +790,7 @@
                 <span class="total-label">Retail Value:</span>
                 <span class="total-value" id="retailValueSilver">$0.00</span>
               </div>
-              <div class="total-item">
+              <div class="total-item total-item-bottom-line">
                 <span class="total-label">Gain/Loss:</span>
                 <span class="total-value" id="lossProfitSilver">$0.00</span>
               </div>
@@ -804,6 +808,10 @@
                 <span class="total-label">Weight (oz):</span>
                 <span class="total-value" id="totalWeightGold">0.00</span>
               </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzGold">$0.00</span>
+              </div>
             </div>
             <div class="total-group">
               <div class="total-item">
@@ -818,7 +826,7 @@
                 <span class="total-label">Retail Value:</span>
                 <span class="total-value" id="retailValueGold">$0.00</span>
               </div>
-              <div class="total-item">
+              <div class="total-item total-item-bottom-line">
                 <span class="total-label">Gain/Loss:</span>
                 <span class="total-value" id="lossProfitGold">$0.00</span>
               </div>
@@ -836,6 +844,10 @@
                 <span class="total-label">Weight (oz):</span>
                 <span class="total-value" id="totalWeightPlatinum">0.00</span>
               </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzPlatinum">$0.00</span>
+              </div>
             </div>
             <div class="total-group">
               <div class="total-item">
@@ -850,7 +862,7 @@
                 <span class="total-label">Retail Value:</span>
                 <span class="total-value" id="retailValuePlatinum">$0.00</span>
               </div>
-              <div class="total-item">
+              <div class="total-item total-item-bottom-line">
                 <span class="total-label">Gain/Loss:</span>
                 <span class="total-value" id="lossProfitPlatinum">$0.00</span>
               </div>
@@ -868,6 +880,10 @@
                 <span class="total-label">Weight (oz):</span>
                 <span class="total-value" id="totalWeightPalladium">0.00</span>
               </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzPalladium">$0.00</span>
+              </div>
             </div>
             <div class="total-group">
               <div class="total-item">
@@ -882,9 +898,45 @@
                 <span class="total-label">Retail Value:</span>
                 <span class="total-value" id="retailValuePalladium">$0.00</span>
               </div>
-              <div class="total-item">
+              <div class="total-item total-item-bottom-line">
                 <span class="total-label">Gain/Loss:</span>
                 <span class="total-value" id="lossProfitPalladium">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <!-- All metals combined totals card -->
+          <div class="total-card total-card-all">
+            <div class="total-title">All Metals</div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Items:</span>
+                <span class="total-value" id="totalItemsAll">0</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Weight (oz):</span>
+                <span class="total-value" id="totalWeightAll">0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzAll">$0.00</span>
+              </div>
+            </div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Purchase Price:</span>
+                <span class="total-value" id="totalPurchasedAll">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Melt Value:</span>
+                <span class="total-value" id="currentValueAll">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Retail Value:</span>
+                <span class="total-value" id="retailValueAll">$0.00</span>
+              </div>
+              <div class="total-item total-item-bottom-line">
+                <span class="total-label">Gain/Loss:</span>
+                <span class="total-value" id="lossProfitAll">$0.00</span>
               </div>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -906,7 +906,7 @@
           </div>
           <!-- All metals combined totals card -->
           <div class="total-card total-card-all">
-            <div class="total-title">All Metals</div>
+            <div class="total-title" data-metal="All">All Metals</div>
             <div class="total-group">
               <div class="total-item">
                 <span class="total-label">Items:</span>
@@ -1181,7 +1181,7 @@
         <div class="modal-body">
           <div class="details-grid">
             <div class="details-panel">
-              <h3 class="details-panel-title">Breakdown by Type</h3>
+              <h3 class="details-panel-title" id="typePanelTitle">Breakdown by Type</h3>
               <div class="chart-canvas-container">
                 <canvas class="chart-canvas" id="typeChart"></canvas>
               </div>
@@ -1190,7 +1190,7 @@
               </div>
             </div>
             <div class="details-panel">
-              <h3 class="details-panel-title">Breakdown by Purchase Location</h3>
+              <h3 class="details-panel-title" id="locationPanelTitle">Breakdown by Purchase Location</h3>
               <div class="chart-canvas-container">
                 <canvas class="chart-canvas" id="locationChart"></canvas>
               </div>

--- a/js/about.js
+++ b/js/about.js
@@ -267,7 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.07.00 – Portfolio visibility overhaul</strong>: Confidence styling for Retail/Gain-Loss, All Metals totals card with Avg Cost/oz, metal detail modal shows full portfolio breakdown per type and location.</li>
+    <li><strong>v3.07.00 – Portfolio visibility overhaul</strong>: Confidence styling for Retail/Gain-Loss, All Metals totals card with Avg Cost/oz and clickable breakdown modal, metal detail modals show full portfolio breakdown per type and location.</li>
     <li><strong>v3.06.02 – eBay search split</strong>: Purchase column searches active listings (what's for sale), Retail column searches sold listings (what items sold for).</li>
     <li><strong>v3.06.01 – CSS cleanup &amp; icon polish</strong>: Removed 125+ lines of dead CSS, replaced eBay emoji icon with clean SVG, overhauled About modal with live site and project links.</li>
     <li><strong>v3.06.00 – Rebrand to StakTrakr</strong>: New canonical brand with multi-domain auto-branding — staktrakr.com, stackrtrackr.com, and stackertrackr.com each show their own name.</li>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.07.00 – Confidence styling + summary refresh</strong>: Retail/Gain-Loss columns show estimated vs confirmed values. New All Metals totals card with Avg Cost/oz. Gain/Loss bottom-line emphasis.</li>
     <li><strong>v3.06.02 – eBay search split</strong>: Purchase column searches active listings (what's for sale), Retail column searches sold listings (what items sold for).</li>
     <li><strong>v3.06.01 – CSS cleanup &amp; icon polish</strong>: Removed 125+ lines of dead CSS, replaced eBay emoji icon with clean SVG, overhauled About modal with live site and project links.</li>
     <li><strong>v3.06.00 – Rebrand to StakTrakr</strong>: New canonical brand with multi-domain auto-branding — staktrakr.com, stackrtrackr.com, and stackertrackr.com each show their own name.</li>

--- a/js/about.js
+++ b/js/about.js
@@ -267,7 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.07.00 – Confidence styling + summary refresh</strong>: Retail/Gain-Loss columns show estimated vs confirmed values. New All Metals totals card with Avg Cost/oz. Gain/Loss bottom-line emphasis.</li>
+    <li><strong>v3.07.00 – Portfolio visibility overhaul</strong>: Confidence styling for Retail/Gain-Loss, All Metals totals card with Avg Cost/oz, metal detail modal shows full portfolio breakdown per type and location.</li>
     <li><strong>v3.06.02 – eBay search split</strong>: Purchase column searches active listings (what's for sale), Retail column searches sold listings (what items sold for).</li>
     <li><strong>v3.06.01 – CSS cleanup &amp; icon polish</strong>: Removed 125+ lines of dead CSS, replaced eBay emoji icon with clean SVG, overhauled About modal with live site and project links.</li>
     <li><strong>v3.06.00 – Rebrand to StakTrakr</strong>: New canonical brand with multi-domain auto-branding — staktrakr.com, stackrtrackr.com, and stackertrackr.com each show their own name.</li>

--- a/js/charts.js
+++ b/js/charts.js
@@ -64,7 +64,7 @@ const getChartTextColor = () => {
  */
 const createPieChart = (canvas, data, title) => {
   const labels = Object.keys(data);
-  const values = Object.values(data).map(item => item.value);
+  const values = Object.values(data).map(item => item.purchase || item.value || 0);
   const colors = generateColors(labels.length);
 
   const ctx = canvas.getContext('2d');
@@ -129,16 +129,19 @@ const createPieChart = (canvas, data, title) => {
               const total = context.dataset.data.reduce((a, b) => a + b, 0);
               const percentage = ((value / total) * 100).toFixed(1);
 
-              // Get breakdown data for additional info
-              const breakdownItem = data[label];
-              const count = breakdownItem ? breakdownItem.count : 0;
-              const weight = breakdownItem ? breakdownItem.weight.toFixed(2) : '0.00';
-
-              return [
-                `${label}: ${formatCurrency(value)} (${percentage}%)`,
-                `Items: ${count}`,
-                `Weight: ${weight} oz`
+              const b = data[label];
+              const lines = [
+                `${label} (${percentage}%)`,
+                `Items: ${b ? b.count : 0} \u00B7 Weight: ${b ? b.weight.toFixed(2) : '0.00'} oz`,
+                `Purchase: ${formatCurrency(value)}`
               ];
+              if (b && b.melt !== undefined) {
+                lines.push(`Melt: ${formatCurrency(b.melt)}`);
+                lines.push(`Retail: ${formatCurrency(b.retail)}`);
+                const gl = b.gainLoss;
+                lines.push(`Gain/Loss: ${gl > 0 ? '+' : ''}${formatCurrency(gl)}`);
+              }
+              return lines;
             }
           }
         }

--- a/js/constants.js
+++ b/js/constants.js
@@ -258,7 +258,7 @@ const API_PROVIDERS = {
  * Updated: 2025-08-15 - Price column styling consistency fixes
  */
 
-const APP_VERSION = "3.06.02";
+const APP_VERSION = "3.07.00";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -10,37 +10,47 @@
  */
 const getBreakdownData = (metal) => {
   const metalItems = inventory.filter(item => item.metal === metal);
+  const currentSpot = spotPrices[metal.toLowerCase()] || 0;
 
   const typeBreakdown = {};
   const locationBreakdown = {};
 
+  const initBucket = () => ({
+    count: 0,
+    weight: 0,
+    purchase: 0,
+    melt: 0,
+    retail: 0,
+    gainLoss: 0
+  });
+
   metalItems.forEach(item => {
-    const itemWeight = item.qty * item.weight;
-    const itemValue = item.qty * item.price;
+    const qty = Number(item.qty) || 1;
+    const itemWeight = qty * (parseFloat(item.weight) || 0);
+    const purchaseTotal = qty * (parseFloat(item.price) || 0);
+    const meltValue = itemWeight * currentSpot;
+    const isManualRetail = item.marketValue && item.marketValue > 0;
+    const retailTotal = isManualRetail ? item.marketValue * qty : meltValue;
+    const gainLoss = retailTotal - purchaseTotal;
 
     // Type breakdown
-    if (!typeBreakdown[item.type]) {
-      typeBreakdown[item.type] = {
-        count: 0,
-        weight: 0,
-        value: 0
-      };
-    }
-    typeBreakdown[item.type].count += item.qty;
+    if (!typeBreakdown[item.type]) typeBreakdown[item.type] = initBucket();
+    typeBreakdown[item.type].count += qty;
     typeBreakdown[item.type].weight += itemWeight;
-    typeBreakdown[item.type].value += itemValue;
+    typeBreakdown[item.type].purchase += purchaseTotal;
+    typeBreakdown[item.type].melt += meltValue;
+    typeBreakdown[item.type].retail += retailTotal;
+    typeBreakdown[item.type].gainLoss += gainLoss;
 
     // Location breakdown
-    if (!locationBreakdown[item.purchaseLocation]) {
-      locationBreakdown[item.purchaseLocation] = {
-        count: 0,
-        weight: 0,
-        value: 0
-      };
-    }
-    locationBreakdown[item.purchaseLocation].count += item.qty;
-    locationBreakdown[item.purchaseLocation].weight += itemWeight;
-    locationBreakdown[item.purchaseLocation].value += itemValue;
+    const loc = item.purchaseLocation || 'Unknown';
+    if (!locationBreakdown[loc]) locationBreakdown[loc] = initBucket();
+    locationBreakdown[loc].count += qty;
+    locationBreakdown[loc].weight += itemWeight;
+    locationBreakdown[loc].purchase += purchaseTotal;
+    locationBreakdown[loc].melt += meltValue;
+    locationBreakdown[loc].retail += retailTotal;
+    locationBreakdown[loc].gainLoss += gainLoss;
   });
 
   return { typeBreakdown, locationBreakdown };
@@ -59,48 +69,65 @@ const createBreakdownElements = (breakdown) => {
   if (Object.keys(breakdown).length === 0) {
     const item = document.createElement('div');
     item.className = 'breakdown-item';
-
     const label = document.createElement('span');
     label.className = 'breakdown-label';
     label.textContent = 'No data available';
-
     item.appendChild(label);
     container.appendChild(item);
     return container;
   }
 
-  // Sort by value descending
-  const sortedEntries = Object.entries(breakdown).sort((a, b) => b[1].value - a[1].value);
+  // Sort by purchase value descending
+  const sortedEntries = Object.entries(breakdown).sort((a, b) => b[1].purchase - a[1].purchase);
 
   sortedEntries.forEach(([key, data]) => {
     const item = document.createElement('div');
     item.className = 'breakdown-item';
 
+    // Header row: name + count/weight
+    const header = document.createElement('div');
+    header.className = 'breakdown-header';
+
     const label = document.createElement('span');
     label.className = 'breakdown-label';
     label.textContent = key;
 
-    const values = document.createElement('div');
-    values.className = 'breakdown-values';
+    const meta = document.createElement('span');
+    meta.className = 'breakdown-meta';
+    meta.textContent = `${data.count} items \u00B7 ${data.weight.toFixed(2)} oz`;
 
-    const count = document.createElement('div');
-    count.className = 'breakdown-count';
-    count.textContent = `${data.count} items`;
+    header.appendChild(label);
+    header.appendChild(meta);
 
-    const weight = document.createElement('div');
-    weight.className = 'breakdown-weight';
-    weight.textContent = `${data.weight.toFixed(2)} oz`;
+    // 2x2 financial grid
+    const grid = document.createElement('div');
+    grid.className = 'breakdown-grid';
 
-    const value = document.createElement('div');
-    value.className = 'breakdown-value';
-    value.textContent = formatCurrency(data.value);
+    const cells = [
+      { label: 'Purchase', value: formatCurrency(data.purchase), cls: 'breakdown-purchase' },
+      { label: 'Melt', value: formatCurrency(data.melt), cls: 'breakdown-melt' },
+      { label: 'Retail', value: formatCurrency(data.retail), cls: 'breakdown-retail' },
+      { label: 'Gain/Loss', value: formatCurrency(Math.abs(data.gainLoss)), cls: data.gainLoss >= 0 ? 'breakdown-gain' : 'breakdown-loss' }
+    ];
 
-    values.appendChild(count);
-    values.appendChild(weight);
-    values.appendChild(value);
+    cells.forEach(cell => {
+      const el = document.createElement('div');
+      el.className = `breakdown-cell ${cell.cls}`;
+      const lbl = document.createElement('span');
+      lbl.className = 'breakdown-cell-label';
+      lbl.textContent = cell.label;
+      const val = document.createElement('span');
+      val.className = 'breakdown-cell-value';
+      val.textContent = cell.label === 'Gain/Loss'
+        ? (data.gainLoss > 0 ? '+' : data.gainLoss < 0 ? '-' : '') + cell.value
+        : cell.value;
+      el.appendChild(lbl);
+      el.appendChild(val);
+      grid.appendChild(el);
+    });
 
-    item.appendChild(label);
-    item.appendChild(values);
+    item.appendChild(header);
+    item.appendChild(grid);
     container.appendChild(item);
   });
 

--- a/js/init.js
+++ b/js/init.js
@@ -297,6 +297,7 @@ document.addEventListener("DOMContentLoaded", () => {
         purchased: safeGetElement(`totalPurchased${metalName}`),
         retailValue: safeGetElement(`retailValue${metalName}`),
         lossProfit: safeGetElement(`lossProfit${metalName}`),
+        avgCostPerOz: safeGetElement(`avgCostPerOz${metalName}`),
       };
     });
 
@@ -308,6 +309,7 @@ document.addEventListener("DOMContentLoaded", () => {
       purchased: safeGetElement("totalPurchasedAll"),
       retailValue: safeGetElement("retailValueAll"),
       lossProfit: safeGetElement("lossProfitAll"),
+      avgCostPerOz: safeGetElement("avgCostPerOzAll"),
     };
 
     // Phase 11: Version Management

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1072,12 +1072,12 @@ const renderTable = () => {
         </a>
       </td>
       <td class="shrink" data-column="meltValue" title="Melt Value (USD)" style="color: var(--text-primary);">${meltDisplay}</td>
-      <td class="shrink" data-column="retailPrice" title="${isManualRetail ? 'Manual retail price' : 'Defaults to melt value'} - Click to search eBay sold listings" style="color: var(--text-primary);">
+      <td class="shrink ${isManualRetail ? 'retail-confirmed' : 'retail-estimated'}" data-column="retailPrice" title="${isManualRetail ? 'Manual retail price (confirmed)' : 'Estimated — defaults to melt value'} - Click to search eBay sold listings">
         <a href="#" class="ebay-sold-link ebay-price-link" data-search="${sanitizeHtml(item.metal + ' ' + item.name)}" title="Search eBay sold listings for ${sanitizeHtml(item.metal)} ${sanitizeHtml(item.name)}">
-          ${retailDisplay}${isManualRetail ? ' <span style="opacity:0.5;font-size:0.8em;" title="Manually set retail price">*</span>' : ''} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+          ${retailDisplay} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>
       </td>
-      <td class="shrink" data-column="gainLoss" title="Gain/Loss (USD)" style="color: ${gainLossColor}; font-weight: ${gainLoss !== null && gainLoss !== 0 ? '600' : 'normal'};">${gainLoss !== null && gainLossDisplay !== '—' ? gainLossPrefix + gainLossDisplay : '—'}</td>
+      <td class="shrink ${!isManualRetail && gainLoss !== null ? 'gainloss-estimated' : ''}" data-column="gainLoss" title="${isManualRetail ? 'Gain/Loss (confirmed retail)' : 'Gain/Loss (estimated — based on melt value)'}" style="color: ${gainLossColor}; font-weight: ${gainLoss !== null && gainLoss !== 0 && isManualRetail ? '600' : 'normal'};">${gainLoss !== null && gainLossDisplay !== '—' ? gainLossPrefix + gainLossDisplay : '—'}</td>
       <td class="shrink" data-column="purchaseLocation">
         ${formatPurchaseLocation(item.purchaseLocation)}
       </td>
@@ -1213,6 +1213,10 @@ const updateSummary = () => {
     if (els.purchased) els.purchased.innerHTML = formatCurrency(totals.totalPurchased || 0);
     if (els.retailValue) els.retailValue.innerHTML = formatCurrency(totals.totalRetailValue || 0);
     if (els.lossProfit) els.lossProfit.innerHTML = formatLossProfit(totals.totalGainLoss || 0);
+    if (els.avgCostPerOz) {
+      const avgCost = totals.totalWeight > 0 ? totals.totalPurchased / totals.totalWeight : 0;
+      els.avgCostPerOz.innerHTML = formatCurrency(avgCost);
+    }
   });
 
   // Calculate combined totals for all metals
@@ -1242,6 +1246,10 @@ const updateSummary = () => {
     if (elements.totals.all.purchased) elements.totals.all.purchased.innerHTML = formatCurrency(allTotals.totalPurchased || 0);
     if (elements.totals.all.retailValue) elements.totals.all.retailValue.innerHTML = formatCurrency(allTotals.totalRetailValue || 0);
     if (elements.totals.all.lossProfit) elements.totals.all.lossProfit.innerHTML = formatLossProfit(allTotals.totalGainLoss || 0);
+    if (elements.totals.all.avgCostPerOz) {
+      const avgCost = allTotals.totalWeight > 0 ? allTotals.totalPurchased / allTotals.totalWeight : 0;
+      elements.totals.all.avgCostPerOz.innerHTML = formatCurrency(avgCost);
+    }
   }
 };
 

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -94,7 +94,7 @@ const getEmbeddedChangelog = (version) => {
     "3.07.00": `
       <li><strong>Confidence styling</strong>: Retail and Gain/Loss columns now show italic/muted for estimated values (melt fallback) vs bold for confirmed (manual retail)</li>
       <li><strong>All Metals summary card</strong>: New combined totals card with portfolio-wide metrics and Avg Cost/oz per metal</li>
-      <li><strong>Gain/Loss bottom line</strong>: Each summary card emphasizes Gain/Loss with a separator and larger font</li>
+      <li><strong>Metal detail modal overhaul</strong>: Full portfolio breakdown (Purchase, Melt, Retail, Gain/Loss) per type and location in a compact 2x2 grid</li>
     `,
     "3.06.02": `
       <li><strong>eBay search split</strong>: Purchase column now searches active listings (what's for sale), Retail column searches sold listings (what items actually sold for)</li>

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,11 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.07.00": `
+      <li><strong>Confidence styling</strong>: Retail and Gain/Loss columns now show italic/muted for estimated values (melt fallback) vs bold for confirmed (manual retail)</li>
+      <li><strong>All Metals summary card</strong>: New combined totals card with portfolio-wide metrics and Avg Cost/oz per metal</li>
+      <li><strong>Gain/Loss bottom line</strong>: Each summary card emphasizes Gain/Loss with a separator and larger font</li>
+    `,
     "3.06.02": `
       <li><strong>eBay search split</strong>: Purchase column now searches active listings (what's for sale), Retail column searches sold listings (what items actually sold for)</li>
     `,

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -95,6 +95,7 @@ const getEmbeddedChangelog = (version) => {
       <li><strong>Confidence styling</strong>: Retail and Gain/Loss columns now show italic/muted for estimated values (melt fallback) vs bold for confirmed (manual retail)</li>
       <li><strong>All Metals summary card</strong>: New combined totals card with portfolio-wide metrics and Avg Cost/oz per metal</li>
       <li><strong>Metal detail modal overhaul</strong>: Full portfolio breakdown (Purchase, Melt, Retail, Gain/Loss) per type and location in a compact 2x2 grid</li>
+      <li><strong>All Metals breakdown modal</strong>: Click the All Metals card header for portfolio-wide by-metal and by-location allocation with pie charts</li>
     `,
     "3.06.02": `
       <li><strong>eBay search split</strong>: Purchase column now searches active listings (what's for sale), Retail column searches sold listings (what items actually sold for)</li>


### PR DESCRIPTION
## Summary

- **Retail/Gain-Loss confidence styling**: Estimated values (melt fallback) show italic + muted, confirmed values (manual retail) show bold — at a glance differentiation
- **"All Metals" summary card**: New combined totals card with Items, Weight, Avg Cost/oz, Purchase, Melt, Retail, Gain/Loss
- **Gain/Loss "bottom line" emphasis**: Top separator + bold + larger font on every card's Gain/Loss row
- **Metal detail modal overhaul**: Full Purchase/Melt/Retail/Gain-Loss breakdown per type and per location in a compact 2x2 grid (replaces old single-value layout)
- **All Metals breakdown modal**: Click the All Metals card header for portfolio-wide by-metal and by-location allocation with pie charts and financial grids

## Files changed (12 files, +342 / -98)

- `css/styles.css` — Confidence classes, breakdown grid, summary card styling
- `js/detailsModal.js` — New `getAllMetalsBreakdownData()`, updated `showDetailsModal()` for All/single-metal branching
- `js/inventory.js` — Confidence CSS classes on retail/gain-loss cells, Avg Cost/oz update
- `js/charts.js` — Pie chart data source + tooltip updated for full financial quartet
- `index.html` — All Metals card HTML, `data-metal="All"`, panel title IDs, Avg Cost/oz rows
- `js/init.js` — `avgCostPerOz` element references
- Changelog/version files updated

## Test plan

- [ ] Individual metal cards still open correctly with by-type and by-location breakdown
- [ ] Click "All Metals" card header → modal opens with "Breakdown by Metal" (left) and "Breakdown by Location" (right)
- [ ] Pie charts render and tooltips show full Purchase/Melt/Retail/Gain-Loss
- [ ] Retail column shows italic/muted for estimated, bold for confirmed
- [ ] Gain/Loss column inherits muted styling when retail is estimated
- [ ] All Metals summary card shows correct totals and Avg Cost/oz
- [ ] Gain/Loss rows in all cards have bottom-line emphasis styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)