### PR TITLE
Add encrypted portable backup (.stvault) v3.14.00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.00] - 2026-02-09
+
+### Added — Encrypted Portable Backup (.stvault)
+
+- **Encrypted backup export**: New "Export Encrypted Backup" button in Settings > Files creates a password-protected `.stvault` file containing all inventory data, settings, API keys, and price history using AES-256-GCM encryption
+- **Encrypted backup import**: "Import Encrypted Backup" reads a `.stvault` file, decrypts with the user's password, and restores all data with a full UI refresh
+- **Password strength indicator**: Live strength bar (Weak → Very Strong) and password match validation in the vault modal
+- **Crypto fallback**: Uses native Web Crypto API (PBKDF2 + AES-256-GCM); falls back to forge.js (~87KB) for Firefox on `file://` protocol where `crypto.subtle` is unavailable
+- **Binary vault format**: 56-byte header (magic bytes, version, PBKDF2 iterations, salt, IV) followed by authenticated ciphertext — portable across devices and browsers
+
+---
+
 ## [3.12.02] - 2026-02-08
 
 ### Fixed

--- a/css/styles.css
+++ b/css/styles.css
@@ -5786,6 +5786,116 @@ th {
 }
 
 /* =============================================================================
+   VAULT ENCRYPTED BACKUP STYLES
+   Password input groups, strength bar, match indicator, separator
+   ============================================================================= */
+
+.password-input-group {
+  display: flex;
+  gap: 0;
+}
+
+.password-input-group input[type="password"],
+.password-input-group input[type="text"] {
+  flex: 1;
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.password-toggle {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-left: none;
+  border-radius: 0 var(--radius) var(--radius) 0;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.2s, color 0.2s;
+}
+
+.password-toggle:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.strength-bar {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  margin-top: 0.375rem;
+  overflow: hidden;
+}
+
+.strength-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease, background 0.3s ease;
+  width: 0%;
+}
+
+.strength-text {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  font-weight: 500;
+}
+
+.password-match {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  font-weight: 500;
+}
+
+.vault-separator {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0.75rem 0;
+  width: 100%;
+}
+
+.vault-dot-pulse {
+  animation: vault-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes vault-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* Dark mode vault styles */
+[data-theme="dark"] .password-toggle {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .password-toggle:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .strength-bar {
+  background: var(--border);
+}
+
+/* Sepia mode vault styles */
+[data-theme="sepia"] .password-toggle {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+[data-theme="sepia"] .password-toggle:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+[data-theme="sepia"] .strength-bar {
+  background: var(--border);
+}
+
+/* =============================================================================
    MODERN RESPONSIVE TABLE REDESIGN
    ============================================================================= */
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Encrypted portable backup (v3.14.00)**: Export all data as a password-protected `.stvault` file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history. Password strength bar + crypto fallback for file:// protocol
 - **NGC cert lookup fix (v3.12.02)**: Clicking a graded item's cert tag now opens NGC with the actual coin details visible
 - **Name column overflow fix (v3.12.02)**: Long names truncate with ellipsis — tags (Year, N#, Grade) always stay visible
 - **Numista Sets (v3.12.02)**: New "Set" type for mint/proof sets with S-prefix Numista IDs (e.g., S4203)

--- a/index.html
+++ b/index.html
@@ -60,6 +60,11 @@
       defer=""
       src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"
     ></script>
+    <!-- forge.js for encryption fallback on file:// protocol -->
+    <script
+      defer=""
+      src="https://cdnjs.cloudflare.com/ajax/libs/forge/0.10.0/forge.min.js"
+    ></script>
 
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="icon" type="image/svg+xml" href="./images/safe-favicon.svg" />
@@ -1786,6 +1791,10 @@
                   <h3>Backup, Restore, Clear</h3>
                   <p class="settings-subtext">Manage local application data.</p>
                   <div class="backup-buttons">
+                    <button class="btn" id="vaultExportBtn">Export Encrypted Backup</button>
+                    <button class="btn info" id="vaultImportBtn">Import Encrypted Backup</button>
+                    <input type="file" id="vaultImportFile" accept=".stvault" hidden />
+                    <hr class="vault-separator" />
                     <button class="btn warning" id="removeInventoryDataBtn">Remove Inventory Data</button>
                     <button class="btn danger" id="boatingAccidentBtn">Wipe All Data</button>
                   </div>
@@ -1831,6 +1840,90 @@
         </div>
         <div class="modal-body">
           ☁️ Feature coming soon ☁️
+        </div>
+      </div>
+    </div>
+
+    <!-- Vault Encrypted Backup Modal -->
+    <div class="modal" id="vaultModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="vaultModalTitle">Encrypted Backup</h2>
+          <button
+            aria-label="Close modal"
+            class="modal-close"
+            id="vaultCloseBtn"
+            onclick="closeVaultModal()"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="encryption-info">
+            <strong>Included:</strong> All inventory data, settings, API keys, and price history.
+          </div>
+
+          <div id="vaultFileInfo" class="encryption-info" style="display: none">
+            <strong>File:</strong> <span id="vaultFileName"></span>
+            (<span id="vaultFileSize"></span>)
+          </div>
+
+          <div class="form-row">
+            <label for="vaultPassword">Password</label>
+            <div class="password-input-group">
+              <input
+                type="password"
+                id="vaultPassword"
+                placeholder="Minimum 8 characters"
+                autocomplete="off"
+              />
+              <button
+                type="button"
+                class="password-toggle"
+                id="vaultPasswordToggle"
+                title="Show/hide password"
+                onclick="toggleVaultPasswordVisibility('vaultPassword', this)"
+              >&#9678;</button>
+            </div>
+          </div>
+
+          <div id="vaultStrengthRow">
+            <div class="strength-bar">
+              <div class="strength-fill" id="vaultStrengthFill"></div>
+            </div>
+            <div class="strength-text" id="vaultStrengthText"></div>
+          </div>
+
+          <div class="form-row" id="vaultConfirmRow">
+            <label for="vaultConfirmPassword">Confirm Password</label>
+            <div class="password-input-group">
+              <input
+                type="password"
+                id="vaultConfirmPassword"
+                placeholder="Re-enter password"
+                autocomplete="off"
+              />
+              <button
+                type="button"
+                class="password-toggle"
+                id="vaultConfirmToggle"
+                title="Show/hide password"
+                onclick="toggleVaultPasswordVisibility('vaultConfirmPassword', this)"
+              >&#9678;</button>
+            </div>
+            <div class="password-match" id="vaultMatchIndicator"></div>
+          </div>
+
+          <div id="vaultStatus" class="encryption-status" style="display: none"></div>
+
+          <div class="encryption-warning">
+            <strong>Warning:</strong> If you forget this password, your backup cannot be recovered.
+          </div>
+
+          <div class="encryption-actions">
+            <button class="btn" id="vaultActionBtn" onclick="handleVaultAction()">Export</button>
+            <button class="btn warning" onclick="closeVaultModal()">Cancel</button>
+          </div>
         </div>
       </div>
     </div>
@@ -2040,6 +2133,7 @@
     <script defer src="./js/catalog-providers.js"></script>
     <script defer src="./js/catalog-manager.js"></script>
     <script defer src="./js/inventory.js"></script>
+    <script defer src="./js/vault.js"></script>
     <script defer src="./js/about.js"></script>
     <script defer src="./js/customMapping.js"></script>
     <script defer src="./js/settings.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.14.00 – Encrypted portable backup</strong>: Export all data as a password-protected .stvault file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history</li>
     <li><strong>v3.12.02 – NGC cert lookup fix</strong>: Cert tag click now opens NGC with actual coin details visible</li>
     <li><strong>v3.12.02 – Numista Sets</strong>: New "Set" type for mint/proof sets with S-prefix Numista IDs</li>
     <li><strong>v3.12.02 – Source column cleanup</strong>: URL sources display domain name only with link icon</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -230,10 +230,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-08 - Patch release: NGC cert fix, name overflow, Numista Sets, source display
+ * Updated: 2026-02-09 - Feature release: Encrypted portable backup (.stvault)
  */
 
-const APP_VERSION = "3.12.02";
+const APP_VERSION = "3.14.00";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -398,6 +398,8 @@ const ITEMS_PER_PAGE_KEY = "settingsItemsPerPage";
  * List of recognized localStorage keys for cleanup validation
  * @constant {string[]}
  */
+const VAULT_FILE_EXTENSION = '.stvault';
+
 const ALLOWED_STORAGE_KEYS = [
   LS_KEY,
   SERIAL_KEY,

--- a/js/events.js
+++ b/js/events.js
@@ -1197,6 +1197,62 @@ const setupEventListeners = () => {
       );
     }
 
+    // Vault Encrypted Backup Buttons
+    if (elements.vaultExportBtn) {
+      safeAttachListener(
+        elements.vaultExportBtn,
+        "click",
+        function () {
+          openVaultModal("export");
+        },
+        "Vault export button",
+      );
+    }
+
+    if (elements.vaultImportBtn) {
+      safeAttachListener(
+        elements.vaultImportBtn,
+        "click",
+        function () {
+          if (elements.vaultImportFile) elements.vaultImportFile.click();
+        },
+        "Vault import button",
+      );
+    }
+
+    if (elements.vaultImportFile) {
+      safeAttachListener(
+        elements.vaultImportFile,
+        "change",
+        function (e) {
+          var file = e.target.files && e.target.files[0];
+          if (file) {
+            openVaultModal("import", file);
+            // Reset input so the same file can be selected again
+            e.target.value = "";
+          }
+        },
+        "Vault import file input",
+      );
+    }
+
+    // Vault modal live password events
+    (function () {
+      var pw = document.getElementById("vaultPassword");
+      var cpw = document.getElementById("vaultConfirmPassword");
+      if (pw) {
+        pw.addEventListener("input", function () {
+          updateStrengthBar(pw.value);
+          if (cpw) updateMatchIndicator(pw.value, cpw.value);
+        });
+      }
+      if (cpw) {
+        cpw.addEventListener("input", function () {
+          if (pw) updateMatchIndicator(pw.value, cpw.value);
+        });
+      }
+    })();
+
     // Remove Inventory Data Button
     if (elements.removeInventoryDataBtn) {
       safeAttachListener(

--- a/js/init.js
+++ b/js/init.js
@@ -150,6 +150,9 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.numistaApiKey = safeGetElement("numistaApiKey");
     elements.removeInventoryDataBtn = safeGetElement("removeInventoryDataBtn");
     elements.boatingAccidentBtn = safeGetElement("boatingAccidentBtn");
+    elements.vaultExportBtn = safeGetElement("vaultExportBtn");
+    elements.vaultImportBtn = safeGetElement("vaultImportBtn");
+    elements.vaultImportFile = safeGetElement("vaultImportFile");
 
     // Modal elements
     debugLog("Phase 4: Initializing modal elements...");
@@ -157,6 +160,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.apiInfoModal = safeGetElement("apiInfoModal");
     elements.apiHistoryModal = safeGetElement("apiHistoryModal");
     elements.cloudSyncModal = safeGetElement("cloudSyncModal");
+    elements.vaultModal = safeGetElement("vaultModal");
     elements.apiQuotaModal = safeGetElement("apiQuotaModal");
     elements.aboutModal = safeGetElement("aboutModal");
     elements.ackModal = safeGetElement("ackModal");

--- a/js/state.js
+++ b/js/state.js
@@ -98,6 +98,11 @@ const elements = {
   exportPdfBtn: null,
   cloudSyncBtn: null,
   syncAllBtn: null,
+  // Vault encrypted backup elements
+  vaultExportBtn: null,
+  vaultImportBtn: null,
+  vaultImportFile: null,
+  vaultModal: null,
   // Emergency reset button
   removeInventoryDataBtn: null,
   boatingAccidentBtn: null,

--- a/js/vault.js
+++ b/js/vault.js
@@ -1,0 +1,828 @@
+/**
+ * Encrypted Vault Backup Module (.stvault)
+ *
+ * Provides AES-256-GCM encrypted export/import of all localStorage data.
+ * Uses Web Crypto API (primary) with forge.js fallback for file:// protocol.
+ *
+ * Binary format (56-byte header + ciphertext):
+ *   0-6   : "STVAULT" magic bytes
+ *   7     : format version (0x01)
+ *   8-11  : PBKDF2 iterations (uint32 big-endian)
+ *   12-43 : 32-byte random salt
+ *   44-55 : 12-byte random IV/nonce
+ *   56+   : AES-256-GCM ciphertext (includes 16-byte auth tag)
+ */
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const VAULT_MAGIC = new Uint8Array([0x53, 0x54, 0x56, 0x41, 0x55, 0x4C, 0x54]); // "STVAULT"
+const VAULT_VERSION = 0x01;
+const VAULT_HEADER_SIZE = 56;
+const VAULT_PBKDF2_ITERATIONS = 100000;
+const VAULT_MIN_PASSWORD_LENGTH = 8;
+const VAULT_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+// =============================================================================
+// CRYPTO ABSTRACTION LAYER
+// =============================================================================
+
+/**
+ * Detect available crypto backend.
+ * @returns {'native'|'forge'|null}
+ */
+function getCryptoBackend() {
+  try {
+    if (
+      typeof crypto !== "undefined" &&
+      crypto.subtle &&
+      typeof crypto.subtle.importKey === "function"
+    ) {
+      return "native";
+    }
+  } catch (_) {
+    /* ignore */
+  }
+  try {
+    if (typeof forge !== "undefined" && forge.cipher && forge.pkcs5) {
+      return "forge";
+    }
+  } catch (_) {
+    /* ignore */
+  }
+  return null;
+}
+
+/**
+ * Generate cryptographically random bytes.
+ * @param {number} length
+ * @returns {Uint8Array}
+ */
+function vaultRandomBytes(length) {
+  const backend = getCryptoBackend();
+  if (backend === "native") {
+    return crypto.getRandomValues(new Uint8Array(length));
+  }
+  if (backend === "forge") {
+    const bytes = forge.random.getBytesSync(length);
+    return new Uint8Array(
+      bytes.split("").map(function (c) {
+        return c.charCodeAt(0);
+      }),
+    );
+  }
+  throw new Error("No crypto backend available");
+}
+
+/**
+ * Derive AES-256 key from password using PBKDF2.
+ * @param {string} password
+ * @param {Uint8Array} salt - 32-byte salt
+ * @param {number} iterations
+ * @returns {Promise<CryptoKey|string>} Native CryptoKey or forge key bytes
+ */
+async function vaultDeriveKey(password, salt, iterations) {
+  const backend = getCryptoBackend();
+  if (backend === "native") {
+    const enc = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      "raw",
+      enc.encode(password),
+      "PBKDF2",
+      false,
+      ["deriveKey"],
+    );
+    return crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt: salt,
+        iterations: iterations,
+        hash: "SHA-256",
+      },
+      keyMaterial,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"],
+    );
+  }
+  if (backend === "forge") {
+    var saltStr = String.fromCharCode.apply(null, salt);
+    var key = forge.pkcs5.pbkdf2(password, saltStr, iterations, 32, "sha256");
+    return key;
+  }
+  throw new Error("No crypto backend available");
+}
+
+/**
+ * Encrypt plaintext with AES-256-GCM.
+ * @param {Uint8Array} plaintext
+ * @param {CryptoKey|string} key
+ * @param {Uint8Array} iv - 12-byte nonce
+ * @returns {Promise<Uint8Array>} ciphertext + 16-byte auth tag
+ */
+async function vaultEncrypt(plaintext, key, iv) {
+  var backend = getCryptoBackend();
+  if (backend === "native") {
+    var result = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: iv },
+      key,
+      plaintext,
+    );
+    return new Uint8Array(result);
+  }
+  if (backend === "forge") {
+    var cipher = forge.cipher.createCipher(
+      "AES-GCM",
+      key,
+    );
+    var ivStr = String.fromCharCode.apply(null, iv);
+    cipher.start({ iv: ivStr, tagLength: 128 });
+    cipher.update(
+      forge.util.createBuffer(String.fromCharCode.apply(null, plaintext)),
+    );
+    cipher.finish();
+
+    var encrypted = cipher.output.getBytes();
+    var tag = cipher.mode.tag.getBytes();
+
+    var combined = new Uint8Array(encrypted.length + tag.length);
+    for (var i = 0; i < encrypted.length; i++) {
+      combined[i] = encrypted.charCodeAt(i);
+    }
+    for (var j = 0; j < tag.length; j++) {
+      combined[encrypted.length + j] = tag.charCodeAt(j);
+    }
+    return combined;
+  }
+  throw new Error("No crypto backend available");
+}
+
+/**
+ * Decrypt ciphertext with AES-256-GCM.
+ * @param {Uint8Array} ciphertext - ciphertext + 16-byte auth tag
+ * @param {CryptoKey|string} key
+ * @param {Uint8Array} iv - 12-byte nonce
+ * @returns {Promise<Uint8Array>} plaintext
+ * @throws {Error} On wrong password or corrupted data (GCM auth tag mismatch)
+ */
+async function vaultDecrypt(ciphertext, key, iv) {
+  var backend = getCryptoBackend();
+  if (backend === "native") {
+    try {
+      var result = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: iv },
+        key,
+        ciphertext,
+      );
+      return new Uint8Array(result);
+    } catch (_) {
+      throw new Error("Incorrect password or corrupted file.");
+    }
+  }
+  if (backend === "forge") {
+    // Split ciphertext and tag (last 16 bytes)
+    var tagLength = 16;
+    if (ciphertext.length < tagLength) {
+      throw new Error("Incorrect password or corrupted file.");
+    }
+    var encBytes = ciphertext.slice(0, ciphertext.length - tagLength);
+    var tagBytes = ciphertext.slice(ciphertext.length - tagLength);
+
+    var encStr = String.fromCharCode.apply(null, encBytes);
+    var tagStr = String.fromCharCode.apply(null, tagBytes);
+    var ivStr = String.fromCharCode.apply(null, iv);
+
+    var decipher = forge.cipher.createDecipher("AES-GCM", key);
+    decipher.start({
+      iv: ivStr,
+      tagLength: 128,
+      tag: forge.util.createBuffer(tagStr),
+    });
+    decipher.update(forge.util.createBuffer(encStr));
+    var pass = decipher.finish();
+
+    if (!pass) {
+      throw new Error("Incorrect password or corrupted file.");
+    }
+    var output = decipher.output.getBytes();
+    return new Uint8Array(
+      output.split("").map(function (c) {
+        return c.charCodeAt(0);
+      }),
+    );
+  }
+  throw new Error("No crypto backend available");
+}
+
+// =============================================================================
+// BINARY FORMAT
+// =============================================================================
+
+/**
+ * Serialize vault header + ciphertext into a single binary blob.
+ * @param {Uint8Array} salt - 32 bytes
+ * @param {Uint8Array} iv - 12 bytes
+ * @param {number} iterations
+ * @param {Uint8Array} ciphertext
+ * @returns {Uint8Array}
+ */
+function serializeVaultFile(salt, iv, iterations, ciphertext) {
+  var file = new Uint8Array(VAULT_HEADER_SIZE + ciphertext.length);
+  // Magic bytes
+  file.set(VAULT_MAGIC, 0);
+  // Version
+  file[7] = VAULT_VERSION;
+  // Iterations (uint32 big-endian)
+  file[8] = (iterations >>> 24) & 0xff;
+  file[9] = (iterations >>> 16) & 0xff;
+  file[10] = (iterations >>> 8) & 0xff;
+  file[11] = iterations & 0xff;
+  // Salt
+  file.set(salt, 12);
+  // IV
+  file.set(iv, 44);
+  // Ciphertext
+  file.set(ciphertext, VAULT_HEADER_SIZE);
+  return file;
+}
+
+/**
+ * Parse a .stvault binary file into its components.
+ * @param {Uint8Array} fileBytes
+ * @returns {{salt: Uint8Array, iv: Uint8Array, iterations: number, ciphertext: Uint8Array}}
+ * @throws {Error} On invalid format
+ */
+function parseVaultFile(fileBytes) {
+  if (fileBytes.length < VAULT_HEADER_SIZE + 16) {
+    throw new Error("Not a valid .stvault file.");
+  }
+  // Check magic bytes
+  for (var i = 0; i < VAULT_MAGIC.length; i++) {
+    if (fileBytes[i] !== VAULT_MAGIC[i]) {
+      throw new Error("Not a valid .stvault file.");
+    }
+  }
+  // Check version
+  var version = fileBytes[7];
+  if (version > VAULT_VERSION) {
+    throw new Error(
+      "Created by a newer StakTrakr version. Please update.",
+    );
+  }
+  // Parse iterations
+  var iterations =
+    (fileBytes[8] << 24) |
+    (fileBytes[9] << 16) |
+    (fileBytes[10] << 8) |
+    fileBytes[11];
+  iterations = iterations >>> 0; // ensure unsigned
+
+  var salt = fileBytes.slice(12, 44);
+  var iv = fileBytes.slice(44, 56);
+  var ciphertext = fileBytes.slice(VAULT_HEADER_SIZE);
+
+  return {
+    salt: salt,
+    iv: iv,
+    iterations: iterations,
+    ciphertext: ciphertext,
+  };
+}
+
+// =============================================================================
+// DATA COLLECTION / RESTORATION
+// =============================================================================
+
+/**
+ * Collect all localStorage data for vault export.
+ * @returns {object|null} Payload object or null if empty
+ */
+function collectVaultData() {
+  var payload = {
+    _meta: {
+      appVersion: typeof APP_VERSION !== "undefined" ? APP_VERSION : "unknown",
+      exportTimestamp: new Date().toISOString(),
+      userAgent: navigator.userAgent,
+    },
+    data: {},
+  };
+
+  var hasData = false;
+
+  for (var i = 0; i < ALLOWED_STORAGE_KEYS.length; i++) {
+    var key = ALLOWED_STORAGE_KEYS[i];
+    try {
+      var val = localStorage.getItem(key);
+      if (val !== null) {
+        payload.data[key] = val;
+        hasData = true;
+      }
+    } catch (e) {
+      debugLog("Vault: could not read key", key, e);
+    }
+  }
+
+  if (!hasData) return null;
+
+  // Compute checksum of the data section
+  var dataJson = JSON.stringify(payload.data);
+  payload._meta.checksum = simpleHash(dataJson);
+
+  return payload;
+}
+
+/**
+ * Simple hash for integrity check (not cryptographic — just detects corruption).
+ * @param {string} str
+ * @returns {string}
+ */
+function simpleHash(str) {
+  var hash = 0;
+  for (var i = 0; i < str.length; i++) {
+    var ch = str.charCodeAt(i);
+    hash = ((hash << 5) - hash + ch) | 0;
+  }
+  return "sh:" + (hash >>> 0).toString(16);
+}
+
+/**
+ * Restore vault data into localStorage and refresh UI.
+ * @param {object} payload - Decrypted vault payload
+ */
+function restoreVaultData(payload) {
+  var data = payload.data;
+  if (!data || typeof data !== "object") {
+    throw new Error("Vault file appears corrupted.");
+  }
+
+  // Write each key to localStorage
+  var keys = Object.keys(data);
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    // Only restore recognized keys
+    if (ALLOWED_STORAGE_KEYS.indexOf(key) !== -1) {
+      try {
+        localStorage.setItem(key, data[key]);
+      } catch (e) {
+        debugLog("Vault: could not write key", key, e);
+      }
+    }
+  }
+
+  // Refresh the full UI
+  try {
+    if (typeof loadInventory === "function") loadInventory();
+    if (typeof renderTable === "function") renderTable();
+    if (typeof renderActiveFilters === "function") renderActiveFilters();
+    if (typeof loadSpotHistory === "function") loadSpotHistory();
+    if (typeof fetchSpotPrice === "function") fetchSpotPrice();
+  } catch (e) {
+    debugLog("Vault: UI refresh error", e);
+  }
+}
+
+// =============================================================================
+// PASSWORD STRENGTH
+// =============================================================================
+
+/**
+ * Evaluate password strength.
+ * @param {string} password
+ * @returns {{score: number, label: string, color: string}}
+ */
+function getPasswordStrength(password) {
+  if (!password || password.length < VAULT_MIN_PASSWORD_LENGTH) {
+    return { score: 0, label: "Too short", color: "var(--danger)" };
+  }
+  var score = 0;
+  if (password.length >= 8) score++;
+  if (password.length >= 12) score++;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^a-zA-Z0-9]/.test(password)) score++;
+
+  // Cap at 4
+  if (score > 4) score = 4;
+
+  var labels = ["Weak", "Fair", "Good", "Strong", "Very Strong"];
+  var colors = [
+    "var(--danger)",
+    "var(--warning)",
+    "var(--info)",
+    "var(--success)",
+    "var(--success)",
+  ];
+
+  return {
+    score: score,
+    label: labels[score],
+    color: colors[score],
+  };
+}
+
+// =============================================================================
+// EXPORT FLOW
+// =============================================================================
+
+/**
+ * Export an encrypted vault backup.
+ * @param {string} password
+ * @returns {Promise<void>}
+ */
+async function exportEncryptedBackup(password) {
+  var backend = getCryptoBackend();
+  if (!backend) {
+    throw new Error(
+      "Encryption not available. Use Chrome/Safari/Edge or serve via HTTP.",
+    );
+  }
+
+  var payload = collectVaultData();
+  if (!payload) {
+    throw new Error("No data to export.");
+  }
+
+  debugLog("Vault: exporting with", backend, "backend");
+
+  var enc = new TextEncoder();
+  var plaintext = enc.encode(JSON.stringify(payload));
+
+  var salt = vaultRandomBytes(32);
+  var iv = vaultRandomBytes(12);
+
+  var key = await vaultDeriveKey(password, salt, VAULT_PBKDF2_ITERATIONS);
+  var ciphertext = await vaultEncrypt(plaintext, key, iv);
+  var fileBytes = serializeVaultFile(salt, iv, VAULT_PBKDF2_ITERATIONS, ciphertext);
+
+  // Download via Blob + anchor
+  var blob = new Blob([fileBytes], { type: "application/octet-stream" });
+  var url = URL.createObjectURL(blob);
+  var timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+
+  var a = document.createElement("a");
+  a.href = url;
+  a.download = "staktrakr_backup_" + timestamp + VAULT_FILE_EXTENSION;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+
+  debugLog("Vault: export complete,", fileBytes.length, "bytes");
+}
+
+// =============================================================================
+// IMPORT FLOW
+// =============================================================================
+
+/**
+ * Import and decrypt a vault backup.
+ * @param {Uint8Array} fileBytes
+ * @param {string} password
+ * @returns {Promise<void>}
+ */
+async function importEncryptedBackup(fileBytes, password) {
+  var backend = getCryptoBackend();
+  if (!backend) {
+    throw new Error(
+      "Encryption not available. Use Chrome/Safari/Edge or serve via HTTP.",
+    );
+  }
+
+  if (fileBytes.length > VAULT_MAX_FILE_SIZE) {
+    throw new Error("File exceeds 50MB limit.");
+  }
+
+  var parsed = parseVaultFile(fileBytes);
+
+  debugLog(
+    "Vault: importing with",
+    backend,
+    "backend,",
+    parsed.iterations,
+    "iterations",
+  );
+
+  var key = await vaultDeriveKey(
+    password,
+    parsed.salt,
+    parsed.iterations,
+  );
+  var plainBytes = await vaultDecrypt(parsed.ciphertext, key, parsed.iv);
+
+  var dec = new TextDecoder();
+  var jsonStr = dec.decode(plainBytes);
+  var payload;
+  try {
+    payload = JSON.parse(jsonStr);
+  } catch (_) {
+    throw new Error("Vault file appears corrupted.");
+  }
+
+  if (!payload || !payload.data) {
+    throw new Error("Vault file appears corrupted.");
+  }
+
+  restoreVaultData(payload);
+  debugLog("Vault: import complete");
+}
+
+// =============================================================================
+// MODAL MANAGEMENT
+// =============================================================================
+
+/** @type {Uint8Array|null} Pending file bytes for import */
+var _vaultPendingFile = null;
+/** @type {string|null} Pending file name for import */
+var _vaultPendingFileName = null;
+
+/**
+ * Open the vault modal in export or import mode.
+ * @param {'export'|'import'} mode
+ * @param {File} [file] - File object for import mode
+ */
+function openVaultModal(mode, file) {
+  var modal = safeGetElement("vaultModal");
+  if (!modal) return;
+
+  var titleEl = safeGetElement("vaultModalTitle");
+  var passwordEl = safeGetElement("vaultPassword");
+  var confirmRow = safeGetElement("vaultConfirmRow");
+  var confirmEl = safeGetElement("vaultConfirmPassword");
+  var strengthRow = safeGetElement("vaultStrengthRow");
+  var fileInfoEl = safeGetElement("vaultFileInfo");
+  var statusEl = safeGetElement("vaultStatus");
+  var actionBtn = safeGetElement("vaultActionBtn");
+
+  // Reset state
+  if (passwordEl) passwordEl.value = "";
+  if (confirmEl) confirmEl.value = "";
+  if (statusEl) {
+    statusEl.style.display = "none";
+    statusEl.className = "encryption-status";
+    statusEl.innerHTML = "";
+  }
+
+  // Update strength bar
+  updateStrengthBar("");
+
+  // Update match indicator
+  updateMatchIndicator("", "");
+
+  modal.setAttribute("data-vault-mode", mode);
+
+  if (mode === "export") {
+    if (titleEl) titleEl.textContent = "Export Encrypted Backup";
+    if (confirmRow) confirmRow.style.display = "";
+    if (strengthRow) strengthRow.style.display = "";
+    if (fileInfoEl) fileInfoEl.style.display = "none";
+    if (actionBtn) {
+      actionBtn.textContent = "Export";
+      actionBtn.className = "btn";
+    }
+    _vaultPendingFile = null;
+    _vaultPendingFileName = null;
+  } else {
+    if (titleEl) titleEl.textContent = "Import Encrypted Backup";
+    if (confirmRow) confirmRow.style.display = "none";
+    if (strengthRow) strengthRow.style.display = "none";
+    if (fileInfoEl) {
+      fileInfoEl.style.display = "";
+      var nameSpan = safeGetElement("vaultFileName");
+      var sizeSpan = safeGetElement("vaultFileSize");
+      if (nameSpan && file) nameSpan.textContent = file.name;
+      if (sizeSpan && file)
+        sizeSpan.textContent = formatFileSize(file.size);
+    }
+    if (actionBtn) {
+      actionBtn.textContent = "Import";
+      actionBtn.className = "btn info";
+    }
+
+    // Read file bytes
+    if (file) {
+      _vaultPendingFileName = file.name;
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        _vaultPendingFile = new Uint8Array(e.target.result);
+      };
+      reader.readAsArrayBuffer(file);
+    }
+  }
+
+  openModalById("vaultModal");
+}
+
+/**
+ * Close the vault modal and reset state.
+ */
+function closeVaultModal() {
+  _vaultPendingFile = null;
+  _vaultPendingFileName = null;
+  closeModalById("vaultModal");
+}
+
+/**
+ * Handle the vault modal action button (export or import).
+ */
+async function handleVaultAction() {
+  var modal = safeGetElement("vaultModal");
+  if (!modal) return;
+
+  var mode = modal.getAttribute("data-vault-mode");
+  var passwordEl = safeGetElement("vaultPassword");
+  var confirmEl = safeGetElement("vaultConfirmPassword");
+  var statusEl = safeGetElement("vaultStatus");
+  var actionBtn = safeGetElement("vaultActionBtn");
+
+  var password = passwordEl ? passwordEl.value : "";
+
+  // Validate password length
+  if (password.length < VAULT_MIN_PASSWORD_LENGTH) {
+    showVaultStatus(
+      "error",
+      "Password must be at least " + VAULT_MIN_PASSWORD_LENGTH + " characters.",
+    );
+    return;
+  }
+
+  if (mode === "export") {
+    var confirm = confirmEl ? confirmEl.value : "";
+    if (password !== confirm) {
+      showVaultStatus("error", "Passwords do not match.");
+      return;
+    }
+
+    // Check crypto backend
+    if (!getCryptoBackend()) {
+      showVaultStatus(
+        "error",
+        "Encryption not available. Use Chrome/Safari/Edge or serve via HTTP.",
+      );
+      return;
+    }
+
+    // Disable button, show progress
+    if (actionBtn) actionBtn.disabled = true;
+    showVaultStatus("info", "Encrypting\u2026");
+
+    try {
+      await exportEncryptedBackup(password);
+      showVaultStatus("success", "Backup exported successfully.");
+    } catch (err) {
+      showVaultStatus("error", err.message || "Export failed.");
+    } finally {
+      if (actionBtn) actionBtn.disabled = false;
+    }
+  } else {
+    // Import mode
+    if (!_vaultPendingFile) {
+      showVaultStatus("error", "No file loaded.");
+      return;
+    }
+
+    if (!getCryptoBackend()) {
+      showVaultStatus(
+        "error",
+        "Encryption not available. Use Chrome/Safari/Edge or serve via HTTP.",
+      );
+      return;
+    }
+
+    if (actionBtn) actionBtn.disabled = true;
+    showVaultStatus("info", "Decrypting\u2026");
+
+    try {
+      await importEncryptedBackup(_vaultPendingFile, password);
+      showVaultStatus("success", "Data restored successfully.");
+    } catch (err) {
+      showVaultStatus("error", err.message || "Import failed.");
+    } finally {
+      if (actionBtn) actionBtn.disabled = false;
+    }
+  }
+}
+
+// =============================================================================
+// MODAL HELPERS
+// =============================================================================
+
+/**
+ * Show status message in the vault modal.
+ * @param {'success'|'error'|'info'|'warning'} type
+ * @param {string} message
+ */
+function showVaultStatus(type, message) {
+  var statusEl = safeGetElement("vaultStatus");
+  if (!statusEl) return;
+
+  statusEl.style.display = "";
+  statusEl.className = "encryption-status";
+
+  var dotClass = "status-" + type;
+  var isAnimated = type === "info";
+
+  statusEl.innerHTML =
+    '<div class="status-indicator ' + dotClass + '">' +
+    '<span class="status-dot' + (isAnimated ? " vault-dot-pulse" : "") + '"></span>' +
+    '<span class="status-text">' + escapeHtml(message) + "</span>" +
+    "</div>";
+}
+
+/**
+ * Escape HTML special characters.
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHtml(str) {
+  var div = document.createElement("div");
+  div.appendChild(document.createTextNode(str));
+  return div.innerHTML;
+}
+
+/**
+ * Format file size in human-readable form.
+ * @param {number} bytes
+ * @returns {string}
+ */
+function formatFileSize(bytes) {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+  return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+/**
+ * Update the password strength bar.
+ * @param {string} password
+ */
+function updateStrengthBar(password) {
+  var fillEl = safeGetElement("vaultStrengthFill");
+  var textEl = safeGetElement("vaultStrengthText");
+  if (!fillEl || !textEl) return;
+
+  if (!password) {
+    fillEl.style.width = "0%";
+    fillEl.style.background = "transparent";
+    textEl.textContent = "";
+    return;
+  }
+
+  var strength = getPasswordStrength(password);
+  var percent = ((strength.score + 1) / 5) * 100;
+  if (strength.score === 0 && password.length < VAULT_MIN_PASSWORD_LENGTH) {
+    percent = (password.length / VAULT_MIN_PASSWORD_LENGTH) * 20;
+  }
+
+  fillEl.style.width = percent + "%";
+  fillEl.style.background = strength.color;
+  textEl.textContent = strength.label;
+  textEl.style.color = strength.color;
+}
+
+/**
+ * Update the password match indicator.
+ * @param {string} password
+ * @param {string} confirm
+ */
+function updateMatchIndicator(password, confirm) {
+  var matchEl = safeGetElement("vaultMatchIndicator");
+  if (!matchEl) return;
+
+  if (!confirm) {
+    matchEl.textContent = "";
+    matchEl.style.color = "";
+    return;
+  }
+
+  if (password === confirm) {
+    matchEl.textContent = "Passwords match";
+    matchEl.style.color = "var(--success)";
+  } else {
+    matchEl.textContent = "Passwords do not match";
+    matchEl.style.color = "var(--danger)";
+  }
+}
+
+/**
+ * Toggle password visibility for a field.
+ * @param {string} inputId
+ * @param {HTMLElement} toggleBtn
+ */
+function toggleVaultPasswordVisibility(inputId, toggleBtn) {
+  var input = safeGetElement(inputId);
+  if (!input) return;
+  if (input.type === "password") {
+    input.type = "text";
+    if (toggleBtn) toggleBtn.textContent = "\u25C9"; // ◉
+  } else {
+    input.type = "password";
+    if (toggleBtn) toggleBtn.textContent = "\u25CE"; // ◎
+  }
+}
+
+// =============================================================================
+// WINDOW EXPORTS
+// =============================================================================
+
+window.openVaultModal = openVaultModal;
+window.closeVaultModal = closeVaultModal;

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,11 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.14.00": `
+      <li><strong>Encrypted portable backup</strong>: Export all data as a password-protected .stvault file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history</li>
+      <li><strong>Password strength indicator</strong>: Live strength bar and match validation in the vault modal</li>
+      <li><strong>Crypto fallback</strong>: Uses Web Crypto API natively; falls back to forge.js on Firefox file:// protocol</li>
+    `,
     "3.12.02": `
       <li><strong>NGC cert lookup fix</strong>: Cert tag click now opens NGC with actual coin details visible</li>
       <li><strong>Name column overflow</strong>: Long names truncate with ellipsis — tags always stay visible</li>


### PR DESCRIPTION
## Summary

- **Encrypted portable backup**: New `.stvault` file format with AES-256-GCM encryption for securely exporting/importing all localStorage data (inventory, settings, API keys, price history)
- **Dual crypto backend**: Web Crypto API (primary) with forge.js fallback for Firefox `file://` protocol
- **Password UX**: Strength bar (Weak → Very Strong), match validation, show/hide toggle, and "no recovery" warning

## Details

Binary format: 56-byte header (magic bytes "STVAULT", format version, PBKDF2 iteration count, 32-byte salt, 12-byte IV) followed by AES-256-GCM ciphertext with 16-byte auth tag. Fresh random salt + IV per export ensures identical data produces different ciphertext each time.

Files changed:
- `js/vault.js` (new) — 828-line encryption module
- `index.html` — forge.js CDN, vault buttons, vault modal HTML
- `js/constants.js` — `VAULT_FILE_EXTENSION`, version → 3.14.00
- `js/state.js` / `js/init.js` / `js/events.js` — DOM refs + event wiring
- `css/styles.css` — password input group, strength bar, theme variants
- `CHANGELOG.md` / `docs/announcements.md` / `js/versionCheck.js` / `js/about.js` — docs + embedded fallbacks

## Test plan

- [x] Export vault with test inventory, verify file downloads with correct `.stvault` extension
- [x] Import exported file with correct password, verify all data restored and UI refreshes
- [ ] Wrong password shows "Incorrect password or corrupted file" — modal stays open for retry
- [ ] Non-.stvault file rejected with clear error
- [ ] Verify modal appearance in light, dark, and sepia themes
- [ ] Firefox on `file://` uses forge.js fallback correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)