### PR TITLE
v3.10.00: Serial #, Numista UX, filter chips, color-keyed breakdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.09.04] - 2026-02-08
+
+### Feature — Year Field + Inline Year Tag + Form Restructure
+
+#### Added
+
+- **Year field**: New optional Year field in add/edit form, stored as `year` in the data model. Accepts single years ("2024") or ranges ("2021-2026")
+- **Inline Year tag**: Year badge displayed on the inventory table Name cell (before the N# tag) with muted informational styling and theme-aware colors
+- **Year in Numista field picker**: Replaced Metal with Year in the "Fill Form Fields" picker — Numista's year range is editable before filling
+- **Year in CSV/JSON export**: "Year" column added to standard CSV export after "Name"; `year` field added to JSON export
+- **Year in CSV import**: Reads "Year", "year", or "issuedYear" columns from imported CSV files
+
+#### Changed
+
+- **Form layout restructured**: Name (wider, 60%) paired with Year (40%); purchase fields grouped together: Purchase Date | Purchase Price, Purchase Location | Retail Price
+- **Removed Metal from Numista picker**: Numista returns "Alloy/Other" which never matches form options — removed to reduce confusion
+- **Data migration**: Existing items with `issuedYear` (from Numista CSV imports) automatically migrate to `year` on load
+
+## [3.09.03] - 2026-02-08
+
+### Patch — Numista Field Picker Layout + Smart Category Search
+
+#### Fixed
+
+- **Numista field picker layout**: Replaced broken `<fieldset>` + flexbox with `<div>` + CSS Grid (`grid-template-columns: auto auto 1fr`) — fixes checkboxes centering and labels/inputs pushed off-screen across browsers
+- **Numista search `category` param**: `searchItems()` now maps `filters.category` instead of `filters.metal` to the Numista API `category` parameter
+
+#### Added
+
+- **Smart category search**: Numista search now maps the form's Type field to Numista categories (Coin→coin, Bar/Round→exonumia, Note/Aurum→banknote) for more relevant results
+- **Metal-augmented queries**: When Metal is set and not already in the search text, it's prepended to the query (e.g., Metal=Silver + "Eagle" → searches "Silver Eagle")
+
 ## [3.09.02] - 2026-02-08
 
 ### Patch — Numista API v3 Integration Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.00] - 2026-02-08
+
+### Feature — Serial #, Numista UX, Filter Chips & Column Tweaks
+
+#### Added
+
+- **Serial # field**: New optional Serial Number input in the add/edit form (between Storage Location and Catalog N#) for bars and notes with physical serial numbers
+- **Serial # in exports/imports**: Serial Number included in CSV, JSON, ZIP, and PDF exports; imported from CSV and JSON with `Serial Number` / `serialNumber` column fallbacks
+- **Enhanced Numista no-results**: When Numista search returns no results, the modal now shows a retry search box (pre-filled with original query) and a quick-pick list of popular bullion items (Silver Eagles, Maple Leafs, Krugerrands, etc.)
+- **Year/Grade/N# filter chips**: Year, Grade, and Numista ID values now generate clickable filter chips in the chip bar (respects minCount threshold)
+- **Year sort tiebreaker**: Items with identical names now sub-sort by Year when sorting the Name column
+
+#### Changed
+
+- **Source column**: "Location" table header renamed to "Source" with storefront icon for clarity (data field unchanged: `purchaseLocation`)
+- **eBay search includes year**: Year is now appended to eBay search URLs between metal and name for more precise results
+- **Form layout**: Notes field moved to end of form (next to Catalog N#); Serial # takes its former position next to Storage Location
+
+#### Fixed
+
+- **Numista Aurum category**: Removed incorrect `'Aurum': 'banknote'` mapping — Goldbacks are "Embedded-asset notes" on Numista, which isn't a valid API category filter. Aurum items now search without a category constraint, returning correct results
+- **eBay search attribute escaping**: Switched from `sanitizeHtml()` to `escapeAttribute()` for `data-search` attributes — item names with double quotes no longer truncate the search URL
+
+## [3.09.05] - 2026-02-08
+
+### Feature — Grade, Grading Authority & Cert # Fields + eBay Search Fix
+
+#### Added
+
+- **Grade field**: New optional Grade dropdown with 3 optgroups — Standard (AG through BU), Mint State (MS-60 through MS-70), and Proof (PF-60 through PF-70)
+- **Grading Authority field**: Dropdown to select grading service — PCGS, NGC, ANACS, or ICG
+- **Cert # field**: Free-text input for certification number
+- **Inline Grade tag**: Color-coded grade badge on inventory table Name cell (after N# tag) — PCGS blue, NGC gold, ANACS green, ICG purple. Theme-aware across light/dark/sepia
+- **Cert verification click**: Grade tags with cert numbers are clickable — opens grading service's cert lookup page in a popup window (PCGS and NGC direct lookup, ANACS and ICG generic verify pages)
+- **Grade tooltip**: Hover shows grading details — authority + cert# when available, or just grade
+- **Grade in CSV/JSON/PDF export**: Grade, Grading Authority, and Cert # columns added to all export formats
+- **Grade in CSV/JSON import**: Reads grade, authority, and cert# from imported files with multiple column name fallbacks
+
+#### Fixed
+
+- **eBay search URL sanitization**: Item names containing quotes `"`, parentheses `()`, or backslashes `\` (allowed since v3.09.04) no longer act as eBay search operators. New `cleanSearchTerm()` strips these characters before building search URLs
+
 ## [3.09.04] - 2026-02-08
 
 ### Feature — Year Field + Inline Year Tag + Form Restructure

--- a/css/styles.css
+++ b/css/styles.css
@@ -475,6 +475,10 @@ section:hover {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
+.grid-name-year {
+  grid-template-columns: 3fr 2fr;
+}
+
 /* =============================================================================
    FORM ELEMENTS
    ============================================================================= */
@@ -1580,6 +1584,7 @@ input[type="submit"] {
   padding: 0;
   overflow: hidden;
   width: 90%;
+  max-width: 700px;
 }
 
 #changeLogModal .modal-content {
@@ -4201,7 +4206,8 @@ input:disabled + .slider {
     padding: var(--spacing);
   }
 
-  .grid-2 {
+  .grid-2,
+  .grid-name-year {
     grid-template-columns: 1fr;
   }
 
@@ -4781,6 +4787,286 @@ th {
   .catalog-link {
     font-size: 0.6rem;
   }
+}
+
+/* =============================================================================
+   NUMISTA TAG — Inline N# badge on inventory table Name cell
+   ============================================================================= */
+.numista-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+  margin-left: 0.35rem;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--primary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: var(--transition);
+  vertical-align: middle;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.numista-tag:hover,
+.numista-tag:focus-visible {
+  background: var(--primary);
+  color: #fff;
+  outline: none;
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] .numista-tag {
+  background: rgba(255, 255, 255, 0.1);
+  color: #60a5fa;
+}
+[data-theme="dark"] .numista-tag:hover,
+[data-theme="dark"] .numista-tag:focus-visible {
+  background: #60a5fa;
+  color: #1a1a2e;
+}
+
+/* Sepia theme overrides */
+[data-theme="sepia"] .numista-tag {
+  background: rgba(0, 0, 0, 0.08);
+  color: #1d4ed8;
+}
+[data-theme="sepia"] .numista-tag:hover,
+[data-theme="sepia"] .numista-tag:focus-visible {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+/* =============================================================================
+   YEAR TAG — Inline year badge on inventory table Name cell
+   ============================================================================= */
+.year-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+  margin-left: 0.35rem;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary, #666);
+  vertical-align: middle;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] .year-tag {
+  background: rgba(255, 255, 255, 0.08);
+  color: #9ca3af;
+}
+
+/* Sepia theme overrides */
+[data-theme="sepia"] .year-tag {
+  background: rgba(0, 0, 0, 0.06);
+  color: #78716c;
+}
+
+/* =============================================================================
+   ITEM MODAL ACTION BAR — Search Numista left, Cancel/Submit right
+   ============================================================================= */
+.item-modal-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+  gap: 0.5rem;
+}
+
+.item-modal-actions-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* =============================================================================
+   NUMISTA RESULTS MODAL — Stacked modal for search results / field picker
+   ============================================================================= */
+#numistaResultsModal {
+  z-index: 10000;
+}
+
+.numista-results-modal-content {
+  max-width: 600px;
+  width: 90%;
+}
+
+.numista-results-list {
+  max-height: 400px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.numista-result-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: var(--transition);
+  background: var(--bg-secondary);
+}
+
+.numista-result-card:hover {
+  border-color: var(--primary);
+  background: var(--bg-tertiary);
+}
+
+.numista-result-card.selected {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px var(--primary);
+}
+
+.numista-result-card img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  border-radius: 4px;
+  flex-shrink: 0;
+  background: var(--bg-primary);
+}
+
+.numista-result-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.numista-result-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.numista-result-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.15rem;
+}
+
+.numista-result-id {
+  font-size: 0.7rem;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+/* Field picker area */
+.numista-field-picker {
+  padding: 0.5rem 0;
+}
+
+.numista-selected-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border: 2px solid var(--primary);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.numista-selected-preview img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.numista-field-checkboxes {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 0.35rem 0.5rem;
+  align-items: center;
+  margin: 0 0 0.75rem 0;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.numista-fields-heading {
+  grid-column: 1 / -1;
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin-bottom: 0.15rem;
+}
+
+.numista-field-checkboxes input[type="checkbox"] {
+  margin: 0;
+}
+
+.numista-field-label {
+  font-weight: 600;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  text-align: right;
+  color: var(--text-secondary, var(--text-primary));
+}
+
+.numista-field-input {
+  min-width: 0;
+  padding: 0.25rem 0.4rem;
+  font-size: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.numista-field-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.numista-field-input:focus {
+  border-color: var(--primary);
+  outline: none;
+}
+
+.numista-field-current {
+  grid-column: 3;
+  font-size: 0.65rem;
+  color: var(--text-muted, #999);
+  margin-top: -0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.numista-field-warn {
+  grid-column: 1 / -1;
+  font-size: 0.7rem;
+  color: var(--danger, #f44336);
+  font-style: italic;
+  margin-top: -0.2rem;
+  padding-left: 1.5rem;
+}
+
+.numista-fill-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.numista-no-results {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 #typeSummary .summary-chip {

--- a/css/styles.css
+++ b/css/styles.css
@@ -479,6 +479,10 @@ section:hover {
   grid-template-columns: 3fr 2fr;
 }
 
+.grid-grade {
+  grid-template-columns: 1fr 1fr 1.5fr;
+}
+
 /* =============================================================================
    FORM ELEMENTS
    ============================================================================= */
@@ -1577,7 +1581,6 @@ input[type="submit"] {
 /* Standardized modal layout for change log and details views */
 /* shared modal content structure */
 #changeLogModal .modal-content,
-#detailsModal .modal-content,
 #itemModal .modal-content {
   display: flex;
   flex-direction: column;
@@ -1585,6 +1588,15 @@ input[type="submit"] {
   overflow: hidden;
   width: 90%;
   max-width: 700px;
+}
+
+#detailsModal .modal-content {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  width: 90%;
+  max-width: 1000px;
 }
 
 #changeLogModal .modal-content {
@@ -1978,7 +1990,8 @@ td {
 
 /* Allow certain columns to be wider */
 td[data-column="name"] {
-  max-width: 25ch; /* Name column can be slightly wider */
+  max-width: none;
+  width: auto;
 }
 
 td[data-column="purchaseLocation"],
@@ -1991,12 +2004,12 @@ td[data-column="storageLocation"] {
   text-overflow: ellipsis;
 }
 
-/* Fixed date column with proper width for full dates */
+/* Fixed date column — compact MM/DD/YY format */
 td[data-column="date"],
 th[data-column="date"] {
-  max-width: 12ch; /* Increased from 8ch to fit full dates like "Feb 28, 2024" */
-  width: 12ch;
-  min-width: 12ch;
+  max-width: 9ch;
+  width: 9ch;
+  min-width: 9ch;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4207,7 +4220,8 @@ input:disabled + .slider {
   }
 
   .grid-2,
-  .grid-name-year {
+  .grid-name-year,
+  .grid-grade {
     grid-template-columns: 1fr;
   }
 
@@ -4334,33 +4348,33 @@ input:disabled + .slider {
   font-weight: bold;
 }
 
-/* Edit column styling for single toggle button */
-#inventoryTable td[data-column="edit"] {
+/* Actions column styling */
+#inventoryTable td[data-column="actions"] {
   text-align: center;
   padding: 0.2rem;
 }
 
-#inventoryTable td[data-column="edit"] .icon-btn {
+#inventoryTable td[data-column="actions"] .icon-btn {
   margin: 0;
 }
 
 /* Style the edit toggle button based on mode */
-#inventoryTable td[data-column="edit"] .edit-toggle {
+#inventoryTable td[data-column="actions"] .edit-toggle {
   color: var(--primary);
   transition: color 0.2s ease;
 }
 
-#inventoryTable td[data-column="edit"] .edit-toggle:hover {
+#inventoryTable td[data-column="actions"] .edit-toggle:hover {
   color: var(--primary-dark);
 }
 
-/* Edit header styling */
-#inventoryTable th[data-column="edit"] {
+/* Actions header styling */
+#inventoryTable th[data-column="actions"] {
   cursor: pointer;
   transition: background-color 0.2s ease;
 }
 
-#inventoryTable th[data-column="edit"]:hover {
+#inventoryTable th[data-column="actions"]:hover {
   background-color: var(--bg-hover);
 }
 
@@ -4496,6 +4510,20 @@ input:disabled + .slider {
   text-align: center;
   margin-top: 0.15rem;
   line-height: 1;
+}
+
+/* Actions column — merged edit/copy/delete */
+#inventoryTable th.actions-col,
+#inventoryTable td.actions-cell {
+  width: 6rem;
+  min-width: 5rem;
+}
+
+.actions-row {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+  align-items: center;
 }
 
 /* Icon column styling */
@@ -4870,6 +4898,161 @@ th {
 }
 
 /* =============================================================================
+   GRADE TAG — Inline grade badge on inventory table Name cell
+   Color-coded by grading authority: PCGS=blue, NGC=gold, ANACS=green, ICG=purple
+   ============================================================================= */
+.grade-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+  margin-left: 0.35rem;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary, #666);
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+/* Clickable grade tags (have cert number) */
+.grade-tag[data-clickable="true"] {
+  cursor: pointer;
+  transition: var(--transition);
+}
+.grade-tag[data-clickable="true"]:hover,
+.grade-tag[data-clickable="true"]:focus-visible {
+  filter: brightness(0.85);
+  outline: none;
+}
+
+/* Authority color coding — Light theme */
+.grade-tag[data-authority="PCGS"] {
+  background: rgba(37, 99, 235, 0.12);
+  color: #2563eb;
+}
+.grade-tag[data-authority="NGC"] {
+  background: rgba(217, 119, 6, 0.12);
+  color: #d97706;
+}
+.grade-tag[data-authority="ANACS"] {
+  background: rgba(5, 150, 105, 0.12);
+  color: #059669;
+}
+.grade-tag[data-authority="ICG"] {
+  background: rgba(124, 58, 237, 0.12);
+  color: #7c3aed;
+}
+
+/* Clickable hover overrides — Light theme */
+.grade-tag[data-clickable="true"][data-authority="PCGS"]:hover,
+.grade-tag[data-clickable="true"][data-authority="PCGS"]:focus-visible {
+  background: #2563eb;
+  color: #fff;
+}
+.grade-tag[data-clickable="true"][data-authority="NGC"]:hover,
+.grade-tag[data-clickable="true"][data-authority="NGC"]:focus-visible {
+  background: #d97706;
+  color: #fff;
+}
+.grade-tag[data-clickable="true"][data-authority="ANACS"]:hover,
+.grade-tag[data-clickable="true"][data-authority="ANACS"]:focus-visible {
+  background: #059669;
+  color: #fff;
+}
+.grade-tag[data-clickable="true"][data-authority="ICG"]:hover,
+.grade-tag[data-clickable="true"][data-authority="ICG"]:focus-visible {
+  background: #7c3aed;
+  color: #fff;
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] .grade-tag {
+  background: rgba(255, 255, 255, 0.08);
+  color: #9ca3af;
+}
+[data-theme="dark"] .grade-tag[data-authority="PCGS"] {
+  background: rgba(96, 165, 250, 0.15);
+  color: #60a5fa;
+}
+[data-theme="dark"] .grade-tag[data-authority="NGC"] {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+}
+[data-theme="dark"] .grade-tag[data-authority="ANACS"] {
+  background: rgba(52, 211, 153, 0.15);
+  color: #34d399;
+}
+[data-theme="dark"] .grade-tag[data-authority="ICG"] {
+  background: rgba(167, 139, 250, 0.15);
+  color: #a78bfa;
+}
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="PCGS"]:hover,
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="PCGS"]:focus-visible {
+  background: #60a5fa;
+  color: #1a1a2e;
+}
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="NGC"]:hover,
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="NGC"]:focus-visible {
+  background: #fbbf24;
+  color: #1a1a2e;
+}
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="ANACS"]:hover,
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="ANACS"]:focus-visible {
+  background: #34d399;
+  color: #1a1a2e;
+}
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="ICG"]:hover,
+[data-theme="dark"] .grade-tag[data-clickable="true"][data-authority="ICG"]:focus-visible {
+  background: #a78bfa;
+  color: #1a1a2e;
+}
+
+/* Sepia theme overrides */
+[data-theme="sepia"] .grade-tag {
+  background: rgba(0, 0, 0, 0.06);
+  color: #78716c;
+}
+[data-theme="sepia"] .grade-tag[data-authority="PCGS"] {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+}
+[data-theme="sepia"] .grade-tag[data-authority="NGC"] {
+  background: rgba(180, 83, 9, 0.1);
+  color: #b45309;
+}
+[data-theme="sepia"] .grade-tag[data-authority="ANACS"] {
+  background: rgba(4, 120, 87, 0.1);
+  color: #047857;
+}
+[data-theme="sepia"] .grade-tag[data-authority="ICG"] {
+  background: rgba(109, 40, 217, 0.1);
+  color: #6d28d9;
+}
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="PCGS"]:hover,
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="PCGS"]:focus-visible {
+  background: #1d4ed8;
+  color: #fff;
+}
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="NGC"]:hover,
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="NGC"]:focus-visible {
+  background: #b45309;
+  color: #fff;
+}
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="ANACS"]:hover,
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="ANACS"]:focus-visible {
+  background: #047857;
+  color: #fff;
+}
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="ICG"]:hover,
+[data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="ICG"]:focus-visible {
+  background: #6d28d9;
+  color: #fff;
+}
+
+/* =============================================================================
    ITEM MODAL ACTION BAR — Search Numista left, Cancel/Submit right
    ============================================================================= */
 .item-modal-actions {
@@ -5067,6 +5250,95 @@ th {
   padding: 2rem 1rem;
   color: var(--text-muted);
   font-style: italic;
+}
+
+/* Enhanced no-results: retry search + quick-picks */
+.numista-no-results-enhanced {
+  padding: 1rem;
+}
+
+.numista-retry-search p {
+  text-align: center;
+  color: var(--text-muted);
+  font-style: italic;
+  margin-bottom: 0.75rem;
+}
+
+.numista-retry-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.numista-retry-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.numista-retry-btn {
+  white-space: nowrap;
+}
+
+.numista-quick-picks-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.numista-quick-picks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.numista-quick-pick {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  cursor: pointer;
+  transition: background 0.15s;
+  text-align: left;
+}
+
+.numista-quick-pick:hover {
+  background: var(--bg-hover);
+}
+
+.quick-pick-id {
+  font-weight: 600;
+  color: var(--primary);
+  font-size: 0.85rem;
+  min-width: 5rem;
+}
+
+.quick-pick-name {
+  flex: 1;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quick-pick-count {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: var(--bg-input);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.75rem;
 }
 
 #typeSummary .summary-chip {
@@ -5618,15 +5890,9 @@ th {
   flex-shrink: 0;
 }
 
-/* All Price columns — width and layout (th + td) */
+/* Purchase Price column — fixed width */
 #inventoryTable th[data-column="purchasePrice"],
-#inventoryTable td[data-column="purchasePrice"],
-#inventoryTable th[data-column="meltValue"],
-#inventoryTable td[data-column="meltValue"],
-#inventoryTable th[data-column="retailPrice"],
-#inventoryTable td[data-column="retailPrice"],
-#inventoryTable th[data-column="gainLoss"],
-#inventoryTable td[data-column="gainLoss"] {
+#inventoryTable td[data-column="purchasePrice"] {
   max-width: 110px !important;
   width: 110px !important;
   min-width: 110px !important;
@@ -5635,6 +5901,23 @@ th {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Melt, Retail, Gain/Loss columns — auto-size to content */
+#inventoryTable th[data-column="meltValue"],
+#inventoryTable td[data-column="meltValue"],
+#inventoryTable th[data-column="retailPrice"],
+#inventoryTable td[data-column="retailPrice"],
+#inventoryTable th[data-column="gainLoss"],
+#inventoryTable td[data-column="gainLoss"] {
+  width: auto !important;
+  min-width: unset !important;
+  max-width: none !important;
+  text-align: right;
+  padding: 0.5rem 0.75rem;
+  white-space: nowrap;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 /* Price headers — inherit system font from .header-text */

--- a/css/styles.css
+++ b/css/styles.css
@@ -3088,15 +3088,24 @@ a.about-badge:hover {
 
 .breakdown-header {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   margin-bottom: 0.25rem;
+}
+
+.breakdown-color-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 0.4rem;
+  flex-shrink: 0;
 }
 
 .breakdown-label {
   font-weight: 600;
   color: var(--text-primary);
   font-size: 0.875rem;
+  flex: 1;
 }
 
 .breakdown-meta {

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,12 @@
 ## What's New
 
+- **Serial # field (v3.10.00)**: New optional Serial Number input for bars and notes with physical serial numbers. Included in all export/import formats
+- **Numista Aurum fix (v3.10.00)**: Goldback / Aurum items now return results from Numista search
+- **Enhanced Numista no-results (v3.10.00)**: Retry search box + popular bullion quick-picks when no results found
+- **Source column + filter chips (v3.10.00)**: "Location" renamed to "Source"; Year, Grade, and N# filter chips added to chip bar
+- **Year sort + eBay year (v3.10.00)**: Name column sub-sorts by Year; eBay search URLs include year
+- **Grade, Authority & Cert # (v3.09.05)**: New optional grading fields — Grade dropdown (AG through PF-70), Grading Authority (PCGS/NGC/ANACS/ICG), and Cert # input. Color-coded grade tags on table with one-click cert verification
+- **eBay search fix (v3.09.05)**: Item names with quotes or parentheses no longer produce broken eBay search results
 - **Year field + inline tag (v3.09.04)**: New optional Year field in add/edit form with inline year badge on inventory table Name cell. Numista picker now fills Year instead of Metal
 - **Form layout restructure (v3.09.04)**: Name wider with Year beside it; purchase fields grouped: Date | Price, Location | Retail Price
 - **Numista field picker fix (v3.09.03)**: Fixed broken layout — checkboxes, labels, and inputs now align correctly using CSS Grid instead of fieldset+flexbox
@@ -12,5 +19,4 @@
 
 ## Development Roadmap
 
-- **Inline catalog & grading tags**: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed
 - **Batch rename / normalize**: Bulk rename items using Numista catalog data and the name normalizer

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,9 @@
 ## What's New
 
+- **Year field + inline tag (v3.09.04)**: New optional Year field in add/edit form with inline year badge on inventory table Name cell. Numista picker now fills Year instead of Metal
+- **Form layout restructure (v3.09.04)**: Name wider with Year beside it; purchase fields grouped: Date | Price, Location | Retail Price
+- **Numista field picker fix (v3.09.03)**: Fixed broken layout — checkboxes, labels, and inputs now align correctly using CSS Grid instead of fieldset+flexbox
+- **Smart category search (v3.09.03)**: Numista search uses your Type selection (Coin, Bar, Round, Note, Aurum) to filter results by category, and prepends Metal to the query when relevant
 - **Numista API v3 fix (v3.09.02)**: Corrected base URL, endpoints, auth headers, query parameters, response parsing, and field mapping — 7 bugs total. Test Connection button now works
 - **localStorage whitelist fix (v3.09.02)**: Catalog cache and settings no longer deleted on page load
 - **Normalized name chips (v3.09.01)**: Filter chip bar now groups item name variants into single chips (e.g., "Silver Eagle 6/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle

--- a/index.html
+++ b/index.html
@@ -879,16 +879,19 @@
                 </div>
               </div>
             </div>
-            <!-- Second row of form fields -->
-            <div class="grid grid-2">
+            <!-- Row: Name & Year (Name wider) -->
+            <div class="grid grid-name-year">
               <div>
                 <label for="itemName">Name</label>
                 <input id="itemName" required type="text" />
               </div>
               <div>
-                <label for="purchaseLocation">Purchase Location</label>
-                <input id="purchaseLocation" type="text" />
+                <label for="itemYear">Year <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <input id="itemYear" type="text" placeholder="e.g. 2024" />
               </div>
+            </div>
+            <!-- Row: Storage Location & Notes -->
+            <div class="grid grid-2">
               <div>
                 <label for="storageLocation">Storage Location</label>
                 <input id="storageLocation" type="text" placeholder="Vault A, Safe B, etc..." />
@@ -898,13 +901,24 @@
                 <input id="itemNotes" type="text" placeholder="Additional notes or comments..." />
               </div>
             </div>
-            <!-- Third row of form fields -->
+            <!-- Row: Purchase Date & Purchase Price -->
             <div class="grid grid-2">
+              <div id="dateField">
+                <label for="itemDate">Purchase Date</label>
+                <input id="itemDate" required type="date" />
+              </div>
               <div>
                 <label for="itemPrice">Purchase Price ($)</label>
                 <div class="currency-input">
                   <input id="itemPrice" min="0" step="0.01" type="number" />
                 </div>
+              </div>
+            </div>
+            <!-- Row: Purchase Location & Retail Price -->
+            <div class="grid grid-2">
+              <div>
+                <label for="purchaseLocation">Purchase Location</label>
+                <input id="purchaseLocation" type="text" />
               </div>
               <div id="marketValueField">
                 <label for="itemMarketValue">Retail Price ($) <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
@@ -912,20 +926,29 @@
                   <input id="itemMarketValue" min="0" step="0.01" type="number" placeholder="Defaults to melt value" />
                 </div>
               </div>
-              <div id="dateField">
-                <label for="itemDate">Purchase Date</label>
-                <input id="itemDate" required type="date" />
-              </div>
+            </div>
+            <!-- Row: Catalog N# -->
+            <div class="grid grid-2">
               <div>
                 <label for="itemCatalog">Catalog (N#)</label>
                 <input id="itemCatalog" type="text" placeholder="Numista catalog #" />
               </div>
             </div>
             <!-- Form action buttons -->
-            <div style="margin-top: 1rem; text-align: right">
-              <button class="btn" id="undoChangeBtn" type="button" style="display:none">Undo</button>
-              <button class="btn" id="cancelItem" type="button">Cancel</button>
-              <button class="btn premium" id="itemModalSubmit" type="submit">Add to Inventory</button>
+            <div class="item-modal-actions">
+              <button class="btn secondary" id="searchNumistaBtn" type="button"
+                      title="Search Numista catalog using the Name or N# field">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+                     style="vertical-align: -2px; margin-right: 0.3rem;">
+                  <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
+                </svg>Search Numista
+              </button>
+              <div class="item-modal-actions-right">
+                <button class="btn" id="undoChangeBtn" type="button" style="display:none">Undo</button>
+                <button class="btn" id="cancelItem" type="button">Cancel</button>
+                <button class="btn premium" id="itemModalSubmit" type="submit">Add to Inventory</button>
+              </div>
             </div>
           </form>
         </div>
@@ -2138,6 +2161,38 @@
         </div>
         <div class="modal-body numista-modal-body">
           <iframe id="numistaIframe" src="" frameborder="0" style="width: 100%; height: 100%; border-radius: var(--radius);"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- =============================================================================
+       NUMISTA RESULTS MODAL
+
+       Stacked modal (z-index 10000) that appears over the item Add/Edit form.
+       Shows search results from Numista API and a field picker to fill form fields.
+       ============================================================================= -->
+    <div class="modal" id="numistaResultsModal" style="display: none">
+      <div class="modal-content numista-results-modal-content">
+        <div class="modal-header">
+          <h2 id="numistaResultsTitle">Numista Results</h2>
+          <button aria-label="Close modal" class="modal-close" id="numistaResultsCloseBtn">&times;</button>
+        </div>
+        <div class="modal-body">
+          <!-- Search results list -->
+          <div id="numistaResultsList" class="numista-results-list"></div>
+
+          <!-- Field picker (hidden until a result is selected) -->
+          <div id="numistaFieldPicker" class="numista-field-picker" style="display: none">
+            <div id="numistaSelectedItem" class="numista-selected-preview"></div>
+            <div id="numistaFieldCheckboxes" class="numista-field-checkboxes">
+              <div class="numista-fields-heading">Fields to fill:</div>
+              <!-- Populated dynamically with value previews by catalog-api.js -->
+            </div>
+            <div class="numista-fill-actions">
+              <button class="btn" id="numistaFillCancelBtn" type="button">Cancel</button>
+              <button class="btn premium" id="numistaFillBtn" type="button">Fill Fields</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -714,32 +714,19 @@
               </th>
               <th class="shrink" data-column="purchaseLocation">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                  <polyline points="9,22 9,12 15,12 15,22"/>
+                  <path d="M3 9l1.5-5h15L21 9"/>
+                  <path d="M3 9v11a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V9"/>
+                  <path d="M9 21V13h6v8"/>
                 </svg>
-                <span class="header-text">Location</span>
+                <span class="header-text">Source</span>
               </th>
-              <th class="icon-col" data-column="edit" aria-label="Edit" title="Edit">
+              <th class="icon-col actions-col" data-column="actions" aria-label="Actions" title="Actions">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                  <circle cx="12" cy="5" r="1.5"/>
+                  <circle cx="12" cy="12" r="1.5"/>
+                  <circle cx="12" cy="19" r="1.5"/>
                 </svg>
-                <span class="header-text">Edit</span>
-              </th>
-              <th class="icon-col" data-column="duplicate" aria-label="Duplicate" title="Duplicate">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/>
-                </svg>
-                <span class="header-text">Copy</span>
-              </th>
-              <th class="icon-col" data-column="delete" aria-label="Delete" title="Delete">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <polyline points="3,6 5,6 21,6"/>
-                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                  <line x1="10" y1="11" x2="10" y2="17"/>
-                  <line x1="14" y1="11" x2="14" y2="17"/>
-                </svg>
-                <span class="header-text">Delete</span>
+                <span class="header-text">Actions</span>
               </th>
             </tr>
           </thead>
@@ -890,15 +877,75 @@
                 <input id="itemYear" type="text" placeholder="e.g. 2024" />
               </div>
             </div>
-            <!-- Row: Storage Location & Notes -->
+            <!-- Row: Grade, Authority & Cert # -->
+            <div class="grid grid-grade">
+              <div>
+                <label for="itemGrade">Grade <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <select id="itemGrade">
+                  <option value="">-- None --</option>
+                  <optgroup label="Standard">
+                    <option value="AG">AG - About Good</option>
+                    <option value="G">G - Good</option>
+                    <option value="VG">VG - Very Good</option>
+                    <option value="F">F - Fine</option>
+                    <option value="VF">VF - Very Fine</option>
+                    <option value="XF">XF - Extremely Fine</option>
+                    <option value="AU">AU - About Uncirculated</option>
+                    <option value="UNC">UNC - Uncirculated</option>
+                    <option value="BU">BU - Brilliant Uncirculated</option>
+                  </optgroup>
+                  <optgroup label="Mint State">
+                    <option value="MS-60">MS-60</option>
+                    <option value="MS-61">MS-61</option>
+                    <option value="MS-62">MS-62</option>
+                    <option value="MS-63">MS-63</option>
+                    <option value="MS-64">MS-64</option>
+                    <option value="MS-65">MS-65</option>
+                    <option value="MS-66">MS-66</option>
+                    <option value="MS-67">MS-67</option>
+                    <option value="MS-68">MS-68</option>
+                    <option value="MS-69">MS-69</option>
+                    <option value="MS-70">MS-70</option>
+                  </optgroup>
+                  <optgroup label="Proof">
+                    <option value="PF-60">PF-60</option>
+                    <option value="PF-61">PF-61</option>
+                    <option value="PF-62">PF-62</option>
+                    <option value="PF-63">PF-63</option>
+                    <option value="PF-64">PF-64</option>
+                    <option value="PF-65">PF-65</option>
+                    <option value="PF-66">PF-66</option>
+                    <option value="PF-67">PF-67</option>
+                    <option value="PF-68">PF-68</option>
+                    <option value="PF-69">PF-69</option>
+                    <option value="PF-70">PF-70</option>
+                  </optgroup>
+                </select>
+              </div>
+              <div>
+                <label for="itemGradingAuthority">Authority <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <select id="itemGradingAuthority">
+                  <option value="">-- None --</option>
+                  <option value="PCGS">PCGS</option>
+                  <option value="NGC">NGC</option>
+                  <option value="ANACS">ANACS</option>
+                  <option value="ICG">ICG</option>
+                </select>
+              </div>
+              <div>
+                <label for="itemCertNumber">Cert # <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <input id="itemCertNumber" type="text" placeholder="e.g. 12345678" />
+              </div>
+            </div>
+            <!-- Row: Storage Location & Serial # -->
             <div class="grid grid-2">
               <div>
                 <label for="storageLocation">Storage Location</label>
                 <input id="storageLocation" type="text" placeholder="Vault A, Safe B, etc..." />
               </div>
               <div>
-                <label for="itemNotes">Notes</label>
-                <input id="itemNotes" type="text" placeholder="Additional notes or comments..." />
+                <label for="itemSerialNumber">Serial # <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <input id="itemSerialNumber" type="text" placeholder="Bar or note serial number" />
               </div>
             </div>
             <!-- Row: Purchase Date & Purchase Price -->
@@ -927,11 +974,15 @@
                 </div>
               </div>
             </div>
-            <!-- Row: Catalog N# -->
+            <!-- Row: Catalog N# & Notes -->
             <div class="grid grid-2">
               <div>
                 <label for="itemCatalog">Catalog (N#)</label>
                 <input id="itemCatalog" type="text" placeholder="Numista catalog #" />
+              </div>
+              <div>
+                <label for="itemNotes">Notes</label>
+                <input id="itemNotes" type="text" placeholder="Additional notes or comments..." />
               </div>
             </div>
             <!-- Form action buttons -->

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.09.04 – Year field + inline tag</strong>: New optional Year field in form with inline year badge on table Name cell. Numista picker fills Year instead of Metal</li>
+    <li><strong>v3.09.04 – Form restructure</strong>: Name wider with Year beside it; purchase fields grouped: Date | Price, Location | Retail Price</li>
+    <li><strong>v3.09.03 – Numista field picker fix</strong>: Replaced broken fieldset+flexbox with CSS Grid — checkboxes, labels, and inputs now align correctly across all browsers</li>
+    <li><strong>v3.09.03 – Smart category search</strong>: Numista search maps Type to API categories and prepends Metal to queries for more relevant results</li>
     <li><strong>v3.09.02 – Numista API v3 fix</strong>: Corrected base URL, endpoints, auth headers, query parameters, response parsing, and field mapping — 7 bugs total. Test Connection button now works</li>
     <li><strong>v3.09.02 – localStorage whitelist fix</strong>: Catalog cache and settings no longer deleted on page load</li>
     <li><strong>v3.09.01 – Name chips</strong>: Filter chip bar groups item name variants into single chips (e.g., "Silver Eagle 6/164"). Click to filter, click again to toggle off. Respects minCount threshold and Smart Grouping toggle</li>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,12 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.10.00 – Serial # field</strong>: New optional Serial Number input for bars and notes. Included in all export/import formats</li>
+    <li><strong>v3.10.00 – Numista Aurum fix</strong>: Goldback / Aurum items now return results from Numista search</li>
+    <li><strong>v3.10.00 – Enhanced no-results</strong>: Numista search shows retry box + popular bullion quick-picks when no results found</li>
+    <li><strong>v3.10.00 – Source column + filter chips</strong>: "Location" renamed to "Source"; Year, Grade, and N# filter chips added</li>
+    <li><strong>v3.09.05 – Grade, Authority & Cert #</strong>: New optional grading fields — Grade dropdown (AG through PF-70), Grading Authority (PCGS/NGC/ANACS/ICG), and Cert # input. Color-coded grade tags on table with one-click cert verification</li>
+    <li><strong>v3.09.05 – eBay search fix</strong>: Item names with quotes or parentheses no longer produce broken eBay search results</li>
     <li><strong>v3.09.04 – Year field + inline tag</strong>: New optional Year field in form with inline year badge on table Name cell. Numista picker fills Year instead of Metal</li>
     <li><strong>v3.09.04 – Form restructure</strong>: Name wider with Year beside it; purchase fields grouped: Date | Price, Location | Retail Price</li>
     <li><strong>v3.09.03 – Numista field picker fix</strong>: Replaced broken fieldset+flexbox with CSS Grid — checkboxes, labels, and inputs now align correctly across all browsers</li>
@@ -285,7 +291,6 @@ const getEmbeddedWhatsNew = () => {
  */
 const getEmbeddedRoadmap = () => {
   return `
-    <li><strong>Inline catalog &amp; grading tags</strong>: Optional (N#), (PCGS), (NGC), (Grade) tags on the Name cell with iframe links — no new column needed</li>
     <li><strong>Batch rename / normalize</strong>: Bulk rename items using Numista catalog data and the name normalizer</li>
   `;
 };

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -276,7 +276,7 @@ class NumistaProvider extends CatalogProvider {
 
     if (filters.page) params.append('page', filters.page);
     if (filters.country) params.append('issuer', filters.country);
-    if (filters.metal) params.append('category', filters.metal);
+    if (filters.category) params.append('category', filters.category);
     if (filters.year) params.append('year', filters.year);
 
     const url = `${this.baseUrl}/types?${params.toString()}`;
@@ -763,6 +763,7 @@ let catalogHistoryEntries = [];
 let catalogHistorySortColumn = "";
 let catalogHistorySortAsc = true;
 let catalogHistoryFilterText = "";
+let selectedNumistaResult = null;
 
 /**
  * Save catalog history to localStorage
@@ -913,6 +914,297 @@ const hideCatalogHistoryModal = () => {
   if (modal) modal.style.display = "none";
 };
 
+// =============================================================================
+// NUMISTA RESULTS MODAL — Search results + field picker UI
+// =============================================================================
+
+/**
+ * Escape HTML for safe insertion into innerHTML
+ * @param {string} str - Raw string
+ * @returns {string} Escaped string
+ */
+const escapeHtmlCatalog = (str) =>
+  String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+/**
+ * Render a single result card HTML string
+ * @param {Object} result - Normalized Numista item data
+ * @param {number} index - Index in results array
+ * @returns {string} HTML string
+ */
+const renderNumistaResultCard = (result, index) => {
+  const imgHtml = result.imageUrl
+    ? `<img src="${escapeHtmlCatalog(result.imageUrl)}" alt="" loading="lazy">`
+    : `<div style="width:48px;height:48px;background:var(--bg-tertiary);border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;">🪙</div>`;
+  const meta = [
+    result.year,
+    result.country,
+    result.metal,
+    result.weight ? `${result.weight}g` : '',
+    result.type
+  ].filter(Boolean).join(' · ');
+
+  return `<div class="numista-result-card" data-result-index="${index}">
+    ${imgHtml}
+    <div class="numista-result-info">
+      <div class="numista-result-name">${escapeHtmlCatalog(result.name)}</div>
+      <div class="numista-result-meta">${escapeHtmlCatalog(meta)}</div>
+      <div class="numista-result-id">N#${escapeHtmlCatalog(result.catalogId)}</div>
+    </div>
+  </div>`;
+};
+
+/**
+ * Render the selected item preview in field picker
+ * @param {Object} result - Normalized Numista item data
+ * @returns {string} HTML string
+ */
+const renderNumistaSelectedItem = (result) => {
+  const imgHtml = result.imageUrl
+    ? `<img src="${escapeHtmlCatalog(result.imageUrl)}" alt="" loading="lazy">`
+    : `<div style="width:48px;height:48px;background:var(--bg-tertiary);border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;">🪙</div>`;
+  const meta = [
+    result.year,
+    result.country,
+    result.metal,
+    result.weight ? `${result.weight}g` : '',
+    result.type
+  ].filter(Boolean).join(' · ');
+
+  return `${imgHtml}
+    <div class="numista-result-info">
+      <div class="numista-result-name">${escapeHtmlCatalog(result.name)}</div>
+      <div class="numista-result-meta">${escapeHtmlCatalog(meta)}</div>
+      <div class="numista-result-id">N#${escapeHtmlCatalog(result.catalogId)}</div>
+    </div>`;
+};
+
+/**
+ * Check if a value matches a valid <select> option
+ * @param {string} selectId - DOM id of the select element
+ * @param {string} value - Value to check
+ * @returns {boolean}
+ */
+const isValidSelectOption = (selectId, value) => {
+  const el = document.getElementById(selectId);
+  if (!el) return false;
+  return Array.from(el.options).some(o => o.value === value);
+};
+
+/**
+ * Render field checkboxes with editable input fields for the selected result.
+ * Each row: [checkbox] [label] [editable text input]
+ * User can tweak values before hitting "Fill Fields".
+ * @param {Object} result - Normalized Numista item data
+ */
+const renderNumistaFieldCheckboxes = (result) => {
+  const container = document.getElementById('numistaFieldCheckboxes');
+  if (!container) return;
+
+  const typeValid = result.type && isValidSelectOption('itemType', result.type);
+
+  // Fields ordered: primary (checked by default) first, then optional (unchecked)
+  const fields = [
+    { key: 'name', label: 'Name', value: result.name || '', available: true, defaultOn: true },
+    { key: 'catalog', label: 'Catalog N#', value: result.catalogId || '', available: true, defaultOn: true },
+    { key: 'year', label: 'Year', value: result.year || '', available: !!result.year, defaultOn: false },
+    {
+      key: 'type', label: 'Type',
+      value: result.type || '',
+      available: typeValid,
+      defaultOn: false,
+      warn: result.type && !typeValid ? `"${result.type}" — not in form options` : ''
+    },
+    { key: 'weight', label: 'Weight (g)', value: result.weight ? String(result.weight) : '', available: result.weight > 0, defaultOn: false },
+  ];
+
+  // Keep the heading, rebuild field rows
+  const heading = container.querySelector('.numista-fields-heading');
+  container.innerHTML = '';
+  if (heading) {
+    container.appendChild(heading);
+  } else {
+    const h = document.createElement('div');
+    h.className = 'numista-fields-heading';
+    h.textContent = 'Fields to fill:';
+    container.appendChild(h);
+  }
+
+  // Map field keys to current form values for "Current:" hints
+  const currentFormValues = {
+    name: (elements.itemName || document.getElementById('itemName'))?.value?.trim() || '',
+    catalog: (elements.itemCatalog || document.getElementById('itemCatalog'))?.value?.trim() || '',
+    year: (elements.itemYear || document.getElementById('itemYear'))?.value?.trim() || '',
+    type: (elements.itemType || document.getElementById('itemType'))?.value || '',
+    weight: (elements.itemWeight || document.getElementById('itemWeight'))?.value?.trim() || '',
+  };
+
+  fields.forEach(f => {
+    // Checkbox — grid column 1
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.name = 'numistaField';
+    cb.value = f.key;
+    cb.checked = f.available && !!f.value && f.defaultOn;
+    if (!f.value) cb.disabled = true;
+
+    // Label — grid column 2
+    const label = document.createElement('span');
+    label.className = 'numista-field-label';
+    label.textContent = f.label + ':';
+
+    // Editable text input — grid column 3
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'numista-field-input';
+    input.name = 'numistaFieldValue_' + f.key;
+    input.value = f.value;
+    input.placeholder = f.available ? '' : 'N/A';
+    if (!f.available && !f.value) input.disabled = true;
+
+    // Toggle input enabled/disabled when checkbox changes
+    cb.addEventListener('change', () => { input.disabled = !cb.checked; });
+    if (!cb.checked) input.disabled = true;
+
+    container.appendChild(cb);
+    container.appendChild(label);
+    container.appendChild(input);
+
+    // "Current:" hint showing existing form value (helps user compare before filling)
+    const currentVal = currentFormValues[f.key];
+    if (currentVal) {
+      const hint = document.createElement('div');
+      hint.className = 'numista-field-current';
+      hint.textContent = `Current: ${currentVal}`;
+      hint.title = currentVal;
+      container.appendChild(hint);
+    }
+
+    // Warning text spanning all columns (e.g. "Alloy/Other — not in form options")
+    if (f.warn) {
+      const warn = document.createElement('div');
+      warn.className = 'numista-field-warn';
+      warn.textContent = f.warn;
+      container.appendChild(warn);
+    }
+  });
+};
+
+/**
+ * Show Numista results modal with search results
+ * @param {Array} results - Array of normalized Numista item data
+ * @param {boolean} directLookup - If true and single result, skip list and show field picker
+ */
+const showNumistaResults = (results, directLookup = false) => {
+  const modal = document.getElementById('numistaResultsModal');
+  const list = document.getElementById('numistaResultsList');
+  const picker = document.getElementById('numistaFieldPicker');
+  const title = document.getElementById('numistaResultsTitle');
+  const preview = document.getElementById('numistaSelectedItem');
+  if (!modal || !list || !picker) return;
+
+  selectedNumistaResult = null;
+  list.innerHTML = '';
+  picker.style.display = 'none';
+
+  if (!results || results.length === 0) {
+    title.textContent = 'No Results';
+    list.innerHTML = '<div class="numista-no-results">No matching items found on Numista.</div>';
+    list.style.display = 'block';
+    modal.style.display = 'flex';
+    return;
+  }
+
+  // Direct lookup with single result → skip to field picker
+  if (directLookup && results.length === 1) {
+    title.textContent = 'Numista Item Found';
+    list.style.display = 'none';
+    selectedNumistaResult = results[0];
+    preview.innerHTML = renderNumistaSelectedItem(results[0]);
+    renderNumistaFieldCheckboxes(results[0]);
+    picker.style.display = 'block';
+    modal.style.display = 'flex';
+    return;
+  }
+
+  // Multiple results → show selectable card list
+  title.textContent = `Numista Results (${results.length})`;
+  // Stash results on the list element for delegated click retrieval
+  list._numistaResults = results;
+  list.innerHTML = results.slice(0, 20).map((r, i) => renderNumistaResultCard(r, i)).join('');
+  list.style.display = 'flex';
+  modal.style.display = 'flex';
+};
+
+/**
+ * Fill form fields from the editable picker inputs.
+ * Reads values from the numistaFieldValue_* text inputs (user may have edited them).
+ */
+const fillFormFromNumistaResult = () => {
+  const container = document.getElementById('numistaFieldCheckboxes');
+  if (!container) return;
+
+  // Collect checked fields and their edited values from the picker inputs
+  const checkboxes = container.querySelectorAll('input[name="numistaField"]');
+  checkboxes.forEach(cb => {
+    if (!cb.checked) return;
+    const input = container.querySelector(`input[name="numistaFieldValue_${cb.value}"]`);
+    if (!input) return;
+    const val = input.value.trim();
+    if (!val) return;
+
+    switch (cb.value) {
+      case 'name': {
+        const el = elements.itemName || document.getElementById('itemName');
+        if (el) el.value = val;
+        break;
+      }
+      case 'year': {
+        const el = elements.itemYear || document.getElementById('itemYear');
+        if (el) el.value = val;
+        break;
+      }
+      case 'type': {
+        const el = elements.itemType || document.getElementById('itemType');
+        if (el) {
+          const valid = Array.from(el.options).map(o => o.value);
+          if (valid.includes(val)) el.value = val;
+        }
+        break;
+      }
+      case 'weight': {
+        const el = elements.itemWeight || document.getElementById('itemWeight');
+        const unitEl = document.getElementById('itemWeightUnit');
+        const num = parseFloat(val);
+        if (el && !isNaN(num) && num > 0) {
+          el.value = num;
+          if (unitEl) unitEl.value = 'g';
+        }
+        break;
+      }
+      case 'catalog': {
+        const el = elements.itemCatalog || document.getElementById('itemCatalog');
+        if (el) el.value = val;
+        break;
+      }
+    }
+  });
+};
+
+/**
+ * Close Numista results modal and clean up state
+ */
+const closeNumistaResultsModal = () => {
+  const modal = document.getElementById('numistaResultsModal');
+  if (modal) modal.style.display = 'none';
+  selectedNumistaResult = null;
+};
+
 // Test function for Numista API
 async function testNumistaAPI() {
   if (!catalogConfig.isNumistaEnabled()) {
@@ -948,6 +1240,9 @@ if (typeof window !== 'undefined') {
   window.recordCatalogHistory = recordCatalogHistory;
   window.loadCatalogHistory = loadCatalogHistory;
   window.saveCatalogHistory = saveCatalogHistory;
+  window.showNumistaResults = showNumistaResults;
+  window.fillFormFromNumistaResult = fillFormFromNumistaResult;
+  window.closeNumistaResultsModal = closeNumistaResultsModal;
 }
 
 // Initialize UI event handlers when DOM is ready
@@ -1036,4 +1331,81 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
+
+  // =========================================================================
+  // NUMISTA RESULTS MODAL — event wiring
+  // =========================================================================
+
+  const numistaResultsModal = document.getElementById('numistaResultsModal');
+  const numistaResultsCloseBtn = document.getElementById('numistaResultsCloseBtn');
+  const numistaFillCancelBtn = document.getElementById('numistaFillCancelBtn');
+  const numistaFillBtn = document.getElementById('numistaFillBtn');
+  const numistaResultsList = document.getElementById('numistaResultsList');
+
+  // Close button
+  if (numistaResultsCloseBtn) {
+    numistaResultsCloseBtn.addEventListener('click', closeNumistaResultsModal);
+  }
+
+  // Cancel button in field picker
+  if (numistaFillCancelBtn) {
+    numistaFillCancelBtn.addEventListener('click', closeNumistaResultsModal);
+  }
+
+  // Fill Fields button
+  if (numistaFillBtn) {
+    numistaFillBtn.addEventListener('click', function() {
+      if (selectedNumistaResult) {
+        fillFormFromNumistaResult();
+      }
+      closeNumistaResultsModal();
+    });
+  }
+
+  // Delegated click on result cards → select and show field picker
+  if (numistaResultsList) {
+    numistaResultsList.addEventListener('click', function(e) {
+      const card = e.target.closest('.numista-result-card');
+      if (!card) return;
+
+      const index = parseInt(card.dataset.resultIndex, 10);
+      const results = numistaResultsList._numistaResults;
+      if (!results || !results[index]) return;
+
+      // Highlight selected card
+      numistaResultsList.querySelectorAll('.numista-result-card').forEach(c => c.classList.remove('selected'));
+      card.classList.add('selected');
+
+      // Transition to field picker
+      selectedNumistaResult = results[index];
+      const preview = document.getElementById('numistaSelectedItem');
+      const picker = document.getElementById('numistaFieldPicker');
+      const title = document.getElementById('numistaResultsTitle');
+      if (preview) preview.innerHTML = renderNumistaSelectedItem(selectedNumistaResult);
+      renderNumistaFieldCheckboxes(selectedNumistaResult);
+      if (numistaResultsList) numistaResultsList.style.display = 'none';
+      if (picker) picker.style.display = 'block';
+      if (title) title.textContent = 'Fill Form Fields';
+    });
+  }
+
+  // Background click dismiss
+  if (numistaResultsModal) {
+    numistaResultsModal.addEventListener('click', function(e) {
+      if (e.target === numistaResultsModal) {
+        closeNumistaResultsModal();
+      }
+    });
+  }
+
+  // ESC key handler — results modal has higher z-index, check it first
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      const resultsModal = document.getElementById('numistaResultsModal');
+      if (resultsModal && resultsModal.style.display !== 'none') {
+        e.stopImmediatePropagation();
+        closeNumistaResultsModal();
+      }
+    }
+  });
 });

--- a/js/charts.js
+++ b/js/charts.js
@@ -86,6 +86,7 @@ const createPieChart = (canvas, data, title) => {
       maintainAspectRatio: false,
       plugins: {
         legend: {
+          display: false,
           position: 'bottom',
           labels: {
             color: getChartTextColor(),
@@ -167,5 +168,8 @@ const destroyCharts = () => {
     }
   });
 };
+
+// Expose generateColors globally for breakdown color-keying
+window.generateColors = generateColors;
 
 // =============================================================================

--- a/js/constants.js
+++ b/js/constants.js
@@ -212,6 +212,20 @@ const API_PROVIDERS = {
 // =============================================================================
 
 /**
+ * Cert verification lookup URLs for grading authorities.
+ * {certNumber} is replaced with the actual certification number.
+ * URLs without {certNumber} open the generic verification page.
+ *
+ * @constant {Object.<string, string>}
+ */
+const CERT_LOOKUP_URLS = {
+  PCGS: 'https://www.pcgs.com/cert/{certNumber}',
+  NGC: 'https://www.ngccoin.com/certlookup/{certNumber}/',
+  ANACS: 'https://anacs.com/verify/',
+  ICG: 'https://www.icgcoin.com/verification/',
+};
+
+/**
  * @constant {string} APP_VERSION - Application version
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
@@ -219,7 +233,7 @@ const API_PROVIDERS = {
  * Updated: 2026-02-08 - Numista API v3 integration fix
  */
 
-const APP_VERSION = "3.09.04";
+const APP_VERSION = "3.10.00";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -858,6 +872,7 @@ if (typeof window !== "undefined") {
   window.disableFeature = disableFeature;
   window.toggleFeature = toggleFeature;
   window.ALLOWED_STORAGE_KEYS = ALLOWED_STORAGE_KEYS;
+  window.CERT_LOOKUP_URLS = CERT_LOOKUP_URLS;
 }
 
 // Expose APP_VERSION globally for non-module usage

--- a/js/constants.js
+++ b/js/constants.js
@@ -219,7 +219,7 @@ const API_PROVIDERS = {
  * Updated: 2026-02-08 - Numista API v3 integration fix
  */
 
-const APP_VERSION = "3.09.02";
+const APP_VERSION = "3.09.04";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -116,7 +116,7 @@ const getAllMetalsBreakdownData = () => {
  * @param {Object} breakdown - Breakdown data object
  * @returns {DocumentFragment} DOM fragment containing the breakdown elements
  */
-const createBreakdownElements = (breakdown) => {
+const createBreakdownElements = (breakdown, colorMap = {}) => {
   const container = document.createDocumentFragment();
 
   if (Object.keys(breakdown).length === 0) {
@@ -140,6 +140,14 @@ const createBreakdownElements = (breakdown) => {
     // Header row: name + count/weight
     const header = document.createElement('div');
     header.className = 'breakdown-header';
+
+    // Color dot matching pie chart segment
+    if (colorMap[key]) {
+      const dot = document.createElement('span');
+      dot.className = 'breakdown-color-dot';
+      dot.style.backgroundColor = colorMap[key];
+      header.appendChild(dot);
+    }
 
     const label = document.createElement('span');
     label.className = 'breakdown-label';
@@ -240,9 +248,20 @@ const showDetailsModal = (metal) => {
     );
   }
 
-  // Append DOM elements for detailed breakdown
-  elements.typeBreakdown.appendChild(createBreakdownElements(leftBreakdown));
-  elements.locationBreakdown.appendChild(createBreakdownElements(rightBreakdown));
+  // Build color maps matching pie chart segment order (by insertion order)
+  const buildColorMap = (breakdown) => {
+    const keys = Object.keys(breakdown);
+    const colors = (window.generateColors || generateColors)(keys.length);
+    const map = {};
+    keys.forEach((key, i) => { map[key] = colors[i]; });
+    return map;
+  };
+  const leftColorMap = buildColorMap(leftBreakdown);
+  const rightColorMap = buildColorMap(rightBreakdown);
+
+  // Append DOM elements for detailed breakdown (with color-keyed headers)
+  elements.typeBreakdown.appendChild(createBreakdownElements(leftBreakdown, leftColorMap));
+  elements.locationBreakdown.appendChild(createBreakdownElements(rightBreakdown, rightColorMap));
 
   // Show modal
   if (window.openModalById) openModalById('detailsModal');

--- a/js/events.js
+++ b/js/events.js
@@ -212,7 +212,7 @@ const updateColumnVisibility = () => {
         "numista",
         "type",
         "metal",
-        "delete",
+        "actions",
       ],
     },
   ];
@@ -236,7 +236,7 @@ const updateColumnVisibility = () => {
     "numista",
     "collectable",
     "notes",
-    "delete",
+    "actions",
   ];
 
   allColumns.forEach((col) => {
@@ -523,11 +523,15 @@ const setupEventListeners = () => {
 
           const purchaseLocation = elements.purchaseLocation.value.trim() || (isEditing ? (existingItem.purchaseLocation || '') : '');
           const storageLocation = elements.storageLocation.value.trim() || (isEditing ? (existingItem.storageLocation || 'Unknown') : 'Unknown');
+          const serialNumber = (elements.itemSerialNumber || document.getElementById('itemSerialNumber'))?.value?.trim() || (isEditing ? (existingItem.serialNumber || '') : '');
           const notes = elements.itemNotes.value.trim() || (isEditing ? (existingItem.notes || '') : '');
           const date = elements.itemDate.value || (isEditing ? (existingItem.date || '') : todayStr());
 
           const catalog = elements.itemCatalog ? elements.itemCatalog.value.trim() : '';
           const year = (elements.itemYear || document.getElementById('itemYear'))?.value?.trim() || '';
+          const grade = (elements.itemGrade || document.getElementById('itemGrade'))?.value?.trim() || '';
+          const gradingAuthority = (elements.itemGradingAuthority || document.getElementById('itemGradingAuthority'))?.value?.trim() || '';
+          const certNumber = (elements.itemCertNumber || document.getElementById('itemCertNumber'))?.value?.trim() || '';
           const marketValueInput = elements.itemMarketValue ? elements.itemMarketValue.value.trim() : '';
           const marketValue = marketValueInput && !isNaN(parseFloat(marketValueInput))
             ? parseFloat(marketValueInput)
@@ -566,8 +570,12 @@ const setupEventListeners = () => {
               date,
               purchaseLocation,
               storageLocation,
+              serialNumber,
               notes,
-              year: year || existingItem.year || existingItem.issuedYear || '',
+              year,
+              grade,
+              gradingAuthority,
+              certNumber,
               isCollectable: false,
               numistaId: catalog,
             };
@@ -606,8 +614,12 @@ const setupEventListeners = () => {
               date,
               purchaseLocation,
               storageLocation,
+              serialNumber,
               notes,
               year,
+              grade,
+              gradingAuthority,
+              certNumber,
               spotPriceAtPurchase,
               premiumPerOz: 0,
               totalPremium: 0,
@@ -733,14 +745,15 @@ const setupEventListeners = () => {
             'Bar': 'exonumia',
             'Round': 'exonumia',
             'Note': 'banknote',
-            'Aurum': 'banknote',
+            // Aurum omitted — Goldbacks are "Embedded-asset notes" on Numista,
+            // which isn't a valid API category. Uncategorized search finds them.
           };
 
           try {
             if (catalogVal) {
               // Direct N# lookup → single result
               const result = await catalogAPI.lookupItem(catalogVal);
-              showNumistaResults(result ? [result] : [], true);
+              showNumistaResults(result ? [result] : [], true, catalogVal);
             } else {
               // Name search → multiple results with smart category/metal filtering
               const typeVal = (elements.itemType || document.getElementById('itemType'))?.value || '';
@@ -755,7 +768,7 @@ const setupEventListeners = () => {
                 ? `${metalVal} ${nameVal}` : nameVal;
 
               const results = await catalogAPI.searchItems(searchQuery, searchFilters);
-              showNumistaResults(results, false);
+              showNumistaResults(results, false, searchQuery);
             }
           } catch (error) {
             console.error('Numista search error:', error);

--- a/js/events.js
+++ b/js/events.js
@@ -527,6 +527,7 @@ const setupEventListeners = () => {
           const date = elements.itemDate.value || (isEditing ? (existingItem.date || '') : todayStr());
 
           const catalog = elements.itemCatalog ? elements.itemCatalog.value.trim() : '';
+          const year = (elements.itemYear || document.getElementById('itemYear'))?.value?.trim() || '';
           const marketValueInput = elements.itemMarketValue ? elements.itemMarketValue.value.trim() : '';
           const marketValue = marketValueInput && !isNaN(parseFloat(marketValueInput))
             ? parseFloat(marketValueInput)
@@ -566,6 +567,7 @@ const setupEventListeners = () => {
               purchaseLocation,
               storageLocation,
               notes,
+              year: year || existingItem.year || existingItem.issuedYear || '',
               isCollectable: false,
               numistaId: catalog,
             };
@@ -605,6 +607,7 @@ const setupEventListeners = () => {
               purchaseLocation,
               storageLocation,
               notes,
+              year,
               spotPriceAtPurchase,
               premiumPerOz: 0,
               totalPremium: 0,
@@ -697,6 +700,72 @@ const setupEventListeners = () => {
           editingChangeLogIndex = null;
         },
         "Item modal close button",
+      );
+    }
+
+    // SEARCH NUMISTA BUTTON — lookup by N# or search by name
+    if (elements.searchNumistaBtn) {
+      safeAttachListener(
+        elements.searchNumistaBtn,
+        "click",
+        async () => {
+          const catalogVal = (elements.itemCatalog || document.getElementById('itemCatalog'))?.value.trim() || '';
+          const nameVal = (elements.itemName || document.getElementById('itemName'))?.value.trim() || '';
+
+          if (!catalogVal && !nameVal) {
+            alert('Enter a Name or Catalog N# to search.');
+            return;
+          }
+
+          if (!catalogAPI || !catalogAPI.activeProvider) {
+            alert('Configure Numista API key in Settings first.');
+            return;
+          }
+
+          const btn = elements.searchNumistaBtn;
+          const originalText = btn.textContent;
+          btn.textContent = 'Searching...';
+          btn.disabled = true;
+
+          // Type → Numista category mapping for smarter search results
+          const TYPE_TO_NUMISTA_CATEGORY = {
+            'Coin': 'coin',
+            'Bar': 'exonumia',
+            'Round': 'exonumia',
+            'Note': 'banknote',
+            'Aurum': 'banknote',
+          };
+
+          try {
+            if (catalogVal) {
+              // Direct N# lookup → single result
+              const result = await catalogAPI.lookupItem(catalogVal);
+              showNumistaResults(result ? [result] : [], true);
+            } else {
+              // Name search → multiple results with smart category/metal filtering
+              const typeVal = (elements.itemType || document.getElementById('itemType'))?.value || '';
+              const metalVal = (elements.itemMetal || document.getElementById('itemMetal'))?.value || '';
+
+              const searchFilters = { limit: 20 };
+              const numistaCategory = TYPE_TO_NUMISTA_CATEGORY[typeVal];
+              if (numistaCategory) searchFilters.category = numistaCategory;
+
+              // Prepend metal to query for better results (avoid doubling e.g. "Silver Silver Eagle")
+              const searchQuery = metalVal && !nameVal.toLowerCase().includes(metalVal.toLowerCase())
+                ? `${metalVal} ${nameVal}` : nameVal;
+
+              const results = await catalogAPI.searchItems(searchQuery, searchFilters);
+              showNumistaResults(results, false);
+            }
+          } catch (error) {
+            console.error('Numista search error:', error);
+            alert('Search failed: ' + error.message);
+          } finally {
+            btn.textContent = originalText;
+            btn.disabled = false;
+          }
+        },
+        "Search Numista button",
       );
     }
 

--- a/js/init.js
+++ b/js/init.js
@@ -108,6 +108,8 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.itemSpotPrice = safeGetElement("itemSpotPrice");
     elements.itemCollectable = safeGetElement("itemCollectable");
     elements.itemCatalog = safeGetElement("itemCatalog");
+    elements.itemYear = safeGetElement("itemYear");
+    elements.searchNumistaBtn = safeGetElement("searchNumistaBtn");
 
     // Header buttons - CRITICAL
     debugLog("Phase 2: Initializing header buttons...");

--- a/js/init.js
+++ b/js/init.js
@@ -109,6 +109,9 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.itemCollectable = safeGetElement("itemCollectable");
     elements.itemCatalog = safeGetElement("itemCatalog");
     elements.itemYear = safeGetElement("itemYear");
+    elements.itemGrade = safeGetElement("itemGrade");
+    elements.itemGradingAuthority = safeGetElement("itemGradingAuthority");
+    elements.itemCertNumber = safeGetElement("itemCertNumber");
     elements.searchNumistaBtn = safeGetElement("searchNumistaBtn");
 
     // Header buttons - CRITICAL
@@ -393,7 +396,7 @@ document.addEventListener("DOMContentLoaded", () => {
         setupColumnResizing();
         
         // Setup Edit header toggle functionality
-        const editHeader = document.querySelector('th[data-column="edit"]');
+        const editHeader = document.querySelector('th[data-column="actions"]');
         if (editHeader) {
           editHeader.style.cursor = 'pointer';
           editHeader.addEventListener('click', (event) => {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -55,6 +55,11 @@ const createBackupZip = async () => {
         premiumPerOz: item.premiumPerOz,
         totalPremium: item.totalPremium,
         numistaId: item.numistaId,
+        year: item.year || '',
+        grade: item.grade || '',
+        gradingAuthority: item.gradingAuthority || '',
+        certNumber: item.certNumber || '',
+        serialNumber: item.serialNumber || '',
         serial: item.serial
       }))
     };
@@ -88,7 +93,7 @@ const createBackupZip = async () => {
     const csvHeaders = [
       "Date", "Metal", "Type", "Name", "Qty", "Weight(oz)",
       "Purchase Price", "Melt Value", "Retail Price", "Gain/Loss",
-      "Purchase Location", "N#", "Notes"
+      "Purchase Location", "N#", "Serial Number", "Notes"
     ];
     const sortedInventory = sortInventoryByDateNewestFirst();
     const csvRows = [];
@@ -115,6 +120,7 @@ const createBackupZip = async () => {
         gainLoss !== null ? formatCurrency(gainLoss) : '—',
         item.purchaseLocation,
         item.numistaId || '',
+        item.serialNumber || '',
         item.notes || ''
       ]);
     }
@@ -144,6 +150,7 @@ const createBackupZip = async () => {
         notes: item.notes,
         isCollectable: item.isCollectable,
         numistaId: item.numistaId,
+        serialNumber: item.serialNumber || '',
         serial: item.serial
       }));
       zip.file('sample_data.json', JSON.stringify(sampleData, null, 2));
@@ -462,6 +469,9 @@ const loadInventory = () => {
         notes: item.notes || "",
         marketValue: item.marketValue || 0,
         year: item.year || item.issuedYear || "",
+        grade: item.grade || '',
+        gradingAuthority: item.gradingAuthority || '',
+        certNumber: item.certNumber || '',
         spotPriceAtPurchase: spotPrice,
         premiumPerOz,
         totalPremium,
@@ -478,6 +488,9 @@ const loadInventory = () => {
         notes: item.notes || "",
         marketValue: item.marketValue || 0,
         year: item.year || item.issuedYear || "",
+        grade: item.grade || '',
+        gradingAuthority: item.gradingAuthority || '',
+        certNumber: item.certNumber || '',
         isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
         composition: item.composition || item.metal || ""
       };
@@ -949,6 +962,28 @@ const renderTable = () => {
       const numistaId = item.numistaId || (typeof catalogManager !== 'undefined'
         && catalogManager.getCatalogId ? catalogManager.getCatalogId(item.serial) : null);
 
+      // Build grade tag (after N# tag in Name cell)
+      const gradeTag = item.grade ? (() => {
+        const authority = item.gradingAuthority || '';
+        const certNum = item.certNumber || '';
+        const isClickable = !!certNum;
+        let tooltip;
+        if (authority && certNum) {
+          tooltip = `${authority} Cert #${certNum} \u2014 Click to verify`;
+        } else if (authority) {
+          tooltip = `Graded by ${authority}: ${item.grade}`;
+        } else {
+          tooltip = `Grade: ${item.grade}`;
+        }
+        const attrs = [
+          authority ? `data-authority="${escapeAttribute(authority)}"` : '',
+          isClickable ? 'data-clickable="true"' : '',
+          certNum ? `data-cert-number="${escapeAttribute(certNum)}"` : '',
+          isClickable ? 'tabindex="0" role="button"' : '',
+        ].filter(Boolean).join(' ');
+        return `<span class="grade-tag" ${attrs} title="${escapeAttribute(tooltip)}">${sanitizeHtml(item.grade)}</span>`;
+      })() : '';
+
       // Format computed displays
       const meltDisplay = currentSpot > 0 ? formatCurrency(meltValue) : '—';
       const retailDisplay = currentSpot > 0 || isManualRetail ? formatCurrency(retailTotal) : '—';
@@ -969,18 +1004,18 @@ const renderTable = () => {
                data-coin-name="${escapeAttribute(item.name)}"
                title="View N#${escapeAttribute(String(numistaId))} on Numista"
                tabindex="0" role="button">N#${sanitizeHtml(String(numistaId))}</span>`
-          : ''}
+          : ''}${gradeTag}
       </td>
       <td class="shrink" data-column="qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
       <td class="shrink" data-column="weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight), item.weight < 1 ? 'Grams (g)' : 'Troy ounces (ozt)')}</td>
       <td class="shrink" data-column="purchasePrice" title="Purchase Price (USD) - Click to search eBay active listings" style="color: var(--text-primary);">
-        <a href="#" class="ebay-buy-link ebay-price-link" data-search="${sanitizeHtml(item.metal + ' ' + item.name)}" title="Search eBay active listings for ${sanitizeHtml(item.metal)} ${sanitizeHtml(item.name)}">
+        <a href="#" class="ebay-buy-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? ' ' + item.year : '') + ' ' + item.name)}" title="Search eBay active listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${formatCurrency(purchasePrice)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>
       </td>
       <td class="shrink" data-column="meltValue" title="Melt Value (USD)" style="color: var(--text-primary);">${meltDisplay}</td>
       <td class="shrink ${isManualRetail ? 'retail-confirmed' : 'retail-estimated'}" data-column="retailPrice" title="${isManualRetail ? 'Manual retail price (confirmed)' : 'Estimated — defaults to melt value'} - Click to search eBay sold listings">
-        <a href="#" class="ebay-sold-link ebay-price-link" data-search="${sanitizeHtml(item.metal + ' ' + item.name)}" title="Search eBay sold listings for ${sanitizeHtml(item.metal)} ${sanitizeHtml(item.name)}">
+        <a href="#" class="ebay-sold-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? ' ' + item.year : '') + ' ' + item.name)}" title="Search eBay sold listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${retailDisplay} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>
       </td>
@@ -988,15 +1023,17 @@ const renderTable = () => {
       <td class="shrink" data-column="purchaseLocation">
         ${formatPurchaseLocation(item.purchaseLocation)}
       </td>
-      <td class="icon-col" data-column="edit"><button class="icon-btn action-icon edit-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit item">
-        <svg class="icon-svg edit-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/></svg>
-      </button></td>
-      <td class="icon-col" data-column="duplicate"><button class="icon-btn action-icon" role="button" tabindex="0" onclick="duplicateItem(${originalIdx})" aria-label="Duplicate ${sanitizeHtml(item.name)}" title="Duplicate item">
-        <svg class="icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg>
-      </button></td>
-      <td class="icon-col" data-column="delete"><button class="icon-btn action-icon danger" role="button" tabindex="0" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">
-        <svg class="icon-svg delete-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12v13a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7zm3-4h6l1 1h4v2H3V4h4l1-1z"/></svg>
-      </button></td>
+      <td class="icon-col actions-cell" data-column="actions"><div class="actions-row">
+        <button class="icon-btn action-icon edit-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit item">
+          <svg class="icon-svg edit-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/></svg>
+        </button>
+        <button class="icon-btn action-icon" role="button" tabindex="0" onclick="duplicateItem(${originalIdx})" aria-label="Duplicate ${sanitizeHtml(item.name)}" title="Duplicate item">
+          <svg class="icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg>
+        </button>
+        <button class="icon-btn action-icon danger" role="button" tabindex="0" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">
+          <svg class="icon-svg delete-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12v13a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7zm3-4h6l1 1h4v2H3V4h4l1-1z"/></svg>
+        </button>
+      </div></td>
       </tr>
       `);
     }
@@ -1004,7 +1041,7 @@ const renderTable = () => {
     const visibleCount = endIndex - startIndex;
     const placeholders = Array.from(
       { length: Math.max(0, itemsPerPage - visibleCount) },
-      () => '<tr><td class="shrink" colspan="14">&nbsp;</td></tr>'
+      () => '<tr><td class="shrink" colspan="12">&nbsp;</td></tr>'
     );
 
     // Find tbody element directly if cached version fails
@@ -1242,10 +1279,14 @@ const editItem = (idx, logIdx = null) => {
   if (elements.itemMarketValue) elements.itemMarketValue.value = item.marketValue > 0 ? item.marketValue : '';
   elements.purchaseLocation.value = item.purchaseLocation || '';
   elements.storageLocation.value = item.storageLocation && item.storageLocation !== 'Unknown' ? item.storageLocation : '';
+  if (elements.itemSerialNumber) elements.itemSerialNumber.value = item.serialNumber || '';
   if (elements.itemNotes) elements.itemNotes.value = item.notes || '';
   elements.itemDate.value = item.date;
   if (elements.itemCatalog) elements.itemCatalog.value = item.numistaId || '';
   if (elements.itemYear) elements.itemYear.value = item.year || item.issuedYear || '';
+  if (elements.itemGrade) elements.itemGrade.value = item.grade || '';
+  if (elements.itemGradingAuthority) elements.itemGradingAuthority.value = item.gradingAuthority || '';
+  if (elements.itemCertNumber) elements.itemCertNumber.value = item.certNumber || '';
   if (elements.itemSerial) elements.itemSerial.value = item.serial;
 
   // Show/hide Undo button based on changelog context
@@ -1297,10 +1338,14 @@ const duplicateItem = (idx) => {
   if (elements.itemMarketValue) elements.itemMarketValue.value = item.marketValue > 0 ? item.marketValue : '';
   elements.purchaseLocation.value = item.purchaseLocation || '';
   elements.storageLocation.value = item.storageLocation && item.storageLocation !== 'Unknown' ? item.storageLocation : '';
+  if (elements.itemSerialNumber) elements.itemSerialNumber.value = item.serialNumber || '';
   if (elements.itemNotes) elements.itemNotes.value = item.notes || '';
   elements.itemDate.value = todayStr(); // Default to today
   if (elements.itemCatalog) elements.itemCatalog.value = item.numistaId || '';
   if (elements.itemYear) elements.itemYear.value = item.year || item.issuedYear || '';
+  if (elements.itemGrade) elements.itemGrade.value = item.grade || '';
+  if (elements.itemGradingAuthority) elements.itemGradingAuthority.value = item.gradingAuthority || '';
+  if (elements.itemCertNumber) elements.itemCertNumber.value = item.certNumber || '';
   if (elements.itemSerial) elements.itemSerial.value = ''; // Serial should be unique per item
 
   // Open unified modal
@@ -1421,6 +1466,9 @@ const importCsv = (file, override = false) => {
           const storageLocation = row['Storage Location'] || '';
           const notes = row['Notes'] || '';
           const year = row['Year'] || row['year'] || row['issuedYear'] || '';
+          const grade = row['Grade'] || row['grade'] || '';
+          const gradingAuthority = row['Grading Authority'] || row['gradingAuthority'] || row['Authority'] || '';
+          const certNumber = (row['Cert #'] || row['certNumber'] || row['Cert Number'] || '').toString();
           const date = parseDate(row['Date']);
 
           // Parse retail price from CSV (backward-compatible with legacy columns)
@@ -1448,6 +1496,7 @@ const importCsv = (file, override = false) => {
           const numistaRaw = (row['N#'] || row['Numista #'] || row['numistaId'] || '').toString();
           const numistaMatch = numistaRaw.match(/\d+/);
           const numistaId = numistaMatch ? numistaMatch[0] : '';
+          const serialNumber = row['Serial Number'] || row['serialNumber'] || '';
           const serial = row['Serial'] || row['serial'] || getNextSerial();
 
           addCompositionOption(composition);
@@ -1466,11 +1515,15 @@ const importCsv = (file, override = false) => {
             storageLocation,
             notes,
             year,
+            grade,
+            gradingAuthority,
+            certNumber,
             spotPriceAtPurchase,
             premiumPerOz,
             totalPremium,
             isCollectable: false,
             numistaId,
+            serialNumber,
             serial
           });
 
@@ -1715,6 +1768,9 @@ const importNumistaCsv = (file, override = false) => {
             isCollectable,
             numistaId,
             year: issuedYear,
+            grade: '',
+            gradingAuthority: '',
+            certNumber: '',
             serial
           });
 
@@ -1896,7 +1952,7 @@ const exportCsv = () => {
   const headers = [
     "Date","Metal","Type","Name","Year","Qty","Weight(oz)",
     "Purchase Price","Melt Value","Retail Price","Gain/Loss",
-    "Purchase Location","N#","Notes"
+    "Purchase Location","N#","Grade","Grading Authority","Cert #","Serial Number","Notes"
   ];
 
   const sortedInventory = sortInventoryByDateNewestFirst();
@@ -1926,6 +1982,10 @@ const exportCsv = () => {
       gainLoss !== null ? formatCurrency(gainLoss) : '—',
       i.purchaseLocation,
       i.numistaId || '',
+      i.grade || '',
+      i.gradingAuthority || '',
+      i.certNumber || '',
+      i.serialNumber || '',
       i.notes || ''
     ]);
   }
@@ -2001,6 +2061,10 @@ const importJson = (file, override = false) => {
         const purchaseLocation = raw.purchaseLocation || '';
         const storageLocation = raw.storageLocation || 'Unknown';
         const notes = raw.notes || '';
+        const year = (raw.year || raw.issuedYear || '').toString().trim();
+        const grade = (raw.grade || '').toString().trim();
+        const gradingAuthority = (raw.gradingAuthority || raw.authority || '').toString().trim();
+        const certNumber = (raw.certNumber || '').toString().trim();
         const date = parseDate(raw.date);
 
         // Parse marketValue (retail price), backward-compatible with legacy fields
@@ -2042,6 +2106,10 @@ const importJson = (file, override = false) => {
           totalPremium,
           isCollectable: false,
           numistaId,
+          year,
+          grade,
+          gradingAuthority,
+          certNumber,
           serial
         });
 
@@ -2161,6 +2229,10 @@ const exportJson = () => {
     storageLocation: item.storageLocation,
     notes: item.notes,
     numistaId: item.numistaId,
+    grade: item.grade || '',
+    gradingAuthority: item.gradingAuthority || '',
+    certNumber: item.certNumber || '',
+    serialNumber: item.serialNumber || '',
     serial: item.serial,
     // Legacy fields preserved for backward compatibility
     spotPriceAtPurchase: item.spotPriceAtPurchase,
@@ -2223,6 +2295,9 @@ const exportPdf = () => {
       gainLoss !== null ? formatCurrency(gainLoss) : '—',
       item.purchaseLocation,
       item.numistaId || '',
+      item.grade || '',
+      item.gradingAuthority || '',
+      item.certNumber || '',
       item.notes || ''
     ];
   });
@@ -2230,7 +2305,7 @@ const exportPdf = () => {
   // Add table
   doc.autoTable({
     head: [['Date', 'Metal', 'Type', 'Name', 'Qty', 'Weight(oz)', 'Purchase',
-            'Melt Value', 'Retail', 'Gain/Loss', 'Location', 'N#', 'Notes']],
+            'Melt Value', 'Retail', 'Gain/Loss', 'Location', 'N#', 'Grade', 'Auth', 'Cert#', 'Notes']],
     body: tableData,
     startY: 30,
     theme: 'striped',
@@ -2319,6 +2394,26 @@ document.addEventListener('click', (e) => {
     const coinName = numistaTag.dataset.coinName || '';
     if (nId && typeof openNumistaModal === 'function') {
       openNumistaModal(nId, coinName);
+    }
+    return;
+  }
+
+  // Grade tag click → open cert verification URL
+  const gradeTag = e.target.closest('.grade-tag[data-clickable="true"]');
+  if (gradeTag) {
+    e.preventDefault();
+    e.stopPropagation();
+    const authority = gradeTag.dataset.authority || '';
+    const certNum = gradeTag.dataset.certNumber || '';
+    if (authority && typeof CERT_LOOKUP_URLS !== 'undefined' && CERT_LOOKUP_URLS[authority]) {
+      const url = CERT_LOOKUP_URLS[authority].replace('{certNumber}', encodeURIComponent(certNum));
+      const popup = window.open(url, `cert_${authority}_${certNum || Date.now()}`,
+        'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
+      if (!popup) {
+        alert(`Popup blocked! Please allow popups or manually visit:\n${url}`);
+      } else {
+        popup.focus();
+      }
     }
     return;
   }

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -75,9 +75,16 @@ const sortInventory = (data = inventory) => {
     }
     // String comparison for everything else
     else {
-      return sortDirection === 'asc' 
-        ? String(valA).localeCompare(String(valB)) 
+      const cmp = sortDirection === 'asc'
+        ? String(valA).localeCompare(String(valB))
         : String(valB).localeCompare(String(valA));
+      // Secondary sort by year when names are equal
+      if (cmp === 0 && sortColumn === 3) {
+        const yearA = parseInt(a.year, 10) || 0;
+        const yearB = parseInt(b.year, 10) || 0;
+        return sortDirection === 'asc' ? yearA - yearB : yearB - yearA;
+      }
+      return cmp;
     }
   });
 };

--- a/js/state.js
+++ b/js/state.js
@@ -62,12 +62,16 @@ const elements = {
   dateField: null,
   purchaseLocation: null,
   storageLocation: null,
+  itemSerialNumber: null,
   itemNotes: null,
   itemDate: null,
   itemSpotPrice: null,
   itemCollectable: null,
   itemCatalog: null,
   itemYear: null,
+  itemGrade: null,
+  itemGradingAuthority: null,
+  itemCertNumber: null,
   searchNumistaBtn: null,
 
   // Spot price sync icons (per-metal)

--- a/js/state.js
+++ b/js/state.js
@@ -67,6 +67,8 @@ const elements = {
   itemSpotPrice: null,
   itemCollectable: null,
   itemCatalog: null,
+  itemYear: null,
+  searchNumistaBtn: null,
 
   // Spot price sync icons (per-metal)
   syncIconSilver: null,

--- a/js/utils.js
+++ b/js/utils.js
@@ -626,7 +626,7 @@ const cleanString = (str = "") =>
     .replace(/<[^>]*>/g, "")
     .normalize("NFD")
     .replace(/\p{Diacritic}/gu, "")
-    .replace(/[\u0000-\u001F\u007F'\"]/g, "")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
     .replace(/\s+/g, " ")
     .trim();
 
@@ -641,11 +641,10 @@ const sanitizeObjectFields = (obj) => {
   for (const key of Object.keys(cleaned)) {
     if (typeof cleaned[key] === "string" && key !== 'notes') {
       const allowHyphen = key === 'date';
-      const allowSlash = key === 'name';
       cleaned[key] =
-        key === 'purchaseLocation'
+        (key === 'name' || key === 'purchaseLocation' || key === 'year')
           ? cleanString(cleaned[key])
-          : stripNonAlphanumeric(cleaned[key], { allowHyphen, allowSlash });
+          : stripNonAlphanumeric(cleaned[key], { allowHyphen });
     }
   }
   return cleaned;
@@ -883,7 +882,7 @@ const sanitizeImportedItem = (item) => {
       .replace(/<[^>]*>/g, '')
       .normalize('NFD')
       .replace(/\p{Diacritic}/gu, '')
-      .replace(/[\u0000-\u0008\u000B-\u001F\u007F'\"]/g, '')
+      .replace(/[\u0000-\u0008\u000B-\u001F\u007F]/g, '')
       .replace(/\r\n?/g, '\n')
       .replace(/[ \t]+/g, ' ')
       .replace(/ *\n */g, '\n')

--- a/js/utils.js
+++ b/js/utils.js
@@ -427,10 +427,10 @@ function parseDate(dateStr) {
 }
 
 /**
- * Formats a date string into Month Day, Year format
+ * Formats a date string into compact MM/DD/YY format
  *
- * @param {string} dateStr - Date in any parseable format
- * @returns {string} Formatted date (e.g., "Jan 1, 1969")
+ * @param {string} dateStr - Date in YYYY-MM-DD format
+ * @returns {string} Formatted date (e.g., "1/1/69")
  */
 const formatDisplayDate = (dateStr) => {
   if (!dateStr || dateStr === '—' || dateStr === 'Unknown') return '—';
@@ -439,14 +439,13 @@ const formatDisplayDate = (dateStr) => {
   if (parts.length !== 3) return '—';
 
   const year = parseInt(parts[0], 10);
-  const month = parseInt(parts[1], 10) - 1;
+  const month = parseInt(parts[1], 10);
   const day = parseInt(parts[2], 10);
 
-  if (isNaN(year) || isNaN(month) || isNaN(day) || month < 0 || month > 11) return '—';
+  if (isNaN(year) || isNaN(month) || isNaN(day) || month < 1 || month > 12) return '—';
 
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  return `${months[month]} ${day}, ${year}`;
+  const yy = String(year).slice(-2);
+  return `${month}/${day}/${yy}`;
 };
 
 /**
@@ -642,7 +641,7 @@ const sanitizeObjectFields = (obj) => {
     if (typeof cleaned[key] === "string" && key !== 'notes') {
       const allowHyphen = key === 'date';
       cleaned[key] =
-        (key === 'name' || key === 'purchaseLocation' || key === 'year')
+        (key === 'name' || key === 'purchaseLocation' || key === 'year' || key === 'grade' || key === 'gradingAuthority' || key === 'certNumber')
           ? cleanString(cleaned[key])
           : stripNonAlphanumeric(cleaned[key], { allowHyphen });
     }
@@ -2640,9 +2639,22 @@ function openEbaySearch(searchTerm) {
   openEbaySoldSearch(searchTerm);
 }
 
+/**
+ * Strips search-operator characters from a search term for use in external URLs.
+ * Removes quotes, parentheses, and backslashes that act as search operators on eBay.
+ * @param {string} term - Raw search term (may contain user-entered punctuation)
+ * @returns {string} Cleaned term safe for external search queries
+ */
+function cleanSearchTerm(term) {
+  return term
+    .replace(/["'()\\]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function openEbayBuySearch(searchTerm) {
   if (!searchTerm) return;
-  const cleanTerm = searchTerm.trim().replace(/\s+/g, ' ');
+  const cleanTerm = cleanSearchTerm(searchTerm);
   const encodedTerm = encodeURIComponent(cleanTerm);
   // eBay active listings URL — items currently for sale, sorted by best match
   const ebayUrl = `https://www.ebay.com/sch/i.html?_from=R40&_nkw=${encodedTerm}&_sacat=0&LH_BIN=1&_sop=12`;
@@ -2651,7 +2663,7 @@ function openEbayBuySearch(searchTerm) {
 
 function openEbaySoldSearch(searchTerm) {
   if (!searchTerm) return;
-  const cleanTerm = searchTerm.trim().replace(/\s+/g, ' ');
+  const cleanTerm = cleanSearchTerm(searchTerm);
   const encodedTerm = encodeURIComponent(cleanTerm);
   // eBay sold listings URL — completed sales, sorted by most recent
   const ebayUrl = `https://www.ebay.com/sch/i.html?_from=R40&_nkw=${encodedTerm}&_sacat=0&LH_Sold=1&LH_Complete=1&_sop=13`;
@@ -2674,6 +2686,7 @@ if (typeof window !== 'undefined') {
   window.openEbaySearch = openEbaySearch;
   window.openEbayBuySearch = openEbayBuySearch;
   window.openEbaySoldSearch = openEbaySoldSearch;
+  window.cleanSearchTerm = cleanSearchTerm;
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,20 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.10.00": `
+      <li><strong>Serial # field</strong>: New optional Serial Number input for bars and notes with physical serial numbers. Included in all CSV/JSON/ZIP exports and imports</li>
+      <li><strong>Numista Aurum fix</strong>: Goldback / Aurum items now return results from Numista search (removed incorrect "banknote" category filter)</li>
+      <li><strong>Enhanced Numista no-results</strong>: When Numista search returns nothing, a retry search box and quick-pick list of popular bullion items appear instead of a dead-end</li>
+      <li><strong>Source column rename</strong>: "Location" column header renamed to "Source" with storefront icon for clarity</li>
+      <li><strong>Year/Grade/N# filter chips</strong>: Year, Grade, and Numista ID values now appear as clickable filter chips in the chip bar</li>
+      <li><strong>Year sort tiebreaker</strong>: Items with identical names now sub-sort by Year when sorting the Name column</li>
+      <li><strong>eBay search year</strong>: Year is now included in eBay search URLs for more precise results</li>
+    `,
+    "3.09.05": `
+      <li><strong>Grade, Authority & Cert #</strong>: New optional grading fields — Grade dropdown (AG through PF-70), Grading Authority (PCGS/NGC/ANACS/ICG), and Cert # input. Color-coded grade tags on table Name cell</li>
+      <li><strong>Cert verification</strong>: Grade tags with cert numbers are clickable — opens the grading service's cert lookup page in a popup window</li>
+      <li><strong>eBay search fix</strong>: Item names with quotes or parentheses no longer produce broken eBay search results</li>
+    `,
     "3.09.04": `
       <li><strong>Year field</strong>: New optional Year field in add/edit form with inline year badge on inventory table (before N# tag). Numista picker fills Year instead of Metal</li>
       <li><strong>Form restructure</strong>: Name wider with Year beside it; purchase fields grouped: Date | Price, Location | Retail Price</li>

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,15 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.09.04": `
+      <li><strong>Year field</strong>: New optional Year field in add/edit form with inline year badge on inventory table (before N# tag). Numista picker fills Year instead of Metal</li>
+      <li><strong>Form restructure</strong>: Name wider with Year beside it; purchase fields grouped: Date | Price, Location | Retail Price</li>
+      <li><strong>Year in import/export</strong>: CSV and JSON exports include Year; imports read Year column; existing <code>issuedYear</code> data auto-migrates</li>
+    `,
+    "3.09.03": `
+      <li><strong>Numista field picker fix</strong>: Replaced broken fieldset+flexbox with CSS Grid — checkboxes, labels, and inputs now align correctly across all browsers</li>
+      <li><strong>Smart category search</strong>: Numista search maps your Type selection to API categories (Coin→coin, Bar/Round→exonumia, Note/Aurum→banknote) and prepends Metal to the query when not already present</li>
+    `,
     "3.09.02": `
       <li><strong>Numista API v3 fix</strong>: Corrected base URL (<code>/v3</code>), endpoint paths (<code>/types</code>), auth header (<code>Numista-API-Key</code>), query parameters (<code>count</code>, <code>issuer</code>, <code>category</code>), response parsing (<code>data.types</code>), and field mapping (<code>min_year</code>/<code>max_year</code>, <code>issuer.name</code>, <code>size</code>, <code>category</code>, <code>obverse_thumbnail</code>, <code>comments</code>, <code>value.numeric_value</code>) — 7 bugs total</li>
       <li><strong>localStorage whitelist fix</strong>: Added <code>staktrakr.catalog.cache</code> and <code>staktrakr.catalog.settings</code> to the allowed storage keys — without these, <code>cleanupStorage()</code> deleted catalog data on every page load</li>


### PR DESCRIPTION
## Summary

- **Serial # field**: New optional Serial Number input for bars/notes with physical serial numbers — wired into all CSV/JSON/ZIP/PDF exports and imports
- **Numista Aurum fix**: Goldback/Aurum items now return results (removed incorrect `banknote` category filter)
- **Enhanced Numista no-results**: Retry search box + curated quick-pick list of popular bullion items when no results found
- **Source column rename**: "Location" → "Source" with storefront icon
- **Year/Grade/N# filter chips**: New clickable chips in the filter bar for Year, Grade, and Numista ID values
- **Year sort tiebreaker**: Name column sub-sorts by Year for identical names
- **eBay search improvements**: Year included in URLs; fixed attribute escaping for names with double quotes
- **Color-keyed pie charts**: Removed redundant Chart.js legends from detail modal; section headers now have colored dots matching their pie slice

## Test plan

- [ ] Add/edit item with Serial # — verify it saves and persists across page reload
- [ ] Export CSV/JSON/ZIP — verify Serial Number column present and populated
- [ ] Import CSV with "Serial Number" column — verify values load correctly
- [ ] Search Numista with Type=Aurum (Goldback) — should return results
- [ ] Search Numista for nonsense term — retry box + popular picks should appear
- [ ] Verify filter chips appear for Year, Grade, and N# values (need 3+ items)
- [ ] Sort by Name column — items with same name should sub-sort by Year
- [ ] Click eBay link on item with year — URL should include year
- [ ] Open detail breakdown modal — pie charts have no legend; section headers have colored dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)