### PR TITLE
Fix API settings persistence, add Numista usage bar (v3.16.01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.01] - 2026-02-09
+
+### Fixed — API Settings & Numista Usage Tracking
+
+- **Cache timeout persistence**: Per-provider cache timeout settings now persist across page reloads. Previously `cacheTimeouts` was written by the UI but never saved to localStorage or read by `getCacheDurationMs()`
+- **Historical data for non-default providers**: `historyDays` default changed from `0` to `30` so Metals-API and MetalPriceAPI fetch historical data on first sync instead of current-only prices
+- **Auto-sync all configured providers**: Page refresh now syncs all providers with API keys and stale caches, not just the default provider
+
+### Added
+
+- **Standalone "Save" button per provider**: Save API key, cache timeout, and history settings without triggering a connection test or price fetch. Brief "Saved!" confirmation replaces the alert dialog
+- **Numista API usage progress bar**: Tracks API calls persistently across page reloads with automatic monthly reset. Shows `X/2000 calls` in Settings > API > Numista section
+
+---
+
 ## [3.16.00] - 2026-02-09
 
 ### Added — Custom Chip Grouping & Smart Grouping Blacklist

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **API settings fixes & Numista usage (v3.16.01)**: Cache timeout now persists per-provider, historical data fetches for all providers, page refresh syncs all configured APIs. New standalone "Save" button per provider. Numista usage progress bar tracks API calls with monthly auto-reset
 - **Custom chip grouping & blacklist (v3.16.00)**: Define custom chip labels with comma-separated name patterns. Right-click any name chip to blacklist it. Dynamic chips auto-extract text from parentheses/quotes in item names. New Settings > Grouping panel for all chip controls
 - **Name column & action icon fix (v3.14.01)**: Long names truncate with ellipsis, N# chips compacted to just "N#" (hover for full ID), action icons no longer clipped on narrow viewports
 - **Encrypted portable backup (v3.14.00)**: Export all data as a password-protected `.stvault` file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history. Password strength bar + crypto fallback for file:// protocol

--- a/index.html
+++ b/index.html
@@ -1555,6 +1555,7 @@
                       <div class="provider-actions-right">
                         <button type="button" class="btn api-quota-btn" data-provider="METALS_DEV">Quota</button>
                         <button type="button" class="btn api-clear-btn warning" data-provider="METALS_DEV">Clear Key</button>
+                        <button type="button" class="btn api-save-btn" data-provider="METALS_DEV">Save</button>
                         <button type="button" class="btn api-sync-btn success" data-provider="METALS_DEV">Save and Test</button>
                       </div>
                     </div>
@@ -1618,6 +1619,7 @@
                       <div class="provider-actions-right">
                         <button type="button" class="btn api-quota-btn" data-provider="METALS_API">Quota</button>
                         <button type="button" class="btn api-clear-btn warning" data-provider="METALS_API">Clear Key</button>
+                        <button type="button" class="btn api-save-btn" data-provider="METALS_API">Save</button>
                         <button type="button" class="btn api-sync-btn success" data-provider="METALS_API">Save and Test</button>
                       </div>
                     </div>
@@ -1681,6 +1683,7 @@
                       <div class="provider-actions-right">
                         <button type="button" class="btn api-quota-btn" data-provider="METAL_PRICE_API">Quota</button>
                         <button type="button" class="btn api-clear-btn warning" data-provider="METAL_PRICE_API">Clear Key</button>
+                        <button type="button" class="btn api-save-btn" data-provider="METAL_PRICE_API">Save</button>
                         <button type="button" class="btn api-sync-btn success" data-provider="METAL_PRICE_API">Save and Test</button>
                       </div>
                     </div>
@@ -1756,6 +1759,7 @@
                       <div class="provider-actions-right">
                         <button type="button" class="btn api-quota-btn" data-provider="CUSTOM">Quota</button>
                         <button type="button" class="btn api-clear-btn warning" data-provider="CUSTOM">Clear Key</button>
+                        <button type="button" class="btn api-save-btn" data-provider="CUSTOM">Save</button>
                         <button type="button" class="btn api-sync-btn success" data-provider="CUSTOM">Save and Test</button>
                       </div>
                     </div>
@@ -1773,6 +1777,7 @@
                 <div class="api-key-note">
                   <p>Get a free API key at <a href="https://en.numista.com/api/" target="_blank" rel="noopener">numista.com/api</a> (2,000 requests/month free tier). Your key is stored locally in your browser.</p>
                 </div>
+                <div id="numistaUsageBar" class="api-usage" style="margin-top: 0.75rem;"></div>
                 <div class="provider-actions" style="margin-top: 0.75rem;">
                   <button class="btn success" id="saveNumistaBtn">Save Key</button>
                   <button class="btn info" id="testNumistaBtn">Test Connection</button>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.16.01 – API settings fixes & Numista usage</strong>: Cache timeout persists per-provider, historical data fetches for all providers, page refresh syncs all configured APIs. Standalone "Save" button per provider. Numista usage progress bar with monthly auto-reset</li>
     <li><strong>v3.16.00 – Custom chip grouping & blacklist</strong>: Define custom chip labels with name patterns, right-click chips to blacklist, auto-extract dynamic chips from parentheses/quotes in names</li>
     <li><strong>v3.14.01 – Name column & action icon fix</strong>: Long names truncate properly, N# chips compacted, action icons no longer clipped</li>
     <li><strong>v3.14.00 – Encrypted portable backup</strong>: Export all data as a password-protected .stvault file (AES-256-GCM). Import on any device to restore inventory, settings, API keys, and price history</li>

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1377,10 +1377,34 @@ const renderNumistaUsageBar = () => {
   const container = document.getElementById('numistaUsageBar');
   if (!container) return;
   const usage = catalogConfig.getNumistaUsage();
-  const usedPercent = Math.min((usage.used / usage.quota) * 100, 100);
+  // Coerce to safe finite numbers and validate month format
+  const used = Number.isFinite(usage.used) ? Math.max(0, usage.used) : 0;
+  const quota = Number.isFinite(usage.quota) && usage.quota > 0 ? usage.quota : 2000;
+  const month = /^\d{4}-\d{2}$/.test(usage.month) ? usage.month : '';
+  const usedPercent = Math.min((used / quota) * 100, 100);
   const remainingPercent = 100 - usedPercent;
-  const warning = usage.used / usage.quota >= 0.9;
-  container.innerHTML = `<div class="api-usage"><div class="usage-bar"><div class="used" style="width:${usedPercent}%"></div><div class="remaining" style="width:${remainingPercent}%"></div></div><div class="usage-text">${usage.used}/${usage.quota} calls (${usage.month})${warning ? " 🚩" : ""}</div></div>`;
+  const warning = used / quota >= 0.9;
+
+  // Build DOM nodes safely (no innerHTML with localStorage-sourced values)
+  container.textContent = '';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'api-usage';
+  const bar = document.createElement('div');
+  bar.className = 'usage-bar';
+  const usedDiv = document.createElement('div');
+  usedDiv.className = 'used';
+  usedDiv.style.width = `${usedPercent}%`;
+  const remainDiv = document.createElement('div');
+  remainDiv.className = 'remaining';
+  remainDiv.style.width = `${remainingPercent}%`;
+  bar.appendChild(usedDiv);
+  bar.appendChild(remainDiv);
+  const text = document.createElement('div');
+  text.className = 'usage-text';
+  text.textContent = `${used}/${quota} calls${month ? ` (${month})` : ''}${warning ? ' 🚩' : ''}`;
+  wrapper.appendChild(bar);
+  wrapper.appendChild(text);
+  container.appendChild(wrapper);
 };
 
 // Export for use in other modules

--- a/js/constants.js
+++ b/js/constants.js
@@ -230,10 +230,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-09 - Feature release: Custom chip grouping & smart grouping blacklist
+ * Updated: 2026-02-09 - Patch: API settings fixes & Numista usage tracking
  */
 
-const APP_VERSION = "3.16.00";
+const APP_VERSION = "3.16.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -1645,6 +1645,20 @@ const setupApiEvents = () => {
       );
     });
 
+    document.querySelectorAll(".api-save-btn").forEach((btn) => {
+      const provider = btn.getAttribute("data-provider");
+      safeAttachListener(
+        btn,
+        "click",
+        () => {
+          if (typeof handleProviderSave === "function") {
+            handleProviderSave(provider);
+          }
+        },
+        "API save button",
+      );
+    });
+
     document.querySelectorAll(".api-sync-btn").forEach((btn) => {
       const provider = btn.getAttribute("data-provider");
       safeAttachListener(

--- a/js/settings.js
+++ b/js/settings.js
@@ -127,6 +127,11 @@ const syncSettingsUI = () => {
     renderApiStatusSummary();
   }
 
+  // Numista usage bar
+  if (typeof renderNumistaUsageBar === 'function') {
+    renderNumistaUsageBar();
+  }
+
   // Set first provider tab active if none visible
   const anyVisible = document.querySelector('.settings-provider-panel[style*="display: block"]');
   if (!anyVisible) {

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,13 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.16.01": `
+      <li><strong>Cache timeout persistence</strong>: Per-provider cache timeout settings now persist across page reloads</li>
+      <li><strong>Historical data for all providers</strong>: Metals-API and MetalPriceAPI now fetch historical data on first sync instead of current-only prices</li>
+      <li><strong>Auto-sync all providers</strong>: Page refresh syncs all configured providers with stale caches, not just the default</li>
+      <li><strong>Standalone "Save" button</strong>: Save API key and settings without triggering a connection test or price fetch</li>
+      <li><strong>Numista usage progress bar</strong>: Tracks API calls persistently with monthly auto-reset — shows X/2000 calls in Settings</li>
+    `,
     "3.16.00": `
       <li><strong>Custom chip grouping</strong>: Define your own chip labels with comma-separated name patterns — group items any way you want</li>
       <li><strong>Smart grouping blacklist</strong>: Right-click any name chip to suppress it. Manage blacklisted chips in Settings &gt; Grouping</li>


### PR DESCRIPTION
## Summary

- **Fix cache timeout persistence**: Per-provider `cacheTimeouts` now saved/loaded in `saveApiConfig`/`loadApiConfig`, and `getCacheDurationMs(provider)` reads per-provider values
- **Fix historical data for non-default providers**: `historyDays` defaults to 30 instead of 0 so Metals-API and MetalPriceAPI fetch history on first sync
- **Fix auto-sync all providers**: Page refresh now syncs all configured providers with stale caches, not just the default
- **Add standalone "Save" button**: Save API key and settings per provider without triggering a connection test or price fetch
- **Add Numista API usage progress bar**: Persistent monthly tracking (X/2000 calls) with auto-reset in Settings > API > Numista

## Test plan

- [ ] Set Metals.dev cache timeout to 6h → close/reopen Settings → verify persists as 6h
- [ ] Configure Metals-API with a key → verify historical data appears in spot history
- [ ] Configure 2+ providers with keys → refresh page → verify all providers sync
- [ ] Click "Save" on a provider → verify key/settings persist without test/fetch
- [ ] Click "Save and Test" → verify existing behavior unchanged
- [ ] Open Settings > API > Numista → verify usage bar shows X/2000 calls
- [ ] Perform a Numista search → reopen settings → verify counter incremented
- [ ] Test on `file://` protocol for all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)