### PR TITLE
v3.17.00 — Inline Name chips, search expansion & settings redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.17.00] - 2026-02-09
+
+### Added — Inline Name Chips, Search Expansion & Backup Fix
+
+- **Inline Name chip settings**: New Settings > Table panel to enable/disable and reorder 6 inline chip types (Grade, Numista, Year, Serial #, Storage Location, Notes Indicator) in the Name cell. Config-driven rendering replaces hard-coded chip order
+- **Table settings section**: New sidebar tab in Settings for table display controls (Visible rows, Inline Name chips). Grouping section renamed to "Chips"
+- **3 new inline chips**: Serial # (purple badge with serial number), Storage Location (muted badge with truncated location), and Notes Indicator (document icon when item has notes) — all disabled by default, enable in Settings > Table
+- **Search expansion**: 6 new fields searchable — Year, Grade, Grading Authority, Cert Number, Numista ID, and Serial Number. Works in both search bar and advanced filter text matching
+
+### Fixed
+
+- **ZIP backup/restore**: chipCustomGroups, chipBlacklist, chipMinCount, featureFlags, and inlineChipConfig now included in ZIP backup and properly restored. Also restores itemsPerPage, sortColumn, and sortDirection (previously backed up but never restored)
+
+---
+
 ## [3.16.02] - 2026-02-09
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,23 +8,12 @@ Project direction and planned work for the StakTrakr precious metals inventory t
 
 These items focus on visual polish and usability improvements that require no backend changes.
 
-### Phase 1 — Numista API Fix
-- **Numista API fix** — the `NumistaProvider` class in `js/catalog-api.js` has never worked due to three bugs: wrong endpoints (`/items/search` → `/types`), wrong auth (query param → `Numista-API-Key` header), non-existent params (`metal`/`country`/`limit` → `category`/`issuer`/`count`). Must be fixed before any Numista features can ship
+### Next Sprint — Inline Chip Settings, Search Expansion & Backup Fix
 
-### Phase 2 — Inline Catalog & Grading Tags
-- **Inline catalog & grading tags** — instead of a dedicated N# table column, append optional clickable tags to the Name cell. Example: `2025 American Eagle (PCGS) (MS70-FS) (N#1234)`. All tags optional — most items just show the name
-  - **Name cell format**: `{item name} (SERVICE) (GRADE) (N#ID)` — only renders tags the item actually has
-  - **Tag click behavior**: opens iframe modal to the relevant service page (Numista catalog, PCGS cert viewer, NGC cert viewer). Same pattern as eBay search links
-  - **Grade display**: Sheldon scale, shown as a separate tag next to the certification service — e.g., `(PCGS) (MS70-FS)` or `(NGC) (PF69-UC)`
-  - **New item modal fields**: Certification Service dropdown (None/PCGS/NGC), Cert Number input, Grade dropdown (Sheldon scale with designations: FS, UC, DCAM, etc.). All optional. Separate from existing Catalog (N#) field
-  - **Data model additions**: `certService` (string: `''`|`'PCGS'`|`'NGC'`), `certNumber` (string), `grade` (string)
-  - **No new table column** — all info lives inline in the Name cell, keeping the table compact
-  - **CSV export**: add `certService`, `certNumber`, `grade` to export headers
-
-### Pause — Evaluate Numista Data
-- Review what fields the working Numista API actually returns (canonical names, denominations, metal, weight, descriptions, images)
-- Decide which fields to surface in the add/edit modal and whether to add new data model fields
-- Assess how Numista naming conventions compare to our current `normalizeItemName()` dictionary
+- **New inline chips in Name cell**: Add Cert#, Storage Location, and Notes indicator chips alongside existing Year, N#, and Grade chips. New chips disabled by default
+- **Inline chip settings UI**: Settings > Grouping panel gains per-chip-type enable/disable toggles for all 6 inline chip types (Year, N#, Grade, Cert#, Storage Location, Notes). User-configurable display order with localStorage persistence
+- **Search expansion**: Add `year`, `grade`, `gradingAuthority`, `certNumber`, `numistaId`, `serialNumber` to the search fields in `js/search.js` and `js/filters.js`. Currently these fields are invisible to search
+- **Backup/restore coverage fix**: Add missing post-v3.14.00 settings to backup export and restore: `chipCustomGroups`, `chipBlacklist`, `chipMinCount`, `featureFlags`, `settingsItemsPerPage`. Also restore `sortColumn`, `sortDirection`, and `searchQuery` which are backed up but never restored
 
 ### Phase 3 — Batch Rename/Normalize (Numista-Powered)
 - **Batch rename/normalize tool** — "Clean Up Names" modal with preview and undo, powered by both the local normalizer and the Numista API
@@ -34,24 +23,34 @@ These items focus on visual polish and usability improvements that require no ba
   - Respects API budget (2,000 req/month free tier) — batch lookups with caching via `LocalProvider`
 
 ### Backlog (No Dependency Order)
-- **Numista integration — Sync & Search** (prerequisite: Phase 1):
+- **Numista integration — Sync & Search**:
   - **"Sync from Numista" button** on the add/edit modal — auto-populates Name, Weight, Type, Metal, Notes from a valid N#
   - **"Numista Lookup" button** — search modal with thumbnails, selecting a result populates N# and triggers Sync
   - **API budget awareness**: free tier = 2,000 requests/month. Cache all lookups in `LocalProvider`
-- **Chip settings modal**: select which columns produce chips and configure top-N limit per category
 - **Pie chart toggle**: switch metal detail modal chart between Purchase / Melt / Retail / Gain-Loss views
 - **Chart.js dashboard improvements** — spot price trend visualization, portfolio value over time
 - **Custom tagging system** — replace the removed `isCollectable` boolean with flexible tags (e.g., "IRA", "stack", "numismatic", "gift")
 
 
 ### Completed (Near-Term)
+- ~~**Custom chip grouping & settings**~~ — **DONE (v3.16.00 – v3.16.02)**: Custom grouping rules with full CRUD (create, edit, delete, toggle). Chip blacklist with right-click suppress. Dynamic name chips from parentheses/quotes. Settings > Grouping panel with chip threshold, smart grouping toggle, dynamic chips toggle, blacklist, and custom rules management. Inline edit for rules via pencil icon
+- ~~**Encrypted portable backup (.stvault)**~~ — **DONE (v3.14.00 – v3.14.01)**: AES-256-GCM encrypted backup/restore with password strength indicator, Web Crypto API with forge.js fallback for `file://` Firefox, binary vault format with 56-byte header. Compact N# chips, name column truncation, and tightened action icons
+- ~~**Portal view (scrollable table)**~~ — **DONE (v3.12.00 – v3.12.02)**: Scrollable table with sticky column headers replaces slice-based pagination. Visible rows dropdown (10/15/25/50/100). NGC cert lookup fix, Numista Sets support, Lunar Series chip. Removed pagination controls, placeholder rows, and `currentPage` state
+- ~~**Unified settings modal**~~ — **DONE (v3.11.00)**: Consolidated API, Files, and Appearance into single modal with sidebar navigation (Site, API, Files, Cloud, Tools). Theme picker, tabbed API providers, items-per-page persistence, bidirectional control sync. Reduced header from 4 buttons to 2 (About + Settings)
+- ~~**Serial # field & Numista UX**~~ — **DONE (v3.10.00 – v3.10.01)**: Serial Number field for bars/notes, Year/Grade/N# filter chips, eBay search includes year, Numista no-results retry with quick-pick bullion list. Numista iframe replaced with popup window for hosted compatibility
+- ~~**Inline catalog & grading tags (Phase 2)**~~ — **DONE (v3.09.04 – v3.09.05)**: Year field with inline tag, Grade dropdown (Standard/Mint State/Proof), Grading Authority (PCGS/NGC/ANACS/ICG), Cert # input, color-coded grade badges in Name cell, clickable cert verification links, smart Numista category search, Year/Grade in CSV/JSON export and import
+- ~~**Numista API fix (Phase 1)**~~ — **DONE (v3.09.02 – v3.09.03)**: Fixed base URL (`/api/v3` → `/v3`), endpoints (`/items/search` → `/types`), auth (query param → `Numista-API-Key` header), params (`limit` → `count`, `country` → `issuer`, `metal` → `category`), response parsing, field mapping, and localStorage key whitelist. Smart category search mapping Type field to Numista categories
 - ~~**Filter chips system (complete)**~~ — **DONE (v3.09.00 – v3.09.01)**: Full chip system: metal, type, location, and normalized name chips. Click-to-filter with toggle. Unified threshold (3+ default), keyword grouping (Goldback/Zombucks/Silverback), starts-with normalizer with 280-item dictionary. Fixed: Silver chip contrast on dark/sepia, duplicate location chips, suppressed "Unknown" locations
-- ~~**Spot price manual input UX**~~ — **DONE (v3.09.00)**: Spot cards with no price data show "Shift+click price to set" hint
+- ~~**Spot price card redesign**~~ — **DONE (v3.08.00 – v3.08.01)**: Background sparkline charts with Chart.js, trend range dropdown (7d/30d/60d/90d), sync icon with spin animation, shift+click manual price entry, Metals.dev timeseries endpoint fix, spot history dedup. Totals moved above inventory table, sparkline colors match metal accents
+- ~~**Portfolio visibility overhaul**~~ — **DONE (v3.07.00 – v3.07.03)**: Retail/Gain-Loss confidence styling, "All Metals" summary card, Avg Cost/oz metric, metal detail modal with full Purchase/Melt/Retail/Gain-Loss breakdown by type and location. Spot history dedup fix
 - ~~**Retail column UX bundle**~~ — **DONE (v3.07.00 + v3.07.02)**: Confidence styling for estimated vs confirmed values (v3.07.00). Shift+click inline editing for all 6 editable columns including Retail — replaces pencil icon approach (v3.07.02)
+- ~~**Light & Sepia theme contrast pass**~~ — **DONE (v3.07.01)**: Clean light backgrounds, WCAG AAA text tokens, table zebra striping with theme-aware tokens, removed sticky action columns, sepia global filter removed, WCAG-compliant text contrast
+- ~~**eBay search split & icon redesign**~~ — **DONE (v3.06.01 – v3.06.02)**: Clean SVG magnifying glass icon, dead CSS cleanup, About modal overhaul. Purchase column opens active listings, Retail column opens sold listings for price research
+- ~~**StakTrakr rebrand**~~ — **DONE (v3.06.00)**: Full rebrand from StackTrackr to StakTrakr across entire codebase with domain-based auto-branding for 3 domains (staktrakr.com, stackrtrackr.com, stackertrackr.com)
+- ~~**Unified add/edit modal**~~ — **DONE (v3.05.00 – v3.05.04)**: Merged two modals into one with mode switching, weight precision fix (2→6 decimals), $0 price display, qty-adjusted financials, fraction weight input, duplicate item button, date timezone bug fix, Numista API key simplification
+- ~~**Spot price manual input UX**~~ — **DONE (v3.09.00)**: Spot cards with no price data show "Shift+click price to set" hint
 - ~~**Duplicate item button**~~ — **DONE (Increment 5)**
 - ~~**Fraction input for weight field**~~ — **DONE (Increment 5)**
-- ~~**Light & Sepia theme contrast pass**~~ — **DONE (v3.07.01)**
-- ~~**eBay search icon redesign**~~ — **DONE (v3.06.01 + v3.06.02)**
 - ~~**Summary cards visual refresh**~~ — **DONE (v3.07.00)**
 - ~~**Metal stats modal overhaul**~~ — **DONE (v3.07.00)**
 - ~~**Dead CSS cleanup pass**~~ — **DONE (v3.06.01)**

--- a/css/styles.css
+++ b/css/styles.css
@@ -1704,6 +1704,30 @@ input[type="submit"] {
   background: rgba(var(--danger-rgb, 220, 53, 69), 0.12);
 }
 
+/* Inline chip config — up/down reorder buttons */
+.inline-chip-move {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.15rem 0.35rem;
+  border-radius: var(--radius);
+  transition: background 0.1s, color 0.1s;
+}
+
+.inline-chip-move:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  color: var(--primary);
+}
+
+.inline-chip-move:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
 .chip-grouping-edit-input {
   width: 100%;
   padding: 0.2rem 0.35rem;
@@ -2372,7 +2396,10 @@ td[data-column="name"] {
 /* Tags never shrink — always visible */
 .name-cell-content > .year-tag,
 .name-cell-content > .numista-tag,
-.name-cell-content > .grade-tag {
+.name-cell-content > .grade-tag,
+.name-cell-content > .serial-tag,
+.name-cell-content > .storage-tag,
+.name-cell-content > .notes-indicator {
   flex-shrink: 0;
 }
 
@@ -5324,6 +5351,94 @@ th {
 [data-theme="sepia"] .grade-tag[data-clickable="true"][data-authority="ICG"]:focus-visible {
   background: #6d28d9;
   color: #fff;
+}
+
+/* =============================================================================
+   SERIAL TAG — Inline serial number badge (purple tint)
+   ============================================================================= */
+.serial-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.1rem 0.3rem;
+  margin-left: 0.25rem;
+  border-radius: var(--radius);
+  background: rgba(139, 92, 246, 0.12);
+  color: #7c3aed;
+  vertical-align: middle;
+  line-height: 1.2;
+  white-space: nowrap;
+  max-width: 8ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-theme="dark"] .serial-tag {
+  background: rgba(139, 92, 246, 0.18);
+  color: #a78bfa;
+}
+
+[data-theme="sepia"] .serial-tag {
+  background: rgba(109, 40, 217, 0.1);
+  color: #6d28d9;
+}
+
+/* =============================================================================
+   STORAGE TAG — Inline storage location badge (muted, truncated)
+   ============================================================================= */
+.storage-tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6rem;
+  font-weight: 500;
+  padding: 0.1rem 0.3rem;
+  margin-left: 0.25rem;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  vertical-align: middle;
+  line-height: 1.2;
+  white-space: nowrap;
+  max-width: 8ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-theme="dark"] .storage-tag {
+  background: rgba(255, 255, 255, 0.06);
+  color: #6b7280;
+}
+
+[data-theme="sepia"] .storage-tag {
+  background: rgba(0, 0, 0, 0.05);
+  color: #a8a29e;
+}
+
+/* =============================================================================
+   NOTES INDICATOR — Small icon when item has notes
+   ============================================================================= */
+.notes-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.25rem;
+  color: var(--text-muted);
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.notes-indicator svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+[data-theme="dark"] .notes-indicator {
+  color: #6b7280;
+}
+
+[data-theme="sepia"] .notes-indicator {
+  color: #a8a29e;
 }
 
 /* =============================================================================

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Inline Name chips & search expansion (v3.17.00)**: 3 new inline chips (Serial #, Storage Location, Notes Indicator) join Grade, Numista, and Year in the Name cell. Enable/disable and reorder all 6 chip types in new Settings > Table panel. Search now covers Year, Grade, Grading Authority, Cert #, Numista ID, and Serial Number. ZIP backup/restore includes all chip settings and display preferences. Settings reorganized: Theme, Table, Chips tabs
 - **Edit custom grouping rules (v3.16.02)**: Inline edit button on custom chip grouping rules — modify label and patterns without delete/recreate. Filter chip threshold setting moved to Grouping panel
 - **API settings fixes & Numista usage (v3.16.01)**: Cache timeout now persists per-provider, historical data fetches for all providers, page refresh syncs all configured APIs. New standalone "Save" button per provider. Numista usage progress bar tracks API calls with monthly auto-reset
 - **Custom chip grouping & blacklist (v3.16.00)**: Define custom chip labels with comma-separated name patterns. Right-click any name chip to blacklist it. Dynamic chips auto-extract text from parentheses/quotes in item names. New Settings > Grouping panel for all chip controls

--- a/index.html
+++ b/index.html
@@ -1361,12 +1361,16 @@
           <!-- Sidebar Navigation -->
           <nav class="settings-sidebar">
             <button class="settings-nav-item active" data-section="site">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-              Site
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="19" cy="13" r="2.5"/><circle cx="16" cy="20" r="2.5"/><circle cx="7" cy="20" r="2.5"/><circle cx="4" cy="13" r="2.5"/><circle cx="12" cy="13" r="3"/></svg>
+              Theme
+            </button>
+            <button class="settings-nav-item" data-section="table">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+              Table
             </button>
             <button class="settings-nav-item" data-section="grouping">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-              Grouping
+              Chips
             </button>
             <button class="settings-nav-item" data-section="api">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/></svg>
@@ -1389,18 +1393,29 @@
           <!-- Content Area -->
           <div class="settings-content-area">
 
-            <!-- ===== SITE SETTINGS ===== -->
+            <!-- ===== THEME SETTINGS ===== -->
             <div class="settings-section-panel" id="settingsPanel_site" style="display: block">
-              <h3>Site Settings</h3>
+              <h3>Theme</h3>
 
               <div class="settings-group">
-                <div class="settings-group-label">Theme</div>
+                <div class="settings-group-label">Color scheme</div>
                 <div class="theme-picker">
                   <button class="theme-option" data-theme="light" title="Light">&#9728;&#65039; Light</button>
                   <button class="theme-option" data-theme="dark" title="Dark">&#127769; Dark</button>
                   <button class="theme-option" data-theme="sepia" title="Sepia">&#128220; Sepia</button>
                 </div>
               </div>
+
+              <div class="settings-placeholder" style="margin-top: 1.5rem;">
+                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="19" cy="13" r="2.5"/><circle cx="16" cy="20" r="2.5"/><circle cx="7" cy="20" r="2.5"/><circle cx="4" cy="13" r="2.5"/><circle cx="12" cy="13" r="3"/></svg>
+                <p>Custom themes coming soon.</p>
+              </div>
+
+            </div>
+
+            <!-- ===== TABLE SETTINGS ===== -->
+            <div class="settings-section-panel" id="settingsPanel_table" style="display: none">
+              <h3>Table Display</h3>
 
               <div class="settings-group">
                 <div class="settings-group-label">Visible rows</div>
@@ -1413,11 +1428,18 @@
                 </select>
               </div>
 
+              <div class="settings-group">
+                <div class="settings-group-label">Inline Name chips</div>
+                <p class="settings-subtext">Choose which badges appear next to item names in the table.</p>
+                <div class="chip-grouping-table-container" id="inlineChipConfigContainer">
+                  <div class="chip-grouping-empty">Loading...</div>
+                </div>
+              </div>
             </div>
 
-            <!-- ===== GROUPING SETTINGS ===== -->
+            <!-- ===== CHIPS ===== -->
             <div class="settings-section-panel" id="settingsPanel_grouping" style="display: none">
-              <h3>Chip Grouping</h3>
+              <h3>Filter Chips</h3>
 
               <div class="settings-group">
                 <div class="settings-group-label">Filter chip threshold</div>
@@ -1807,7 +1829,6 @@
                         <button class="btn success" id="importJsonMerge">Merge JSON</button>
                         <input accept=".json" hidden id="importJsonFile" type="file" />
                       </div>
-                      <button class="btn secondary" id="cloudSyncBtn">Cloud Sync</button>
                     </div>
                     <progress class="import-progress" id="importProgress" value="0" max="0"></progress>
                     <div class="import-progress-text" id="importProgressText"></div>

--- a/js/about.js
+++ b/js/about.js
@@ -267,6 +267,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.17.00 – Inline Name chips & search expansion</strong>: 3 new inline chips (Serial #, Storage Location, Notes Indicator) in the Name cell. Enable/disable and reorder all 6 chip types in new Settings &gt; Table panel. Search covers Year, Grade, Grading Authority, Cert #, Numista ID, and Serial Number. ZIP backup/restore includes all chip and display settings. Settings reorganized: Theme, Table, Chips tabs</li>
     <li><strong>v3.16.02 – Edit custom grouping rules</strong>: Inline edit button on custom chip rules — modify label and patterns without delete/recreate. Filter chip threshold moved to Grouping panel</li>
     <li><strong>v3.16.01 – API settings fixes & Numista usage</strong>: Cache timeout persists per-provider, historical data fetches for all providers, page refresh syncs all configured APIs. Standalone "Save" button per provider. Numista usage progress bar with monthly auto-reset</li>
     <li><strong>v3.16.00 – Custom chip grouping & blacklist</strong>: Define custom chip labels with name patterns, right-click chips to blacklist, auto-extract dynamic chips from parentheses/quotes in names</li>

--- a/js/filters.js
+++ b/js/filters.js
@@ -770,7 +770,13 @@ const filterInventoryAdvanced = () => {
           item.type,
           item.purchaseLocation,
           item.storageLocation || '',
-          item.notes || ''
+          item.notes || '',
+          String(item.year || ''),
+          item.grade || '',
+          item.gradingAuthority || '',
+          String(item.certNumber || ''),
+          String(item.numistaId || ''),
+          item.serialNumber || ''
         ].join(' ').toLowerCase();
         
         // Check for exact phrase match first
@@ -956,7 +962,13 @@ const filterInventoryAdvanced = () => {
           formattedDate.includes(word) ||
           String(Number.isFinite(Number(item.qty)) ? Number(item.qty) : '').includes(word) ||
           String(Number.isFinite(Number(item.weight)) ? Number(item.weight) : '').includes(word) ||
-          String(Number.isFinite(Number(item.price)) ? Number(item.price) : '').includes(word)
+          String(Number.isFinite(Number(item.price)) ? Number(item.price) : '').includes(word) ||
+          (item.year && wordRegex.test(String(item.year))) ||
+          (item.grade && wordRegex.test(item.grade)) ||
+          (item.gradingAuthority && wordRegex.test(item.gradingAuthority)) ||
+          (item.certNumber && wordRegex.test(String(item.certNumber))) ||
+          (item.numistaId && wordRegex.test(String(item.numistaId))) ||
+          (item.serialNumber && wordRegex.test(item.serialNumber))
         );
       });
     });

--- a/js/search.js
+++ b/js/search.js
@@ -62,7 +62,13 @@ const filterInventory = () => {
           item.type,
           item.purchaseLocation,
           item.storageLocation || '',
-          item.notes || ''
+          item.notes || '',
+          String(item.year || ''),
+          item.grade || '',
+          item.gradingAuthority || '',
+          String(item.certNumber || ''),
+          String(item.numistaId || ''),
+          item.serialNumber || ''
         ].join(' ').toLowerCase();
         
         // Check for exact phrase match first
@@ -248,7 +254,13 @@ const filterInventory = () => {
           formattedDate.includes(word) ||
           String(Number.isFinite(Number(item.qty)) ? Number(item.qty) : '').includes(word) ||
           String(Number.isFinite(Number(item.weight)) ? Number(item.weight) : '').includes(word) ||
-          String(Number.isFinite(Number(item.price)) ? Number(item.price) : '').includes(word)
+          String(Number.isFinite(Number(item.price)) ? Number(item.price) : '').includes(word) ||
+          (item.year && wordRegex.test(String(item.year))) ||
+          (item.grade && wordRegex.test(item.grade)) ||
+          (item.gradingAuthority && wordRegex.test(item.gradingAuthority)) ||
+          (item.certNumber && wordRegex.test(String(item.certNumber))) ||
+          (item.numistaId && wordRegex.test(String(item.numistaId))) ||
+          (item.serialNumber && wordRegex.test(item.serialNumber))
         );
       });
     });

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -91,6 +91,17 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.17.00": `
+      <li><strong>Settings reorganized</strong>: New Theme, Table, and Chips tabs. Visible rows moved to Table. Grouping renamed to Chips</li>
+      <li><strong>Inline Name chip settings</strong>: Enable/disable and reorder 6 chip types (Grade, Numista, Year, Serial #, Storage, Notes) in Settings &gt; Table</li>
+      <li><strong>3 new inline chips</strong>: Serial # (purple badge), Storage Location (muted badge), and Notes Indicator (document icon) — disabled by default</li>
+      <li><strong>Search expansion</strong>: Year, Grade, Grading Authority, Cert #, Numista ID, and Serial Number now searchable</li>
+      <li><strong>ZIP backup fix</strong>: Chip settings, feature flags, and display preferences now survive ZIP backup/restore round trips</li>
+    `,
+    "3.16.02": `
+      <li><strong>Edit custom grouping rules</strong>: Inline edit button on each rule row — modify label and patterns without delete/recreate</li>
+      <li><strong>Filter chip threshold relocated</strong>: Moved from Settings &gt; Site to Settings &gt; Grouping</li>
+    `,
     "3.16.01": `
       <li><strong>Cache timeout persistence</strong>: Per-provider cache timeout settings now persist across page reloads</li>
       <li><strong>Historical data for all providers</strong>: Metals-API and MetalPriceAPI now fetch historical data on first sync instead of current-only prices</li>


### PR DESCRIPTION
## Summary

- **3 new inline chips** in the Name cell: Serial # (purple badge), Storage Location (muted badge), Notes Indicator (document icon) — all disabled by default
- **Inline chip config**: Enable/disable and reorder all 6 chip types (Grade, Numista, Year, Serial #, Storage, Notes) in new Settings > Table panel
- **Search expansion**: 6 new fields searchable — Year, Grade, Grading Authority, Cert #, Numista ID, Serial Number
- **ZIP backup fix**: chipCustomGroups, chipBlacklist, chipMinCount, featureFlags, inlineChipConfig, itemsPerPage, sortColumn, sortDirection now included in backup and properly restored
- **Settings reorganized**: Theme tab (color scheme + custom themes teaser), Table tab (Visible rows + Inline Name chips), Chips tab (renamed from Grouping), Cloud Sync button removed from Files (redundant with Cloud tab)

## Test plan

- [ ] Search for "MS70", "PCGS", "2024", a cert number, a Numista ID, a serial number — verify matches
- [ ] Settings > Table > Inline Name Chips — toggle chips on/off, reorder, verify Name cell updates
- [ ] Enable Serial #/Storage/Notes chips — verify they appear with correct styling on items that have data
- [ ] Storage chip should NOT appear for items with "Unknown" storage location
- [ ] Create ZIP backup → restore on clean profile → verify chipCustomGroups, chipBlacklist, chipMinCount, featureFlags, inlineChipConfig, itemsPerPage survive round trip
- [ ] Create .stvault backup → restore → verify inlineChipConfig survives
- [ ] Verify dark and sepia themes render new chip styles correctly
- [ ] Settings sidebar: Theme, Table, Chips, API, Files, Cloud, Tools — all tabs navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)