### PR TITLE
Fix name column overflow, compact N# chips, tighten action icons (v3.14.01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.01] - 2026-02-09
+
+### Fixed
+
+- **Name column truncation**: Added `max-width: 340px` constraint so long item names properly truncate with ellipsis instead of pushing the table wider than the viewport
+- **Numista N# chips compacted**: Inline catalog tags shortened from `N#298883` to just `N#` — full catalog number shown on hover tooltip
+- **Action icons clipped**: Reduced icon button size (2.4rem → 1.6rem) and tightened gap (0.25rem → 0.1rem) so Edit/Copy/Delete buttons fit within the Actions column without overflow
+
+---
+
 ## [3.14.00] - 2026-02-09
 
 ### Added — Encrypted Portable Backup (.stvault)

--- a/css/styles.css
+++ b/css/styles.css
@@ -2185,9 +2185,9 @@ td {
   max-width: 20ch; /* Limit to approximately 20 characters */
 }
 
-/* Allow certain columns to be wider */
+/* Name column — constrain width so flex-based truncation kicks in */
 td[data-column="name"] {
-  max-width: none;
+  max-width: 340px;
   width: auto;
   overflow: hidden; /* Constrain inner flex container to cell's computed width */
 }
@@ -4550,13 +4550,13 @@ input:disabled + .slider {
 /* Actions column — merged edit/copy/delete */
 #inventoryTable th.actions-col,
 #inventoryTable td.actions-cell {
-  width: 6rem;
-  min-width: 5rem;
+  width: 5rem;
+  min-width: 4.5rem;
 }
 
 .actions-row {
   display: flex;
-  gap: 0.25rem;
+  gap: 0.1rem;
   justify-content: center;
   align-items: center;
 }
@@ -4589,9 +4589,9 @@ input:disabled + .slider {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.4rem;
-  height: 2.4rem;
-  padding: 0.25rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0.15rem;
   background: transparent;
   border: 0;
   border-radius: 6px;
@@ -4864,8 +4864,8 @@ th {
   align-items: center;
   font-size: 0.65rem;
   font-weight: 600;
-  padding: 0.1rem 0.35rem;
-  margin-left: 0.35rem;
+  padding: 0.1rem 0.3rem;
+  margin-left: 0.25rem;
   border-radius: var(--radius);
   background: var(--bg-tertiary);
   color: var(--primary);

--- a/docs/CLOUD-SYNC-DESIGN.md
+++ b/docs/CLOUD-SYNC-DESIGN.md
@@ -1,0 +1,184 @@
+# Cloud Sync Architecture — Design Spec (Draft)
+
+## Context
+
+StakTrakr is a pure client-side app (vanilla JS, localStorage, `file://` compatible). As of v3.14.00, the `.stvault` encrypted backup feature provides manual portable backups via cloud drives (iCloud, Google Drive, Dropbox). This spec outlines the architecture for **automated cloud sync** — starting with Supabase, designed to support additional providers later.
+
+**Goal**: Let users sync their StakTrakr data across devices without manual file management, while preserving the zero-backend, client-side-only architecture.
+
+**Non-goals (for now)**: Real-time collaboration, multi-user shared inventories, row-level conflict resolution.
+
+---
+
+## Foundation: What We Already Have
+
+The vault module (`js/vault.js`) provides the serialize/deserialize layer:
+
+- **`collectVaultData()`** — reads all `ALLOWED_STORAGE_KEYS` into a JSON payload with metadata
+- **`restoreVaultData(payload)`** — writes keys back to localStorage + refreshes UI
+- **AES-256-GCM encryption** — password-based encryption with Web Crypto + forge.js fallback
+
+These functions are provider-agnostic. Any sync adapter just needs to transport the JSON payload (optionally encrypted) to/from a remote store.
+
+---
+
+## Sync Strategy: Snapshot Sync (Phase 1)
+
+**Full-state snapshot** — upload/download the entire app state as a single blob. Same approach as `.stvault` but automated.
+
+| Pros | Cons |
+|------|------|
+| Simple to implement | Overwrites everything on each sync |
+| No conflict resolution needed | Inefficient for large inventories |
+| Reuses existing vault serialize/deserialize | No merge — last-write-wins |
+| Works with any blob storage provider | |
+
+**Why not row-level sync?** StakTrakr's data model is a flat JSON array in a single localStorage key (`LS_KEY`). Row-level sync would require: item-level timestamps, conflict resolution UI, and a relational schema on the server side. That's Phase 2+ complexity.
+
+**Why not CRDTs?** Overkill for a single-user app syncing across their own devices. CRDTs solve multi-user concurrent editing — not our use case.
+
+---
+
+## Sync Adapter Interface
+
+```javascript
+// Each provider implements this interface
+const SyncAdapter = {
+  id: 'supabase',           // unique provider key
+  name: 'Supabase Cloud',   // display name for settings UI
+
+  // Auth
+  authenticate(credentials) → Promise<{success, user, error}>
+  signOut()                  → Promise<void>
+  isAuthenticated()          → boolean
+
+  // Sync
+  push(payload)              → Promise<{success, timestamp, error}>
+  pull()                     → Promise<{success, payload, timestamp, error}>
+  getLastSyncTime()          → Promise<{timestamp}>
+
+  // UI
+  getAuthFields()            → [{id, label, type, placeholder}]  // dynamic form fields
+  getStatusInfo()            → {connected, lastSync, userLabel}
+};
+```
+
+The settings UI renders auth fields dynamically based on `getAuthFields()` — Supabase shows email/password, Nextcloud shows server URL + app password, etc.
+
+---
+
+## Provider Assessment
+
+### Tier 1: Supabase (Start Here)
+
+| Aspect | Details |
+|--------|---------|
+| **Integration** | Official CDN JS client (`@supabase/supabase-js@2`) — no build tools needed |
+| **Auth** | Email/password, magic link, OAuth (Google, GitHub, etc.) |
+| **Storage** | Supabase Storage — S3-compatible, upload/download Blobs via simple API |
+| **CORS** | Works out of the box, including from `file://` protocol |
+| **Cost** | Free tier: 1GB storage, 50K monthly active users, 2GB bandwidth |
+| **Encryption** | Data encrypted at rest by Supabase; we add client-side AES-256-GCM on top |
+| **Path** | `staktrakr-vaults/{userId}/vault.stvault` |
+
+**Why Supabase first**: Zero CORS friction, official vanilla JS CDN, built-in auth, generous free tier, simplest path from concept to working feature.
+
+### Tier 2: Nextcloud / Owncloud (Self-Hosted Option)
+
+| Aspect | Details |
+|--------|---------|
+| **Protocol** | WebDAV — standard HTTP methods (PUT/GET/DELETE) on `remote.php/dav/files/USERNAME/` |
+| **Auth** | App Passwords (recommended) with Basic Auth header, or OAuth2 |
+| **CORS** | **Not supported by default** — requires WebAppPassword Nextcloud app or manual server config |
+| **JS Libraries** | npm packages exist (`webdav`, `nextcloud-link`) but need bundlers; for vanilla JS, manual `fetch()` with WebDAV methods |
+| **User setup** | User provides: server URL, username, app password |
+| **Path** | `StakTrakr/vault.stvault` in user's Nextcloud files |
+
+**Reality check**: CORS is the main friction point. Options:
+1. User installs WebAppPassword app on their Nextcloud — enables CORS for our origin
+2. We provide a tiny proxy script users can deploy alongside Nextcloud (PHP one-liner)
+3. We document it as "advanced / self-hosted" with setup instructions
+
+**Still valuable** — privacy-focused users (which overlap heavily with precious metals collectors) would appreciate this option.
+
+### Tier 3: Generic WebDAV
+
+Same as Nextcloud but for any WebDAV server. Would cover Owncloud, Seafile, and some NAS devices (Synology, QNAP) that expose WebDAV.
+
+### Tier 4: S3-Compatible Storage
+
+Direct S3/R2/MinIO/Backblaze B2 integration. "Enterprise Dropbox" — user provides endpoint, access key, secret key, bucket name. CORS must be configured on the bucket. Niche but powerful for technical users.
+
+---
+
+## Phase 1: Supabase Implementation (Estimated Scope)
+
+### New Files
+
+- **`js/sync.js`** — Sync orchestrator: adapter registry, sync scheduling, conflict detection (timestamp-based), status management
+- **`js/sync-supabase.js`** — Supabase adapter implementing the SyncAdapter interface
+
+### Files to Modify
+
+- **`index.html`** — Supabase CDN script tag, sync UI in Settings > Cloud panel, sync status indicator in header
+- **`js/constants.js`** — Supabase URL/anon key constants, new localStorage keys for sync state
+- **`js/state.js`** / **`js/init.js`** / **`js/events.js`** — DOM refs, element lookups, event wiring
+- **`css/styles.css`** — Sync status styles, auth form styles
+
+### Settings > Cloud Panel (currently placeholder)
+
+Transform the "Cloud Sync — Feature coming soon" placeholder into:
+- Provider selector dropdown
+- Dynamic auth form (email/password for Supabase)
+- Sign up / Sign in / Sign out buttons
+- Sync status: connected, last sync time, data size
+- Manual "Sync Now" button
+- Auto-sync toggle with interval setting
+
+### Sync Flow
+
+1. User opens Settings > Cloud, selects Supabase
+2. Signs up or signs in with email/password
+3. On first sync: uploads current state as encrypted `.stvault` blob to Supabase Storage
+4. On subsequent syncs: compares local `lastModified` timestamp with remote — newer wins
+5. Auto-sync option: syncs on page load and every N minutes
+6. Manual "Sync Now" for on-demand push/pull
+
+### Security Model
+
+- Client-side AES-256-GCM encryption before upload (reuse vault encryption)
+- Supabase Row Level Security: users can only access their own files
+- Supabase anon key is public (safe) — auth tokens scoped per user
+- Master password for encryption is separate from Supabase account password
+- Master password never sent to Supabase — only encrypted blobs travel over the wire
+
+### Open Questions
+
+1. **Encryption password for sync**: Require a separate "sync encryption password" on first setup? Or reuse the vault export password? (If separate, need to store a password hint or salt locally)
+2. **Conflict UI**: When remote is newer AND local has changes since last sync — show a merge prompt? Or always last-write-wins?
+3. **Auto-sync frequency**: Every 5 minutes? On every data change? Configurable?
+4. **Multiple devices**: If user has 3 devices, does each push overwrite? Need device ID tracking?
+5. **Supabase project**: Who hosts the Supabase project — you (shared instance for all users) or each user brings their own?
+
+---
+
+## Phase 2+: Future Providers
+
+Once the adapter interface is proven with Supabase:
+- **Nextcloud adapter** — WebDAV PUT/GET with app password auth, documented CORS setup guide
+- **Generic WebDAV adapter** — covers Owncloud, Seafile, NAS devices
+- **S3 adapter** — for power users with their own buckets
+
+Each adapter is a single JS file implementing the interface. The sync orchestrator and UI are shared.
+
+---
+
+## Verification Plan
+
+1. Sign up for Supabase, sync inventory, verify blob appears in storage
+2. Sign in on a different browser/device, pull data, verify full restore
+3. Edit on device A, sync, pull on device B — verify changes propagate
+4. Test with no internet — verify graceful degradation
+5. Test wrong encryption password — verify clear error
+6. Test Supabase free tier limits with realistic inventory sizes
+7. Verify `file://` protocol compatibility with Supabase CDN client

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Name column & action icon fix (v3.14.01)**: Long names truncate with ellipsis, N# chips compacted to just "N#" (hover for full ID), action icons no longer clipped on narrow viewports
 - **Encrypted portable backup (v3.14.00)**: Export all data as a password-protected `.stvault` file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history. Password strength bar + crypto fallback for file:// protocol
 - **NGC cert lookup fix (v3.12.02)**: Clicking a graded item's cert tag now opens NGC with the actual coin details visible
 - **Name column overflow fix (v3.12.02)**: Long names truncate with ellipsis — tags (Year, N#, Grade) always stay visible

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.14.01 – Name column & action icon fix</strong>: Long names truncate properly, N# chips compacted, action icons no longer clipped</li>
     <li><strong>v3.14.00 – Encrypted portable backup</strong>: Export all data as a password-protected .stvault file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history</li>
     <li><strong>v3.12.02 – NGC cert lookup fix</strong>: Cert tag click now opens NGC with actual coin details visible</li>
     <li><strong>v3.12.02 – Numista Sets</strong>: New "Set" type for mint/proof sets with S-prefix Numista IDs</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -233,7 +233,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-09 - Feature release: Encrypted portable backup (.stvault)
  */
 
-const APP_VERSION = "3.14.00";
+const APP_VERSION = "3.14.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1008,8 +1008,8 @@ const renderTable = () => {
         ${filterLink('name', item.name, 'var(--text-primary)', undefined, item.name)}${gradeTag}${numistaId
           ? `<span class="numista-tag" data-numista-id="${escapeAttribute(String(numistaId))}"
                data-coin-name="${escapeAttribute(item.name)}"
-               title="View N#${escapeAttribute(String(numistaId))} on Numista"
-               tabindex="0" role="button">N#${sanitizeHtml(String(numistaId))}</span>`
+               title="N#${escapeAttribute(String(numistaId))} — View on Numista"
+               tabindex="0" role="button">N#</span>`
           : ''}${item.year
           ? `<span class="year-tag" title="Year: ${escapeAttribute(String(item.year))}">${sanitizeHtml(String(item.year))}</span>`
           : ''}

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,11 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.14.01": `
+      <li><strong>Name column truncation fix</strong>: Long item names now properly truncate with ellipsis — chips (Grade, N#, Year) stay visible</li>
+      <li><strong>Compact N# chips</strong>: Numista catalog tags shortened to "N#" with full ID shown on hover</li>
+      <li><strong>Tighter action icons</strong>: Edit/copy/delete buttons use less space — trash icon no longer clipped on narrow viewports</li>
+    `,
     "3.14.00": `
       <li><strong>Encrypted portable backup</strong>: Export all data as a password-protected .stvault file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history</li>
       <li><strong>Password strength indicator</strong>: Live strength bar and match validation in the vault modal</li>


### PR DESCRIPTION
## Summary

- **Name column truncation**: Added `max-width: 340px` to `td[data-column="name"]` so the existing flex-based ellipsis truncation actually engages — long Numista names no longer push the table past the viewport
- **Compact N# chips**: Inline catalog tags shortened from `N#298883` to just `N#` with full ID on hover tooltip — saves ~50px per chip
- **Tighter action icons**: Icon buttons reduced from 2.4rem to 1.6rem, gap from 0.25rem to 0.1rem — trash icon no longer clipped off-screen
- **Cloud sync design spec**: Added `docs/CLOUD-SYNC-DESIGN.md` for future Supabase sync implementation

## Test plan

- [ ] Verify long item names truncate with `...` and show full name on hover
- [ ] Verify N# chips display as compact `N#` pill, full catalog ID visible on hover
- [ ] Verify clicking N# chip still opens Numista modal correctly
- [ ] Verify all 3 action icons (gear/copy/trash) visible without clipping
- [ ] Verify Grade and Year tags remain visible alongside truncated names
- [ ] Test at various viewport widths (1200px, 1024px, 768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)