### PR TITLE
Add catalog API call history & v3.09.02 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.09.02] - 2026-02-08
+
+### Patch — Numista API v3 Integration Fix
+
+#### Fixed
+
+- **Numista base URL**: Changed from `/api/v3` to `/v3` — the `/api` prefix does not exist in the Numista API
+- **Numista lookup endpoint**: Changed from `/items/{id}?apikey=` to `/types/{id}?lang=en` with `Numista-API-Key` header authentication
+- **Numista search endpoint**: Changed from `/items/search` to `/types` with `Numista-API-Key` header authentication
+- **Numista search parameters**: `limit` → `count` (capped at 50), `country` → `issuer`, `metal` → `category`, added `page` and `lang=en`
+- **Numista search response**: Changed from `data.items` to `data.types` to match actual API response structure
+- **Numista field mapping**: `year` composed from `min_year`/`max_year`, `country` from `issuer.name`, `composition` handles string or object, `diameter` from `size`, `type` from `category`, `mintage` hardcoded to 0 (per-issue not per-type), `estimatedValue` from `value.numeric_value`, `imageUrl` from `obverse_thumbnail` with nested fallback, `description` from `comments`
+- **localStorage whitelist**: Added `staktrakr.catalog.cache` and `staktrakr.catalog.settings` to `ALLOWED_STORAGE_KEYS` — without these, `cleanupStorage()` deleted catalog data on every page load
+
 ## [3.09.01] - 2026-02-07
 
 ### Patch — Name Chips + Silver Contrast Fix + Duplicate Chip Fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,10 @@ Project direction and planned work for the StakTrakr precious metals inventory t
 
 These items focus on visual polish and usability improvements that require no backend changes.
 
+### Phase 1 — Numista API Fix
+- **Numista API fix** — the `NumistaProvider` class in `js/catalog-api.js` has never worked due to three bugs: wrong endpoints (`/items/search` → `/types`), wrong auth (query param → `Numista-API-Key` header), non-existent params (`metal`/`country`/`limit` → `category`/`issuer`/`count`). Must be fixed before any Numista features can ship
+
+### Phase 2 — Inline Catalog & Grading Tags
 - **Inline catalog & grading tags** — instead of a dedicated N# table column, append optional clickable tags to the Name cell. Example: `2025 American Eagle (PCGS) (MS70-FS) (N#1234)`. All tags optional — most items just show the name
   - **Name cell format**: `{item name} (SERVICE) (GRADE) (N#ID)` — only renders tags the item actually has
   - **Tag click behavior**: opens iframe modal to the relevant service page (Numista catalog, PCGS cert viewer, NGC cert viewer). Same pattern as eBay search links
@@ -16,22 +20,32 @@ These items focus on visual polish and usability improvements that require no ba
   - **Data model additions**: `certService` (string: `''`|`'PCGS'`|`'NGC'`), `certNumber` (string), `grade` (string)
   - **No new table column** — all info lives inline in the Name cell, keeping the table compact
   - **CSV export**: add `certService`, `certNumber`, `grade` to export headers
-- **~~Normalized name chips~~** — **DONE (v3.09.01)**: Grouped name chips in filter bar (e.g., "Silver Eagle 6/164") using `normalizeItemName()` dictionary. Click-to-filter with toggle. Respects minCount threshold and GROUPED_NAME_CHIPS feature flag. Remaining sub-items:
-  - **Batch rename/normalize tool**: reuse the normalizer to offer a "Clean Up Names" feature with preview and undo
-  - **Chip settings modal**: select which columns produce chips and configure top-N limit per category
-- **Numista API fix** — the `NumistaProvider` class in `js/catalog-api.js` has never worked due to three bugs: wrong endpoints (`/items/search` → `/types`), wrong auth (query param → `Numista-API-Key` header), non-existent params (`metal`/`country`/`limit` → `category`/`issuer`/`count`). Must be fixed before any Numista features can ship
-- **Numista integration — Sync & Search** (prerequisite: Numista API fix):
+
+### Pause — Evaluate Numista Data
+- Review what fields the working Numista API actually returns (canonical names, denominations, metal, weight, descriptions, images)
+- Decide which fields to surface in the add/edit modal and whether to add new data model fields
+- Assess how Numista naming conventions compare to our current `normalizeItemName()` dictionary
+
+### Phase 3 — Batch Rename/Normalize (Numista-Powered)
+- **Batch rename/normalize tool** — "Clean Up Names" modal with preview and undo, powered by both the local normalizer and the Numista API
+  - For items with a Numista catalog number (N#): look up canonical title from Numista, offer to rename to the official name
+  - For items without N#: use `normalizeItemName()` dictionary matching, then optionally search Numista to find and attach the correct catalog entry
+  - Key value: standardizes names for users who don't follow naming conventions (e.g., "Silver Eagle" → "American Silver Eagle" based on Numista's canonical title)
+  - Respects API budget (2,000 req/month free tier) — batch lookups with caching via `LocalProvider`
+
+### Backlog (No Dependency Order)
+- **Numista integration — Sync & Search** (prerequisite: Phase 1):
   - **"Sync from Numista" button** on the add/edit modal — auto-populates Name, Weight, Type, Metal, Notes from a valid N#
   - **"Numista Lookup" button** — search modal with thumbnails, selecting a result populates N# and triggers Sync
   - **API budget awareness**: free tier = 2,000 requests/month. Cache all lookups in `LocalProvider`
+- **Chip settings modal**: select which columns produce chips and configure top-N limit per category
 - **Pie chart toggle**: switch metal detail modal chart between Purchase / Melt / Retail / Gain-Loss views
 - **Chart.js dashboard improvements** — spot price trend visualization, portfolio value over time
 - **Custom tagging system** — replace the removed `isCollectable` boolean with flexible tags (e.g., "IRA", "stack", "numismatic", "gift")
 
 
 ### Completed (Near-Term)
-- ~~**Normalized name chips**~~ — **DONE (v3.09.01)**: Grouped name chips in filter bar using `normalizeItemName()` dictionary. Click-to-filter with toggle. Respects minCount threshold and feature flag. Also fixed: Silver chip contrast on dark/sepia, duplicate location chips
-- ~~**Filter chips cleanup**~~ — **DONE (v3.09.00)**: Unified threshold application (all categories respect minCount), removed date chips, suppressed "Unknown" locations, removed dead `columnFilters` and `updateTypeSummary()`, default threshold 3+, chips update after all mutations
+- ~~**Filter chips system (complete)**~~ — **DONE (v3.09.00 – v3.09.01)**: Full chip system: metal, type, location, and normalized name chips. Click-to-filter with toggle. Unified threshold (3+ default), keyword grouping (Goldback/Zombucks/Silverback), starts-with normalizer with 280-item dictionary. Fixed: Silver chip contrast on dark/sepia, duplicate location chips, suppressed "Unknown" locations
 - ~~**Spot price manual input UX**~~ — **DONE (v3.09.00)**: Spot cards with no price data show "Shift+click price to set" hint
 - ~~**Retail column UX bundle**~~ — **DONE (v3.07.00 + v3.07.02)**: Confidence styling for estimated vs confirmed values (v3.07.00). Shift+click inline editing for all 6 editable columns including Retail — replaces pencil icon approach (v3.07.02)
 - ~~**Duplicate item button**~~ — **DONE (Increment 5)**
@@ -46,25 +60,47 @@ These items focus on visual polish and usability improvements that require no ba
 
 ---
 
-## Medium-Term (Infrastructure)
+## Medium-Term (BYO-Backend — Supabase Cloud Sync)
 
-These items require backend work and represent a shift from pure client-side to a more capable architecture.
+Replaces the original SQLite/auth/hosting plan with a **zero-cost, zero-server** architecture. The app stays 100% static on Cloudflare Pages. Users who want cloud sync and multi-device access bring their own free Supabase project (URL + anon key). Users who don't want cloud continue using localStorage exactly as today — no change.
 
-- **SQLite backend** — persistent storage for trend data, historical charts, and audit trails
-- **User authentication** — JWT-based auth for multi-device access
-- **Data migration** — localStorage to SQLite with backwards-compatible fallback
-- **Multi-device sync** — share inventory data across browsers/devices via the backend
-- **Bulk Numista enrichment** — batch-process existing inventory items that have N# IDs but are missing metadata (weight, description, etc.). Queue API calls respecting the 2,000/month limit, backfill fields, and report what was updated. Only practical with server-side job queue
+### Why Supabase
+- **Direct browser access** — PostgREST exposes Postgres tables as a REST API callable via `fetch()`. No serverless functions, no proxy, no middleware needed
+- **Free tier is generous** — 500MB storage, 50K row reads, unlimited API requests. More than enough for a personal inventory tracker
+- **User owns their data** — each user creates their own Supabase project. StakTrakr never sees, stores, or proxies anyone's data
+- **Row-Level Security** — anon key is safe to expose in the browser because RLS policies control access. Each user's project is isolated
+- **Real-time subscriptions** — built-in WebSocket support for live sync between open tabs/devices (future enhancement)
+- **No auth system needed** — the Supabase project itself IS the authentication. Whoever has the URL + key owns the data
+
+### Implementation Plan
+
+- **Settings UI** — new "Cloud Sync" section in the settings/files modal. Two fields: Supabase URL and Anon Key. Stored in localStorage (these are the only credentials the app needs). Toggle to enable/disable cloud sync
+- **One-click table setup** — "Initialize Database" button that runs `CREATE TABLE` statements via the Supabase REST API. Creates: `inventory`, `spot_history`, `change_log`, `settings`. User never touches SQL
+- **Schema versioning** — `schema_version` field in the `settings` table. Future app updates can detect outdated schemas and run migrations automatically via the API
+- **Bidirectional sync** — on page load: pull from Supabase if configured, merge with localStorage cache. On save: write to both localStorage AND Supabase. localStorage acts as offline cache so the app works without internet
+- **Conflict resolution** — last-write-wins using `updatedAt` timestamps. Simple, predictable, sufficient for a single-user inventory app. If two devices edit the same item, the most recent edit wins
+- **Spot price history** — `spot_history` table stores daily price snapshots. Enables trend charts, portfolio value over time, and historical gain/loss analysis without localStorage size constraints
+- **Bulk Numista enrichment** — batch-process inventory items with N# IDs, calling the Numista API to backfill metadata. Results cached in Supabase. Respects 2,000 req/month free tier budget
+- **`file://` protocol handling** — cloud sync requires HTTP (CORS blocks `fetch()` from `file://`). Detect protocol and show a clear message: "Cloud sync requires the hosted version at [your-url]"
+
+### What This Eliminates
+- ~~SQLite backend~~ — Supabase is Postgres, managed by the user's free project
+- ~~User authentication~~ — each user's Supabase project IS their auth
+- ~~Docker/Proxmox hosting~~ — static site + BYO database, nothing to host
+- ~~Data migration~~ — simplified to a one-time localStorage → Supabase export
+- ~~Public deployment security concerns~~ — app never holds anyone's data
 
 ---
 
-## Long-Term (Self-Hosting & Distribution)
+## Long-Term (Polish & Distribution)
 
-These items focus on making StakTrakr easy for others to deploy and run.
+These items enhance the user experience and make StakTrakr easier to share and deploy.
 
-- **Mobile-responsive card view** — the current table layout is built for desktop/laptop screens and doesn't work well on phones. Add a responsive breakpoint (e.g., ≤768px) that transitions the inventory from a multi-column table to a card-based layout where each item renders as a compact card showing key fields (name, metal, weight, purchase price, melt value, gain/loss). Cards should be tappable to open the detail/edit modal. The table view remains default on wider screens — this is a progressive enhancement, not a replacement. Tablets may work with either view depending on orientation. Requires significant CSS and likely a parallel render path in `inventory.js` (card template vs table row template)
-- **Docker build & image** — production-ready Dockerfile and docker-compose.yml for self-hosting. nginx:alpine serving static files, health checks, environment-based configuration. Publish image to Docker Hub or GitHub Container Registry for one-command deployment
-- **Proxmox LXC setup guide/script** — step-by-step guide or automated script for deploying StakTrakr in a Proxmox LXC container. Lightweight alternative to full VM, ideal for home lab users running Proxmox on mini PCs
+- **Mobile-responsive card view** — responsive breakpoint (≤768px) transitions from table to card layout. Each card shows key fields (name, metal, weight, purchase price, melt value, gain/loss), tappable to open detail/edit modal. Table remains default on wider screens. Progressive enhancement, not a replacement
+- **User photo upload** — photograph coins/bars and attach images to inventory items. With Supabase, images can be stored in Supabase Storage (5GB free tier) instead of requiring a custom backend. Displayed in edit modal and optionally as row/card thumbnails. Multiple images per item (obverse/reverse)
+- **Mobile camera capture** — camera button in add/edit modal using `<input type="file" accept="image/*" capture="environment">`. Pairs with photo upload and mobile card view
+- **Docker build & image** — optional self-hosting via Dockerfile + docker-compose.yml for users who prefer local infrastructure. nginx:alpine serving static files. Supabase can be self-hosted too via `supabase/supabase` Docker image for fully offline deployments
+- **Proxmox LXC setup guide** — guide/script for deploying in a Proxmox LXC container. Pairs with Docker image for home lab users
 
 ---
 
@@ -72,11 +108,8 @@ These items focus on making StakTrakr easy for others to deploy and run.
 
 Items that are explicitly out of scope until prerequisites are met.
 
-- **Encryption feature** — requires backend first (session management, key storage). See CLAUDE.md for rationale.
-- **Public-facing deployment** — currently a personal server deployment; public hosting requires auth, rate limiting, and security hardening
-- **User photo upload** — allow users to photograph their own coins/bars and attach images to inventory items. Stored server-side (filesystem or BLOB column in SQLite). Displayed in the edit modal and optionally as a row thumbnail. Avoids all Numista copyright issues since users own the photos. Could support multiple images per item (obverse/reverse). Low priority — trends, statistics, and hosted build come first
-- **Numista image caching (CC-licensed only)** — for items where the Numista API returns a `picture_copyright` field with an explicit Creative Commons license, cache those images server-side with proper attribution. Non-CC images get a placeholder with a "View on Numista" link. Requires per-image license checking logic. Depends on SQLite backend + user photo upload infrastructure
-- **Mobile camera capture** — on mobile devices, add a camera button to the add/edit modal that triggers the device camera via `<input type="file" accept="image/*" capture="environment">`. Snap a photo of a coin/bar and attach it directly to the inventory item. Pairs with the user photo upload feature (server-side storage required) and the mobile card view (photos could appear as card thumbnails). Pure client-side version could store photos as base64 in localStorage, but this doesn't scale — practical implementation needs the SQLite backend
-- **Table CSS hardening** — audit responsive breakpoints, test mobile layout, ensure 14 columns degrade gracefully
+- **Encryption at rest** — encrypt inventory data before writing to Supabase. User provides a passphrase that derives an encryption key (never stored). Supabase stores only ciphertext. Adds complexity to sync logic — evaluate after BYO-Backend is stable
+- **Numista image caching (CC-licensed only)** — for Numista API responses with Creative Commons `picture_copyright`, cache images in Supabase Storage with attribution. Non-CC images get a placeholder with "View on Numista" link. Depends on working Numista API + Supabase Storage
+- **Table CSS hardening** — audit responsive breakpoints, test mobile layout, ensure columns degrade gracefully
 - **Full UI review walkthrough** — hands-on walk-through cataloging visual issues, layout inconsistencies, and UX friction
-- **eBay API integration** — if/when backend exists, proxy eBay Browse API for sold listing lookups to pre-populate retail estimates
+- **eBay API integration** — proxy eBay Browse API for sold listing lookups to pre-populate retail estimates. Could run as a Supabase Edge Function (Deno) to avoid CORS issues

--- a/css/styles.css
+++ b/css/styles.css
@@ -1380,6 +1380,14 @@ input[type="submit"] {
   cursor: pointer;
 }
 
+#catalogHistoryTable {
+  width: 100%;
+  min-width: 100%;
+}
+
+#catalogHistoryTable th {
+  cursor: pointer;
+}
 
 .api-info-body {
   margin-bottom: 1rem;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,12 +1,12 @@
 ## What's New
 
+- **Numista API v3 fix (v3.09.02)**: Corrected base URL, endpoints, auth headers, query parameters, response parsing, and field mapping — 7 bugs total. Test Connection button now works
+- **localStorage whitelist fix (v3.09.02)**: Catalog cache and settings no longer deleted on page load
 - **Normalized name chips (v3.09.01)**: Filter chip bar now groups item name variants into single chips (e.g., "Silver Eagle 6/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle
 - **Silver chip contrast fix (v3.09.01)**: Silver metal chip text no longer invisible on dark/sepia themes at page load
 - **Duplicate location chip fix (v3.09.01)**: Clicking a location chip no longer produces two chips
-- **Filter chips cleanup (v3.09.00)**: Default threshold lowered to 3+, date chips removed, "Unknown" locations suppressed, all locations respect minCount dropdown. Dead code removed. Chips now update after every inventory mutation
-- **Spot card hint (v3.09.00)**: Cards with no price data show "Shift+click price to set" — discoverability for the manual price entry pattern
 
 ## Development Roadmap
 
 - **Inline catalog & grading tags**: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed
-- **Numista API fix**: Correct endpoints, auth headers, and parameters in the NumistaProvider class
+- **Batch rename / normalize**: Bulk rename items using Numista catalog data and the name normalizer

--- a/index.html
+++ b/index.html
@@ -1360,6 +1360,7 @@
               <button class="btn success" id="saveNumistaBtn" style="margin-top: 0.5rem;">Save Key</button>
               <button class="btn info" id="testNumistaBtn" style="margin-top: 0.5rem;">Test Connection</button>
               <button class="btn secondary" id="clearNumistaBtn" style="margin-top: 0.5rem;">Clear Key</button>
+              <button class="btn" id="catalogHistoryBtn" style="margin-top: 0.5rem;">History</button>
             </div>
             <div id="numistaStatus" class="api-status" style="margin-top: 0.5rem;"></div>
           </div>
@@ -2076,8 +2077,52 @@
     </div>
     
     <!-- =============================================================================
+       CATALOG HISTORY MODAL
+
+       Modal for viewing catalog API call history (Numista lookups, searches).
+       Mirrors the apiHistoryModal structure with sortable/filterable table.
+       ============================================================================= -->
+    <div class="modal" id="catalogHistoryModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Catalog API History</h2>
+          <button
+            aria-label="Close modal"
+            class="modal-close"
+            id="catalogHistoryCloseBtn"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="api-history-body">
+            <div class="api-history-table">
+              <div class="api-history-filter">
+                <input
+                  type="text"
+                  id="catalogHistoryFilter"
+                  placeholder="Filter history..."
+                />
+                <button
+                  type="button"
+                  class="btn secondary"
+                  id="catalogHistoryClearFilterBtn"
+                >
+                  Clear
+                </button>
+              </div>
+              <div class="api-history-table-wrapper">
+                <table id="catalogHistoryTable"></table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- =============================================================================
        NUMISTA MODAL
-       
+
        Modal for viewing Numista coin database pages in an embedded iframe.
        Features navigation controls and responsive 90% width display.
        ============================================================================= -->

--- a/js/about.js
+++ b/js/about.js
@@ -267,11 +267,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.09.02 – Numista API v3 fix</strong>: Corrected base URL, endpoints, auth headers, query parameters, response parsing, and field mapping — 7 bugs total. Test Connection button now works</li>
+    <li><strong>v3.09.02 – localStorage whitelist fix</strong>: Catalog cache and settings no longer deleted on page load</li>
     <li><strong>v3.09.01 – Name chips</strong>: Filter chip bar groups item name variants into single chips (e.g., "Silver Eagle 6/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle</li>
     <li><strong>v3.09.01 – Silver contrast fix</strong>: Silver metal chip text no longer invisible on dark/sepia themes at page load</li>
     <li><strong>v3.09.01 – Duplicate chip fix</strong>: Clicking a location chip no longer produces two chips</li>
-    <li><strong>v3.09.00 – Filter chips cleanup</strong>: Default threshold 3+, date chips removed, "Unknown" locations suppressed, all locations respect minCount dropdown. Dead code removed. Chips update after every mutation</li>
-    <li><strong>v3.09.00 – Spot card hint</strong>: Cards with no price data show "Shift+click price to set" for discoverability</li>
   `;
 };
 
@@ -282,7 +282,7 @@ const getEmbeddedWhatsNew = () => {
 const getEmbeddedRoadmap = () => {
   return `
     <li><strong>Inline catalog &amp; grading tags</strong>: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed</li>
-    <li><strong>Numista API fix</strong>: Correct endpoints, auth headers, and parameters in the NumistaProvider class</li>
+    <li><strong>Batch rename / normalize</strong>: Bulk rename items using Numista catalog data and the name normalizer</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -216,10 +216,10 @@ const API_PROVIDERS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2025-08-15 - Price column styling consistency fixes
+ * Updated: 2026-02-08 - Numista API v3 integration fix
  */
 
-const APP_VERSION = "3.09.01";
+const APP_VERSION = "3.09.02";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -344,6 +344,9 @@ const CATALOG_MAP_KEY = "catalogMap";
 /** @constant {string} SPOT_HISTORY_KEY - LocalStorage key for spot price history */
 const SPOT_HISTORY_KEY = "metalSpotHistory";
 
+/** @constant {string} CATALOG_HISTORY_KEY - LocalStorage key for catalog API call history */
+const CATALOG_HISTORY_KEY = "staktrakr.catalog.history";
+
 /** @constant {string} THEME_KEY - LocalStorage key for theme preference */
 const THEME_KEY = "appTheme";
 
@@ -403,6 +406,9 @@ const ALLOWED_STORAGE_KEYS = [
   "staktrakr.debug",
   "stackrtrackr.debug",
   "catalog_api_config",
+  "staktrakr.catalog.cache",
+  "staktrakr.catalog.settings",
+  CATALOG_HISTORY_KEY,
   SPOT_TREND_RANGE_KEY,
 ];
 

--- a/js/events.js
+++ b/js/events.js
@@ -1803,6 +1803,20 @@ const setupApiEvents = () => {
       );
     }
 
+    const catalogHistoryBtn = document.getElementById("catalogHistoryBtn");
+    if (catalogHistoryBtn) {
+      safeAttachListener(
+        catalogHistoryBtn,
+        "click",
+        () => {
+          if (typeof showCatalogHistoryModal === "function") {
+            showCatalogHistoryModal();
+          }
+        },
+        "Catalog history button",
+      );
+    }
+
     const syncAllBtn = document.getElementById("syncAllBtn");
     if (syncAllBtn) {
       safeAttachListener(
@@ -1846,6 +1860,32 @@ const setupApiEvents = () => {
         "API history close button",
       );
     }
+    const catalogHistoryModal = document.getElementById("catalogHistoryModal");
+    const catalogHistoryCloseBtn = document.getElementById("catalogHistoryCloseBtn");
+    if (catalogHistoryModal) {
+      safeAttachListener(
+        catalogHistoryModal,
+        "click",
+        (e) => {
+          if (e.target === catalogHistoryModal && typeof hideCatalogHistoryModal === "function") {
+            hideCatalogHistoryModal();
+          }
+        },
+        "Catalog history modal background",
+      );
+    }
+    if (catalogHistoryCloseBtn) {
+      safeAttachListener(
+        catalogHistoryCloseBtn,
+        "click",
+        () => {
+          if (typeof hideCatalogHistoryModal === "function") {
+            hideCatalogHistoryModal();
+          }
+        },
+        "Catalog history close button",
+      );
+    }
     if (providersModal) {
       safeAttachListener(
         providersModal,
@@ -1887,6 +1927,7 @@ const setupApiEvents = () => {
           const detailsModal = document.getElementById("detailsModal");
           const changeLogModal = document.getElementById("changeLogModal");
           const storageReportModal = document.getElementById("storageReportModal");
+          const catalogHistModal = document.getElementById("catalogHistoryModal");
 
           if (
             filesModal &&
@@ -1912,6 +1953,12 @@ const setupApiEvents = () => {
             typeof hideApiHistoryModal === "function"
           ) {
             hideApiHistoryModal();
+          } else if (
+            catalogHistModal &&
+            catalogHistModal.style.display === "flex" &&
+            typeof hideCatalogHistoryModal === "function"
+          ) {
+            hideCatalogHistoryModal();
           } else if (
             providersModal &&
             providersModal.style.display === "flex" &&

--- a/js/state.js
+++ b/js/state.js
@@ -265,6 +265,9 @@ let spotPrices = {
 /** @type {Array} Historical spot price records */
 let spotHistory = [];
 
+/** @type {Array} Catalog API call history records */
+let catalogHistory = [];
+
 /** @type {Object|null} Current Metals API configuration */
 let apiConfig = null;
 

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,10 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.09.02": `
+      <li><strong>Numista API v3 fix</strong>: Corrected base URL (<code>/v3</code>), endpoint paths (<code>/types</code>), auth header (<code>Numista-API-Key</code>), query parameters (<code>count</code>, <code>issuer</code>, <code>category</code>), response parsing (<code>data.types</code>), and field mapping (<code>min_year</code>/<code>max_year</code>, <code>issuer.name</code>, <code>size</code>, <code>category</code>, <code>obverse_thumbnail</code>, <code>comments</code>, <code>value.numeric_value</code>) — 7 bugs total</li>
+      <li><strong>localStorage whitelist fix</strong>: Added <code>staktrakr.catalog.cache</code> and <code>staktrakr.catalog.settings</code> to the allowed storage keys — without these, <code>cleanupStorage()</code> deleted catalog data on every page load</li>
+    `,
     "3.09.01": `
       <li><strong>Normalized name chips</strong>: Filter chip bar groups item name variants into single chips (e.g., "Silver Eagle 15/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle</li>
       <li><strong>Name normalizer rewrite</strong>: Precise starts-with matching replaces fuzzy word matching — no more phantom chips for items you don't own (e.g., "American Gold Eagle" when you only have Silver Eagles)</li>


### PR DESCRIPTION
## Summary

- **Catalog API history modal**: Sortable, filterable table logging all Numista API calls (lookups, searches, market value, test connection) with timing, provider, result, and error details. Mirrors the existing metals API history pattern exactly
- **Roadmap update**: Phased near-term plan, BYO-Backend (Supabase) replaces SQLite/auth stack
- **v3.09.02 changelog/announcements**: Prior Numista API v3 fix documented across CHANGELOG.md, announcements.md, about.js, versionCheck.js

## Changed Files

| File | Change |
|------|--------|
| `js/constants.js` | `CATALOG_HISTORY_KEY` constant + whitelist entry |
| `js/state.js` | `catalogHistory` state variable |
| `index.html` | History button on Numista card + catalog history modal HTML |
| `css/styles.css` | `#catalogHistoryTable` styling |
| `js/catalog-api.js` | Logging functions, CatalogAPI method instrumentation, window exports |
| `js/events.js` | Button click, modal close/dismiss, ESC key handler |
| `CHANGELOG.md` | v3.09.02 entry |
| `docs/announcements.md` | What's New + Roadmap updates |
| `js/about.js` | Embedded What's New + Roadmap fallbacks |
| `js/versionCheck.js` | Embedded changelog for v3.09.02 |

## Test plan

- [ ] Open API settings → verify "History" button on Numista card
- [ ] Click "Test Connection" → verify entry logged with action "test"
- [ ] Click "History" → modal opens showing the test entry
- [ ] Verify 7 columns: Time, Action, Query, Result, Items, Provider, Duration
- [ ] Type in filter input → table filters dynamically
- [ ] Click column header → sorts asc/desc
- [ ] Hover failed result cell → error tooltip appears
- [ ] Reload page → History persists from localStorage
- [ ] Press ESC → modal closes
- [ ] Click outside modal → modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)