### PR TITLE
v3.08.01: Layout polish — totals above table, sparkline colors, 25-row default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.08.01] - 2026-02-07
+
+### Patch — Move Metals Totals Above Inventory Table
+
+#### Changed
+
+- **Layout reorder**: Moved the per-metal portfolio summary cards (`.totals-section`) above the inventory table so the page flows: Spot Price Cards → Metals Totals → Search/Table/Pagination. Puts the portfolio bottom line closer to spot prices for an overview-first information hierarchy
+- **Sparkline colors match metal accent**: Sparkline trend lines now read the active theme's CSS custom properties (`--silver`, `--gold`, `--platinum`, `--palladium`) instead of hardcoded colors, matching the totals card accent bars across all themes
+- **Default rows per page**: Changed from 10 to 25; removed 10 and 15 row options from the dropdown (25 / 50 / 100 remain)
+
 ## [3.08.00] - 2026-02-07
 
 ### Increment 7 — Spot Price Card Redesign with Sparkline Trends

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Totals above table (v3.08.01)**: Per-metal portfolio summary cards now appear above the inventory table — Spot Prices → Totals → Table. Sparkline colors now match metal accent bars. Default rows per page raised to 25
 - **Spot price card redesign (v3.08.00)**: Background sparkline trend charts on all 4 spot cards, sync icon replaces button panel, shift+click for manual price entry, per-card range dropdown (7d/30d/60d/90d). Historical backfill dedup prevents duplicate entries on repeated syncs
 - **Shift+click inline editing (v3.07.02)**: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels
 - **Light & Sepia theme contrast pass (v3.07.01)**: Clean gray-to-white light palette with visible card elevation. Darkened metal/type text colors to pass WCAG AA in both themes

--- a/index.html
+++ b/index.html
@@ -317,6 +317,203 @@
           </div>
         </div>
       </section><!-- =============================================================================
+         TOTALS SECTION
+
+         Comprehensive financial summary cards for each metal type showing:
+         - Total items and weight in inventory
+         - Purchase price vs current value calculations
+         - Average prices (overall, collectable, non-collectable)
+         - Premium analysis and profit/loss calculations
+         - Clickable totals titles opening analytics modals with pie charts
+
+         All calculations are performed by updateSummary() in inventory.js
+         Values are updated automatically when inventory changes
+         ============================================================================= -->
+      <section class="totals-section">
+        <div class="totals">
+          <!-- Silver totals card -->
+          <div class="total-card silver">
+            <div class="total-title" data-metal="Silver">Silver</div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Items:</span>
+                <span class="total-value" id="totalItemsSilver">0</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Weight (oz):</span>
+                <span class="total-value" id="totalWeightSilver">0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzSilver">$0.00</span>
+              </div>
+            </div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Purchase Price:</span>
+                <span class="total-value" id="totalPurchasedSilver">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Melt Value:</span>
+                <span class="total-value" id="currentValueSilver">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Retail Value:</span>
+                <span class="total-value" id="retailValueSilver">$0.00</span>
+              </div>
+              <div class="total-item total-item-bottom-line">
+                <span class="total-label">Gain/Loss:</span>
+                <span class="total-value" id="lossProfitSilver">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <!-- Gold totals card -->
+          <div class="total-card gold">
+            <div class="total-title" data-metal="Gold">Gold</div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Items:</span>
+                <span class="total-value" id="totalItemsGold">0</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Weight (oz):</span>
+                <span class="total-value" id="totalWeightGold">0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzGold">$0.00</span>
+              </div>
+            </div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Purchase Price:</span>
+                <span class="total-value" id="totalPurchasedGold">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Melt Value:</span>
+                <span class="total-value" id="currentValueGold">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Retail Value:</span>
+                <span class="total-value" id="retailValueGold">$0.00</span>
+              </div>
+              <div class="total-item total-item-bottom-line">
+                <span class="total-label">Gain/Loss:</span>
+                <span class="total-value" id="lossProfitGold">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <!-- Platinum totals card -->
+          <div class="total-card platinum">
+            <div class="total-title" data-metal="Platinum">Platinum</div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Items:</span>
+                <span class="total-value" id="totalItemsPlatinum">0</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Weight (oz):</span>
+                <span class="total-value" id="totalWeightPlatinum">0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzPlatinum">$0.00</span>
+              </div>
+            </div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Purchase Price:</span>
+                <span class="total-value" id="totalPurchasedPlatinum">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Melt Value:</span>
+                <span class="total-value" id="currentValuePlatinum">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Retail Value:</span>
+                <span class="total-value" id="retailValuePlatinum">$0.00</span>
+              </div>
+              <div class="total-item total-item-bottom-line">
+                <span class="total-label">Gain/Loss:</span>
+                <span class="total-value" id="lossProfitPlatinum">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <!-- Palladium totals card -->
+          <div class="total-card palladium">
+            <div class="total-title" data-metal="Palladium">Palladium</div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Items:</span>
+                <span class="total-value" id="totalItemsPalladium">0</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Weight (oz):</span>
+                <span class="total-value" id="totalWeightPalladium">0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzPalladium">$0.00</span>
+              </div>
+            </div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Purchase Price:</span>
+                <span class="total-value" id="totalPurchasedPalladium">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Melt Value:</span>
+                <span class="total-value" id="currentValuePalladium">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Retail Value:</span>
+                <span class="total-value" id="retailValuePalladium">$0.00</span>
+              </div>
+              <div class="total-item total-item-bottom-line">
+                <span class="total-label">Gain/Loss:</span>
+                <span class="total-value" id="lossProfitPalladium">$0.00</span>
+              </div>
+            </div>
+          </div>
+          <!-- All metals combined totals card -->
+          <div class="total-card total-card-all">
+            <div class="total-title" data-metal="All">All Metals</div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Items:</span>
+                <span class="total-value" id="totalItemsAll">0</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Weight (oz):</span>
+                <span class="total-value" id="totalWeightAll">0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Avg Cost/oz:</span>
+                <span class="total-value" id="avgCostPerOzAll">$0.00</span>
+              </div>
+            </div>
+            <div class="total-group">
+              <div class="total-item">
+                <span class="total-label">Purchase Price:</span>
+                <span class="total-value" id="totalPurchasedAll">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Melt Value:</span>
+                <span class="total-value" id="currentValueAll">$0.00</span>
+              </div>
+              <div class="total-item">
+                <span class="total-label">Retail Value:</span>
+                <span class="total-value" id="retailValueAll">$0.00</span>
+              </div>
+              <div class="total-item total-item-bottom-line">
+                <span class="total-label">Gain/Loss:</span>
+                <span class="total-value" id="lossProfitAll">$0.00</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <!-- =============================================================================
          INVENTORY FORM SECTION
          
          Primary data entry form for adding new inventory items. Includes fields for:
@@ -553,9 +750,7 @@
           <div class="table-footer-controls">
             <div class="table-item-count"><strong id="itemCount"></strong></div>
             <select id="itemsPerPage" class="control-select" title="Rows per page">
-              <option value="10" selected>10</option>
-              <option value="15">15</option>
-              <option value="25">25</option>
+              <option value="25" selected>25</option>
               <option value="50">50</option>
               <option value="100">100</option>
             </select>
@@ -617,203 +812,6 @@
           </div>
       </section>
     </section>
-    <!-- =============================================================================
-       TOTALS SECTION
-
-         Comprehensive financial summary cards for each metal type showing:
-         - Total items and weight in inventory
-         - Purchase price vs current value calculations
-         - Average prices (overall, collectable, non-collectable)
-         - Premium analysis and profit/loss calculations
-         - Clickable totals titles opening analytics modals with pie charts
-
-         All calculations are performed by updateSummary() in inventory.js
-         Values are updated automatically when inventory changes
-         ============================================================================= -->
-      <section class="totals-section">
-        <div class="totals">
-          <!-- Silver totals card -->
-          <div class="total-card silver">
-            <div class="total-title" data-metal="Silver">Silver</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsSilver">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightSilver">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzSilver">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedSilver">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValueSilver">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValueSilver">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain/Loss:</span>
-                <span class="total-value" id="lossProfitSilver">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- Gold totals card -->
-          <div class="total-card gold">
-            <div class="total-title" data-metal="Gold">Gold</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsGold">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightGold">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzGold">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedGold">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValueGold">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValueGold">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain/Loss:</span>
-                <span class="total-value" id="lossProfitGold">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- Platinum totals card -->
-          <div class="total-card platinum">
-            <div class="total-title" data-metal="Platinum">Platinum</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsPlatinum">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightPlatinum">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzPlatinum">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedPlatinum">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValuePlatinum">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValuePlatinum">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain/Loss:</span>
-                <span class="total-value" id="lossProfitPlatinum">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- Palladium totals card -->
-          <div class="total-card palladium">
-            <div class="total-title" data-metal="Palladium">Palladium</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsPalladium">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightPalladium">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzPalladium">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedPalladium">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValuePalladium">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValuePalladium">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain/Loss:</span>
-                <span class="total-value" id="lossProfitPalladium">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- All metals combined totals card -->
-          <div class="total-card total-card-all">
-            <div class="total-title" data-metal="All">All Metals</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsAll">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightAll">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzAll">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedAll">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValueAll">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValueAll">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain/Loss:</span>
-                <span class="total-value" id="lossProfitAll">$0.00</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
       <!-- =============================================================================
          IMPORT/EXPORT SECTION
          

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.08.01 – Layout &amp; polish</strong>: Totals cards moved above inventory table, sparkline colors match metal accent bars, default rows per page raised to 25</li>
     <li><strong>v3.08.00 – Spot price card redesign</strong>: Background sparkline trends on all 4 cards, sync icon replaces button panel, shift+click manual price entry, per-card range dropdown (7d/30d/60d/90d). Dedup fix for historical backfill</li>
     <li><strong>v3.07.02 – Shift+click inline editing</strong>: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels</li>
     <li><strong>v3.07.00 – Portfolio visibility overhaul</strong>: Confidence styling for Retail/Gain-Loss, All Metals totals card with Avg Cost/oz and clickable breakdown modal, metal detail modals show full portfolio breakdown per type and location</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -219,7 +219,7 @@ const API_PROVIDERS = {
  * Updated: 2025-08-15 - Price column styling consistency fixes
  */
 
-const APP_VERSION = "3.08.00";
+const APP_VERSION = "3.08.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/spot.js
+++ b/js/spot.js
@@ -335,18 +335,17 @@ const resetSpotByName = (metalName) => {
 // =============================================================================
 
 /**
- * Returns the theme-aware color for a metal sparkline
+ * Returns the theme-aware color for a metal sparkline by reading the
+ * CSS custom property (--silver, --gold, etc.) from the active theme.
+ * Falls back to hardcoded defaults if getComputedStyle is unavailable.
  * @param {string} metalKey - 'silver', 'gold', 'platinum', 'palladium'
  * @returns {string} CSS color string
  */
 const getMetalColor = (metalKey) => {
-  const colors = {
-    silver: "#94a3b8",
-    gold: "#eab308",
-    platinum: "#a78bfa",
-    palladium: "#f97316",
-  };
-  return colors[metalKey] || "#6366f1";
+  const prop = getComputedStyle(document.documentElement).getPropertyValue(`--${metalKey}`).trim();
+  if (prop) return prop;
+  const fallback = { silver: "#d1d5db", gold: "#fbbf24", platinum: "#f3f4f6", palladium: "#d8b4fe" };
+  return fallback[metalKey] || "#6366f1";
 };
 
 /**

--- a/js/state.js
+++ b/js/state.js
@@ -14,7 +14,7 @@ let editingChangeLogIndex = null;
 
 /** @type {Object} Pagination state */
 let currentPage = 1; // Current page number (1-based)
-let itemsPerPage = 10; // Number of items to display per page (default changed to 10+)
+let itemsPerPage = 25; // Number of items to display per page
 
 /** @type {string} Current search query */
 let searchQuery = "";

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,11 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.08.01": `
+      <li><strong>Totals above table</strong>: Per-metal portfolio summary cards now appear above the inventory table — Spot Prices → Totals → Table</li>
+      <li><strong>Sparkline color consistency</strong>: Trend lines now use the same metal accent colors as the totals card bars, across all themes</li>
+      <li><strong>Default 25 rows</strong>: Table now shows 25 rows by default (10 and 15 removed from dropdown)</li>
+    `,
     "3.08.00": `
       <li><strong>Sparkline trend charts</strong>: Background Chart.js line charts on all 4 spot price cards showing price history with gradient fill</li>
       <li><strong>Trend range dropdown</strong>: Per-card 7d/30d/60d/90d selector with persistent preference</li>


### PR DESCRIPTION
## Summary

- **Totals above table**: Moved per-metal portfolio summary cards above the inventory table — page now flows Spot Prices → Totals → Search/Table/Pagination for an overview-first information hierarchy
- **Sparkline color consistency**: Trend line colors now read the active theme's CSS custom properties (`--silver`, `--gold`, `--platinum`, `--palladium`) instead of hardcoded values, matching the totals card accent bars across all 4 themes
- **Default 25 rows**: Raised default rows per page from 10 to 25; removed 10 and 15 from the dropdown (25 / 50 / 100 remain)

## Files changed

| File | Change |
|------|--------|
| `index.html` | Moved `.totals-section` above `.inventory-section`; trimmed pagination dropdown |
| `js/spot.js` | `getMetalColor()` reads `getComputedStyle()` CSS vars instead of hardcoded hex |
| `js/state.js` | `itemsPerPage` default 10 → 25 |
| `js/constants.js` | `APP_VERSION` → `"3.08.01"` |
| `CHANGELOG.md` | New `[3.08.01]` entry |
| `docs/announcements.md` | Updated What's New |
| `js/versionCheck.js` | Embedded changelog fallback |
| `js/about.js` | Embedded What's New fallback |

## Test plan

- [ ] Page loads without JS errors on `file://` and HTTP
- [ ] Section order is: Spot Cards → Totals → Search/Table/Pagination → Footer
- [ ] Totals update when inventory changes (add/edit/delete item)
- [ ] Totals card click-through opens metal detail modal
- [ ] Sparkline colors match totals card accent bars in all 4 themes (light/dark/sepia/system)
- [ ] Theme switch updates sparkline colors immediately
- [ ] Table defaults to 25 rows; dropdown shows 25/50/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)