### PR TITLE
Fix: Gain/Loss and Source columns not sorting (v3.10.00)

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -102,8 +102,8 @@ const setupColumnResizing = () => {
       }
     }
 
-    // Skip adding resize handles to action columns (edit/notes/delete)
-    if (index >= headers.length - 3) return;
+    // Skip adding resize handle to the Actions column (last column)
+    if (index >= headers.length - 1) return;
 
     const resizeHandle = document.createElement("div");
     resizeHandle.className = "resize-handle";
@@ -445,8 +445,8 @@ const setupEventListeners = () => {
     if (inventoryTable) {
       const headers = inventoryTable.querySelectorAll("th");
       headers.forEach((header, index) => {
-        // Skip action columns (edit/notes/delete)
-        if (index >= headers.length - 3) {
+        // Skip the Actions column (last column)
+        if (index >= headers.length - 1) {
           return;
         }
 


### PR DESCRIPTION
## Summary

- **Gain/Loss column** and **Source column** were not responding to sort clicks or column resizing
- Root cause: skip guard used `headers.length - 3` from when Edit/Notes/Delete were 3 separate `<th>` columns — after merging into a single Actions column, this incorrectly skipped the last 3 data columns instead of just 1
- Fixed both the sort-click handler (line 449) and the resize-handle setup (line 106) to use `headers.length - 1`

## Test plan

- [ ] Click Gain/Loss header — should sort ascending/descending
- [ ] Click Source header — should sort ascending/descending
- [ ] Drag resize handle on Gain/Loss column — should resize
- [ ] Drag resize handle on Source column — should resize
- [ ] Verify Actions column still has no sort or resize behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)