### PR TITLE
v3.08.00: Spot price card redesign with sparkline trends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.08.00] - 2026-02-07
+
+### Increment 7 — Spot Price Card Redesign with Sparkline Trends
+
+#### Added
+
+- **Background sparkline charts**: Each spot price card now shows a Chart.js line chart with gradient fill behind the price, visualizing price trends from spot history. Minimum 2 data points required; empty state shows the card normally without a sparkline
+- **Trend range dropdown**: Per-card `<select>` with 7d / 30d / 60d / 90d options. Preference saved to localStorage per metal, restored on load
+- **Sync icon**: Compact SVG refresh icon in the card header replaces the old Sync button. Spins during API fetch via CSS animation. Disabled when no API is configured
+- **Shift+click manual price entry**: Hold Shift and click the spot price value to open an inline `<input>` — same pattern as inventory table inline editing. Enter saves, Escape/blur cancels. New data point appears in sparkline immediately
+
+#### Changed
+
+- **Removed expandable button panel**: The old Sync / Add / History button row (`.spot-actions`) and manual input form (`.manual-input`) are removed entirely. Sync is now an icon, manual entry is shift+click, and history is the sparkline itself
+- **Card layout**: Spot cards now use a header row (label + controls) above the price value, with an absolutely-positioned canvas behind all content for the sparkline
+- **Spot history dedup**: `recordSpot()` now performs full-array dedup (via `.some()`) when an explicit timestamp is provided (historical backfill), preventing duplicate entries on repeated syncs with 30-day backfill
+
+#### Fixed
+
+- **Metals.dev timeseries endpoint**: Batch endpoint was using non-existent `/metals/spot?days=N` — replaced with actual `/timeseries?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD`. Response parser rewritten to handle the real `{ rates: { "date": { metals: { gold: N } } } }` structure
+- **History metal name mismatch**: `METALS[metal]?.name` used lowercase key (`"silver"`) against uppercase `METALS` keys (`"SILVER"`), causing history entries to record with wrong metal name. Fixed to use `Object.values(METALS).find()` lookup
+
+#### Technical
+
+- New `sparklineInstances` state object for Chart.js instance cleanup
+- New `SPOT_TREND_RANGE_KEY` localStorage key with security whitelist entry
+- `updateAllSparklines()` called from: init, sync, cache refresh, theme change, range dropdown change, manual price save
+- Capture-phase shift+click listener for `.spot-card-value` elements
+
+## [3.07.03] - 2026-02-07
+
+### Patch — Spot History Deduplication Fix
+
+#### Fixed
+
+- **Duplicate spot history entries on repeated syncs**: `recordSpot()` only compared against the last array entry, so batch historical backfills (30 days × 4 metals) re-inserted the same timestamp+metal pair on every sync. Now performs full-array dedup via `.some()` when an explicit timestamp is provided (historical backfill), while keeping the fast O(1) tail check for real-time entries
+
 ## [3.07.02] - 2026-02-07
 
 ### Patch — Shift+Click Inline Editing

--- a/css/styles.css
+++ b/css/styles.css
@@ -670,120 +670,164 @@ input[type="submit"] {
 }
 
 /* =============================================================================
-   SPOT PRICE CARDS
+   SPOT PRICE CARDS — Sparkline Redesign
    ============================================================================= */
-.spot-input .grid.grid-2 {
-  margin-top: var(--spacing-sm);
-}
 
 .spot-input {
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
+  padding: 0;
   border: 1px solid var(--border);
+  overflow: hidden;
 }
 
 .spot-card {
+  position: relative;
   background: var(--bg-primary);
-  border-radius: var(--radius);
-  padding: var(--spacing);
+  border-radius: var(--radius-lg);
+  padding: 0;
   text-align: center;
-  margin-bottom: var(--spacing);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
-  cursor: pointer;
+  overflow: hidden;
+}
+
+/* Sparkline canvas — positioned behind card content */
+.spot-sparkline {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+/* Card header: label + controls row */
+.spot-card-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+  padding: var(--spacing) var(--spacing) 0;
 }
 
 .spot-card-label {
   font-size: 0.75rem;
   color: var(--text-muted);
-  margin-bottom: 0.25rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-weight: 500;
 }
 
+.spot-card-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+/* Range dropdown */
+.spot-range-select {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.spot-range-select:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
+
+/* Sync icon button */
+.spot-sync-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.spot-sync-icon:hover:not(:disabled) {
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+.spot-sync-icon:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.spot-sync-icon.syncing svg {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* Card value — above sparkline */
 .spot-card-value {
+  position: relative;
+  z-index: 1;
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--primary);
+  cursor: default;
 }
 
 /* Spot price change indicators */
-.spot-up {
-  color: var(--success);
-}
-
-.spot-down {
-  color: var(--danger);
-}
-
-.spot-unchanged {
-  color: var(--warning);
-}
+.spot-up { color: var(--success); }
+.spot-down { color: var(--danger); }
+.spot-unchanged { color: var(--warning); }
 
 .spot-card-timestamp {
+  position: relative;
+  z-index: 1;
   font-size: 0.7rem;
   color: var(--text-muted);
   margin-top: 0.25rem;
   font-weight: 400;
   line-height: 1.2;
+  padding: 0 var(--spacing) var(--spacing);
 }
 
-/* Spot Price Action Buttons */
-.spot-actions {
-  display: none;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing);
-  justify-content: center;
-}
-
-.spot-action-btn {
-  flex: 1;
-  padding: var(--spacing-sm) var(--spacing);
-  font-size: 0.75rem;
-  font-weight: 500;
-  min-height: 2rem;
-  border-radius: var(--radius);
-  transition: var(--transition);
-}
-
-.spot-action-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  background: var(--text-muted);
-}
-
-.spot-action-btn:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow);
-}
-
-/* Manual input section (hidden by default) */
-.manual-input {
+/* Inline edit input (shift+click on price) */
+.spot-inline-input {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-align: center;
+  width: 7em;
+  border: 2px solid var(--primary);
+  border-radius: var(--radius-sm, 4px);
   background: var(--bg-primary);
-  border-radius: var(--radius);
-  padding: var(--spacing);
-  border: 1px solid var(--border);
-  margin-top: var(--spacing-sm);
-  animation: slideDown 0.2s ease-out;
+  color: var(--primary);
+  padding: 0.1rem 0.25rem;
+  outline: none;
 }
 
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+/* Hide number spinners on inline input */
+.spot-inline-input::-webkit-outer-spin-button,
+.spot-inline-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
-
-.manual-input label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-bottom: var(--spacing-sm);
+.spot-inline-input[type=number] {
+  -moz-appearance: textfield;
 }
 
 /* Settings Modal - API Provider Blocks */

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,12 +1,12 @@
 ## What's New
 
-- **Shift+click inline editing (v3.07.02)**: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels. Removed pencil icon and save/cancel buttons — clean keyboard-only editing
-- **Light & Sepia theme contrast pass (v3.07.01)**: Clean gray-to-white light palette with visible card elevation. Darkened metal/type text colors to pass WCAG AA in both themes. Estimated Retail/Gain-Loss now uses muted text color instead of opacity
-- **Portfolio visibility overhaul (v3.07.00)**: Confidence styling for Retail/Gain-Loss (estimated vs confirmed), new "All Metals" totals card with Avg Cost/oz and clickable breakdown modal, metal detail modals now show full portfolio breakdown per type and location
+- **Spot price card redesign (v3.08.00)**: Background sparkline trend charts on all 4 spot cards, sync icon replaces button panel, shift+click for manual price entry, per-card range dropdown (7d/30d/60d/90d). Historical backfill dedup prevents duplicate entries on repeated syncs
+- **Shift+click inline editing (v3.07.02)**: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels
+- **Light & Sepia theme contrast pass (v3.07.01)**: Clean gray-to-white light palette with visible card elevation. Darkened metal/type text colors to pass WCAG AA in both themes
+- **Portfolio visibility overhaul (v3.07.00)**: Confidence styling for Retail/Gain-Loss (estimated vs confirmed), new "All Metals" totals card with Avg Cost/oz and clickable breakdown modal
 
 ## Development Roadmap
 
+- **Inline catalog & grading tags**: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed
 - **Filter chips rebuild**: Top-N per category model, normalized name chips, chip settings modal
-- **N# column restore**: Re-add Numista catalog column with filter-on-click and iframe link
 - **Numista API fix**: Correct endpoints, auth headers, and parameters in the NumistaProvider class
-- **Mobile card view**: Responsive layout that switches from table to card-based view on small screens

--- a/index.html
+++ b/index.html
@@ -227,220 +227,92 @@
             gap: 1rem;
           "
         >
-          <!-- Silver spot price controls -->
+          <!-- Silver spot price card -->
           <div class="spot-input silver">
-            <div class="spot-card">
-              <div class="spot-card-label">Silver Spot Price</div>
-              <div class="spot-card-value" id="spotPriceDisplaySilver">$ -</div>
-              <div class="spot-card-timestamp" id="spotTimestampSilver">
-                No data
+            <div class="spot-card" data-metal="silver">
+              <canvas class="spot-sparkline" id="sparklineSilver" aria-hidden="true"></canvas>
+              <div class="spot-card-header">
+                <div class="spot-card-label">Silver Spot Price</div>
+                <div class="spot-card-controls">
+                  <select class="spot-range-select" id="spotRangeSilver" title="Trend period">
+                    <option value="7">7d</option>
+                    <option value="30">30d</option>
+                    <option value="60">60d</option>
+                    <option value="90" selected>90d</option>
+                  </select>
+                  <button class="spot-sync-icon" id="syncIconSilver" title="Sync from API" disabled>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                  </button>
+                </div>
               </div>
+              <div class="spot-card-value" id="spotPriceDisplaySilver" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-timestamp" id="spotTimestampSilver">No data</div>
             </div>
-            <div class="spot-actions">
-              <button
-                class="btn spot-action-btn"
-                id="syncBtnSilver"
-                title="Sync from API"
-                disabled
-              >
-                Sync
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="addBtnSilver"
-                title="Add/Override Price"
-              >
-                Add
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="historyBtnSilver"
-                title="View Spot History"
-              >
-                History
-              </button>
-            </div>
-            <div
-              class="manual-input"
-              id="manualInputSilver"
-              style="display: none"
-            >
-              <label for="userSpotPriceSilver">Manual Silver Price</label>
-              <div class="currency-input">
-                <input
-                  id="userSpotPriceSilver"
-                  min="0"
-                  placeholder="Enter price"
-                  step="0.01"
-                  type="number"
-                />
-              </div>
-              <div class="grid grid-2">
-                <button class="btn" id="saveSpotBtnSilver">Save</button>
-                <button class="btn" id="cancelSpotBtnSilver">Cancel</button>
-              </div>
           </div>
-        </div>
-          <!-- Gold spot price controls -->
+          <!-- Gold spot price card -->
           <div class="spot-input gold">
-            <div class="spot-card">
-              <div class="spot-card-label">Gold Spot Price</div>
-              <div class="spot-card-value" id="spotPriceDisplayGold">$ -</div>
-              <div class="spot-card-timestamp" id="spotTimestampGold">
-                No data
+            <div class="spot-card" data-metal="gold">
+              <canvas class="spot-sparkline" id="sparklineGold" aria-hidden="true"></canvas>
+              <div class="spot-card-header">
+                <div class="spot-card-label">Gold Spot Price</div>
+                <div class="spot-card-controls">
+                  <select class="spot-range-select" id="spotRangeGold" title="Trend period">
+                    <option value="7">7d</option>
+                    <option value="30">30d</option>
+                    <option value="60">60d</option>
+                    <option value="90" selected>90d</option>
+                  </select>
+                  <button class="spot-sync-icon" id="syncIconGold" title="Sync from API" disabled>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                  </button>
+                </div>
               </div>
-            </div>
-            <div class="spot-actions">
-              <button
-                class="btn spot-action-btn"
-                id="syncBtnGold"
-                title="Sync from API"
-                disabled
-              >
-                Sync
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="addBtnGold"
-                title="Add/Override Price"
-              >
-                Add
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="historyBtnGold"
-                title="View Spot History"
-              >
-                History
-              </button>
-            </div>
-            <div
-              class="manual-input"
-              id="manualInputGold"
-              style="display: none"
-            >
-              <label for="userSpotPriceGold">Manual Gold Price</label>
-              <div class="currency-input">
-                <input
-                  id="userSpotPriceGold"
-                  min="0"
-                  placeholder="Enter price"
-                  step="0.01"
-                  type="number"
-                />
-              </div>
-              <div class="grid grid-2">
-                <button class="btn" id="saveSpotBtnGold">Save</button>
-                <button class="btn" id="cancelSpotBtnGold">Cancel</button>
-              </div>
+              <div class="spot-card-value" id="spotPriceDisplayGold" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-timestamp" id="spotTimestampGold">No data</div>
             </div>
           </div>
-          <!-- Platinum spot price controls -->
+          <!-- Platinum spot price card -->
           <div class="spot-input platinum">
-            <div class="spot-card">
-              <div class="spot-card-label">Platinum Spot Price</div>
-              <div class="spot-card-value" id="spotPriceDisplayPlatinum">$ -</div>
-              <div class="spot-card-timestamp" id="spotTimestampPlatinum">
-                No data
+            <div class="spot-card" data-metal="platinum">
+              <canvas class="spot-sparkline" id="sparklinePlatinum" aria-hidden="true"></canvas>
+              <div class="spot-card-header">
+                <div class="spot-card-label">Platinum Spot Price</div>
+                <div class="spot-card-controls">
+                  <select class="spot-range-select" id="spotRangePlatinum" title="Trend period">
+                    <option value="7">7d</option>
+                    <option value="30">30d</option>
+                    <option value="60">60d</option>
+                    <option value="90" selected>90d</option>
+                  </select>
+                  <button class="spot-sync-icon" id="syncIconPlatinum" title="Sync from API" disabled>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                  </button>
+                </div>
               </div>
-            </div>
-            <div class="spot-actions">
-              <button
-                class="btn spot-action-btn"
-                id="syncBtnPlatinum"
-                title="Sync from API"
-                disabled
-              >
-                Sync
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="addBtnPlatinum"
-                title="Add/Override Price"
-              >
-                Add
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="historyBtnPlatinum"
-                title="View Spot History"
-              >
-                History
-              </button>
-            </div>
-            <div
-              class="manual-input"
-              id="manualInputPlatinum"
-              style="display: none"
-            >
-              <label for="userSpotPricePlatinum">Manual Platinum Price</label>
-              <div class="currency-input">
-                <input
-                  id="userSpotPricePlatinum"
-                  min="0"
-                  placeholder="Enter price"
-                  step="0.01"
-                  type="number"
-                />
-              </div>
-              <div class="grid grid-2">
-                <button class="btn" id="saveSpotBtnPlatinum">Save</button>
-                <button class="btn" id="cancelSpotBtnPlatinum">Cancel</button>
-              </div>
+              <div class="spot-card-value" id="spotPriceDisplayPlatinum" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-timestamp" id="spotTimestampPlatinum">No data</div>
             </div>
           </div>
-          <!-- Palladium spot price controls -->
+          <!-- Palladium spot price card -->
           <div class="spot-input palladium">
-            <div class="spot-card">
-              <div class="spot-card-label">Palladium Spot Price</div>
-              <div class="spot-card-value" id="spotPriceDisplayPalladium">$ -</div>
-              <div class="spot-card-timestamp" id="spotTimestampPalladium">
-                No data
+            <div class="spot-card" data-metal="palladium">
+              <canvas class="spot-sparkline" id="sparklinePalladium" aria-hidden="true"></canvas>
+              <div class="spot-card-header">
+                <div class="spot-card-label">Palladium Spot Price</div>
+                <div class="spot-card-controls">
+                  <select class="spot-range-select" id="spotRangePalladium" title="Trend period">
+                    <option value="7">7d</option>
+                    <option value="30">30d</option>
+                    <option value="60">60d</option>
+                    <option value="90" selected>90d</option>
+                  </select>
+                  <button class="spot-sync-icon" id="syncIconPalladium" title="Sync from API" disabled>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                  </button>
+                </div>
               </div>
-            </div>
-            <div class="spot-actions">
-              <button
-                class="btn spot-action-btn"
-                id="syncBtnPalladium"
-                title="Sync from API"
-                disabled
-              >
-                Sync
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="addBtnPalladium"
-                title="Add/Override Price"
-              >
-                Add
-              </button>
-              <button
-                class="btn spot-action-btn"
-                id="historyBtnPalladium"
-                title="View Spot History"
-              >
-                History
-              </button>
-            </div>
-            <div
-              class="manual-input"
-              id="manualInputPalladium"
-              style="display: none"
-            >
-              <label for="userSpotPricePalladium">Manual Palladium Price</label>
-              <div class="currency-input">
-                <input
-                  id="userSpotPricePalladium"
-                  min="0"
-                  placeholder="Enter price"
-                  step="0.01"
-                  type="number"
-                />
-              </div>
-              <div class="grid grid-2">
-                <button class="btn" id="saveSpotBtnPalladium">Save</button>
-                <button class="btn" id="cancelSpotBtnPalladium">Cancel</button>
-              </div>
+              <div class="spot-card-value" id="spotPriceDisplayPalladium" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-timestamp" id="spotTimestampPalladium">No data</div>
             </div>
           </div>
         </div>

--- a/js/about.js
+++ b/js/about.js
@@ -267,8 +267,8 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.07.02 – Shift+click inline editing</strong>: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels. Removed pencil icon and save/cancel buttons — clean keyboard-only editing</li>
-    <li><strong>v3.07.01 – Light &amp; Sepia theme contrast pass</strong>: Clean gray-to-white light palette, darkened metal/type text for WCAG AA, estimated values use muted color instead of opacity. Sepia: removed global filter, fixed text contrast</li>
+    <li><strong>v3.08.00 – Spot price card redesign</strong>: Background sparkline trends on all 4 cards, sync icon replaces button panel, shift+click manual price entry, per-card range dropdown (7d/30d/60d/90d). Dedup fix for historical backfill</li>
+    <li><strong>v3.07.02 – Shift+click inline editing</strong>: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels</li>
     <li><strong>v3.07.00 – Portfolio visibility overhaul</strong>: Confidence styling for Retail/Gain-Loss, All Metals totals card with Avg Cost/oz and clickable breakdown modal, metal detail modals show full portfolio breakdown per type and location</li>
   `;
 };
@@ -279,10 +279,9 @@ const getEmbeddedWhatsNew = () => {
  */
 const getEmbeddedRoadmap = () => {
   return `
+    <li><strong>Inline catalog &amp; grading tags</strong>: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed</li>
     <li><strong>Filter chips rebuild</strong>: Top-N per category model, normalized name chips, chip settings modal</li>
-    <li><strong>N# column restore</strong>: Re-add Numista catalog column with filter-on-click and iframe link</li>
     <li><strong>Numista API fix</strong>: Correct endpoints, auth headers, and parameters in the NumistaProvider class</li>
-    <li><strong>Mobile card view</strong>: Responsive layout that switches from table to card-based view on small screens</li>
   `;
 };
 

--- a/js/init.js
+++ b/js/init.js
@@ -246,11 +246,11 @@ document.addEventListener("DOMContentLoaded", () => {
     // Phase 9: Initialize Metal-Specific Elements
     debugLog("Phase 9: Initializing metal-specific elements...");
 
-    // Initialize nested objects
+    // Initialize nested objects for spot price cards
     elements.spotPriceDisplay = {};
-    elements.userSpotPriceInput = {};
-    elements.saveSpotBtn = {};
-    elements.historyBtn = {};
+    elements.spotSyncIcon = {};
+    elements.spotRangeSelect = {};
+    elements.spotSparkline = {};
 
     Object.values(METALS).forEach((metalConfig) => {
       const metalKey = metalConfig.key;
@@ -258,25 +258,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
       debugLog(`  Setting up ${metalName} elements...`);
 
-      // Spot price display elements with CORRECT IDs
       elements.spotPriceDisplay[metalKey] = safeGetElement(
         `spotPriceDisplay${metalName}`,
       );
-      elements.userSpotPriceInput[metalKey] = safeGetElement(
-        `userSpotPrice${metalName}`,
+      elements.spotSyncIcon[metalKey] = safeGetElement(
+        `syncIcon${metalName}`,
       );
-      elements.saveSpotBtn[metalKey] = safeGetElement(
-        `saveSpotBtn${metalName}`,
+      elements.spotRangeSelect[metalKey] = safeGetElement(
+        `spotRange${metalName}`,
       );
-      elements.historyBtn[metalKey] = safeGetElement(
-        `historyBtn${metalName}`,
+      elements.spotSparkline[metalKey] = safeGetElement(
+        `sparkline${metalName}`,
       );
 
-      // Debug log for each metal
-      const displayEl = document.getElementById(`spotPriceDisplay${metalName}`);
-      const inputEl = document.getElementById(`userSpotPrice${metalName}`);
-      debugLog(`    - ${metalName} display element:`, !!displayEl);
-      debugLog(`    - ${metalName} input element:`, !!inputEl);
+      debugLog(`    - ${metalName} display element:`, !!document.getElementById(`spotPriceDisplay${metalName}`));
+      debugLog(`    - ${metalName} sparkline canvas:`, !!document.getElementById(`sparkline${metalName}`));
     });
 
     // Phase 10: Initialize Totals Elements
@@ -361,6 +357,9 @@ document.addEventListener("DOMContentLoaded", () => {
         renderActiveFilters();
       }
       fetchSpotPrice();
+      if (typeof updateAllSparklines === "function") {
+        updateAllSparklines();
+      }
       updateSyncButtonStates();
       if (typeof updateStorageStats === "function") {
         updateStorageStats();

--- a/js/state.js
+++ b/js/state.js
@@ -28,6 +28,14 @@ let chartInstances = {
   locationChart: null,
 };
 
+/** @type {Object} Sparkline Chart.js instances keyed by metal (for cleanup) */
+let sparklineInstances = {
+  silver: null,
+  gold: null,
+  platinum: null,
+  palladium: null,
+};
+
 /** @type {Set<string>} Available composition options */
 let compositionOptions = new Set(["Gold", "Silver", "Platinum", "Palladium", "Alloy"]);
 
@@ -38,9 +46,9 @@ let marketValueViewItems = new Set();
 const elements = {
   // Spot price elements
   spotPriceDisplay: {},
-  userSpotPriceInput: {},
-  saveSpotBtn: {},
-  historyBtn: {},
+  spotSyncIcon: {},
+  spotRangeSelect: {},
+  spotSparkline: {},
 
   // Form elements
   inventoryForm: null,
@@ -63,11 +71,11 @@ const elements = {
   itemCollectable: null,
   itemCatalog: null,
 
-  // Spot price buttons
-  saveSpotBtnSilver: null,
-  saveSpotBtnGold: null,
-  historyBtnSilver: null,
-  historyBtnGold: null,
+  // Spot price sync icons (per-metal)
+  syncIconSilver: null,
+  syncIconGold: null,
+  syncIconPlatinum: null,
+  syncIconPalladium: null,
 
   // Import elements
   importCsvFile: null,

--- a/js/theme.js
+++ b/js/theme.js
@@ -24,6 +24,9 @@ const setTheme = (theme) => {
   if (typeof renderTable === "function") {
     renderTable();
   }
+  if (typeof updateAllSparklines === "function") {
+    updateAllSparklines();
+  }
 };
 
 /**

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,10 +91,17 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.08.00": `
+      <li><strong>Sparkline trend charts</strong>: Background Chart.js line charts on all 4 spot price cards showing price history with gradient fill</li>
+      <li><strong>Trend range dropdown</strong>: Per-card 7d/30d/60d/90d selector with persistent preference</li>
+      <li><strong>Sync icon</strong>: Compact refresh icon replaces old Sync/Add/History button panel, spins during fetch</li>
+      <li><strong>Shift+click manual price</strong>: Hold Shift and click the spot price to edit inline — Enter saves, Escape cancels</li>
+      <li><strong>History dedup fix</strong>: Repeated syncs with 30-day backfill no longer create duplicate spotHistory entries</li>
+    `,
     "3.07.02": `
       <li><strong>Shift+click inline editing</strong>: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels, click away cancels</li>
       <li><strong>Removed pencil icon</strong>: Name column no longer shows the edit icon — shift+click replaces it for all 6 editable columns</li>
-      <li><strong>Removed save/cancel icons</strong>: Inline edit fields use Enter/Escape only — no more ✔️/✖️ buttons competing for space in narrow cells</li>
+      <li><strong>Removed save/cancel icons</strong>: Inline edit fields use Enter/Escape only — no more buttons competing for space in narrow cells</li>
       <li><strong>Hidden number spinners</strong>: Qty, Weight, and price fields no longer show browser-native up/down arrows</li>
     `,
     "3.07.01": `


### PR DESCRIPTION
## Summary

- **Sparkline trend charts**: Background Chart.js line charts on all 4 spot price cards showing historical price trends with metal-specific gradient fills
- **Card UI overhaul**: Replaced expandable button panel (Sync/Add/History) with per-card range dropdown (7d/30d/60d/90d, default 90d), inline sync icon with spin animation, and shift+click manual price entry
- **API & data fixes**: Corrected Metals.dev timeseries endpoint and response parser, updated Metals-API and MetalPriceAPI batch endpoints, fixed metal name case mismatch, added `recordSpot()` full-array dedup for historical backfill (v3.07.03), sync icon offers cache override via confirm dialog

## Technical Details

- Chart.js `linear` x-axis scale for true edge-to-edge sparkline rendering
- Card padding moved from `.spot-card` to content elements so Chart.js `responsive` mode sizes to full card dimensions
- Sparkline range preferences persisted in localStorage (`spotTrendRange`)
- Capture-phase click listener for shift+click inline editing (same pattern as inventory table)
- 14 files changed, 666 insertions, 559 deletions

## Test plan

- [ ] Sparklines render on all 4 cards with existing spot history data
- [ ] Range dropdown changes sparkline range, persists across refresh
- [ ] Sync icon triggers API sync, spins during fetch, sparkline refreshes after
- [ ] Sync icon on cached data shows confirm dialog to override cache
- [ ] Shift+click price opens inline edit, Enter saves, Escape cancels
- [ ] Manual price entry appears in sparkline as new data point
- [ ] Theme switch re-renders sparklines with correct metal colors
- [ ] Empty state (no history) shows card normally without sparkline
- [ ] Repeated syncs don't create duplicate history entries
- [ ] Verify all 4 themes (dark, light, sepia, system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)