### PR TITLE
v3.12.02: NGC cert fix, name overflow, Numista Sets, source display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .mcp.json
 CLAUDE.md
 TAXONOMY.md
+SPRINT.md
 
 # Node modules (if added in future)
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.02] - 2026-02-08
+
+### Fixed
+
+- **NGC cert lookup**: Cert tag click now opens NGC with query params (`CertNum`, `Grade`, `lookup`) so the actual coin details display instead of the blank lookup form
+- **Name column overflow**: Long item names no longer push Source and Actions columns off-screen. Name text truncates with ellipsis; Year, N#, and Grade tags always stay visible via flex layout
+- **"- Route 66" chip**: Leading dash/punctuation stripped from normalized chip names after suffix removal
+- **Source column display**: URL-like sources (e.g., "apmex.com") now display the domain name only ("apmex") with a link icon; plain text sources show without icon
+
+### Added
+
+- **"Lunar Series" chip**: Items with "Year of the" in the name (e.g., "Year of the Dragon") now group under a "Lunar Series" filter chip
+- **Numista Sets support**: New "Set" inventory type with purple color. Numista S-prefix IDs (e.g., S4203) route to the correct `set.php` URL pattern instead of `pieces{ID}.html`
+
+---
+
 ## [3.12.01] - 2026-02-08
 
 ### Fixed — Sticky header

--- a/css/styles.css
+++ b/css/styles.css
@@ -66,6 +66,8 @@
   --type-bar-text: #ffffff;
   --type-note-bg: #047857;
   --type-note-text: #f8fafc;
+  --type-set-bg: #8B5CF6;
+  --type-set-text: #ffffff;
   --type-other-bg: #6d35d0;
   --type-other-text: #f8fafc;
 
@@ -115,6 +117,8 @@
   --type-bar-text: #1e293b;
   --type-note-bg: #047857;
   --type-note-text: #ffffff;
+  --type-set-bg: #a78bfa;
+  --type-set-text: #1e293b;
   --type-other-bg: #8b5cf6;
   --type-other-text: #ffffff;
 
@@ -169,6 +173,8 @@
   --type-bar-text: #ffffff;
   --type-note-bg: #066b52;
   --type-note-text: #ffffff;
+  --type-set-bg: #7c3aed;
+  --type-set-text: #ffffff;
   --type-other-bg: #6a3fa8;
   --type-other-text: #ffffff;
 
@@ -2183,6 +2189,33 @@ td {
 td[data-column="name"] {
   max-width: none;
   width: auto;
+  overflow: hidden; /* Constrain inner flex container to cell's computed width */
+}
+
+/* Name cell flex layout — name text truncates, tags stay visible */
+.name-cell-content {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* Name text truncates with ellipsis */
+.name-cell-content > .filter-text {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Tags never shrink — always visible */
+.name-cell-content > .year-tag,
+.name-cell-content > .numista-tag,
+.name-cell-content > .grade-tag {
+  flex-shrink: 0;
 }
 
 td[data-column="purchaseLocation"],
@@ -2219,13 +2252,11 @@ th[data-column="date"] {
 /* Metal column expansion on hover - CELLS ONLY */
 #inventoryTable td[data-column="metal"]:hover {
   max-width: none;
-  white-space: normal;
-  word-wrap: break-word;
+  white-space: nowrap;
   z-index: 10;
   background: var(--bg-primary);
   box-shadow: var(--shadow);
   border-radius: var(--radius-sm);
-  padding: 0.5rem;
 }
 
 /* Price column toggle styling */
@@ -4732,6 +4763,7 @@ th {
 .type-round { color: var(--type-round-bg); }
 .type-bar { color: var(--type-bar-bg); }
 .type-note { color: var(--type-note-bg); }
+.type-set { color: var(--type-set-bg); }
 .type-other { color: var(--type-other-bg); }
 
 /* =============================================================================
@@ -5409,6 +5441,10 @@ th {
 .type-chip.note {
   background-color: var(--type-note-bg);
   color: var(--type-note-text);
+}
+.type-chip.set {
+  background-color: var(--type-set-bg);
+  color: var(--type-set-text);
 }
 .type-chip.other {
   background-color: var(--type-other-bg);

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,10 @@
 ## What's New
 
+- **NGC cert lookup fix (v3.12.02)**: Clicking a graded item's cert tag now opens NGC with the actual coin details visible
+- **Name column overflow fix (v3.12.02)**: Long names truncate with ellipsis — tags (Year, N#, Grade) always stay visible
+- **Numista Sets (v3.12.02)**: New "Set" type for mint/proof sets with S-prefix Numista IDs (e.g., S4203)
+- **"Lunar Series" chip (v3.12.02)**: "Year of the Dragon/Snake/etc." items group under one chip
+- **Source column cleanup (v3.12.02)**: URL sources like "apmex.com" display as "apmex" with link icon
 - **Sticky header fix (v3.12.01)**: Column headers now correctly pin at the top of the scrollable portal view during vertical scroll
 - **Portal view (v3.12.00)**: Inventory table now renders all items in a scrollable container with sticky column headers — pagination removed. Visible rows (10/15/25/50/100) control viewport height
 - **Unified Settings modal (v3.11.00)**: API, Files, and Appearance consolidated into a single Settings modal with sidebar navigation. Header simplified to About + Settings

--- a/index.html
+++ b/index.html
@@ -800,6 +800,7 @@
                   <option value="Round">Round</option>
                   <option value="Note">Note</option>
                   <option value="Aurum">Aurum</option>
+                  <option value="Set">Set</option>
                   <option value="Other">Other</option>
                 </select>
               </div>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,9 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.12.02 – NGC cert lookup fix</strong>: Cert tag click now opens NGC with actual coin details visible</li>
+    <li><strong>v3.12.02 – Numista Sets</strong>: New "Set" type for mint/proof sets with S-prefix Numista IDs</li>
+    <li><strong>v3.12.02 – Source column cleanup</strong>: URL sources display domain name only with link icon</li>
     <li><strong>v3.12.01 – Sticky header fix</strong>: Column headers now correctly pin at the top of the scrollable portal view during vertical scroll</li>
     <li><strong>v3.12.00 – Portal view</strong>: Inventory table now renders all items in a scrollable container with sticky column headers — pagination removed. Visible rows (10/15/25/50/100) control viewport height</li>
     <li><strong>v3.11.00 – Unified Settings modal</strong>: API, Files, and Appearance consolidated into a single Settings modal with sidebar navigation. Header simplified to About + Settings</li>

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -339,6 +339,7 @@ const normalizeItemName = (fullName) => {
     'goldback': 'Goldback',
     'zombucks': 'Zombucks',
     'silverback': 'Silverback',
+    'year of the': 'Lunar Series',
   };
   for (const [keyword, groupName] of Object.entries(keywordGroups)) {
     if (nameLower.includes(keyword)) {
@@ -360,6 +361,9 @@ const normalizeItemName = (fullName) => {
     .replace(/\b(?:FS|FR|DCAM|First Strike|First Release|Deep Cameo)\b.*/i, '')
     .replace(/\s+(?:Silver|Gold|Platinum|Palladium)\s+(?:Coin|Bar|Round)\s*$/i, '')
     .trim();
+
+  // Clean up any leading punctuation/dashes left after stripping
+  name = name.replace(/^[\s\-–—:,]+/, '').trim();
 
   return name || fullName.trim();
 };

--- a/js/catalog-providers.js
+++ b/js/catalog-providers.js
@@ -6,14 +6,18 @@
 class NumistaCatalogProvider extends CatalogProvider {
   constructor(){ super({ name: 'Numista', key: 'numista' }); }
   normalizeId(id){
-    const s = (id||'').toString().trim().replace(/^N#?/i,'');
-    return s;
+    return id ? id.replace(/^[NS]?#?\s*/i, '').trim() : null;
   }
   buildLink(id){
     const nid = this.normalizeId(id);
-    return nid ? `https://en.numista.com/catalogue/pieces${nid}.html` : null;
+    if (!nid) return null;
+    const isSet = /^S/i.test(id);
+    if (isSet) {
+      return `https://en.numista.com/catalogue/set.php?id=${nid}`;
+    }
+    return `https://en.numista.com/catalogue/pieces${nid}.html`;
   }
-  isValid(id){ return /^N?#?\d+$/i.test(id) || /^\d+$/.test(id); }
+  isValid(id){ return /^[NS]?#?\d+$/i.test(id) || /^\d+$/.test(id); }
 }
 
 const CatalogProviders = (function(){

--- a/js/constants.js
+++ b/js/constants.js
@@ -220,7 +220,7 @@ const API_PROVIDERS = {
  */
 const CERT_LOOKUP_URLS = {
   PCGS: 'https://www.pcgs.com/cert/{certNumber}',
-  NGC: 'https://www.ngccoin.com/certlookup/{certNumber}/',
+  NGC: 'https://www.ngccoin.com/certlookup/{certNumber}/?CertNum={certNumber}&Grade={grade}&lookup=',
   ANACS: 'https://anacs.com/verify/',
   ICG: 'https://www.icgcoin.com/verification/',
 };
@@ -230,10 +230,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-08 - Unified Settings modal
+ * Updated: 2026-02-08 - Patch release: NGC cert fix, name overflow, Numista Sets, source display
  */
 
-const APP_VERSION = "3.12.01";
+const APP_VERSION = "3.12.02";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -736,6 +736,8 @@ const setupEventListeners = () => {
             'Note': 'banknote',
             // Aurum omitted — Goldbacks are "Embedded-asset notes" on Numista,
             // which isn't a valid API category. Uncategorized search finds them.
+            // Set omitted — Numista sets use a different URL scheme (set.php)
+            // and are not searchable via the /types API endpoint.
           };
 
           try {

--- a/js/numista-modal.js
+++ b/js/numista-modal.js
@@ -13,7 +13,11 @@
  * @param {string} coinName - The name of the coin (used for window title)
  */
 function openNumistaModal(numistaId, coinName) {
-  const url = `https://en.numista.com/catalogue/pieces${numistaId}.html`;
+  const isSet = /^S/i.test(numistaId);
+  const cleanId = numistaId.replace(/^[NS]?#?\s*/i, '').trim();
+  const url = isSet
+    ? `https://en.numista.com/catalogue/set.php?id=${cleanId}`
+    : `https://en.numista.com/catalogue/pieces${cleanId}.html`;
 
   const popup = window.open(
     url,

--- a/js/utils.js
+++ b/js/utils.js
@@ -653,7 +653,7 @@ const sanitizeObjectFields = (obj) => {
  * Allowed inventory item types
  * @constant {string[]}
  */
-const VALID_TYPES = ["Coin", "Bar", "Round", "Note", "Aurum", "Other"];
+const VALID_TYPES = ["Coin", "Bar", "Round", "Note", "Aurum", "Set", "Other"];
 
 /**
  * Normalizes item type to one of the predefined options

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,13 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.12.02": `
+      <li><strong>NGC cert lookup fix</strong>: Cert tag click now opens NGC with actual coin details visible</li>
+      <li><strong>Name column overflow</strong>: Long names truncate with ellipsis — tags always stay visible</li>
+      <li><strong>Numista Sets</strong>: New "Set" type for mint/proof sets with S-prefix Numista IDs</li>
+      <li><strong>"Lunar Series" chip</strong>: "Year of the Dragon/Snake/etc." items group under one chip</li>
+      <li><strong>Source column cleanup</strong>: URL sources display domain name only with link icon</li>
+    `,
     "3.12.01": `
       <li><strong>Sticky header fix</strong>: Column headers now correctly pin at the top of the scrollable table during vertical scroll</li>
     `,


### PR DESCRIPTION
## Summary

- **NGC cert lookup**: Query params added so cert tag click shows actual coin details instead of blank form
- **Name column overflow**: Flex layout truncates long names with ellipsis; Grade/N#/Year tags right-aligned and always visible (order: Grade → N# → Year)
- **"- Route 66" chip fix**: Leading dashes stripped from normalized chip names after suffix removal
- **"Lunar Series" chip**: "Year of the Dragon/Snake/etc." items group under one filter chip
- **Numista Sets**: New "Set" inventory type (purple) with S-prefix ID routing to `set.php` URL
- **Source column**: URL sources display domain name only ("apmex" not "apmex.com") with link icon
- **Metal hover fix**: Column text no longer wraps/malforms on hover

## Test plan

- [ ] Click a graded NGC item's cert tag → verify popup shows coin details
- [ ] Add item with long name → verify name truncates, tags stay visible on right
- [ ] Hover truncated name → verify tooltip shows full name
- [ ] Check "Route 66" items don't show leading dash in chip label
- [ ] Verify "Year of the Dragon/Snake" items group under "Lunar Series" chip
- [ ] Enter S-prefix Numista ID (e.g., S4203) → verify popup opens correct sets URL
- [ ] Select "Set" type in add form → verify it persists and renders with purple color
- [ ] Enter "apmex.com" as source → verify displays "apmex" with link icon
- [ ] Hover metal column → verify text stays on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)