### PR TITLE
v3.09.01: Name chips + normalizer rewrite + chip fixes

### DIFF
--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,13 +1,12 @@
 ## What's New
 
-- **Totals above table (v3.08.01)**: Per-metal portfolio summary cards now appear above the inventory table — Spot Prices → Totals → Table. Sparkline colors now match metal accent bars. Default rows per page raised to 25
-- **Spot price card redesign (v3.08.00)**: Background sparkline trend charts on all 4 spot cards, sync icon replaces button panel, shift+click for manual price entry, per-card range dropdown (7d/30d/60d/90d). Historical backfill dedup prevents duplicate entries on repeated syncs
-- **Shift+click inline editing (v3.07.02)**: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels
-- **Light & Sepia theme contrast pass (v3.07.01)**: Clean gray-to-white light palette with visible card elevation. Darkened metal/type text colors to pass WCAG AA in both themes
-- **Portfolio visibility overhaul (v3.07.00)**: Confidence styling for Retail/Gain-Loss (estimated vs confirmed), new "All Metals" totals card with Avg Cost/oz and clickable breakdown modal
+- **Normalized name chips (v3.09.01)**: Filter chip bar now groups item name variants into single chips (e.g., "Silver Eagle 6/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle
+- **Silver chip contrast fix (v3.09.01)**: Silver metal chip text no longer invisible on dark/sepia themes at page load
+- **Duplicate location chip fix (v3.09.01)**: Clicking a location chip no longer produces two chips
+- **Filter chips cleanup (v3.09.00)**: Default threshold lowered to 3+, date chips removed, "Unknown" locations suppressed, all locations respect minCount dropdown. Dead code removed. Chips now update after every inventory mutation
+- **Spot card hint (v3.09.00)**: Cards with no price data show "Shift+click price to set" — discoverability for the manual price entry pattern
 
 ## Development Roadmap
 
 - **Inline catalog & grading tags**: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed
-- **Filter chips rebuild**: Top-N per category model, normalized name chips, chip settings modal
 - **Numista API fix**: Correct endpoints, auth headers, and parameters in the NumistaProvider class

--- a/index.html
+++ b/index.html
@@ -596,17 +596,15 @@
           
           <!-- Integrated Filters -->
           <div class="search-filters">
-            <div id="typeSummary"></div>
             <div class="filter-controls">
               <div class="control-group">
                 <label for="chipMinCount" class="control-label">Filter Chips:</label>
                 <select id="chipMinCount" class="control-select" title="Minimum number of items before showing a filter chip">
-                  <option value="1">1+</option>
                   <option value="2">2+</option>
-                  <option value="3">3+</option>
+                  <option value="3" selected>3+</option>
                   <option value="5">5+</option>
                   <option value="10">10+</option>
-                  <option value="100" selected>100+</option>
+                  <option value="100">100+</option>
                 </select>
               </div>
               <div class="control-group">

--- a/js/about.js
+++ b/js/about.js
@@ -267,10 +267,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.08.01 – Layout &amp; polish</strong>: Totals cards moved above inventory table, sparkline colors match metal accent bars, default rows per page raised to 25</li>
-    <li><strong>v3.08.00 – Spot price card redesign</strong>: Background sparkline trends on all 4 cards, sync icon replaces button panel, shift+click manual price entry, per-card range dropdown (7d/30d/60d/90d). Dedup fix for historical backfill</li>
-    <li><strong>v3.07.02 – Shift+click inline editing</strong>: Hold Shift and click any editable cell (Name, Qty, Weight, Purchase Price, Retail Price, Location) to edit in place. Enter saves, Escape cancels</li>
-    <li><strong>v3.07.00 – Portfolio visibility overhaul</strong>: Confidence styling for Retail/Gain-Loss, All Metals totals card with Avg Cost/oz and clickable breakdown modal, metal detail modals show full portfolio breakdown per type and location</li>
+    <li><strong>v3.09.01 – Name chips</strong>: Filter chip bar groups item name variants into single chips (e.g., "Silver Eagle 6/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle</li>
+    <li><strong>v3.09.01 – Silver contrast fix</strong>: Silver metal chip text no longer invisible on dark/sepia themes at page load</li>
+    <li><strong>v3.09.01 – Duplicate chip fix</strong>: Clicking a location chip no longer produces two chips</li>
+    <li><strong>v3.09.00 – Filter chips cleanup</strong>: Default threshold 3+, date chips removed, "Unknown" locations suppressed, all locations respect minCount dropdown. Dead code removed. Chips update after every mutation</li>
+    <li><strong>v3.09.00 – Spot card hint</strong>: Cards with no price data show "Shift+click price to set" for discoverability</li>
   `;
 };
 
@@ -281,7 +282,6 @@ const getEmbeddedWhatsNew = () => {
 const getEmbeddedRoadmap = () => {
   return `
     <li><strong>Inline catalog &amp; grading tags</strong>: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed</li>
-    <li><strong>Filter chips rebuild</strong>: Top-N per category model, normalized name chips, chip settings modal</li>
     <li><strong>Numista API fix</strong>: Correct endpoints, auth headers, and parameters in the NumistaProvider class</li>
   `;
 };

--- a/js/constants.js
+++ b/js/constants.js
@@ -219,7 +219,7 @@ const API_PROVIDERS = {
  * Updated: 2025-08-15 - Price column styling consistency fixes
  */
 
-const APP_VERSION = "3.08.01";
+const APP_VERSION = "3.09.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -638,6 +638,11 @@ const setupEventListeners = () => {
           } catch (closeErr) {
             console.warn('Failed to close item modal:', closeErr);
           }
+
+          // Update filter chips after inventory mutation
+          if (typeof renderActiveFilters === 'function') {
+            renderActiveFilters();
+          }
         },
         "Unified item form",
       );
@@ -1129,6 +1134,7 @@ const setupEventListeners = () => {
             localStorage.removeItem(LS_KEY);
             loadInventory();
             renderTable();
+            renderActiveFilters();
             alert("Inventory data cleared.");
           }
         },
@@ -1158,6 +1164,7 @@ const setupEventListeners = () => {
 
             loadInventory();
             renderTable();
+            renderActiveFilters();
             loadSpotHistory();
             fetchSpotPrice();
 
@@ -1381,14 +1388,15 @@ const setupSearch = () => {
         function () {
           const value = this.value;
           if (value) {
-            columnFilters.type = value;
+            activeFilters.type = { values: [value], exclude: false };
           } else {
-            delete columnFilters.type;
+            delete activeFilters.type;
           }
           searchQuery = "";
           if (elements.searchInput) elements.searchInput.value = "";
           currentPage = 1;
           renderTable();
+          renderActiveFilters();
         },
         "Type filter select",
       );
@@ -1401,14 +1409,15 @@ const setupSearch = () => {
         function () {
           const value = this.value;
           if (value) {
-            columnFilters.metal = value;
+            activeFilters.metal = { values: [value], exclude: false };
           } else {
-            delete columnFilters.metal;
+            delete activeFilters.metal;
           }
           searchQuery = "";
           if (elements.searchInput) elements.searchInput.value = "";
           currentPage = 1;
           renderTable();
+          renderActiveFilters();
         },
         "Metal filter select",
       );

--- a/js/init.js
+++ b/js/init.js
@@ -199,7 +199,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
       elements.changeLogBtn = safeGetElement("changeLogBtn");
       elements.backupReminder = safeGetElement("backupReminder");
-      elements.typeSummary = safeGetElement("typeSummary");
       elements.changeLogModal = safeGetElement("changeLogModal");
       elements.changeLogCloseBtn = safeGetElement("changeLogCloseBtn");
       elements.changeLogClearBtn = safeGetElement("changeLogClearBtn");
@@ -220,10 +219,10 @@ document.addEventListener("DOMContentLoaded", () => {
       const chipMinEl = document.getElementById('chipMinCount');
       const saved = localStorage.getItem('chipMinCount');
       if (!saved) {
-        localStorage.setItem('chipMinCount', '100');
+        localStorage.setItem('chipMinCount', '3');
       }
       if (chipMinEl) {
-        chipMinEl.value = localStorage.getItem('chipMinCount') || '100';
+        chipMinEl.value = localStorage.getItem('chipMinCount') || '3';
       }
     } catch (e) {
       // ignore storage errors
@@ -349,6 +348,15 @@ document.addEventListener("DOMContentLoaded", () => {
     // Initialize API system
     apiConfig = loadApiConfig();
     apiCache = loadApiCache();
+
+    // Apply saved theme attribute early so CSS variables resolve correctly
+    // before renderActiveFilters() computes contrast colors in Phase 13
+    const earlyTheme = localStorage.getItem(THEME_KEY);
+    if (earlyTheme === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else if (earlyTheme === 'sepia') {
+      document.documentElement.setAttribute('data-theme', 'sepia');
+    }
 
     // Phase 13: Initial Rendering
     debugLog("Phase 13: Rendering initial display...");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -234,6 +234,7 @@ const restoreBackupZip = async (file) => {
 
     loadInventory();
     renderTable();
+    renderActiveFilters();
     loadSpotHistory();
     fetchSpotPrice();
     alert("Data imported successfully.");
@@ -890,18 +891,6 @@ const startCellEdit = (idx, field, element) => {
 window.startCellEdit = startCellEdit;
 
 
-/**
- * Legacy chip-type filter system - now disabled in favor of renderActiveFilters
- * This function now just clears the typeSummary container to avoid conflicts
- */
-const updateTypeSummary = (items = inventory) => {
-  const el = elements.typeSummary || document.getElementById('typeSummary');
-  if (!el) return;
-  
-  // Clear the container to avoid conflicts with the new renderActiveFilters system
-  el.innerHTML = '';
-};
-window.updateTypeSummary = updateTypeSummary;
 
 /**
  * Hides table columns that contain no data after filtering.
@@ -1014,7 +1003,6 @@ const renderTable = () => {
     
     tbody.innerHTML = rows.concat(placeholders).join('');
     hideEmptyColumns();
-    updateTypeSummary(filteredInventory);
 
     debugLog('renderTable complete');
 
@@ -1169,6 +1157,7 @@ const deleteItem = (idx) => {
     inventory.splice(idx, 1);
     saveInventory();
     renderTable();
+    renderActiveFilters();
     if (item) logChange(item.name, 'Deleted', JSON.stringify(item), '', idx);
   }
 };
@@ -1528,9 +1517,6 @@ const importCsv = (file, override = false) => {
         if (typeof renderActiveFilters === 'function') {
           renderActiveFilters();
         }
-        if (typeof updateTypeSummary === 'function') {
-          updateTypeSummary();
-        }
         if (typeof updateStorageStats === 'function') {
           updateStorageStats();
         }
@@ -1774,9 +1760,6 @@ const importNumistaCsv = (file, override = false) => {
         renderTable();
         if (typeof renderActiveFilters === 'function') {
           renderActiveFilters();
-        }
-        if (typeof updateTypeSummary === 'function') {
-          updateTypeSummary();
         }
         if (typeof updateStorageStats === 'function') {
           updateStorageStats();
@@ -2120,9 +2103,6 @@ const importJson = (file, override = false) => {
       renderTable();
       if (typeof renderActiveFilters === 'function') {
         renderActiveFilters();
-      }
-      if (typeof updateTypeSummary === 'function') {
-        updateTypeSummary();
       }
       if (typeof updateStorageStats === "function") {
         updateStorageStats();

--- a/js/search.js
+++ b/js/search.js
@@ -19,13 +19,16 @@ const filterInventory = () => {
   // Legacy filtering for compatibility
   let result = inventory;
 
-  Object.entries(columnFilters).forEach(([field, value]) => {
-    const lower = value.toLowerCase();
-    result = result.filter((item) => {
-      const rawVal = item[field] ?? (field === 'metal' ? item.metal : '');
-      const fieldVal = String(rawVal ?? '').toLowerCase();
-      return fieldVal === lower;
-    });
+  Object.entries(activeFilters).forEach(([field, criteria]) => {
+    if (criteria && typeof criteria === 'object' && Array.isArray(criteria.values)) {
+      const lowerVals = criteria.values.map(v => String(v).toLowerCase());
+      result = result.filter((item) => {
+        const rawVal = item[field] ?? (field === 'metal' ? item.metal : '');
+        const fieldVal = String(rawVal ?? '').toLowerCase();
+        const match = lowerVals.includes(fieldVal);
+        return criteria.exclude ? !match : match;
+      });
+    }
   });
 
   if (!searchQuery.trim()) return result;

--- a/js/state.js
+++ b/js/state.js
@@ -19,9 +19,6 @@ let itemsPerPage = 25; // Number of items to display per page
 /** @type {string} Current search query */
 let searchQuery = "";
 
-/** @type {Object<string, string>} Active column filters */
-let columnFilters = {};
-
 /** @type {Object} Chart instances for proper cleanup */
 let chartInstances = {
   typeChart: null,
@@ -136,7 +133,6 @@ const elements = {
   // Change log elements
     changeLogBtn: null,
     backupReminder: null,
-    typeSummary: null,
   changeLogModal: null,
   changeLogCloseBtn: null,
   changeLogClearBtn: null,

--- a/js/utils.js
+++ b/js/utils.js
@@ -272,6 +272,13 @@ const updateSpotTimestamp = (metalName) => {
   const cacheHtml = getLastUpdateTime(metalName, "cache");
   const apiHtml = getLastUpdateTime(metalName, "api");
 
+  // If no price data at all, show shift+click hint for discoverability
+  if (!cacheHtml && !apiHtml) {
+    el.innerHTML = "Shift+click price to set";
+    el.onclick = null;
+    return;
+  }
+
   el.dataset.mode = "cache";
   el.dataset.cache = cacheHtml;
   el.dataset.api = apiHtml;

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,21 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.09.01": `
+      <li><strong>Normalized name chips</strong>: Filter chip bar groups item name variants into single chips (e.g., "Silver Eagle 15/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle</li>
+      <li><strong>Name normalizer rewrite</strong>: Precise starts-with matching replaces fuzzy word matching — no more phantom chips for items you don't own (e.g., "American Gold Eagle" when you only have Silver Eagles)</li>
+      <li><strong>Silver chip contrast fix</strong>: Silver metal chip text no longer invisible on dark/sepia themes at page load</li>
+      <li><strong>Duplicate location chip fix</strong>: Clicking a location chip no longer produces two chips</li>
+    `,
+    "3.09.00": `
+      <li><strong>Spot card hint</strong>: Cards with no price data show "Shift+click price to set" for discoverability</li>
+      <li><strong>Default chip threshold</strong>: Filter chips now appear at 3+ items (was 100+)</li>
+      <li><strong>Unified thresholds</strong>: Purchase and storage location chips now respect the minCount dropdown</li>
+      <li><strong>Date chips removed</strong>: Too granular — removed entirely</li>
+      <li><strong>"Unknown" suppressed</strong>: Empty and "Unknown" location values no longer produce chips</li>
+      <li><strong>Dead code cleanup</strong>: Removed legacy columnFilters, updateTypeSummary, and 9 stale console.log calls</li>
+      <li><strong>Chips update on mutations</strong>: Filter chips now refresh after delete, import, wipe, and add/edit</li>
+    `,
     "3.08.01": `
       <li><strong>Totals above table</strong>: Per-metal portfolio summary cards now appear above the inventory table — Spot Prices → Totals → Table</li>
       <li><strong>Sparkline color consistency</strong>: Trend lines now use the same metal accent colors as the totals card bars, across all themes</li>


### PR DESCRIPTION
## Summary

- **Normalized name chips**: Filter chip bar shows grouped name chips (e.g., "American Silver Eagle 15/164") aggregating year variants, grades, and editions. Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle
- **`normalizeItemName()` rewrite**: Precise starts-with matching replaces fuzzy word matching — no more phantom chips for items you don't own (e.g., "American Gold Eagle" when only Silver Eagles exist). Suffix stripping handles grading (PCGS/NGC), grades (MS70/PR69), conditions (BU/Antiqued), and packaging (In Capsule/TEP)
- **Silver chip contrast fix**: Early theme attribute application before Phase 13 rendering so CSS variables resolve correctly for contrast color computation
- **Duplicate location chip fix**: Expanded dedup skip list to cover all category summary fields
- **UI tweaks**: Removed 1+ chip threshold option (2+ minimum), default 3+, name chips show full base name with country prefix

Also includes all v3.06.02 through v3.09.00 changes (sparkline spot cards, inline editing, theme contrast, filter chips cleanup, etc.)

## Test plan

- [ ] Open app in dark theme — Silver chip text should be readable on first load
- [ ] Click a location chip — only ONE chip should appear, not two
- [ ] Name chips visible: "American Silver Eagle", "Tuvalu Black Flag", etc. with correct counts
- [ ] Click a name chip → filters to matching items. Click again → removes filter
- [ ] Set Smart Grouping to "No" → name chips disappear
- [ ] Chip threshold dropdown starts at 2+ (no 1+ option), defaults to 3+
- [ ] No console errors on page load
- [ ] All 4 themes render chips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)