### PR TITLE
v3.09.01: Keyword grouping for Goldback, Zombucks, Silverback chips

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -333,6 +333,19 @@ const normalizeItemName = (fullName) => {
     return bestMatch;
   }
 
+  // Step 3b: Keyword-based grouping for series that span multiple
+  // denominations, states, or variants (no consistent prefix to match)
+  const keywordGroups = {
+    'goldback': 'Goldback',
+    'zombucks': 'Zombucks',
+    'silverback': 'Silverback',
+  };
+  for (const [keyword, groupName] of Object.entries(keywordGroups)) {
+    if (nameLower.includes(keyword)) {
+      return groupName;
+    }
+  }
+
   // Step 4: No lookup match — strip known suffixes for clean grouping
   // First, collapse embedded weight patterns (" 1 oz ", " 30 gram ") to a single space
   name = name.replace(/\s+\d+(?:\s*\/\s*\d+)?\s*(?:oz|ounce|gram|g)\s+/i, ' ');


### PR DESCRIPTION
## Summary
- Adds keyword-based grouping to `normalizeItemName()` for series that span multiple denominations/states (Goldback, Zombucks, Silverback)
- These items have no consistent prefix, so the normalizer now checks for keywords anywhere in the name as a fallback after starts-with matching

## Test plan
- [ ] Verify Goldback items (e.g., "1 Florida Goldback", "5 New Hampshire Goldback") group under a single "Goldback" chip
- [ ] Verify Zombucks and Silverback items similarly group under their respective chips
- [ ] Confirm existing name chips (Silver Eagle, Maple Leaf, etc.) still work correctly
- [ ] Verify chips appear at 3+ threshold default
- [ ] No console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)