### PR TITLE
v3.16.00: Custom chip grouping, blacklist, dynamic chips + prior releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.00] - 2026-02-09
+
+### Added — Custom Chip Grouping & Smart Grouping Blacklist
+
+- **Custom grouping rules**: Define chip labels with comma/semicolon-separated name patterns to create user-defined filter chips (e.g., "Washington Quarter" matching "Washington Quarter, America The Beautiful Quarter"). Managed in Settings > Grouping
+- **Chip blacklist**: Right-click any name chip to suppress it from the chip bar. Blacklisted chips can be restored in Settings > Grouping
+- **Dynamic name chips**: Auto-extract text from parentheses `()` and double quotes `""` in item names as additional filterable chips. Skips grade strings (BU, MS-XX) and text under 3 characters
+- **Grouping settings panel**: New Settings > Grouping section consolidates Smart Name Grouping toggle (moved from Site), Dynamic Chips toggle, Blacklist management, and Custom Rules management
+- **`DYNAMIC_NAME_CHIPS` feature flag**: Toggle dynamic chip extraction on/off, with URL override support (`?dynamic_name_chips=0`)
+
+### Changed
+
+- **Smart Grouping toggle relocated**: Moved from Settings > Site to Settings > Grouping for better organization with related chip features
+
+---
+
 ## [3.14.01] - 2026-02-09
 
 ### Fixed

--- a/css/styles.css
+++ b/css/styles.css
@@ -1561,6 +1561,105 @@ input[type="submit"] {
   margin-bottom: 0.5rem;
 }
 
+/* Chip grouping controls (blacklist & custom rules) */
+.chip-grouping-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.chip-grouping-input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.8125rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.chip-grouping-input-wide {
+  flex: 2;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.8125rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.chip-grouping-table-container {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-top: 0.25rem;
+}
+
+.chip-grouping-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.chip-grouping-table thead {
+  position: sticky;
+  top: 0;
+  background: var(--bg-card);
+  z-index: 1;
+}
+
+.chip-grouping-table th,
+.chip-grouping-table td {
+  padding: 0.3rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+}
+
+.chip-grouping-table th {
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+}
+
+.chip-grouping-table td.chip-grouping-patterns {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chip-grouping-empty {
+  text-align: center;
+  padding: 1rem;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-style: italic;
+}
+
+.chip-grouping-delete {
+  background: none;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.1rem 0.3rem;
+  border-radius: var(--radius);
+  transition: background 0.1s;
+}
+
+.chip-grouping-delete:hover {
+  background: rgba(var(--danger-rgb, 220, 53, 69), 0.12);
+}
+
 /* Theme picker */
 .theme-picker {
   display: flex;
@@ -3814,6 +3913,83 @@ a.about-badge:hover {
 
 .filter-chip:active {
   transform: translateY(0);
+}
+
+.filter-chip.dynamic-chip {
+  font-style: italic;
+}
+
+.filter-chip.custom-chip {
+  font-weight: 600;
+}
+
+/* Chip context menu (right-click on name/dynamic chips) */
+.chip-context-menu {
+  position: fixed;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg, 0 4px 12px rgba(0,0,0,0.15));
+  z-index: 10000;
+  min-width: 160px;
+  padding: 0.25rem 0;
+}
+
+.chip-context-menu-item {
+  padding: 0.5rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.chip-context-menu-item:hover {
+  background: var(--bg-hover, var(--border));
+}
+
+.chip-confirm-message {
+  padding: 0.5rem 0.75rem 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.chip-confirm-buttons {
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem 0.5rem;
+}
+
+.chip-confirm-yes,
+.chip-confirm-no {
+  flex: 1;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.chip-confirm-yes {
+  background: var(--danger);
+  color: #fff;
+  border-color: var(--danger);
+}
+
+.chip-confirm-yes:hover {
+  opacity: 0.85;
+}
+
+.chip-confirm-no {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.chip-confirm-no:hover {
+  background: var(--bg-hover, var(--border));
 }
 
 .search-results-info {

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Custom chip grouping & blacklist (v3.16.00)**: Define custom chip labels with comma-separated name patterns. Right-click any name chip to blacklist it. Dynamic chips auto-extract text from parentheses/quotes in item names. New Settings > Grouping panel for all chip controls
 - **Name column & action icon fix (v3.14.01)**: Long names truncate with ellipsis, N# chips compacted to just "N#" (hover for full ID), action icons no longer clipped on narrow viewports
 - **Encrypted portable backup (v3.14.00)**: Export all data as a password-protected `.stvault` file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history. Password strength bar + crypto fallback for file:// protocol
 - **NGC cert lookup fix (v3.12.02)**: Clicking a graded item's cert tag now opens NGC with the actual coin details visible

--- a/index.html
+++ b/index.html
@@ -1364,6 +1364,10 @@
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
               Site
             </button>
+            <button class="settings-nav-item" data-section="grouping">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+              Grouping
+            </button>
             <button class="settings-nav-item" data-section="api">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/></svg>
               API
@@ -1421,6 +1425,12 @@
                 </select>
               </div>
 
+            </div>
+
+            <!-- ===== GROUPING SETTINGS ===== -->
+            <div class="settings-section-panel" id="settingsPanel_grouping" style="display: none">
+              <h3>Chip Grouping</h3>
+
               <div class="settings-group">
                 <div class="settings-group-label">Smart name grouping</div>
                 <p class="settings-subtext">Group item names by base name (e.g., "American Silver Eagle (3)").</p>
@@ -1428,6 +1438,42 @@
                   <option value="yes">Enabled</option>
                   <option value="no">Disabled</option>
                 </select>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Dynamic name chips</div>
+                <p class="settings-subtext">Auto-extract text from parentheses and quotes in item names as additional filter chips.</p>
+                <select id="settingsDynamicChips">
+                  <option value="yes">Enabled</option>
+                  <option value="no">Disabled</option>
+                </select>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Chip blacklist</div>
+                <p class="settings-subtext">Suppressed auto-generated chips. Right-click any name chip to add it here.</p>
+                <div class="chip-grouping-controls">
+                  <select id="blacklistInput" class="chip-grouping-input">
+                    <option value="">Select a chip to suppress…</option>
+                  </select>
+                  <button type="button" class="btn" id="addBlacklistBtn">Add</button>
+                </div>
+                <div class="chip-grouping-table-container" id="blacklistTableContainer">
+                  <div class="chip-grouping-empty">No blacklisted chips</div>
+                </div>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Custom grouping rules</div>
+                <p class="settings-subtext">Define chip labels with comma or semicolon-separated name patterns.</p>
+                <div class="chip-grouping-controls">
+                  <input type="text" id="customGroupLabelInput" class="chip-grouping-input" placeholder="Chip label">
+                  <input type="text" id="customGroupPatternsInput" class="chip-grouping-input-wide" placeholder="Patterns (comma-separated)">
+                  <button type="button" class="btn" id="addCustomGroupBtn">Add Rule</button>
+                </div>
+                <div class="chip-grouping-table-container" id="customGroupTableContainer">
+                  <div class="chip-grouping-empty">No custom grouping rules</div>
+                </div>
               </div>
             </div>
 
@@ -2121,6 +2167,7 @@
     <script defer src="./js/charts.js"></script>
     <script defer src="./js/theme.js"></script>
     <script defer src="./js/search.js"></script>
+    <script defer src="./js/chip-grouping.js"></script>
     <script defer src="./js/filters.js"></script>
     <script defer src="./js/sorting.js"></script>
     <script defer src="./js/pagination.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.16.00 – Custom chip grouping & blacklist</strong>: Define custom chip labels with name patterns, right-click chips to blacklist, auto-extract dynamic chips from parentheses/quotes in names</li>
     <li><strong>v3.14.01 – Name column & action icon fix</strong>: Long names truncate properly, N# chips compacted, action icons no longer clipped</li>
     <li><strong>v3.14.00 – Encrypted portable backup</strong>: Export all data as a password-protected .stvault file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history</li>
     <li><strong>v3.12.02 – NGC cert lookup fix</strong>: Cert tag click now opens NGC with actual coin details visible</li>

--- a/js/chip-grouping.js
+++ b/js/chip-grouping.js
@@ -1,0 +1,624 @@
+// CHIP GROUPING MODULE
+// =============================================================================
+// Custom grouping rules, chip blacklist, and dynamic chip extraction.
+// Loads before filters.js; exposes functions on window.*.
+
+(function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------------
+  // Internal state
+  // ---------------------------------------------------------------------------
+  let _customGroups = [];
+  let _blacklistArr = [];
+  let _blacklistSet = new Set();
+
+  // Known grade strings to exclude from dynamic chip extraction
+  const GRADE_PATTERN = /^(BU|MS[-\s]?\d{1,2}|PF[-\s]?\d{1,2}|PR[-\s]?\d{1,2}|AG|G[-\s]?\d{1,2}|VG[-\s]?\d{1,2}|F[-\s]?\d{1,2}|VF[-\s]?\d{1,2}|EF[-\s]?\d{1,2}|AU[-\s]?\d{1,2}|UNC)$/i;
+
+  // ---------------------------------------------------------------------------
+  // Custom Grouping Rules CRUD
+  // ---------------------------------------------------------------------------
+
+  /** Load custom groups from localStorage */
+  const loadCustomGroups = () => {
+    _customGroups = loadDataSync('chipCustomGroups', []);
+    return _customGroups;
+  };
+
+  /** Save custom groups to localStorage */
+  const saveCustomGroups = () => {
+    saveDataSync('chipCustomGroups', _customGroups);
+  };
+
+  /**
+   * Add a custom grouping rule.
+   * @param {string} label - Display label for the chip
+   * @param {string} patternsStr - Comma or semicolon separated match patterns
+   * @returns {Object|null} The new rule, or null if validation fails
+   */
+  const addCustomGroup = (label, patternsStr) => {
+    if (!label || !label.trim()) return null;
+    if (!patternsStr || !patternsStr.trim()) return null;
+
+    const patterns = patternsStr
+      .split(/[,;]/)
+      .map(p => p.trim())
+      .filter(p => p.length > 0);
+
+    if (patterns.length === 0) return null;
+
+    const group = {
+      id: 'cg_' + Date.now(),
+      label: label.trim(),
+      patterns,
+      enabled: true,
+    };
+
+    _customGroups.push(group);
+    saveCustomGroups();
+    return group;
+  };
+
+  /** Remove a custom group by ID */
+  const removeCustomGroup = (id) => {
+    _customGroups = _customGroups.filter(g => g.id !== id);
+    saveCustomGroups();
+  };
+
+  /** Toggle a custom group's enabled state */
+  const toggleCustomGroup = (id) => {
+    const group = _customGroups.find(g => g.id === id);
+    if (group) {
+      group.enabled = !group.enabled;
+      saveCustomGroups();
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Chip Blacklist CRUD
+  // ---------------------------------------------------------------------------
+
+  const _rebuildBlacklistSet = () => {
+    _blacklistSet = new Set(_blacklistArr.map(n => n.toLowerCase()));
+  };
+
+  /** Load blacklist from localStorage */
+  const loadChipBlacklist = () => {
+    _blacklistArr = loadDataSync('chipBlacklist', []);
+    _rebuildBlacklistSet();
+    return _blacklistArr;
+  };
+
+  /** Save blacklist to localStorage */
+  const saveChipBlacklist = () => {
+    saveDataSync('chipBlacklist', _blacklistArr);
+    _rebuildBlacklistSet();
+  };
+
+  /** Add a name to the blacklist (case-insensitive dedup) */
+  const addToBlacklist = (name) => {
+    if (!name || !name.trim()) return;
+    const trimmed = name.trim();
+    if (_blacklistSet.has(trimmed.toLowerCase())) return; // already present
+    _blacklistArr.push(trimmed);
+    saveChipBlacklist();
+  };
+
+  /** Remove a name from the blacklist */
+  const removeFromBlacklist = (name) => {
+    const lower = name.toLowerCase();
+    _blacklistArr = _blacklistArr.filter(n => n.toLowerCase() !== lower);
+    saveChipBlacklist();
+  };
+
+  /** Fast blacklist membership check */
+  const isBlacklisted = (name) => {
+    if (!name) return false;
+    return _blacklistSet.has(name.toLowerCase());
+  };
+
+  // ---------------------------------------------------------------------------
+  // Dynamic Chip Extraction
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Extract text from parentheses and quoted strings in item names.
+   * Returns { extractedText: count } for texts appearing in 2+ items.
+   * Skips grade strings and text shorter than 3 characters.
+   *
+   * @param {Array<Object>} inventory - Inventory items
+   * @returns {Object} Map of extracted text → count
+   */
+  const extractDynamicChips = (inventory) => {
+    const counts = {};
+
+    inventory.forEach(item => {
+      const name = (item.name || '').trim();
+      if (!name) return;
+
+      const seen = new Set(); // avoid counting same text twice per item
+
+      // Extract text inside parentheses: (text)
+      const parenMatches = name.match(/\(([^)]+)\)/g);
+      if (parenMatches) {
+        parenMatches.forEach(m => {
+          const text = m.slice(1, -1).trim();
+          if (text.length >= 3 && !GRADE_PATTERN.test(text) && !seen.has(text.toLowerCase())) {
+            seen.add(text.toLowerCase());
+            counts[text] = (counts[text] || 0) + 1;
+          }
+        });
+      }
+
+      // Extract text inside double quotes: "text"
+      const quoteMatches = name.match(/"([^"]+)"/g);
+      if (quoteMatches) {
+        quoteMatches.forEach(m => {
+          const text = m.slice(1, -1).trim();
+          if (text.length >= 3 && !GRADE_PATTERN.test(text) && !seen.has(text.toLowerCase())) {
+            seen.add(text.toLowerCase());
+            counts[text] = (counts[text] || 0) + 1;
+          }
+        });
+      }
+    });
+
+    return counts;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Custom Group Counting
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Count items matching each enabled custom group.
+   * @param {Array<Object>} inventory
+   * @returns {Object} { groupId: { label, count } }
+   */
+  const countCustomGroups = (inventory) => {
+    const results = {};
+    _customGroups.forEach(group => {
+      if (!group.enabled) return;
+      let count = 0;
+      inventory.forEach(item => {
+        const itemName = (item.name || '').toLowerCase();
+        if (group.patterns.some(p => itemName.includes(p.toLowerCase()))) {
+          count++;
+        }
+      });
+      if (count > 0) {
+        results[group.id] = { label: group.label, count };
+      }
+    });
+    return results;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Settings Panel Rendering
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Populate the blacklist dropdown with all current name chips + dynamic chips
+   * from the live inventory, respecting chipMinCount and excluding already-blacklisted.
+   */
+  const populateBlacklistDropdown = () => {
+    const select = document.getElementById('blacklistInput');
+    if (!select) return;
+
+    // Preserve current selection if any
+    const prev = select.value;
+
+    // Clear existing options
+    select.innerHTML = '<option value="">Select a chip to suppress\u2026</option>';
+
+    // Get inventory (let-declared global — not on window, but accessible via lexical scope)
+    const inv = typeof inventory !== 'undefined' ? inventory : [];
+    if (!inv || inv.length === 0) return;
+
+    // Get chipMinCount threshold
+    const chipMinCountEl = document.getElementById('chipMinCount');
+    let minCount = 2;
+    if (chipMinCountEl && chipMinCountEl.value) {
+      minCount = parseInt(chipMinCountEl.value, 10);
+    } else {
+      minCount = parseInt(localStorage.getItem('chipMinCount') || '3', 10);
+    }
+
+    const candidates = {}; // name → count
+
+    // Collect grouped name chips (same logic as generateCategorySummary)
+    if (window.featureFlags && window.featureFlags.isEnabled('GROUPED_NAME_CHIPS')) {
+      inv.forEach(item => {
+        const itemName = (item.name || '').trim();
+        if (!itemName) return;
+        let baseName = itemName;
+        if (window.autocomplete && typeof window.autocomplete.normalizeItemName === 'function') {
+          baseName = window.autocomplete.normalizeItemName(itemName);
+        }
+        candidates[baseName] = (candidates[baseName] || 0) + 1;
+      });
+    }
+
+    // Collect dynamic chips
+    if (window.featureFlags && window.featureFlags.isEnabled('DYNAMIC_NAME_CHIPS')) {
+      const dynamicCounts = extractDynamicChips(inv);
+      for (const [text, count] of Object.entries(dynamicCounts)) {
+        if (!candidates[text]) {
+          candidates[text] = count;
+        }
+      }
+    }
+
+    // Build sorted list: meets minCount, not already blacklisted
+    const customLabelsLower = new Set(_customGroups.filter(g => g.enabled).map(g => g.label.toLowerCase()));
+    const options = Object.entries(candidates)
+      .filter(([name, count]) => count >= minCount && !_blacklistSet.has(name.toLowerCase()) && !customLabelsLower.has(name.toLowerCase()))
+      .sort((a, b) => a[0].localeCompare(b[0]));
+
+    if (options.length === 0) {
+      const opt = document.createElement('option');
+      opt.value = '';
+      opt.textContent = 'No available chips to blacklist';
+      opt.disabled = true;
+      select.appendChild(opt);
+      return;
+    }
+
+    // Add name chip group
+    const nameGroup = document.createElement('optgroup');
+    nameGroup.label = 'Name Chips';
+    let hasNames = false;
+
+    const dynamicGroup = document.createElement('optgroup');
+    dynamicGroup.label = 'Dynamic Chips';
+    let hasDynamic = false;
+
+    // Separate name chips from dynamic chips
+    const dynamicKeys = new Set();
+    if (window.featureFlags && window.featureFlags.isEnabled('DYNAMIC_NAME_CHIPS')) {
+      const dynamicCounts = extractDynamicChips(inv);
+      for (const key of Object.keys(dynamicCounts)) {
+        dynamicKeys.add(key);
+      }
+    }
+
+    options.forEach(([name, count]) => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = `${name} (${count})`;
+
+      if (dynamicKeys.has(name)) {
+        dynamicGroup.appendChild(opt);
+        hasDynamic = true;
+      } else {
+        nameGroup.appendChild(opt);
+        hasNames = true;
+      }
+    });
+
+    if (hasNames) select.appendChild(nameGroup);
+    if (hasDynamic) select.appendChild(dynamicGroup);
+
+    // Restore previous selection if still valid
+    if (prev && select.querySelector(`option[value="${CSS.escape(prev)}"]`)) {
+      select.value = prev;
+    }
+  };
+
+  /** Render the blacklist table inside #blacklistTableContainer */
+  const renderBlacklistTable = () => {
+    const container = document.getElementById('blacklistTableContainer');
+    if (!container) return;
+
+    if (_blacklistArr.length === 0) {
+      container.innerHTML = '<div class="chip-grouping-empty">No blacklisted chips</div>';
+      return;
+    }
+
+    let html = '<table class="chip-grouping-table"><thead><tr><th>Chip Name</th><th></th></tr></thead><tbody>';
+    _blacklistArr.forEach(name => {
+      html += `<tr>
+        <td>${_escHtml(name)}</td>
+        <td><button class="chip-grouping-delete" data-blacklist-name="${_escAttr(name)}" title="Remove from blacklist">&times;</button></td>
+      </tr>`;
+    });
+    html += '</tbody></table>';
+    container.innerHTML = html;
+
+    // Wire delete buttons
+    container.querySelectorAll('.chip-grouping-delete[data-blacklist-name]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        removeFromBlacklist(btn.dataset.blacklistName);
+        renderBlacklistTable();
+        populateBlacklistDropdown(); // refresh dropdown to show restored chip
+        if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      });
+    });
+  };
+
+  /** Render the custom group table inside #customGroupTableContainer */
+  const renderCustomGroupTable = () => {
+    const container = document.getElementById('customGroupTableContainer');
+    if (!container) return;
+
+    if (_customGroups.length === 0) {
+      container.innerHTML = '<div class="chip-grouping-empty">No custom grouping rules</div>';
+      return;
+    }
+
+    let html = '<table class="chip-grouping-table"><thead><tr><th>Label</th><th>Patterns</th><th>On</th><th></th></tr></thead><tbody>';
+    _customGroups.forEach(group => {
+      const checked = group.enabled ? 'checked' : '';
+      html += `<tr>
+        <td>${_escHtml(group.label)}</td>
+        <td class="chip-grouping-patterns">${_escHtml(group.patterns.join(', '))}</td>
+        <td><input type="checkbox" ${checked} data-toggle-group="${_escAttr(group.id)}" title="Toggle rule"></td>
+        <td><button class="chip-grouping-delete" data-delete-group="${_escAttr(group.id)}" title="Delete rule">&times;</button></td>
+      </tr>`;
+    });
+    html += '</tbody></table>';
+    container.innerHTML = html;
+
+    // Wire toggle checkboxes
+    container.querySelectorAll('input[data-toggle-group]').forEach(cb => {
+      cb.addEventListener('change', () => {
+        toggleCustomGroup(cb.dataset.toggleGroup);
+        if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      });
+    });
+
+    // Wire delete buttons
+    container.querySelectorAll('.chip-grouping-delete[data-delete-group]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        removeCustomGroup(btn.dataset.deleteGroup);
+        renderCustomGroupTable();
+        if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      });
+    });
+  };
+
+  // ---------------------------------------------------------------------------
+  // Context Menu (right-click on name/dynamic chips)
+  // ---------------------------------------------------------------------------
+
+  let _contextMenuEl = null;
+
+  /** Show a context menu to blacklist a chip name */
+  const showChipContextMenu = (x, y, chipName) => {
+    _hideContextMenu();
+
+    const menu = document.createElement('div');
+    menu.className = 'chip-context-menu';
+    menu.style.left = x + 'px';
+    menu.style.top = y + 'px';
+
+    const item = document.createElement('div');
+    item.className = 'chip-context-menu-item';
+    item.textContent = 'Add to blacklist';
+    item.addEventListener('click', () => {
+      addToBlacklist(chipName);
+      _hideContextMenu();
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      // Also update settings table and dropdown if open
+      renderBlacklistTable();
+      populateBlacklistDropdown();
+    });
+    menu.appendChild(item);
+
+    document.body.appendChild(menu);
+    _contextMenuEl = menu;
+
+    // Adjust position if off-screen
+    const rect = menu.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      menu.style.left = (window.innerWidth - rect.width - 8) + 'px';
+    }
+    if (rect.bottom > window.innerHeight) {
+      menu.style.top = (window.innerHeight - rect.height - 8) + 'px';
+    }
+
+    // Close on click-away or Escape
+    setTimeout(() => {
+      document.addEventListener('click', _hideContextMenu, { once: true });
+      document.addEventListener('keydown', _onContextMenuKey);
+    }, 0);
+  };
+
+  const _hideContextMenu = () => {
+    if (_contextMenuEl && _contextMenuEl.parentNode) {
+      _contextMenuEl.parentNode.removeChild(_contextMenuEl);
+    }
+    _contextMenuEl = null;
+    document.removeEventListener('keydown', _onContextMenuKey);
+  };
+
+  const _onContextMenuKey = (e) => {
+    if (e.key === 'Escape') {
+      _hideContextMenu();
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Shift+Click Blacklist Confirmation
+  // ---------------------------------------------------------------------------
+
+  let _confirmEl = null;
+
+  /**
+   * Show a lightweight floating confirmation to blacklist a chip.
+   * Triggered by shift+click on name/dynamic chips.
+   */
+  const showBlacklistConfirm = (x, y, chipName) => {
+    _hideBlacklistConfirm();
+
+    const popup = document.createElement('div');
+    popup.className = 'chip-context-menu';
+    popup.style.left = x + 'px';
+    popup.style.top = y + 'px';
+
+    const msg = document.createElement('div');
+    msg.className = 'chip-confirm-message';
+    msg.textContent = `Ignore "${chipName}"?`;
+    popup.appendChild(msg);
+
+    const btnRow = document.createElement('div');
+    btnRow.className = 'chip-confirm-buttons';
+
+    const yesBtn = document.createElement('button');
+    yesBtn.className = 'chip-confirm-yes';
+    yesBtn.textContent = 'Ignore';
+    yesBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      addToBlacklist(chipName);
+      _hideBlacklistConfirm();
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      renderBlacklistTable();
+      populateBlacklistDropdown();
+    });
+
+    const noBtn = document.createElement('button');
+    noBtn.className = 'chip-confirm-no';
+    noBtn.textContent = 'Cancel';
+    noBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      _hideBlacklistConfirm();
+    });
+
+    btnRow.appendChild(yesBtn);
+    btnRow.appendChild(noBtn);
+    popup.appendChild(btnRow);
+
+    document.body.appendChild(popup);
+    _confirmEl = popup;
+
+    // Adjust position if off-screen
+    const rect = popup.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      popup.style.left = (window.innerWidth - rect.width - 8) + 'px';
+    }
+    if (rect.bottom > window.innerHeight) {
+      popup.style.top = (window.innerHeight - rect.height - 8) + 'px';
+    }
+
+    // Close on click-away or Escape
+    setTimeout(() => {
+      document.addEventListener('click', _hideBlacklistConfirm, { once: true });
+      document.addEventListener('keydown', _onConfirmKey);
+    }, 0);
+  };
+
+  const _hideBlacklistConfirm = () => {
+    if (_confirmEl && _confirmEl.parentNode) {
+      _confirmEl.parentNode.removeChild(_confirmEl);
+    }
+    _confirmEl = null;
+    document.removeEventListener('keydown', _onConfirmKey);
+  };
+
+  const _onConfirmKey = (e) => {
+    if (e.key === 'Escape') {
+      _hideBlacklistConfirm();
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Settings Event Wiring
+  // ---------------------------------------------------------------------------
+
+  /** Wire event listeners for the Grouping settings panel */
+  const setupChipGroupingEvents = () => {
+    // Add to blacklist (from dropdown)
+    const addBlacklistBtn = document.getElementById('addBlacklistBtn');
+    const blacklistInput = document.getElementById('blacklistInput');
+    if (addBlacklistBtn && blacklistInput) {
+      const doAddBlacklist = () => {
+        const val = blacklistInput.value;
+        if (val) {
+          addToBlacklist(val);
+          renderBlacklistTable();
+          populateBlacklistDropdown(); // refresh dropdown to remove the just-added item
+          if (typeof renderActiveFilters === 'function') renderActiveFilters();
+        }
+      };
+      addBlacklistBtn.addEventListener('click', doAddBlacklist);
+      // Also allow double-click on select to add immediately
+      blacklistInput.addEventListener('change', () => {
+        // Auto-add when a selection is made — no extra click needed
+        doAddBlacklist();
+      });
+    }
+
+    // Add custom group
+    const addGroupBtn = document.getElementById('addCustomGroupBtn');
+    const groupLabelInput = document.getElementById('customGroupLabelInput');
+    const groupPatternsInput = document.getElementById('customGroupPatternsInput');
+    if (addGroupBtn && groupLabelInput && groupPatternsInput) {
+      const doAddGroup = () => {
+        const label = groupLabelInput.value.trim();
+        const patterns = groupPatternsInput.value.trim();
+        if (label && patterns) {
+          const result = addCustomGroup(label, patterns);
+          if (result) {
+            groupLabelInput.value = '';
+            groupPatternsInput.value = '';
+            renderCustomGroupTable();
+            if (typeof renderActiveFilters === 'function') renderActiveFilters();
+          }
+        }
+      };
+      addGroupBtn.addEventListener('click', doAddGroup);
+      groupPatternsInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); doAddGroup(); }
+      });
+      groupLabelInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); groupPatternsInput.focus(); }
+      });
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  const _escHtml = (str) => {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  };
+
+  const _escAttr = (str) => {
+    return str.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  };
+
+  // ---------------------------------------------------------------------------
+  // Initialization
+  // ---------------------------------------------------------------------------
+
+  // Load persisted data on script load
+  loadCustomGroups();
+  loadChipBlacklist();
+
+  // ---------------------------------------------------------------------------
+  // Expose to window
+  // ---------------------------------------------------------------------------
+  window.loadCustomGroups = loadCustomGroups;
+  window.saveCustomGroups = saveCustomGroups;
+  window.addCustomGroup = addCustomGroup;
+  window.removeCustomGroup = removeCustomGroup;
+  window.toggleCustomGroup = toggleCustomGroup;
+  window.loadChipBlacklist = loadChipBlacklist;
+  window.saveChipBlacklist = saveChipBlacklist;
+  window.addToBlacklist = addToBlacklist;
+  window.removeFromBlacklist = removeFromBlacklist;
+  window.isBlacklisted = isBlacklisted;
+  window.extractDynamicChips = extractDynamicChips;
+  window.countCustomGroups = countCustomGroups;
+  window.populateBlacklistDropdown = populateBlacklistDropdown;
+  window.renderBlacklistTable = renderBlacklistTable;
+  window.renderCustomGroupTable = renderCustomGroupTable;
+  window.showChipContextMenu = showChipContextMenu;
+  window.showBlacklistConfirm = showBlacklistConfirm;
+  window.setupChipGroupingEvents = setupChipGroupingEvents;
+
+})();

--- a/js/constants.js
+++ b/js/constants.js
@@ -230,10 +230,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-09 - Feature release: Encrypted portable backup (.stvault)
+ * Updated: 2026-02-09 - Feature release: Custom chip grouping & smart grouping blacklist
  */
 
-const APP_VERSION = "3.14.01";
+const APP_VERSION = "3.16.00";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -430,6 +430,8 @@ const ALLOWED_STORAGE_KEYS = [
   CATALOG_HISTORY_KEY,
   SPOT_TREND_RANGE_KEY,
   ITEMS_PER_PAGE_KEY,
+  "chipCustomGroups",
+  "chipBlacklist",
 ];
 
 // Persist current application version for comparison on future loads
@@ -499,6 +501,13 @@ const FEATURE_FLAGS = {
     urlOverride: true,
     userToggle: true,
     description: "Group item names by base name (e.g., 'American Silver Eagle (3)' instead of separate year chips)",
+    phase: "beta"
+  },
+  DYNAMIC_NAME_CHIPS: {
+    enabled: true,
+    urlOverride: true,
+    userToggle: true,
+    description: "Auto-extract text from parentheses and quotes in item names as additional filter chips",
     phase: "beta"
   }
 };

--- a/js/settings.js
+++ b/js/settings.js
@@ -108,6 +108,17 @@ const syncSettingsUI = () => {
     groupSetting.value = featureFlags.isEnabled('GROUPED_NAME_CHIPS') ? 'yes' : 'no';
   }
 
+  // Dynamic name chips
+  const dynamicSetting = document.getElementById('settingsDynamicChips');
+  if (dynamicSetting && window.featureFlags) {
+    dynamicSetting.value = featureFlags.isEnabled('DYNAMIC_NAME_CHIPS') ? 'yes' : 'no';
+  }
+
+  // Chip grouping tables and dropdown
+  if (typeof window.populateBlacklistDropdown === 'function') window.populateBlacklistDropdown();
+  if (typeof window.renderBlacklistTable === 'function') window.renderBlacklistTable();
+  if (typeof window.renderCustomGroupTable === 'function') window.renderCustomGroupTable();
+
   // Storage footer
   updateSettingsFooter();
 
@@ -224,6 +235,24 @@ const setupSettingsEventListeners = () => {
       if (groupInline) groupInline.value = groupSetting.value;
       if (typeof renderActiveFilters === 'function') renderActiveFilters();
     });
+  }
+
+  // Dynamic name chips toggle
+  const dynamicChipsSetting = document.getElementById('settingsDynamicChips');
+  if (dynamicChipsSetting) {
+    dynamicChipsSetting.addEventListener('change', () => {
+      const isEnabled = dynamicChipsSetting.value === 'yes';
+      if (window.featureFlags) {
+        if (isEnabled) featureFlags.enable('DYNAMIC_NAME_CHIPS');
+        else featureFlags.disable('DYNAMIC_NAME_CHIPS');
+      }
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+    });
+  }
+
+  // Chip grouping events (blacklist + custom rules)
+  if (typeof window.setupChipGroupingEvents === 'function') {
+    window.setupChipGroupingEvents();
   }
 
   // Settings modal close button

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,12 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.16.00": `
+      <li><strong>Custom chip grouping</strong>: Define your own chip labels with comma-separated name patterns — group items any way you want</li>
+      <li><strong>Smart grouping blacklist</strong>: Right-click any name chip to suppress it. Manage blacklisted chips in Settings &gt; Grouping</li>
+      <li><strong>Dynamic name chips</strong>: Text inside parentheses and quotes in item names auto-generates filterable chips</li>
+      <li><strong>Grouping settings panel</strong>: New Settings &gt; Grouping tab with Smart Grouping, Dynamic Chips, Blacklist, and Custom Rules controls</li>
+    `,
     "3.14.01": `
       <li><strong>Name column truncation fix</strong>: Long item names now properly truncate with ellipsis — chips (Grade, N#, Year) stay visible</li>
       <li><strong>Compact N# chips</strong>: Numista catalog tags shortened to "N#" with full ID shown on hover</li>


### PR DESCRIPTION
## Summary

- **Custom chip grouping & blacklist (v3.16.00)**: User-defined chip labels with comma-separated name patterns, chip blacklist via right-click or shift+click, dynamic chips auto-extracted from parentheses/quotes in item names, new Settings > Grouping panel with live inventory dropdown
- **Encrypted portable backup (v3.14.00–v3.14.01)**: AES-256-GCM `.stvault` export/import with password strength bar and crypto fallback for file:// protocol. Name column truncation and action icon fixes
- **Portal view & unified settings (v3.11.00–v3.12.02)**: Scrollable table with sticky headers, unified Settings modal with sidebar nav, NGC cert lookup fix, Numista Sets, source column cleanup
- **Prior releases (v3.09.01–v3.10.01)**: Serial # field, normalized name chips, filter chips for Year/Grade/N#, spot price sparkline redesign, inline editing, eBay search fixes

## Test plan

- [ ] Add custom grouping rule → verify chip appears with correct count, click filters correctly
- [ ] Shift+click a name chip → confirm "Ignore" popup, chip disappears after confirming
- [ ] Settings > Grouping → blacklist dropdown shows inventory chips with counts, add/remove works
- [ ] Dynamic chips appear for parenthesized/quoted text in item names
- [ ] Export/import `.stvault` backup → verify custom rules and blacklist survive round-trip
- [ ] Verify `file://` protocol compatibility (all localStorage operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)