### PR TITLE
v3.12.01: Portal view with sticky headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.01] - 2026-02-08
+
+### Fixed — Sticky header
+
+- **Sticky header fix**: Column headers now correctly pin at the top of the scrollable table during vertical scroll. Removed inline `position: relative` set by column-resize JS that overrode CSS `position: sticky` on all non-Actions headers
+- **Scroll container fallback**: Portal scroll container now has a CSS `max-height: 70vh` fallback so sticky headers work even before JS measures exact row heights
+- **Specificity fixes**: Removed `position: relative` from `th[data-column="purchasePrice"]` and `th.icon-col` CSS rules that outranked the sticky rule
+- **Overflow fix**: `.table-section` now uses `overflow: visible` to prevent base `section{overflow:hidden}` from creating a competing scroll context
+
+---
+
+## [3.12.00] - 2026-02-08
+
+### Feature — Portal View (Scrollable Table)
+
+#### Added
+
+- **Portal view**: Inventory table now renders all items in a scrollable container with sticky column headers — replaces slice-based pagination
+- **Visible rows control**: Dropdown (10 / 15 / 25 / 50 / 100) sets the viewport height of the scrollable table; users scroll to see remaining items
+- **Sticky headers**: Column headers stay pinned at the top during vertical scroll via CSS `position: sticky`
+
+#### Changed
+
+- **"Items per page" → "Visible rows"**: Label updated in both the table footer dropdown and the Settings modal
+- **Table footer simplified**: Item count + visible-rows dropdown only; pagination bar (first/prev/1/2/3.../next/last) removed entirely
+
+#### Removed
+
+- **Pagination controls**: `calculateTotalPages()`, `renderPagination()`, `goToPage()` functions removed from `pagination.js`
+- **Placeholder rows**: Empty padding rows no longer rendered to maintain fixed table height
+- **`currentPage` state**: Page tracking variable and all associated resets removed from state, events, search, filters, and settings modules
+- **Pagination CSS**: All `.pagination-*` rules and responsive overrides deleted
+
+---
+
+## [3.11.00] - 2026-02-08
+
+### Feature — Unified Settings Modal
+
+#### Added
+
+- **Settings modal**: Consolidated API, Files, and Appearance into a single near-full-screen modal with sidebar navigation (Site, API, Files, Cloud, Tools)
+- **Settings button**: Gear icon replaces API, Files, and Theme buttons in the header — now just About + Settings
+- **Theme picker**: 3-button theme selector (Light, Dark, Sepia) in Site Settings replaces the cycling toggle button
+- **Items per page persistence**: Items-per-page setting now persists to localStorage via `ITEMS_PER_PAGE_KEY` — no longer resets to 25 on reload
+- **Tabbed API providers**: API provider configuration uses tabbed panels (Metals.dev | Metals-API | MetalPriceAPI | Custom) instead of scrollable list
+- **Settings footer**: Storage usage and app version displayed in the modal footer bar
+- **Cloud & Tools placeholders**: Sidebar sections ready for future BYO-Backend sync and bulk operations
+- **Bidirectional control sync**: Filter chip threshold and smart name grouping controls sync between inline controls and Settings modal
+
+#### Changed
+
+- **Header simplified**: 4 header buttons (About, API, Files, Theme) reduced to 2 (About, Settings)
+- **API providers inline**: Provider configuration moved from separate `apiProvidersModal` into tabbed panels within the API section
+- **Backup reminder**: Now opens Settings → Files section instead of standalone Files modal
+
+#### Removed
+
+- **`apiModal`**: Standalone API modal replaced by Settings → API section
+- **`filesModal`**: Standalone Files modal replaced by Settings → Files section
+- **`apiProvidersModal`**: Standalone providers modal replaced by inline tabbed panels
+- **`appearanceBtn`**: Theme cycling button replaced by Settings → Site → Theme picker
+
 ## [3.10.01] - 2026-02-08
 
 ### Fix — Numista iframe blocked on hosted sites + column sort regression

--- a/css/styles.css
+++ b/css/styles.css
@@ -1314,6 +1314,12 @@ input[type="submit"] {
   max-height: none;
   display: flex;
   flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+#apiHistoryModal .modal-content::before {
+  display: none;
 }
 
 /* Storage report options modal */
@@ -1423,69 +1429,266 @@ input[type="submit"] {
   margin-top: 0.75rem;
 }
 
-/* Settings-style modal layout */
-#apiModal .modal-content,
-#filesModal .modal-content {
-  max-width: 750px;
-  max-height: 90vh;
+/* =============================================================================
+   UNIFIED SETTINGS MODAL
+   ============================================================================= */
+
+/* Settings modal content — near full-screen
+   Compound selector for higher specificity than base .modal-content */
+.modal-content.settings-modal-content {
+  width: 90vw;
+  max-width: 1100px;
+  height: 85vh;
+  max-height: 85vh;
   display: flex;
   flex-direction: column;
   padding: 0;
   overflow: hidden;
 }
 
-#apiModal .modal-header,
-#filesModal .modal-header {
+/* Hide base modal gradient line — settings header has its own */
+.modal-content.settings-modal-content::before {
+  display: none;
+}
+
+.settings-modal-content > .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
   color: #f8fafc;
-  padding: var(--spacing-xl);
-  position: relative;
+  padding: var(--spacing) var(--spacing-xl);
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   box-shadow: var(--shadow);
+  flex-shrink: 0;
 }
 
-#apiModal .modal-header h2,
-#filesModal .modal-header h2 {
+.settings-modal-content > .modal-header h2 {
   margin: 0;
   color: #f8fafc;
-  text-align: center;
 }
 
-#apiModal .modal-body,
-#filesModal .modal-body {
-  padding: var(--spacing-xl);
-  overflow-y: auto;
+/* Sidebar + content layout */
+.settings-modal-layout {
+  display: flex;
   flex: 1;
+  overflow: hidden;
+}
+
+.settings-sidebar {
+  width: 160px;
+  min-width: 160px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-sm) 0;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+.settings-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background 0.15s, color 0.15s;
+}
+
+.settings-nav-item:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.settings-nav-item.active {
+  background: var(--bg-card);
+  color: var(--primary);
+  border-left: 3px solid var(--primary);
+  font-weight: 600;
+}
+
+.settings-nav-item svg {
+  flex-shrink: 0;
+}
+
+/* Content area */
+.settings-content-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-xl);
   scrollbar-width: thin;
   scrollbar-color: var(--primary) var(--bg-secondary);
 }
 
-#apiModal .modal-body::-webkit-scrollbar,
-#filesModal .modal-body::-webkit-scrollbar {
-  width: 8px;
+.settings-content-area::-webkit-scrollbar { width: 8px; }
+.settings-content-area::-webkit-scrollbar-track { background: var(--bg-secondary); border-radius: var(--radius); }
+.settings-content-area::-webkit-scrollbar-thumb { background-color: var(--primary); border-radius: var(--radius); }
+.settings-content-area::-webkit-scrollbar-thumb:hover { background-color: var(--primary-hover); }
+
+.settings-section-panel h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1.125rem;
 }
 
-#apiModal .modal-body::-webkit-scrollbar-track,
-#filesModal .modal-body::-webkit-scrollbar-track {
-  background: var(--bg-secondary);
+/* Settings groups (Site section) */
+.settings-group {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-group:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.settings-group-label {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+/* Theme picker */
+.theme-picker {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.theme-option {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--border);
   border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
 }
 
-#apiModal .modal-body::-webkit-scrollbar-thumb,
-#filesModal .modal-body::-webkit-scrollbar-thumb {
-  background-color: var(--primary);
-  border-radius: var(--radius);
+.theme-option:hover {
+  border-color: var(--primary);
 }
 
-#apiModal .modal-body::-webkit-scrollbar-thumb:hover,
-#filesModal .modal-body::-webkit-scrollbar-thumb:hover {
-  background-color: var(--primary-hover);
+.theme-option.active {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: #fff;
 }
 
-#filesModal .modal-body {
+/* Provider tabs */
+.settings-provider-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--border);
+  margin: 1rem 0 0 0;
+}
+
+.settings-provider-tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.settings-provider-tab:hover {
+  color: var(--text-primary);
+}
+
+.settings-provider-tab.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
+
+.settings-provider-panel {
+  padding-top: 1rem;
+}
+
+/* Placeholder sections (Cloud, Tools) */
+.settings-placeholder {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing);
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  color: var(--text-secondary);
+  text-align: center;
+  gap: 1rem;
+}
+
+.settings-placeholder p {
+  font-size: 0.9375rem;
+  margin: 0;
+}
+
+/* Footer bar */
+.settings-footer {
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+  text-align: center;
+  flex-shrink: 0;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+/* Mobile: sidebar becomes horizontal strip */
+@media (max-width: 768px) {
+  .modal-content.settings-modal-content {
+    width: 98vw;
+    height: 95vh;
+    max-height: 95vh;
+  }
+
+  .settings-modal-layout {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    min-width: unset;
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .settings-nav-item {
+    white-space: nowrap;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+  }
+
+  .settings-nav-item.active {
+    border-left: none;
+    border-bottom: 3px solid var(--primary);
+  }
+
+  .settings-content-area {
+    padding: var(--spacing);
+  }
 }
 
 
@@ -1545,38 +1748,7 @@ input[type="submit"] {
   text-align: center;
 }
 
-/* API Providers modal layout */
-#apiProvidersModal .modal-content {
-  width: 90vw;
-  max-width: 800px;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  padding: 0;
-  overflow: hidden;
-}
-
-#apiProvidersModal .modal-header {
-  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: #f8fafc;
-  padding: var(--spacing-xl);
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-}
-
-#apiProvidersModal .modal-header h2 {
-  margin: 0;
-  color: #f8fafc;
-  text-align: center;
-}
-
-#apiProvidersModal .modal-body {
-  padding: var(--spacing-xl);
-  overflow-y: auto;
-  flex: 1;
-}
+/* Provider panels within Settings modal inherit scrollable content area */
 
 /* Standardized modal layout for change log and details views */
 /* shared modal content structure */
@@ -1838,13 +2010,29 @@ table {
 }
 
 .table-section {
-  overflow-x: auto;
-  overflow-y: visible;
-  -webkit-overflow-scrolling: touch;
   width: 100%;
   max-width: 100%;
   min-height: auto;
   box-sizing: border-box;
+  /* Visual chrome — wraps portal-scroll + footer controls */
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  /* Override base section{overflow:hidden} — portal-scroll handles overflow,
+     and hidden here would create an intermediate scroll container that
+     breaks position:sticky on thead th in some browsers */
+  overflow: visible;
+}
+
+/* Scroll container wrapping only the <table> — footer stays outside.
+   max-height MUST be set so the container actually constrains content
+   and becomes a real scroll container (required for position:sticky).
+   JS updatePortalHeight() overrides with a precise row-based value. */
+.portal-scroll {
+  overflow-x: auto;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  max-height: 70vh;
 }
 
 #inventoryTable {
@@ -1853,14 +2041,17 @@ table {
      remains available via .table-section when necessary. */
   width: 100%;
   table-layout: auto;
-  border: 2px solid var(--border);
-  border-radius: var(--radius);
   background: var(--bg-primary);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  /* override base table rules that block position:sticky on thead th:
+     - border-collapse:separate keeps each cell's box independent
+     - border-spacing:0 eliminates visual gaps (same look as collapse)
+     - overflow:visible lets sticky reach the .table-section scroll container */
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: visible;
 }
 
 #inventoryTable tbody {
-  min-height: calc(10 * 2.2rem);
   height: auto;
 }
 
@@ -2040,7 +2231,8 @@ th[data-column="date"] {
 /* Price column toggle styling */
 #inventoryTable th[data-column="purchasePrice"] {
   cursor: pointer;
-  position: relative;
+  /* position: sticky inherited from #inventoryTable thead th —
+     sticky acts as relative for child/pseudo positioning */
 }
 
 #inventoryTable th[data-column="purchasePrice"]:after {
@@ -3163,54 +3355,7 @@ a.about-badge:hover {
    Numista pages now open in popup windows via js/numista-modal.js
    ============================================================================= */
 
-/* =============================================================================
-   PAGINATION
-   ============================================================================= */
-
-.pagination-section {
-  margin: var(--spacing) 0;
-}
-
-.pagination-controls {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--spacing-xs);
-  padding: 0.125rem 0;
-}
-
-.pagination-buttons {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 var(--spacing-xs);
-}
-
-.pagination-left,
-.pagination-right {
-  display: flex;
-  gap: var(--spacing-sm);
-}
-
-.pagination-center {
-  display: flex;
-  gap: var(--spacing-sm);
-  justify-content: center;
-  flex-grow: 1;
-}
-
-.items-per-page {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-}
-
-.items-label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--text-muted);
-}
+/* Pagination section removed — replaced by portal (scrollable table) view */
 
 .change-log-label {
   font-weight: 700;
@@ -3246,44 +3391,6 @@ a.about-badge:hover {
   cursor: pointer;
 }
 
-.pagination-select {
-  width: 6rem;
-  height: 1.375rem;
-}
-
-.pagination-btn {
-  min-width: 2rem;
-  height: 1.25rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-weight: 500;
-  transition: var(--transition);
-  cursor: pointer;
-  padding: 0;
-  font-size: 0.75rem;
-}
-
-.pagination-btn.active {
-  background: var(--primary);
-  color: #f8fafc;
-  border-color: var(--primary);
-  font-weight: 600;
-}
-
-.pagination-btn:hover:not(:disabled) {
-  background: var(--bg-secondary);
-  border-color: var(--border-hover);
-}
-
-.pagination-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 .beta-warning {
   margin-top: var(--spacing-xs);
@@ -4059,26 +4166,6 @@ input:disabled + .slider {
     padding: var(--spacing);
   }
 
-  .pagination-controls {
-    grid-template-columns: 1fr;
-    text-align: center;
-  }
-
-  .pagination-left,
-  .pagination-right {
-    justify-content: center;
-    margin-bottom: var(--spacing-sm);
-  }
-
-    .pagination-center {
-      flex-direction: row;
-      flex-wrap: wrap;
-      gap: var(--spacing-sm);
-    }
-
-    .items-per-page {
-      justify-content: center;
-    }
 
     .table-controls {
       flex-direction: column;
@@ -4223,10 +4310,6 @@ input:disabled + .slider {
     width: 4rem;
   }
 
-  .pagination-btn {
-    padding: 0;
-    font-size: 0.7rem;
-  }
 }
 
 @media (min-width: 600px) {
@@ -4238,13 +4321,21 @@ input:disabled + .slider {
     grid-template-columns: repeat(2, 1fr);
   }
 }
-#inventoryTable th.icon-col,
 #inventoryTable td.icon-col {
   width: 3.5rem;
   padding: 0.25rem;
   text-align: center;
   vertical-align: middle;
   position: relative;
+}
+
+#inventoryTable th.icon-col {
+  width: 3.5rem;
+  padding: 0.25rem;
+  text-align: center;
+  vertical-align: middle;
+  /* position: sticky inherited from #inventoryTable thead th —
+     sticky acts as relative for child/pseudo positioning */
 }
 
 /* Enhanced action icons without hover animations */
@@ -4539,6 +4630,9 @@ th {
   color: var(--text-secondary);
   background: var(--bg-secondary);
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 }
 
 /* Ensure uniform font family for entire table */

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,11 @@
 ## What's New
 
+- **Sticky header fix (v3.12.01)**: Column headers now correctly pin at the top of the scrollable portal view during vertical scroll
+- **Portal view (v3.12.00)**: Inventory table now renders all items in a scrollable container with sticky column headers — pagination removed. Visible rows (10/15/25/50/100) control viewport height
+- **Unified Settings modal (v3.11.00)**: API, Files, and Appearance consolidated into a single Settings modal with sidebar navigation. Header simplified to About + Settings
+- **Theme picker (v3.11.00)**: 3-button theme selector (Light / Dark / Sepia) replaces the cycling toggle
+- **Tabbed API providers (v3.11.00)**: Provider configuration uses tabbed panels instead of a scrollable list
+- **Items per page persisted (v3.11.00)**: Items-per-page setting now survives page reloads
 - **Numista iframe fix (v3.10.01)**: Numista pages now open in a popup window — fixes "Can't Open This Page" error on hosted sites
 - **Sort fix (v3.10.01)**: Gain/Loss and Source columns now sort and resize correctly
 - **Serial # field (v3.10.00)**: New optional Serial Number input for bars and notes with physical serial numbers. Included in all export/import formats

--- a/index.html
+++ b/index.html
@@ -184,27 +184,9 @@
       </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
         <button class="btn theme-btn" id="aboutBtn" title="About" aria-label="About">📖</button>
-        <button class="btn theme-btn" id="apiBtn" title="API" aria-label="API">🔌</button>
-        <!-- Community button commented out for revision
-        <a
-          class="btn"
-          id="communityBtn"
-          href="https://www.reddit.com/r/stackrtrackr/"
-          target="_blank"
-          rel="noopener"
-          title="Community"
-          aria-label="Community"
-        >
-          <img
-            src="https://www.redditstatic.com/desktop2x/img/favicon/favicon-32x32.png"
-            alt=""
-            style="height: 1em; width: 1em"
-          />
-          Community
-        </a>
-        -->
-        <button class="btn theme-btn" id="filesBtn" title="Files" aria-label="Files">📁</button>
-        <button class="btn theme-btn" id="appearanceBtn" title="Theme" aria-label="Theme"></button>
+        <button class="btn theme-btn" id="settingsBtn" title="Settings" aria-label="Settings">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        </button>
       </div>
     </div>
     <div class="container">
@@ -632,9 +614,10 @@
            - Responsive design with column resizing capability
 
         Table rendering handled by renderTable() in inventory.js
-         Pagination controls limit display to selected items per page
+         Portal view shows all items in a scrollable table with sticky headers
          ============================================================================= -->
         <section class="table-section">
+          <div class="portal-scroll">
           <table id="inventoryTable">
           <thead>
             <tr>
@@ -732,9 +715,12 @@
           </thead>
           <tbody></tbody>
           </table>
+          </div>
           <div class="table-footer-controls">
             <div class="table-item-count"><strong id="itemCount"></strong></div>
-            <select id="itemsPerPage" class="control-select" title="Rows per page">
+            <select id="itemsPerPage" class="control-select" title="Visible rows">
+              <option value="10">10</option>
+              <option value="15">15</option>
               <option value="25" selected>25</option>
               <option value="50">50</option>
               <option value="100">100</option>
@@ -762,40 +748,6 @@
             </div>
           </div>
         </section>
-        <!-- Pagination Controls -->
-        <section class="pagination-section">
-          <div class="pagination-container">
-            <div class="pagination-controls">
-              <div class="pagination-buttons">
-                <div class="pagination-left">
-                  <button
-                    class="pagination-btn"
-                    id="firstPage"
-                    title="First Page"
-                  >
-                    «
-                  </button>
-                  <button
-                    class="pagination-btn"
-                    id="prevPage"
-                    title="Previous Page"
-                  >
-                    ‹
-                  </button>
-                </div>
-                <div class="pagination-center" id="pageNumbers"></div>
-                <div class="pagination-right">
-                  <button class="pagination-btn" id="nextPage" title="Next Page">
-                    ›
-                  </button>
-                  <button class="pagination-btn" id="lastPage" title="Last Page">
-                    »
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-      </section>
     </section>
       <!-- =============================================================================
          IMPORT/EXPORT SECTION
@@ -1387,679 +1339,482 @@
     <!-- =============================================================================
        ============================================================================= -->
 
-    <div class="modal" id="apiModal" style="display: none">
-      <div class="modal-content">
+    <!-- =============================================================================
+       UNIFIED SETTINGS MODAL
+       Consolidates API, Files, and Appearance into a single sidebar-navigated modal.
+       Sub-modals (apiInfoModal, apiHistoryModal, catalogHistoryModal, apiQuotaModal)
+       remain as stacking overlays.
+       ============================================================================= -->
+    <div class="modal" id="settingsModal" style="display: none">
+      <div class="modal-content settings-modal-content">
         <div class="modal-header">
-          <h2>API</h2>
-          <button aria-label="Close modal" class="modal-close" id="apiCloseBtn">
-            ×
-          </button>
+          <h2>Settings</h2>
+          <button aria-label="Close modal" class="modal-close" id="settingsCloseBtn">&times;</button>
         </div>
-        <div class="modal-body">
-          <div class="settings-section">
-            <h3 style="margin-bottom: 1rem">Metals API Configuration</h3>
-            <p class="settings-subtext">Manage API cache, history, and providers.</p>
+        <div class="settings-modal-layout">
+          <!-- Sidebar Navigation -->
+          <nav class="settings-sidebar">
+            <button class="settings-nav-item active" data-section="site">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+              Site
+            </button>
+            <button class="settings-nav-item" data-section="api">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/></svg>
+              API
+            </button>
+            <button class="settings-nav-item" data-section="files">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+              Files
+            </button>
+            <button class="settings-nav-item" data-section="cloud">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
+              Cloud
+            </button>
+            <button class="settings-nav-item" data-section="tools">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+              Tools
+            </button>
+          </nav>
 
+          <!-- Content Area -->
+          <div class="settings-content-area">
 
+            <!-- ===== SITE SETTINGS ===== -->
+            <div class="settings-section-panel" id="settingsPanel_site" style="display: block">
+              <h3>Site Settings</h3>
 
-            <div class="api-status-summary" id="apiStatusSummary"></div>
-
-            <div class="settings-actions">
-              <button type="button" class="btn" id="providersBtn">
-                Providers 🖥️
-              </button>
-              <button type="button" class="btn success" id="syncAllBtn">
-                Sync All ♻️
-              </button>
-              <button type="button" class="btn danger" id="flushCacheBtn">
-                Flush Cache 🚽
-              </button>
-              <button type="button" class="btn" id="apiHistoryBtn">
-                History 📜
-              </button>
-            </div>
-          </div>
-          <div class="settings-section">
-            <h3 style="margin-bottom: 1rem">Numista API</h3>
-            <div class="api-key-row">
-              <label for="numistaApiKey">API Key:</label>
-              <input
-                type="password"
-                id="numistaApiKey"
-                placeholder="Enter your Numista API key"
-              />
-            </div>
-            <div class="api-key-note">
-              <p>Get a free API key at <a href="https://en.numista.com/api/" target="_blank" rel="noopener">numista.com/api</a> (2,000 requests/month free tier). Your key is stored locally in your browser.</p>
-              <button class="btn success" id="saveNumistaBtn" style="margin-top: 0.5rem;">Save Key</button>
-              <button class="btn info" id="testNumistaBtn" style="margin-top: 0.5rem;">Test Connection</button>
-              <button class="btn secondary" id="clearNumistaBtn" style="margin-top: 0.5rem;">Clear Key</button>
-              <button class="btn" id="catalogHistoryBtn" style="margin-top: 0.5rem;">History</button>
-            </div>
-            <div id="numistaStatus" class="api-status" style="margin-top: 0.5rem;"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="modal" id="filesModal" style="display: none">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2>Files</h2>
-          <button aria-label="Close modal" class="modal-close" id="filesCloseBtn">
-            ×
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="settings-card-grid">
-            <div class="settings-card">
-              <h3>Import</h3>
-              <p class="settings-subtext">Import your data files.</p>
-              <div class="import-block">
-                <div class="import-export-grid">
-                  <div class="import-csv-grid">
-                    <button class="btn warning" id="importCsvOverride">Import CSV</button>
-                    <button class="btn success" id="importCsvMerge">Merge CSV</button>
-                    <input accept=".csv" hidden id="importCsvFile" type="file" />
-                  </div>
-                  <div class="import-json-grid">
-                    <button class="btn warning" id="importJsonOverride">Import JSON</button>
-                    <button class="btn success" id="importJsonMerge">Merge JSON</button>
-                    <input accept=".json" hidden id="importJsonFile" type="file" />
-                  </div>
-                  <button class="btn secondary" id="cloudSyncBtn">Cloud Sync ☁️</button>
+              <div class="settings-group">
+                <div class="settings-group-label">Theme</div>
+                <div class="theme-picker">
+                  <button class="theme-option" data-theme="light" title="Light">&#9728;&#65039; Light</button>
+                  <button class="theme-option" data-theme="dark" title="Dark">&#127769; Dark</button>
+                  <button class="theme-option" data-theme="sepia" title="Sepia">&#128220; Sepia</button>
                 </div>
-                <progress
-                  class="import-progress"
-                  id="importProgress"
-                  value="0"
-                  max="0"
-                ></progress>
-                <div class="import-progress-text" id="importProgressText"></div>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Visible rows</div>
+                <select id="settingsItemsPerPage">
+                  <option value="10">10</option>
+                  <option value="15">15</option>
+                  <option value="25">25</option>
+                  <option value="50">50</option>
+                  <option value="100">100</option>
+                </select>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Filter chip threshold</div>
+                <p class="settings-subtext">Minimum item count for a filter chip to appear.</p>
+                <select id="settingsChipMinCount">
+                  <option value="2">2+</option>
+                  <option value="3">3+</option>
+                  <option value="5">5+</option>
+                  <option value="10">10+</option>
+                  <option value="100">100+ (off)</option>
+                </select>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Smart name grouping</div>
+                <p class="settings-subtext">Group item names by base name (e.g., "American Silver Eagle (3)").</p>
+                <select id="settingsGroupNameChips">
+                  <option value="yes">Enabled</option>
+                  <option value="no">Disabled</option>
+                </select>
               </div>
             </div>
 
-            <div class="settings-card">
-              <h3>Export</h3>
-              <p class="settings-subtext">Export your data files.</p>
-              <div class="export-block">
-                <div class="import-export-grid">
-                  <button class="btn info" id="exportCsvBtn">
-                    Export CSV
-                  </button>
-                  <button class="btn info" id="exportJsonBtn">
-                    Export JSON
-                  </button>
-                  <button class="btn info" id="exportPdfBtn">
-                    Export PDF
-                  </button>
-                </div>
-              </div>
-            </div>
+            <!-- ===== API ===== -->
+            <div class="settings-section-panel" id="settingsPanel_api" style="display: none">
+              <h3>Metals API Configuration</h3>
+              <p class="settings-subtext">Manage API cache, history, and providers.</p>
 
-            <div class="settings-card">
-              <h3>Third-Party</h3>
-              <p class="settings-subtext">Import data from external services like Numista.</p>
-                <div class="third-party-block">
-                  <div class="import-export-grid">
-                    <div class="grid grid-2">
-                      <button class="btn warning" id="importNumistaBtn">Import Numista CSV</button>
-                      <button class="btn success" id="mergeNumistaBtn">Merge Numista CSV</button>
+              <div class="api-status-summary" id="apiStatusSummary"></div>
+
+              <div class="settings-actions">
+                <button type="button" class="btn success" id="syncAllBtn">Sync All</button>
+                <button type="button" class="btn danger" id="flushCacheBtn">Flush Cache</button>
+                <button type="button" class="btn" id="apiHistoryBtn">History</button>
+              </div>
+
+              <!-- Provider Tabs -->
+              <div class="settings-provider-tabs">
+                <button class="settings-provider-tab active" data-provider="METALS_DEV">Metals.dev</button>
+                <button class="settings-provider-tab" data-provider="METALS_API">Metals-API</button>
+                <button class="settings-provider-tab" data-provider="METAL_PRICE_API">MetalPriceAPI</button>
+                <button class="settings-provider-tab" data-provider="CUSTOM">Custom</button>
+              </div>
+
+              <!-- Provider Panels (one per provider, same IDs as before) -->
+              <div class="settings-provider-panel" id="providerPanel_METALS_DEV" style="display: block">
+                <div class="api-provider" data-provider="METALS_DEV">
+                  <div class="provider-header">
+                    <span class="provider-name">Metals.dev</span>
+                    <span class="provider-url">https://api.metals.dev/v1</span>
+                    <span class="provider-batch-badge">Batch Optimized</span>
+                  </div>
+                  <a href="#" class="api-info-link" data-provider="METALS_DEV">Provider Information</a>
+                  <div class="api-key-row">
+                    <label for="apiKey_METALS_DEV">API Key:</label>
+                    <input type="password" id="apiKey_METALS_DEV" placeholder="Enter your API key" />
+                  </div>
+                  <div class="provider-settings">
+                    <h4>Provider Settings</h4>
+                    <div class="provider-setting-row">
+                      <label for="cacheTimeout_METALS_DEV">Cache Timeout:</label>
+                      <select id="cacheTimeout_METALS_DEV" class="provider-cache-select">
+                        <option value="0">No Cache</option>
+                        <option value="1">1 hour</option>
+                        <option value="6">6 hours</option>
+                        <option value="12">12 hours</option>
+                        <option value="24" selected>24 hours</option>
+                      </select>
                     </div>
-                    <input type="file" id="numistaImportFile" accept=".csv" hidden />
-                    <div class="beta-warning">⚠️ Numista import is a beta feature</div>
+                    <div class="provider-setting-row">
+                      <label for="historyDays_METALS_DEV">History Days:</label>
+                      <input type="number" id="historyDays_METALS_DEV" class="provider-history-input" min="1" max="30" value="29" placeholder="1-30">
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyTimes_METALS_DEV">Times per Day:</label>
+                      <input type="text" id="historyTimes_METALS_DEV" class="provider-history-input" placeholder="08:00,20:00">
+                    </div>
+                    <div class="metal-selection">
+                      <label>Select Metals to Track:</label>
+                      <div class="metal-checkboxes">
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                      </div>
+                    </div>
+                    <div class="batch-optimization">
+                      <div class="batch-info" id="batchInfo_METALS_DEV">Batch Request: 4 metals + 30 days = 1 API call<br><span class="batch-savings">(saves 123 calls vs individual requests)</span></div>
+                    </div>
+                    <div class="provider-info">
+                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
+                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span></div>
+                      <div class="provider-history"></div>
+                    </div>
+                  </div>
+                  <div class="provider-footer">
+                    <div class="provider-actions">
+                      <button type="button" class="btn provider-default-btn" data-provider="METALS_DEV"></button>
+                      <div class="provider-actions-right">
+                        <button type="button" class="btn api-quota-btn" data-provider="METALS_DEV">Quota</button>
+                        <button type="button" class="btn api-clear-btn warning" data-provider="METALS_DEV">Clear Key</button>
+                        <button type="button" class="btn api-sync-btn success" data-provider="METALS_DEV">Save and Test</button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
 
-            <div class="settings-card boating-accident-section">
-              <h3>Backup, Restore, Clear</h3>
-              <p class="settings-subtext">Manage local application data.</p>
-              <div class="backup-buttons">
-                <button class="btn warning" id="removeInventoryDataBtn">
-                  Remove Inventory Data
-                </button>
-                <button class="btn danger" id="boatingAccidentBtn">
-                  Wipe All Data
-                </button>
-                <div class="beta-warning">⚠️ have you or someone you know been involved in a 🚤 accident?</div>
+              <div class="settings-provider-panel" id="providerPanel_METALS_API" style="display: none">
+                <div class="api-provider" data-provider="METALS_API">
+                  <div class="provider-header">
+                    <span class="provider-name">Metals-API.com</span>
+                    <span class="provider-url">https://metals-api.com/api</span>
+                    <span class="provider-batch-badge">Batch Optimized</span>
+                  </div>
+                  <a href="#" class="api-info-link" data-provider="METALS_API">Provider Information</a>
+                  <div class="api-key-row">
+                    <label for="apiKey_METALS_API">API Key:</label>
+                    <input type="password" id="apiKey_METALS_API" placeholder="Enter your API key" />
+                  </div>
+                  <div class="provider-settings">
+                    <h4>Provider Settings</h4>
+                    <div class="provider-setting-row">
+                      <label for="cacheTimeout_METALS_API">Cache Timeout:</label>
+                      <select id="cacheTimeout_METALS_API" class="provider-cache-select">
+                        <option value="0">No Cache</option>
+                        <option value="1">1 hour</option>
+                        <option value="6">6 hours</option>
+                        <option value="12">12 hours</option>
+                        <option value="24" selected>24 hours</option>
+                      </select>
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyDays_METALS_API">History Days:</label>
+                      <input type="number" id="historyDays_METALS_API" class="provider-history-input" min="1" max="365" value="30" placeholder="1-365">
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyTimes_METALS_API">Times per Day:</label>
+                      <input type="text" id="historyTimes_METALS_API" class="provider-history-input" placeholder="08:00,20:00">
+                    </div>
+                    <div class="metal-selection">
+                      <label>Select Metals to Track:</label>
+                      <div class="metal-checkboxes">
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                      </div>
+                    </div>
+                    <div class="batch-optimization">
+                      <div class="batch-info" id="batchInfo_METALS_API">Batch Request: 4 metals + 30 days = 1 API call<br><span class="batch-savings">(saves 123 calls vs individual requests)</span></div>
+                    </div>
+                    <div class="provider-info">
+                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
+                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span></div>
+                      <div class="provider-history"></div>
+                    </div>
+                  </div>
+                  <div class="provider-footer">
+                    <div class="provider-actions">
+                      <button type="button" class="btn provider-default-btn" data-provider="METALS_API"></button>
+                      <div class="provider-actions-right">
+                        <button type="button" class="btn api-quota-btn" data-provider="METALS_API">Quota</button>
+                        <button type="button" class="btn api-clear-btn warning" data-provider="METALS_API">Clear Key</button>
+                        <button type="button" class="btn api-sync-btn success" data-provider="METALS_API">Save and Test</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
 
-    <div class="modal" id="apiProvidersModal" style="display: none">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2>API Providers</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="apiProvidersCloseBtn"
-          >
-            ×
-          </button>
-        </div>
-        <div class="modal-body">
-          <p class="settings-subtext">
-            Configure API keys, select metals to track, set cache policies, and optimize with batch requests for significant API savings.
-          </p>
-          <div class="api-providers">
-              <div class="api-provider" data-provider="METALS_DEV">
-                <div class="provider-header">
-                  <span class="provider-name">Metals.dev</span>
-                  <span class="provider-url">https://api.metals.dev/v1</span>
-                  <span class="provider-batch-badge">✨ Batch Optimized</span>
+              <div class="settings-provider-panel" id="providerPanel_METAL_PRICE_API" style="display: none">
+                <div class="api-provider" data-provider="METAL_PRICE_API">
+                  <div class="provider-header">
+                    <span class="provider-name">MetalPriceAPI.com</span>
+                    <span class="provider-url">https://api.metalpriceapi.com/v1</span>
+                    <span class="provider-batch-badge">Batch Optimized</span>
+                  </div>
+                  <a href="#" class="api-info-link" data-provider="METAL_PRICE_API">Provider Information</a>
+                  <div class="api-key-row">
+                    <label for="apiKey_METAL_PRICE_API">API Key:</label>
+                    <input type="password" id="apiKey_METAL_PRICE_API" placeholder="Enter your API key" />
+                  </div>
+                  <div class="provider-settings">
+                    <h4>Provider Settings</h4>
+                    <div class="provider-setting-row">
+                      <label for="cacheTimeout_METAL_PRICE_API">Cache Timeout:</label>
+                      <select id="cacheTimeout_METAL_PRICE_API" class="provider-cache-select">
+                        <option value="0">No Cache</option>
+                        <option value="1">1 hour</option>
+                        <option value="6">6 hours</option>
+                        <option value="12">12 hours</option>
+                        <option value="24" selected>24 hours</option>
+                      </select>
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyDays_METAL_PRICE_API">History Days:</label>
+                      <input type="number" id="historyDays_METAL_PRICE_API" class="provider-history-input" min="1" max="365" value="30" placeholder="1-365">
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyTimes_METAL_PRICE_API">Times per Day:</label>
+                      <input type="text" id="historyTimes_METAL_PRICE_API" class="provider-history-input" placeholder="08:00,20:00">
+                    </div>
+                    <div class="metal-selection">
+                      <label>Select Metals to Track:</label>
+                      <div class="metal-checkboxes">
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                      </div>
+                    </div>
+                    <div class="batch-optimization">
+                      <div class="batch-info" id="batchInfo_METAL_PRICE_API">Batch Request: 4 metals + 30 days = 1 API call<br><span class="batch-savings">(saves 123 calls vs individual requests)</span></div>
+                    </div>
+                    <div class="provider-info">
+                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
+                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span></div>
+                      <div class="provider-history"></div>
+                    </div>
+                  </div>
+                  <div class="provider-footer">
+                    <div class="provider-actions">
+                      <button type="button" class="btn provider-default-btn" data-provider="METAL_PRICE_API"></button>
+                      <div class="provider-actions-right">
+                        <button type="button" class="btn api-quota-btn" data-provider="METAL_PRICE_API">Quota</button>
+                        <button type="button" class="btn api-clear-btn warning" data-provider="METAL_PRICE_API">Clear Key</button>
+                        <button type="button" class="btn api-sync-btn success" data-provider="METAL_PRICE_API">Save and Test</button>
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                <a href="#" class="api-info-link" data-provider="METALS_DEV">
-                  Provider Information
-                </a>
-                <div class="api-key-row">
-                  <label for="apiKey_METALS_DEV">API Key:</label>
-                  <input
-                    type="password"
-                    id="apiKey_METALS_DEV"
-                    placeholder="Enter your API key"
-                  />
-                </div>
-                
-                <!-- Provider Settings Section -->
-                <div class="provider-settings">
-                  <h4>Provider Settings</h4>
-                  
-                  <div class="provider-setting-row">
-                    <label for="cacheTimeout_METALS_DEV">Cache Timeout:</label>
-                    <select id="cacheTimeout_METALS_DEV" class="provider-cache-select">
-                      <option value="0">No Cache</option>
-                      <option value="1">1 hour</option>
-                      <option value="6">6 hours</option>
-                      <option value="12">12 hours</option>
-                      <option value="24" selected>24 hours</option>
+              </div>
+
+              <div class="settings-provider-panel" id="providerPanel_CUSTOM" style="display: none">
+                <div class="api-provider" data-provider="CUSTOM">
+                  <div class="provider-header">
+                    <span class="provider-name">Custom Provider</span>
+                  </div>
+                  <div class="api-field-row">
+                    <label for="apiBase_CUSTOM">Base URL:</label>
+                    <input type="text" id="apiBase_CUSTOM" placeholder="https://api.example.com" />
+                  </div>
+                  <div class="api-field-row">
+                    <label for="apiEndpoint_CUSTOM">Endpoint:</label>
+                    <input type="text" id="apiEndpoint_CUSTOM" placeholder="/latest?key={API_KEY}&metal={METAL}" />
+                  </div>
+                  <div class="api-field-row">
+                    <label for="apiFormat_CUSTOM">Metal Format:</label>
+                    <select id="apiFormat_CUSTOM">
+                      <option value="symbol">Symbol</option>
+                      <option value="word">Word</option>
                     </select>
                   </div>
-                  
-                  <div class="provider-setting-row">
-                    <label for="historyDays_METALS_DEV">History Days:</label>
-                    <input type="number" id="historyDays_METALS_DEV" class="provider-history-input"
-                           min="1" max="30" value="29" placeholder="1-30">
+                  <div class="api-key-row">
+                    <label for="apiKey_CUSTOM">API Key:</label>
+                    <input type="password" id="apiKey_CUSTOM" placeholder="Enter your API key" />
                   </div>
-
-                  <div class="provider-setting-row">
-                    <label for="historyTimes_METALS_DEV">Times per Day:</label>
-                    <input type="text" id="historyTimes_METALS_DEV" class="provider-history-input"
-                           placeholder="08:00,20:00">
-                  </div>
-
-                  <!-- Metal Selection -->
-                  <div class="metal-selection">
-                    <label>Select Metals to Track:</label>
-                    <div class="metal-checkboxes">
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="silver" checked>
-                        <span class="metal-name">Silver (AG)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="gold" checked>
-                        <span class="metal-name">Gold (AU)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="platinum" checked>
-                        <span class="metal-name">Platinum (PT)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="palladium" checked>
-                        <span class="metal-name">Palladium (PD)</span>
-                      </label>
+                  <div class="provider-settings">
+                    <h4>Provider Settings</h4>
+                    <div class="provider-setting-row">
+                      <label for="cacheTimeout_CUSTOM">Cache Timeout:</label>
+                      <select id="cacheTimeout_CUSTOM" class="provider-cache-select">
+                        <option value="0">No Cache</option>
+                        <option value="1">1 hour</option>
+                        <option value="6">6 hours</option>
+                        <option value="12">12 hours</option>
+                        <option value="24" selected>24 hours</option>
+                      </select>
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyDays_CUSTOM">History Days:</label>
+                      <input type="number" id="historyDays_CUSTOM" class="provider-history-input" min="1" max="365" value="30" placeholder="1-365">
+                    </div>
+                    <div class="provider-setting-row">
+                      <label for="historyTimes_CUSTOM">Times per Day:</label>
+                      <input type="text" id="historyTimes_CUSTOM" class="provider-history-input" placeholder="08:00,20:00">
+                    </div>
+                    <div class="metal-selection">
+                      <label>Select Metals to Track:</label>
+                      <div class="metal-checkboxes">
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
+                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                      </div>
+                    </div>
+                    <div class="batch-optimization">
+                      <div class="batch-info" id="batchInfo_CUSTOM">Individual Requests: 4 metals = 4 API calls<br><span class="batch-savings">(batch requests not supported)</span></div>
+                    </div>
+                    <div class="provider-info">
+                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
+                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span></div>
+                      <div class="provider-history"></div>
                     </div>
                   </div>
-                  
-                <!-- Batch Optimization Display -->
-                <div class="batch-optimization">
-                  <div class="batch-info" id="batchInfo_METALS_DEV">
-                    📊 Batch Request: 4 metals + 30 days = 1 API call<br>
-                    <span class="batch-savings">(saves 123 calls vs individual requests)</span>
-                  </div>
-                </div>
-                <div class="provider-info">
-                  <div class="api-key-note">
-                    Your API key is stored locally and never shared.
-                  </div>
-                  <div class="provider-status">
-                    <span class="status-dot"></span>
-                    <span class="status-text">Disconnected</span>
-                  </div>
-                  <div class="provider-history"></div>
-                </div>
-              </div>
-
-              <div class="provider-footer">
-                <div class="provider-actions">
-                  <button
-                    type="button"
-                    class="btn provider-default-btn"
-                    data-provider="METALS_DEV"
-                  >
-                    </button>
-                    <div class="provider-actions-right">
-                      <button
-                        type="button"
-                        class="btn api-quota-btn"
-                        data-provider="METALS_DEV"
-                      >
-                        Quota
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-clear-btn warning"
-                        data-provider="METALS_DEV"
-                      >
-                        Clear Key
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-sync-btn success"
-                        data-provider="METALS_DEV"
-                      >
-                        Save and Test
-                      </button>
+                  <div class="provider-footer">
+                    <div class="provider-actions">
+                      <button type="button" class="btn provider-default-btn" data-provider="CUSTOM"></button>
+                      <div class="provider-actions-right">
+                        <button type="button" class="btn api-quota-btn" data-provider="CUSTOM">Quota</button>
+                        <button type="button" class="btn api-clear-btn warning" data-provider="CUSTOM">Clear Key</button>
+                        <button type="button" class="btn api-sync-btn success" data-provider="CUSTOM">Save and Test</button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
 
-              <div class="api-provider" data-provider="METALS_API">
-                <div class="provider-header">
-                  <span class="provider-name">Metals-API.com</span>
-                  <span class="provider-url">https://metals-api.com/api</span>
-                  <span class="provider-batch-badge">✨ Batch Optimized</span>
-                </div>
-                <a href="#" class="api-info-link" data-provider="METALS_API">
-                  Provider Information
-                </a>
+              <!-- Numista API Section -->
+              <div class="settings-section" style="margin-top: 1.5rem">
+                <h3 style="margin-bottom: 1rem">Numista API</h3>
                 <div class="api-key-row">
-                  <label for="apiKey_METALS_API">API Key:</label>
-                  <input
-                    type="password"
-                    id="apiKey_METALS_API"
-                    placeholder="Enter your API key"
-                  />
+                  <label for="numistaApiKey">API Key:</label>
+                  <input type="password" id="numistaApiKey" placeholder="Enter your Numista API key" />
                 </div>
-                
-                <!-- Provider Settings Section -->
-                <div class="provider-settings">
-                  <h4>Provider Settings</h4>
-                  
-                  <div class="provider-setting-row">
-                    <label for="cacheTimeout_METALS_API">Cache Timeout:</label>
-                    <select id="cacheTimeout_METALS_API" class="provider-cache-select">
-                      <option value="0">No Cache</option>
-                      <option value="1">1 hour</option>
-                      <option value="6">6 hours</option>
-                      <option value="12">12 hours</option>
-                      <option value="24" selected>24 hours</option>
-                    </select>
-                  </div>
-                  
-                  <div class="provider-setting-row">
-                    <label for="historyDays_METALS_API">History Days:</label>
-                    <input type="number" id="historyDays_METALS_API" class="provider-history-input"
-                           min="1" max="365" value="30" placeholder="1-365">
-                  </div>
-
-                  <div class="provider-setting-row">
-                    <label for="historyTimes_METALS_API">Times per Day:</label>
-                    <input type="text" id="historyTimes_METALS_API" class="provider-history-input"
-                           placeholder="08:00,20:00">
-                  </div>
-
-                  <!-- Metal Selection -->
-                  <div class="metal-selection">
-                    <label>Select Metals to Track:</label>
-                    <div class="metal-checkboxes">
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="silver" checked>
-                        <span class="metal-name">Silver (AG)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="gold" checked>
-                        <span class="metal-name">Gold (AU)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="platinum" checked>
-                        <span class="metal-name">Platinum (PT)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="palladium" checked>
-                        <span class="metal-name">Palladium (PD)</span>
-                      </label>
-                    </div>
-                  </div>
-                  
-                <!-- Batch Optimization Display -->
-                <div class="batch-optimization">
-                  <div class="batch-info" id="batchInfo_METALS_API">
-                    📊 Batch Request: 4 metals + 30 days = 1 API call<br>
-                    <span class="batch-savings">(saves 123 calls vs individual requests)</span>
-                  </div>
+                <div class="api-key-note">
+                  <p>Get a free API key at <a href="https://en.numista.com/api/" target="_blank" rel="noopener">numista.com/api</a> (2,000 requests/month free tier). Your key is stored locally in your browser.</p>
                 </div>
-                <div class="provider-info">
-                  <div class="api-key-note">
-                    Your API key is stored locally and never shared.
-                  </div>
-                  <div class="provider-status">
-                    <span class="status-dot"></span>
-                    <span class="status-text">Disconnected</span>
-                  </div>
-                  <div class="provider-history"></div>
+                <div class="provider-actions" style="margin-top: 0.75rem;">
+                  <button class="btn success" id="saveNumistaBtn">Save Key</button>
+                  <button class="btn info" id="testNumistaBtn">Test Connection</button>
+                  <button class="btn secondary" id="clearNumistaBtn">Clear Key</button>
+                  <button class="btn" id="catalogHistoryBtn">History</button>
                 </div>
+                <div id="numistaStatus" class="api-status" style="margin-top: 0.5rem;"></div>
               </div>
+            </div>
 
-              <div class="provider-footer">
-                <div class="provider-actions">
-                  <button
-                    type="button"
-                    class="btn provider-default-btn"
-                    data-provider="METALS_API"
-                  >
-                    </button>
-                    <div class="provider-actions-right">
-                      <button
-                        type="button"
-                        class="btn api-quota-btn"
-                        data-provider="METALS_API"
-                      >
-                        Quota
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-clear-btn warning"
-                        data-provider="METALS_API"
-                      >
-                        Clear Key
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-sync-btn success"
-                        data-provider="METALS_API"
-                      >
-                        Save and Test
-                      </button>
+            <!-- ===== FILES ===== -->
+            <div class="settings-section-panel" id="settingsPanel_files" style="display: none">
+              <h3>Files</h3>
+              <div class="settings-card-grid">
+                <div class="settings-card">
+                  <h3>Import</h3>
+                  <p class="settings-subtext">Import your data files.</p>
+                  <div class="import-block">
+                    <div class="import-export-grid">
+                      <div class="import-csv-grid">
+                        <button class="btn warning" id="importCsvOverride">Import CSV</button>
+                        <button class="btn success" id="importCsvMerge">Merge CSV</button>
+                        <input accept=".csv" hidden id="importCsvFile" type="file" />
+                      </div>
+                      <div class="import-json-grid">
+                        <button class="btn warning" id="importJsonOverride">Import JSON</button>
+                        <button class="btn success" id="importJsonMerge">Merge JSON</button>
+                        <input accept=".json" hidden id="importJsonFile" type="file" />
+                      </div>
+                      <button class="btn secondary" id="cloudSyncBtn">Cloud Sync</button>
+                    </div>
+                    <progress class="import-progress" id="importProgress" value="0" max="0"></progress>
+                    <div class="import-progress-text" id="importProgressText"></div>
+                  </div>
+                </div>
+                <div class="settings-card">
+                  <h3>Export</h3>
+                  <p class="settings-subtext">Export your data files.</p>
+                  <div class="export-block">
+                    <div class="import-export-grid">
+                      <button class="btn info" id="exportCsvBtn">Export CSV</button>
+                      <button class="btn info" id="exportJsonBtn">Export JSON</button>
+                      <button class="btn info" id="exportPdfBtn">Export PDF</button>
                     </div>
                   </div>
                 </div>
-              </div>
-
-              <div class="api-provider" data-provider="METAL_PRICE_API">
-                <div class="provider-header">
-                  <span class="provider-name">MetalPriceAPI.com</span>
-                  <span class="provider-url">
-                    https://api.metalpriceapi.com/v1
-                  </span>
-                  <span class="provider-batch-badge">✨ Batch Optimized</span>
-                </div>
-                <a
-                  href="#"
-                  class="api-info-link"
-                  data-provider="METAL_PRICE_API"
-                >
-                  Provider Information
-                </a>
-                <div class="api-key-row">
-                  <label for="apiKey_METAL_PRICE_API">API Key:</label>
-                  <input
-                    type="password"
-                    id="apiKey_METAL_PRICE_API"
-                    placeholder="Enter your API key"
-                  />
-                </div>
-                
-                <!-- Provider Settings Section -->
-                <div class="provider-settings">
-                  <h4>Provider Settings</h4>
-                  
-                  <div class="provider-setting-row">
-                    <label for="cacheTimeout_METAL_PRICE_API">Cache Timeout:</label>
-                    <select id="cacheTimeout_METAL_PRICE_API" class="provider-cache-select">
-                      <option value="0">No Cache</option>
-                      <option value="1">1 hour</option>
-                      <option value="6">6 hours</option>
-                      <option value="12">12 hours</option>
-                      <option value="24" selected>24 hours</option>
-                    </select>
-                  </div>
-                  
-                  <div class="provider-setting-row">
-                    <label for="historyDays_METAL_PRICE_API">History Days:</label>
-                    <input type="number" id="historyDays_METAL_PRICE_API" class="provider-history-input"
-                           min="1" max="365" value="30" placeholder="1-365">
-                  </div>
-
-                  <div class="provider-setting-row">
-                    <label for="historyTimes_METAL_PRICE_API">Times per Day:</label>
-                    <input type="text" id="historyTimes_METAL_PRICE_API" class="provider-history-input"
-                           placeholder="08:00,20:00">
-                  </div>
-
-                  <!-- Metal Selection -->
-                  <div class="metal-selection">
-                    <label>Select Metals to Track:</label>
-                    <div class="metal-checkboxes">
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="silver" checked>
-                        <span class="metal-name">Silver (AG)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="gold" checked>
-                        <span class="metal-name">Gold (AU)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="platinum" checked>
-                        <span class="metal-name">Platinum (PT)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="palladium" checked>
-                        <span class="metal-name">Palladium (PD)</span>
-                      </label>
-                    </div>
-                  </div>
-                  
-                <!-- Batch Optimization Display -->
-                <div class="batch-optimization">
-                  <div class="batch-info" id="batchInfo_METAL_PRICE_API">
-                    📊 Batch Request: 4 metals + 30 days = 1 API call<br>
-                    <span class="batch-savings">(saves 123 calls vs individual requests)</span>
-                  </div>
-                </div>
-                <div class="provider-info">
-                  <div class="api-key-note">
-                    Your API key is stored locally and never shared.
-                  </div>
-                  <div class="provider-status">
-                    <span class="status-dot"></span>
-                    <span class="status-text">Disconnected</span>
-                  </div>
-                  <div class="provider-history"></div>
-                </div>
-              </div>
-              <div class="provider-footer">
-                <div class="provider-actions">
-                  <button
-                    type="button"
-                    class="btn provider-default-btn"
-                    data-provider="METAL_PRICE_API"
-                  >
-                    </button>
-                    <div class="provider-actions-right">
-                      <button
-                        type="button"
-                        class="btn api-quota-btn"
-                        data-provider="METAL_PRICE_API"
-                      >
-                        Quota
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-clear-btn warning"
-                        data-provider="METAL_PRICE_API"
-                      >
-                        Clear Key
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-sync-btn success"
-                        data-provider="METAL_PRICE_API"
-                      >
-                        Save and Test
-                      </button>
+                <div class="settings-card">
+                  <h3>Third-Party</h3>
+                  <p class="settings-subtext">Import data from external services like Numista.</p>
+                  <div class="third-party-block">
+                    <div class="import-export-grid">
+                      <div class="grid grid-2">
+                        <button class="btn warning" id="importNumistaBtn">Import Numista CSV</button>
+                        <button class="btn success" id="mergeNumistaBtn">Merge Numista CSV</button>
+                      </div>
+                      <input type="file" id="numistaImportFile" accept=".csv" hidden />
+                      <div class="beta-warning">Numista import is a beta feature</div>
                     </div>
                   </div>
                 </div>
-              </div>
-
-              <div class="api-provider" data-provider="CUSTOM">
-                <div class="provider-header">
-                  <span class="provider-name">Custom Provider</span>
-                </div>
-                <div class="api-field-row">
-                  <label for="apiBase_CUSTOM">Base URL:</label>
-                  <input
-                    type="text"
-                    id="apiBase_CUSTOM"
-                    placeholder="https://api.example.com"
-                  />
-                </div>
-                <div class="api-field-row">
-                  <label for="apiEndpoint_CUSTOM">Endpoint:</label>
-                  <input
-                    type="text"
-                    id="apiEndpoint_CUSTOM"
-                    placeholder="/latest?key={API_KEY}&metal={METAL}"
-                  />
-                </div>
-                <div class="api-field-row">
-                  <label for="apiFormat_CUSTOM">Metal Format:</label>
-                  <select id="apiFormat_CUSTOM">
-                    <option value="symbol">Symbol</option>
-                    <option value="word">Word</option>
-                  </select>
-                </div>
-                <div class="api-key-row">
-                  <label for="apiKey_CUSTOM">API Key:</label>
-                  <input
-                    type="password"
-                    id="apiKey_CUSTOM"
-                    placeholder="Enter your API key"
-                  />
-                </div>
-                
-                <!-- Provider Settings Section -->
-                <div class="provider-settings">
-                  <h4>Provider Settings</h4>
-                  
-                  <div class="provider-setting-row">
-                    <label for="cacheTimeout_CUSTOM">Cache Timeout:</label>
-                    <select id="cacheTimeout_CUSTOM" class="provider-cache-select">
-                      <option value="0">No Cache</option>
-                      <option value="1">1 hour</option>
-                      <option value="6">6 hours</option>
-                      <option value="12">12 hours</option>
-                      <option value="24" selected>24 hours</option>
-                    </select>
-                  </div>
-                  
-                  <div class="provider-setting-row">
-                    <label for="historyDays_CUSTOM">History Days:</label>
-                    <input type="number" id="historyDays_CUSTOM" class="provider-history-input"
-                           min="1" max="365" value="30" placeholder="1-365">
-                  </div>
-
-                  <div class="provider-setting-row">
-                    <label for="historyTimes_CUSTOM">Times per Day:</label>
-                    <input type="text" id="historyTimes_CUSTOM" class="provider-history-input"
-                           placeholder="08:00,20:00">
-                  </div>
-
-                  <!-- Metal Selection -->
-                  <div class="metal-selection">
-                    <label>Select Metals to Track:</label>
-                    <div class="metal-checkboxes">
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="silver" checked>
-                        <span class="metal-name">Silver (AG)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="gold" checked>
-                        <span class="metal-name">Gold (AU)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="platinum" checked>
-                        <span class="metal-name">Platinum (PT)</span>
-                      </label>
-                      <label class="metal-checkbox">
-                        <input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="palladium" checked>
-                        <span class="metal-name">Palladium (PD)</span>
-                      </label>
-                    </div>
-                  </div>
-                  
-                <!-- Batch Optimization Display -->
-                <div class="batch-optimization">
-                  <div class="batch-info" id="batchInfo_CUSTOM">
-                    📊 Individual Requests: 4 metals = 4 API calls<br>
-                    <span class="batch-savings">(batch requests not supported)</span>
-                  </div>
-                </div>
-                <div class="provider-info">
-                  <div class="api-key-note">
-                    Your API key is stored locally and never shared.
-                  </div>
-                  <div class="provider-status">
-                    <span class="status-dot"></span>
-                    <span class="status-text">Disconnected</span>
-                  </div>
-                  <div class="provider-history"></div>
-                </div>
-              </div>
-              <div class="provider-footer">
-                <div class="provider-actions">
-                  <button
-                    type="button"
-                    class="btn provider-default-btn"
-                    data-provider="CUSTOM"
-                  >
-                    </button>
-                    <div class="provider-actions-right">
-                      <button
-                        type="button"
-                        class="btn api-quota-btn"
-                        data-provider="CUSTOM"
-                      >
-                        Quota
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-clear-btn warning"
-                        data-provider="CUSTOM"
-                      >
-                        Clear Key
-                      </button>
-                      <button
-                        type="button"
-                        class="btn api-sync-btn success"
-                        data-provider="CUSTOM"
-                      >
-                        Save and Test
-                      </button>
-                    </div>
+                <div class="settings-card boating-accident-section">
+                  <h3>Backup, Restore, Clear</h3>
+                  <p class="settings-subtext">Manage local application data.</p>
+                  <div class="backup-buttons">
+                    <button class="btn warning" id="removeInventoryDataBtn">Remove Inventory Data</button>
+                    <button class="btn danger" id="boatingAccidentBtn">Wipe All Data</button>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-      </div>
+
+            <!-- ===== CLOUD SYNC (placeholder) ===== -->
+            <div class="settings-section-panel" id="settingsPanel_cloud" style="display: none">
+              <h3>Cloud Sync</h3>
+              <div class="settings-placeholder">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
+                <p>BYO-Backend (Supabase) coming soon.</p>
+              </div>
+            </div>
+
+            <!-- ===== TOOLS (placeholder) ===== -->
+            <div class="settings-section-panel" id="settingsPanel_tools" style="display: none">
+              <h3>Tools</h3>
+              <div class="settings-placeholder">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                <p>Bulk rename, bulk operations coming soon.</p>
+              </div>
+            </div>
+
+          </div><!-- .settings-content-area -->
+        </div><!-- .settings-modal-layout -->
+        <div class="settings-footer" id="settingsFooter"></div>
+      </div><!-- .settings-modal-content -->
+    </div><!-- #settingsModal -->
 
     <div class="modal" id="cloudSyncModal" style="display: none">
       <div class="modal-content">
@@ -2252,7 +2007,7 @@
        1. constants.js - Global configuration and version
        2. state.js - Application state and DOM element caching
        3. utils.js - Utility functions and formatters
-       4. Feature modules - charts, theme, search, sorting, pagination, etc.
+       4. Feature modules - charts, theme, search, sorting, portal view, etc.
        5. Core modules - spot price management and inventory operations
        6. events.js - Event listener setup (requires all other modules)
        7. init.js - Application initialization and startup
@@ -2286,6 +2041,7 @@
     <script defer src="./js/inventory.js"></script>
     <script defer src="./js/about.js"></script>
     <script defer src="./js/customMapping.js"></script>
+    <script defer src="./js/settings.js"></script>
     <script defer src="./js/events.js"></script>
     
     <!-- Test Scripts (Development) -->

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,12 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.12.01 – Sticky header fix</strong>: Column headers now correctly pin at the top of the scrollable portal view during vertical scroll</li>
+    <li><strong>v3.12.00 – Portal view</strong>: Inventory table now renders all items in a scrollable container with sticky column headers — pagination removed. Visible rows (10/15/25/50/100) control viewport height</li>
+    <li><strong>v3.11.00 – Unified Settings modal</strong>: API, Files, and Appearance consolidated into a single Settings modal with sidebar navigation. Header simplified to About + Settings</li>
+    <li><strong>v3.11.00 – Theme picker</strong>: 3-button theme selector replaces cycling toggle</li>
+    <li><strong>v3.11.00 – Tabbed API providers</strong>: Provider config uses tabbed panels instead of scrollable list</li>
+    <li><strong>v3.11.00 – Items per page persisted</strong>: Setting now survives page reloads</li>
     <li><strong>v3.10.01 – Numista iframe fix</strong>: Numista pages now open in a popup window — fixes "Can't Open This Page" error on hosted sites</li>
     <li><strong>v3.10.01 – Sort fix</strong>: Gain/Loss and Source columns now sort and resize correctly</li>
     <li><strong>v3.10.00 – Serial # field</strong>: New optional Serial Number input for bars and notes. Included in all export/import formats</li>

--- a/js/api.js
+++ b/js/api.js
@@ -530,56 +530,9 @@ const hideApiHistoryModal = () => {
  * Shows API providers modal
  */
 const showApiProvidersModal = () => {
-  const modal = document.getElementById("apiProvidersModal");
-  if (modal) {
-    refreshProviderStatuses();
-    updateProviderHistoryTables();
-    
-    // Initialize provider settings
-    Object.keys(API_PROVIDERS).forEach(provider => {
-      setupProviderSettingsListeners(provider);
-      
-      // Load current settings
-      const config = loadApiConfig();
-      
-      // Set cache timeout
-      const cacheSelect = document.getElementById(`cacheTimeout_${provider}`);
-      if (cacheSelect) {
-        const timeout = config.cacheTimeouts?.[provider] || 24;
-        cacheSelect.value = timeout;
-      }
-      
-      // Set history days
-      const historyInput = document.getElementById(`historyDays_${provider}`);
-      if (historyInput) {
-        const defaultDays = provider === "METALS_DEV" ? 29 : 30;
-        let days = config.historyDays?.[provider];
-        if (typeof days !== "number" || isNaN(days)) days = defaultDays;
-        if (provider === "METALS_DEV" && days > 30) days = 30;
-        historyInput.value = days;
-      }
-
-      // Set history times
-      const timesInput = document.getElementById(`historyTimes_${provider}`);
-      if (timesInput) {
-        const times = config.historyTimes?.[provider] || [];
-        timesInput.value = Array.isArray(times) ? times.join(',') : '';
-      }
-
-      // Set metal selections
-      const metals = config.metals?.[provider] || {};
-      ['silver', 'gold', 'platinum', 'palladium'].forEach(metal => {
-        const checkbox = document.querySelector(`.provider-metal[data-provider="${provider}"][data-metal="${metal}"]`);
-        if (checkbox) {
-          checkbox.checked = metals[metal] !== false;
-        }
-      });
-      
-      // Update batch calculation
-      updateBatchCalculation(provider);
-    });
-    
-    modal.style.display = "flex";
+  // Redirect to Settings modal API section
+  if (typeof showSettingsModal === "function") {
+    showSettingsModal('api');
   }
 };
 
@@ -587,8 +540,10 @@ const showApiProvidersModal = () => {
  * Hides API providers modal
  */
 const hideApiProvidersModal = () => {
-  const modal = document.getElementById("apiProvidersModal");
-  if (modal) modal.style.display = "none";
+  // Legacy — Settings modal handles its own close
+  if (typeof hideSettingsModal === "function") {
+    hideSettingsModal();
+  }
 };
 
 /**
@@ -1423,11 +1378,10 @@ const updateSyncButtonStates = (syncing = false) => {
  * Updates API status display in modal
  */
 /**
- * Shows settings modal and populates API fields
+ * Populates the API section fields with current configuration.
+ * Called when switching to the API section in the Settings modal.
  */
-const showApiModal = () => {
-  const modal = document.getElementById("apiModal");
-  if (!modal) return;
+const populateApiSection = () => {
   let currentConfig = loadApiConfig() || {
     provider: "",
     keys: {},
@@ -1457,39 +1411,92 @@ const showApiModal = () => {
 
   updateDefaultProviderButtons();
   updateProviderHistoryTables();
-  modal.style.display = "flex";
+
+  // Initialize provider settings listeners and load saved values
+  const cfg = loadApiConfig();
+  Object.keys(API_PROVIDERS).forEach(provider => {
+    if (typeof setupProviderSettingsListeners === 'function') {
+      setupProviderSettingsListeners(provider);
+    }
+
+    // Load saved cache timeout
+    const cacheSelect = document.getElementById(`cacheTimeout_${provider}`);
+    if (cacheSelect) {
+      cacheSelect.value = cfg.cacheTimeouts?.[provider] || 24;
+    }
+
+    // Load saved history days
+    const historyInput = document.getElementById(`historyDays_${provider}`);
+    if (historyInput) {
+      const defaultDays = provider === "METALS_DEV" ? 29 : 30;
+      let days = cfg.historyDays?.[provider];
+      if (typeof days !== "number" || isNaN(days)) days = defaultDays;
+      if (provider === "METALS_DEV" && days > 30) days = 30;
+      historyInput.value = days;
+    }
+
+    // Load saved history times
+    const timesInput = document.getElementById(`historyTimes_${provider}`);
+    if (timesInput) {
+      const times = cfg.historyTimes?.[provider] || [];
+      timesInput.value = Array.isArray(times) ? times.join(',') : '';
+    }
+
+    // Load saved metal selections
+    const metals = cfg.metals?.[provider] || {};
+    ['silver', 'gold', 'platinum', 'palladium'].forEach(metal => {
+      const checkbox = document.querySelector(`.provider-metal[data-provider="${provider}"][data-metal="${metal}"]`);
+      if (checkbox) {
+        checkbox.checked = metals[metal] !== false;
+      }
+    });
+
+    if (typeof updateBatchCalculation === 'function') {
+      updateBatchCalculation(provider);
+    }
+  });
+
+  if (typeof refreshProviderStatuses === 'function') {
+    refreshProviderStatuses();
+  }
 };
 
 /**
- * Hides API modal
+ * Legacy showApiModal — redirects to Settings modal API section
+ */
+const showApiModal = () => {
+  if (typeof showSettingsModal === "function") {
+    showSettingsModal('api');
+  }
+};
+
+/**
+ * Legacy hideApiModal — redirects to hideSettingsModal
  */
 const hideApiModal = () => {
-  const modal = document.getElementById("apiModal");
-  if (modal) {
-    modal.style.display = "none";
+  if (typeof hideSettingsModal === "function") {
+    hideSettingsModal();
   }
 };
 
+/**
+ * Legacy showFilesModal — redirects to Settings modal Files section
+ */
 const showFilesModal = () => {
-  const modal = document.getElementById("filesModal");
-  if (window.openModalById) {
-    openModalById('filesModal');
-  } else if (modal) {
-    modal.style.display = "flex";
-    document.body.style.overflow = 'hidden';
+  if (typeof showSettingsModal === "function") {
+    showSettingsModal('files');
   }
 };
 
+/**
+ * Legacy hideFilesModal — redirects to hideSettingsModal
+ */
 const hideFilesModal = () => {
-  if (window.closeModalById) {
-    closeModalById('filesModal');
+  if (typeof hideSettingsModal === "function") {
+    hideSettingsModal();
   } else {
-    const modal = document.getElementById("filesModal");
-    if (modal) {
-      modal.style.display = "none";
-    }
-    try { 
-      document.body.style.overflow = ''; 
+    try {
+      document.body.style.overflow = '';
     } catch (e) {
       console.warn('Failed to reset body overflow:', e);
     }
@@ -1547,6 +1554,7 @@ const hideProviderInfo = () => {
   window.hideApiModal = hideApiModal;
   window.showFilesModal = showFilesModal;
   window.hideFilesModal = hideFilesModal;
+  window.populateApiSection = populateApiSection;
   window.showProviderInfo = showProviderInfo;
   window.hideProviderInfo = hideProviderInfo;
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -230,10 +230,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-08 - Numista API v3 integration fix
+ * Updated: 2026-02-08 - Unified Settings modal
  */
 
-const APP_VERSION = "3.10.01";
+const APP_VERSION = "3.12.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -391,6 +391,9 @@ const FEATURE_FLAGS_KEY = "featureFlags";
 /** @constant {string} SPOT_TREND_RANGE_KEY - LocalStorage key for sparkline trend range preferences */
 const SPOT_TREND_RANGE_KEY = "spotTrendRange";
 
+/** @constant {string} ITEMS_PER_PAGE_KEY - LocalStorage key for items per page setting */
+const ITEMS_PER_PAGE_KEY = "settingsItemsPerPage";
+
 /**
  * List of recognized localStorage keys for cleanup validation
  * @constant {string[]}
@@ -424,6 +427,7 @@ const ALLOWED_STORAGE_KEYS = [
   "staktrakr.catalog.settings",
   CATALOG_HISTORY_KEY,
   SPOT_TREND_RANGE_KEY,
+  ITEMS_PER_PAGE_KEY,
 ];
 
 // Persist current application version for comparison on future loads

--- a/js/filters.js
+++ b/js/filters.js
@@ -22,7 +22,6 @@ const clearAllFilters = () => {
   const metalFilter = document.getElementById('metalFilter');
   if (metalFilter) metalFilter.value = '';
 
-  currentPage = 1;
   // Update chip UI before rerendering the table
   renderActiveFilters();
   renderTable();
@@ -54,7 +53,6 @@ const removeFilter = (field, value) => {
     }
   }
 
-  currentPage = 1;
   renderTable();
 };
 
@@ -935,7 +933,6 @@ const applyQuickFilter = (field, value, isGrouped = false) => {
   }
 
   // Don't clear search query - allow search + filters to work together
-  currentPage = 1;
   renderTable();
   renderActiveFilters();
 };

--- a/js/init.js
+++ b/js/init.js
@@ -112,20 +112,19 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.itemGrade = safeGetElement("itemGrade");
     elements.itemGradingAuthority = safeGetElement("itemGradingAuthority");
     elements.itemCertNumber = safeGetElement("itemCertNumber");
+    elements.itemSerialNumber = safeGetElement("itemSerialNumber");
     elements.searchNumistaBtn = safeGetElement("searchNumistaBtn");
 
     // Header buttons - CRITICAL
     debugLog("Phase 2: Initializing header buttons...");
     elements.appLogo = safeGetElement("appLogo");
-    elements.appearanceBtn = safeGetElement("appearanceBtn");
-    elements.apiBtn = safeGetElement("apiBtn");
-    elements.filesBtn = safeGetElement("filesBtn", true);
+    elements.settingsBtn = safeGetElement("settingsBtn", true);
     elements.aboutBtn = safeGetElement("aboutBtn");
 
     // Check if critical buttons exist
     debugLog(
-      "Files Button found:",
-      !!document.getElementById("filesBtn"),
+      "Settings Button found:",
+      !!document.getElementById("settingsBtn"),
     );
 
     // Import/Export elements
@@ -154,11 +153,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Modal elements
     debugLog("Phase 4: Initializing modal elements...");
-    elements.apiModal = safeGetElement("apiModal");
-    elements.filesModal = safeGetElement("filesModal");
+    elements.settingsModal = safeGetElement("settingsModal");
     elements.apiInfoModal = safeGetElement("apiInfoModal");
     elements.apiHistoryModal = safeGetElement("apiHistoryModal");
-    elements.apiProvidersModal = safeGetElement("apiProvidersModal");
     elements.cloudSyncModal = safeGetElement("cloudSyncModal");
     elements.apiQuotaModal = safeGetElement("apiQuotaModal");
     elements.aboutModal = safeGetElement("aboutModal");
@@ -195,11 +192,6 @@ document.addEventListener("DOMContentLoaded", () => {
     // Pagination elements
     debugLog("Phase 5: Initializing pagination elements...");
     elements.itemsPerPage = safeGetElement("itemsPerPage");
-    elements.prevPage = safeGetElement("prevPage");
-    elements.nextPage = safeGetElement("nextPage");
-    elements.firstPage = safeGetElement("firstPage");
-    elements.lastPage = safeGetElement("lastPage");
-    elements.pageNumbers = safeGetElement("pageNumbers");
     elements.itemCount = safeGetElement("itemCount");
 
       elements.changeLogBtn = safeGetElement("changeLogBtn");
@@ -354,6 +346,18 @@ document.addEventListener("DOMContentLoaded", () => {
     apiConfig = loadApiConfig();
     apiCache = loadApiCache();
 
+    // Load persisted items-per-page setting
+    try {
+      const savedIpp = localStorage.getItem(ITEMS_PER_PAGE_KEY);
+      if (savedIpp) {
+        const parsed = parseInt(savedIpp, 10);
+        if ([10, 15, 25, 50, 100].includes(parsed)) {
+          itemsPerPage = parsed;
+          if (elements.itemsPerPage) elements.itemsPerPage.value = String(parsed);
+        }
+      }
+    } catch (e) { /* ignore */ }
+
     // Apply saved theme attribute early so CSS variables resolve correctly
     // before renderActiveFilters() computes contrast colors in Phase 13
     const earlyTheme = localStorage.getItem(THEME_KEY);
@@ -393,6 +397,9 @@ document.addEventListener("DOMContentLoaded", () => {
         setupPagination();
         setupBulkEditControls();
         setupThemeToggle();
+        if (typeof setupSettingsEventListeners === 'function') {
+          setupSettingsEventListeners();
+        }
         setupColumnResizing();
         
         // Setup Edit header toggle functionality
@@ -434,7 +441,7 @@ document.addEventListener("DOMContentLoaded", () => {
     debugLog("✓ API configured:", !!apiConfig);
     debugLog("✓ Inventory items:", inventory.length);
     debugLog("✓ Critical elements check:");
-    debugLog("  - Files button:", !!elements.filesBtn);
+    debugLog("  - Settings button:", !!elements.settingsBtn);
     debugLog("  - Inventory form:", !!elements.inventoryForm);
     debugLog("  - Inventory table:", !!elements.inventoryTable);
     // Phase 16: Storage optimization pass
@@ -469,43 +476,12 @@ document.addEventListener('DOMContentLoaded', function() {
 function setupBasicEventListeners() {
   debugLog("Setting up basic event listeners as fallback...");
 
-  // Files button
-  const filesBtn = document.getElementById("filesBtn");
-  if (filesBtn) {
-    filesBtn.onclick = function () {
-      if (typeof showFilesModal === "function") {
-        showFilesModal();
-      }
-    };
-  }
-
-  // Appearance button (four-state theme toggle)
-  const appearanceBtn = document.getElementById("appearanceBtn");
-  if (appearanceBtn) {
-    appearanceBtn.onclick = function (e) {
-      e.preventDefault();
-      const savedTheme = localStorage.getItem(THEME_KEY) || "system";
-      if (savedTheme === "dark") {
-        setTheme("light");
-      } else if (savedTheme === "light") {
-        setTheme("sepia");
-      } else if (savedTheme === "sepia") {
-        setTheme("system");
-      } else {
-        setTheme("dark");
-      }
-      if (typeof updateThemeButton === "function") {
-        updateThemeButton();
-      }
-    };
-  }
-
-  // API button
-  const apiBtn = document.getElementById("apiBtn");
-  if (apiBtn) {
-    apiBtn.onclick = function () {
-      if (typeof showApiModal === "function") {
-        showApiModal();
+  // Settings button
+  const settingsBtn = document.getElementById("settingsBtn");
+  if (settingsBtn) {
+    settingsBtn.onclick = function () {
+      if (typeof showSettingsModal === "function") {
+        showSettingsModal();
       }
     };
   }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -72,7 +72,6 @@ const createBackupZip = async () => {
       spotPrices: spotPrices,
       theme: localStorage.getItem(THEME_KEY) || 'light',
       itemsPerPage: itemsPerPage,
-      currentPage: currentPage,
       searchQuery: searchQuery,
       sortColumn: sortColumn,
       sortDirection: sortDirection,
@@ -937,13 +936,10 @@ const renderTable = () => {
     updateItemCount(filteredInventory.length, inventory.length);
     const sortedInventory = sortInventory(filteredInventory);
     debugLog('renderTable start', sortedInventory.length, 'items');
-    const totalPages = calculateTotalPages(sortedInventory);
-    const startIndex = (currentPage - 1) * itemsPerPage;
-    const endIndex = Math.min(startIndex + itemsPerPage, sortedInventory.length);
 
     const rows = [];
 
-    for (let i = startIndex; i < endIndex; i++) {
+    for (let i = 0; i < sortedInventory.length; i++) {
       const item = sortedInventory[i];
       const originalIdx = inventory.indexOf(item);
       debugLog('renderTable row', i, item.name);
@@ -1038,20 +1034,14 @@ const renderTable = () => {
       `);
     }
 
-    const visibleCount = endIndex - startIndex;
-    const placeholders = Array.from(
-      { length: Math.max(0, itemsPerPage - visibleCount) },
-      () => '<tr><td class="shrink" colspan="12">&nbsp;</td></tr>'
-    );
-
     // Find tbody element directly if cached version fails
     const tbody = elements.inventoryTable || document.querySelector('#inventoryTable tbody');
     if (!tbody) {
       console.error('Could not find table tbody element');
       return;
     }
-    
-    tbody.innerHTML = rows.concat(placeholders).join('');
+
+    tbody.innerHTML = rows.join('');
     hideEmptyColumns();
 
     debugLog('renderTable complete');
@@ -1071,7 +1061,7 @@ const renderTable = () => {
       header.appendChild(indicator);
     }
 
-    renderPagination(sortedInventory);
+    updatePortalHeight();
     updateSummary();
     
     // Re-setup column resizing and responsive visibility after table re-render

--- a/js/search.js
+++ b/js/search.js
@@ -265,7 +265,6 @@ const searchInput = document.getElementById('searchInput');
 if (searchInput) {
   const debouncedSearch = debounce((query) => {
     searchQuery = query;
-    currentPage = 1;
     filterInventory();
   }, 300);
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,251 @@
+// SETTINGS MODAL
+// =============================================================================
+
+/**
+ * Opens the unified Settings modal, optionally navigating to a section.
+ * @param {string} [section='site'] - Section to display: 'site', 'api', 'files', 'cloud', 'tools'
+ */
+const showSettingsModal = (section = 'site') => {
+  const modal = document.getElementById('settingsModal');
+  if (!modal) return;
+
+  syncSettingsUI();
+  switchSettingsSection(section);
+
+  if (window.openModalById) {
+    openModalById('settingsModal');
+  } else {
+    modal.style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+  }
+};
+
+/**
+ * Closes the Settings modal.
+ */
+const hideSettingsModal = () => {
+  if (window.closeModalById) {
+    closeModalById('settingsModal');
+  } else {
+    const modal = document.getElementById('settingsModal');
+    if (modal) modal.style.display = 'none';
+    try { document.body.style.overflow = ''; } catch (e) { /* ignore */ }
+  }
+};
+
+/**
+ * Switches the visible section panel in the Settings modal.
+ * @param {string} name - Section key: 'site', 'api', 'files', 'cloud', 'tools'
+ */
+const switchSettingsSection = (name) => {
+  // Hide all panels
+  document.querySelectorAll('.settings-section-panel').forEach(panel => {
+    panel.style.display = 'none';
+  });
+
+  // Show target panel
+  const target = document.getElementById(`settingsPanel_${name}`);
+  if (target) target.style.display = 'block';
+
+  // Update active nav item
+  document.querySelectorAll('.settings-nav-item').forEach(item => {
+    item.classList.toggle('active', item.dataset.section === name);
+  });
+
+  // Populate API data when switching to API section
+  if (name === 'api' && typeof populateApiSection === 'function') {
+    populateApiSection();
+  }
+};
+
+/**
+ * Switches the visible provider tab in the API section.
+ * @param {string} key - Provider key: 'METALS_DEV', 'METALS_API', 'METAL_PRICE_API', 'CUSTOM'
+ */
+const switchProviderTab = (key) => {
+  // Hide all provider panels
+  document.querySelectorAll('.settings-provider-panel').forEach(panel => {
+    panel.style.display = 'none';
+  });
+
+  // Show target panel
+  const target = document.getElementById(`providerPanel_${key}`);
+  if (target) target.style.display = 'block';
+
+  // Update active tab
+  document.querySelectorAll('.settings-provider-tab').forEach(tab => {
+    tab.classList.toggle('active', tab.dataset.provider === key);
+  });
+};
+
+/**
+ * Syncs all Settings UI controls with current application state.
+ * Called each time the modal opens to ensure controls reflect live values.
+ */
+const syncSettingsUI = () => {
+  // Theme picker
+  const currentTheme = localStorage.getItem(THEME_KEY) || 'light';
+  document.querySelectorAll('.theme-option').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.theme === currentTheme);
+  });
+
+  // Items per page
+  const ippSelect = document.getElementById('settingsItemsPerPage');
+  if (ippSelect) {
+    ippSelect.value = String(itemsPerPage);
+  }
+
+  // Chip min count — sync with inline control
+  const chipMinSetting = document.getElementById('settingsChipMinCount');
+  const chipMinInline = document.getElementById('chipMinCount');
+  if (chipMinSetting) {
+    chipMinSetting.value = localStorage.getItem('chipMinCount') || '3';
+  }
+
+  // Smart name grouping — sync with inline control
+  const groupSetting = document.getElementById('settingsGroupNameChips');
+  if (groupSetting && window.featureFlags) {
+    groupSetting.value = featureFlags.isEnabled('GROUPED_NAME_CHIPS') ? 'yes' : 'no';
+  }
+
+  // Storage footer
+  updateSettingsFooter();
+
+  // API status
+  if (typeof renderApiStatusSummary === 'function') {
+    renderApiStatusSummary();
+  }
+
+  // Set first provider tab active if none visible
+  const anyVisible = document.querySelector('.settings-provider-panel[style*="display: block"]');
+  if (!anyVisible) {
+    switchProviderTab('METALS_DEV');
+  }
+};
+
+/**
+ * Updates the storage + version footer bar at the bottom of the Settings modal.
+ */
+const updateSettingsFooter = () => {
+  const footerEl = document.getElementById('settingsFooter');
+  if (!footerEl) return;
+
+  let storageText = '';
+  try {
+    let totalBytes = 0;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      const val = localStorage.getItem(key);
+      totalBytes += (key.length + (val ? val.length : 0)) * 2; // UTF-16
+    }
+    const mb = (totalBytes / (1024 * 1024)).toFixed(2);
+    storageText = `Storage: ${mb} MB / 5 MB`;
+  } catch (e) {
+    storageText = 'Storage: unknown';
+  }
+
+  footerEl.textContent = `${storageText}  \u00b7  v${APP_VERSION}`;
+};
+
+/**
+ * Wires up all Settings modal event listeners.
+ * Called once during initialization.
+ */
+const setupSettingsEventListeners = () => {
+  // Sidebar navigation
+  document.querySelectorAll('.settings-nav-item').forEach(item => {
+    item.addEventListener('click', () => {
+      switchSettingsSection(item.dataset.section);
+    });
+  });
+
+  // Provider tabs
+  document.querySelectorAll('.settings-provider-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      switchProviderTab(tab.dataset.provider);
+    });
+  });
+
+  // Theme picker buttons
+  document.querySelectorAll('.theme-option').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const theme = btn.dataset.theme;
+      if (typeof setTheme === 'function') {
+        setTheme(theme);
+      }
+      if (typeof updateThemeButton === 'function') {
+        updateThemeButton();
+      }
+      // Update active state
+      document.querySelectorAll('.theme-option').forEach(b => {
+        b.classList.toggle('active', b.dataset.theme === theme);
+      });
+    });
+  });
+
+  // Items per page
+  const ippSelect = document.getElementById('settingsItemsPerPage');
+  if (ippSelect) {
+    ippSelect.addEventListener('change', () => {
+      const val = parseInt(ippSelect.value, 10);
+      itemsPerPage = val;
+      // Persist
+      try { localStorage.setItem(ITEMS_PER_PAGE_KEY, String(val)); } catch (e) { /* ignore */ }
+      // Sync footer select
+      if (elements.itemsPerPage) elements.itemsPerPage.value = String(val);
+      renderTable();
+    });
+  }
+
+  // Chip min count in settings
+  const chipMinSetting = document.getElementById('settingsChipMinCount');
+  if (chipMinSetting) {
+    chipMinSetting.addEventListener('change', () => {
+      const val = chipMinSetting.value;
+      localStorage.setItem('chipMinCount', val);
+      // Sync inline control
+      const chipMinInline = document.getElementById('chipMinCount');
+      if (chipMinInline) chipMinInline.value = val;
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+    });
+  }
+
+  // Smart name grouping in settings
+  const groupSetting = document.getElementById('settingsGroupNameChips');
+  if (groupSetting) {
+    groupSetting.addEventListener('change', () => {
+      const isEnabled = groupSetting.value === 'yes';
+      if (window.featureFlags) {
+        if (isEnabled) featureFlags.enable('GROUPED_NAME_CHIPS');
+        else featureFlags.disable('GROUPED_NAME_CHIPS');
+      }
+      // Sync inline control
+      const groupInline = document.getElementById('groupNameChips');
+      if (groupInline) groupInline.value = groupSetting.value;
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+    });
+  }
+
+  // Settings modal close button
+  const closeBtn = document.getElementById('settingsCloseBtn');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', hideSettingsModal);
+  }
+
+  // Settings modal backdrop click
+  const modal = document.getElementById('settingsModal');
+  if (modal) {
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) hideSettingsModal();
+    });
+  }
+};
+
+// Expose globally
+if (typeof window !== 'undefined') {
+  window.showSettingsModal = showSettingsModal;
+  window.hideSettingsModal = hideSettingsModal;
+  window.switchSettingsSection = switchSettingsSection;
+  window.switchProviderTab = switchProviderTab;
+  window.setupSettingsEventListeners = setupSettingsEventListeners;
+}

--- a/js/state.js
+++ b/js/state.js
@@ -12,9 +12,8 @@ let notesIndex = null;
 /** @type {number|null} Change log entry currently being edited */
 let editingChangeLogIndex = null;
 
-/** @type {Object} Pagination state */
-let currentPage = 1; // Current page number (1-based)
-let itemsPerPage = 25; // Number of items to display per page
+/** @type {number} Number of visible rows in the portal (scrollable table) view */
+let itemsPerPage = 25;
 
 /** @type {string} Current search query */
 let searchQuery = "";
@@ -127,13 +126,8 @@ const elements = {
   typeChart: null,
   locationChart: null,
 
-  // Pagination elements
+  // Portal view elements
   itemsPerPage: null,
-  prevPage: null,
-  nextPage: null,
-  firstPage: null,
-  lastPage: null,
-  pageNumbers: null,
   itemCount: null,
 
   // Change log elements
@@ -170,15 +164,13 @@ const elements = {
   ackModal: null,
   ackAcceptBtn: null,
 
-  // Appearance, API & Files elements
-  appearanceBtn: null,
-  apiBtn: null,
-  filesBtn: null,
-  apiModal: null,
-  filesModal: null,
+  // Settings modal elements
+  settingsBtn: null,
+  settingsModal: null,
+
+  // Sub-modals (stacking overlays opened from within Settings)
   apiInfoModal: null,
   apiHistoryModal: null,
-  apiProvidersModal: null,
   cloudSyncModal: null,
   apiQuotaModal: null,
 

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,19 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.12.01": `
+      <li><strong>Sticky header fix</strong>: Column headers now correctly pin at the top of the scrollable table during vertical scroll</li>
+    `,
+    "3.12.00": `
+      <li><strong>Portal view</strong>: Inventory table now renders all items in a scrollable container with sticky column headers — pagination removed</li>
+      <li><strong>Visible rows</strong>: Dropdown (10 / 15 / 25 / 50 / 100) sets the viewport height; scroll to see remaining items</li>
+    `,
+    "3.11.00": `
+      <li><strong>Unified Settings modal</strong>: API, Files, and Appearance consolidated into a single near-full-screen modal with sidebar navigation. Header simplified to About + Settings</li>
+      <li><strong>Theme picker</strong>: 3-button theme selector (Light / Dark / Sepia) replaces the cycling toggle button</li>
+      <li><strong>Tabbed API providers</strong>: Provider configuration uses tabbed panels instead of a scrollable list</li>
+      <li><strong>Items per page persisted</strong>: Items-per-page setting now survives page reloads</li>
+    `,
     "3.10.01": `
       <li><strong>Numista iframe fix</strong>: Numista pages now open in a popup window instead of an iframe — fixes "Can't Open This Page" error on hosted deployments (X-Frame-Options)</li>
       <li><strong>Sort fix</strong>: Gain/Loss and Source columns now sort and resize correctly</li>


### PR DESCRIPTION
## Summary

- **Portal view (v3.12.00)**: Replaced slice-based pagination with a scrollable table that renders all items at once. Visible rows dropdown (10/15/25/50/100) controls viewport height. Column headers pin via CSS `position: sticky`
- **Sticky header fix (v3.12.01)**: Fixed column-resize JS setting inline `position: relative` on every `th` except Actions, overriding CSS `position: sticky`. Also fixed CSS specificity conflicts, added `max-height` fallback on scroll container, and cleared `overflow: hidden` from `.table-section`
- **Includes prior unreleased work**: v3.09.04 through v3.11.00 (Year field, Serial #, grading fields, Numista fixes, unified Settings modal, theme picker, and more)

## Test plan

- [ ] Table renders all items in scrollable container — no pagination controls
- [ ] Column headers stay pinned at top during vertical scroll (all columns, not just Actions)
- [ ] Visible rows dropdown (10/15/25/50/100) changes table viewport height
- [ ] Column resize drag handles still work correctly on all headers
- [ ] Horizontal scroll moves headers and body together
- [ ] Search/filter narrows visible items; table height adjusts
- [ ] Settings modal "Visible rows" syncs with table footer dropdown
- [ ] Setting persists across page reloads
- [ ] All themes (light/dark/sepia) render correctly with sticky header
- [ ] Mobile responsive behavior works
- [ ] Inline editing (shift+click) works inside scrollable table

🤖 Generated with [Claude Code](https://claude.com/claude-code)