### PR TITLE
v3.16.02 — Edit custom grouping rules, relocate chip threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.02] - 2026-02-09
+
+### Added
+
+- **Edit custom grouping rules**: Pencil icon on each rule row enables inline editing of label and patterns without deleting and recreating. Supports Enter to save, Escape to cancel
+
+### Changed
+
+- **Filter chip threshold relocated**: Moved from Settings > Site to Settings > Grouping alongside related chip controls
+
+---
+
 ## [3.16.01] - 2026-02-09
 
 ### Fixed — API Settings & Numista Usage Tracking

--- a/css/styles.css
+++ b/css/styles.css
@@ -1660,6 +1660,65 @@ input[type="submit"] {
   background: rgba(var(--danger-rgb, 220, 53, 69), 0.12);
 }
 
+.chip-grouping-actions {
+  white-space: nowrap;
+}
+
+.chip-grouping-edit,
+.chip-grouping-save,
+.chip-grouping-cancel {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.1rem 0.3rem;
+  border-radius: var(--radius);
+  transition: background 0.1s;
+}
+
+.chip-grouping-edit {
+  color: var(--text-muted);
+}
+
+.chip-grouping-edit:hover {
+  color: var(--info);
+  background: rgba(var(--info-rgb, 13, 110, 253), 0.12);
+}
+
+.chip-grouping-save {
+  color: var(--success);
+}
+
+.chip-grouping-save:hover {
+  background: rgba(var(--success-rgb, 25, 135, 84), 0.12);
+}
+
+.chip-grouping-cancel {
+  color: var(--text-muted);
+}
+
+.chip-grouping-cancel:hover {
+  color: var(--danger);
+  background: rgba(var(--danger-rgb, 220, 53, 69), 0.12);
+}
+
+.chip-grouping-edit-input {
+  width: 100%;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.8125rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input, var(--bg));
+  color: var(--text);
+  box-sizing: border-box;
+}
+
+.chip-grouping-edit-wide {
+  min-width: 120px;
+}
+
 /* Theme picker */
 .theme-picker {
   display: flex;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Edit custom grouping rules (v3.16.02)**: Inline edit button on custom chip grouping rules — modify label and patterns without delete/recreate. Filter chip threshold setting moved to Grouping panel
 - **API settings fixes & Numista usage (v3.16.01)**: Cache timeout now persists per-provider, historical data fetches for all providers, page refresh syncs all configured APIs. New standalone "Save" button per provider. Numista usage progress bar tracks API calls with monthly auto-reset
 - **Custom chip grouping & blacklist (v3.16.00)**: Define custom chip labels with comma-separated name patterns. Right-click any name chip to blacklist it. Dynamic chips auto-extract text from parentheses/quotes in item names. New Settings > Grouping panel for all chip controls
 - **Name column & action icon fix (v3.14.01)**: Long names truncate with ellipsis, N# chips compacted to just "N#" (hover for full ID), action icons no longer clipped on narrow viewports

--- a/index.html
+++ b/index.html
@@ -1413,6 +1413,12 @@
                 </select>
               </div>
 
+            </div>
+
+            <!-- ===== GROUPING SETTINGS ===== -->
+            <div class="settings-section-panel" id="settingsPanel_grouping" style="display: none">
+              <h3>Chip Grouping</h3>
+
               <div class="settings-group">
                 <div class="settings-group-label">Filter chip threshold</div>
                 <p class="settings-subtext">Minimum item count for a filter chip to appear.</p>
@@ -1424,12 +1430,6 @@
                   <option value="100">100+ (off)</option>
                 </select>
               </div>
-
-            </div>
-
-            <!-- ===== GROUPING SETTINGS ===== -->
-            <div class="settings-section-panel" id="settingsPanel_grouping" style="display: none">
-              <h3>Chip Grouping</h3>
 
               <div class="settings-group">
                 <div class="settings-group-label">Smart name grouping</div>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.16.02 – Edit custom grouping rules</strong>: Inline edit button on custom chip rules — modify label and patterns without delete/recreate. Filter chip threshold moved to Grouping panel</li>
     <li><strong>v3.16.01 – API settings fixes & Numista usage</strong>: Cache timeout persists per-provider, historical data fetches for all providers, page refresh syncs all configured APIs. Standalone "Save" button per provider. Numista usage progress bar with monthly auto-reset</li>
     <li><strong>v3.16.00 – Custom chip grouping & blacklist</strong>: Define custom chip labels with name patterns, right-click chips to blacklist, auto-extract dynamic chips from parentheses/quotes in names</li>
     <li><strong>v3.14.01 – Name column & action icon fix</strong>: Long names truncate properly, N# chips compacted, action icons no longer clipped</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -230,10 +230,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-09 - Patch: API settings fixes & Numista usage tracking
+ * Updated: 2026-02-09 - Patch: Edit custom grouping rules, relocate chip threshold
  */
 
-const APP_VERSION = "3.16.01";
+const APP_VERSION = "3.16.02";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary

- **Inline edit for custom grouping rules**: Pencil icon (✎) on each rule row transforms label and patterns into editable inputs. Save with checkmark or Enter, cancel with × or Escape. New `updateCustomGroup()` CRUD function
- **Filter chip threshold relocated**: Moved from Settings > Site to Settings > Grouping for better co-location with all chip-related controls
- **CSS**: Edit/Save/Cancel button styles, inline edit input styles matching table compact sizing

## Test plan

- [ ] Open Settings > Grouping, create a custom rule, verify pencil icon appears
- [ ] Click pencil, verify row transforms to inline inputs pre-filled with current values
- [ ] Edit label and/or patterns, click checkmark — verify rule updates and chips reflect change
- [ ] Click pencil, then cancel (× or Escape) — verify original values preserved
- [ ] Verify Enter on label field focuses patterns, Enter on patterns saves
- [ ] Verify filter chip threshold now appears in Grouping panel, not Site panel
- [ ] Verify chip threshold still syncs with toolbar dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)