### PR TITLE
Merge groups, uniform chip styling, dropdown fix (v3.19.00)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1481,7 +1481,7 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Filter chip categories</div>
-                <p class="settings-subtext">Enable, disable, and reorder chip categories in the filter bar.</p>
+                <p class="settings-subtext">Enable, disable, and reorder chip categories. Assign the same Group letter to merge categories so their chips sort together.</p>
                 <div class="chip-grouping-table-container" id="filterChipCategoryContainer">
                   <div class="chip-grouping-empty">Loading…</div>
                 </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -504,16 +504,16 @@ const saveInlineChipConfig = (config) => {
  * @constant {Array<{id: string, label: string, enabled: boolean}>}
  */
 const FILTER_CHIP_CATEGORY_DEFAULTS = [
-  { id: 'metal',            label: 'Metals',            enabled: true },
-  { id: 'type',             label: 'Types',             enabled: true },
-  { id: 'name',             label: 'Names',             enabled: true },
-  { id: 'customGroup',      label: 'Custom Groups',     enabled: true },
-  { id: 'dynamicName',      label: 'Dynamic Names',     enabled: true },
-  { id: 'purchaseLocation', label: 'Purchase Location', enabled: true },
-  { id: 'storageLocation',  label: 'Storage Location',  enabled: true },
-  { id: 'year',             label: 'Years',             enabled: true },
-  { id: 'grade',            label: 'Grades',            enabled: true },
-  { id: 'numistaId',        label: 'Numista IDs',       enabled: true },
+  { id: 'metal',            label: 'Metals',            enabled: true, group: null },
+  { id: 'type',             label: 'Types',             enabled: true, group: null },
+  { id: 'name',             label: 'Names',             enabled: true, group: null },
+  { id: 'customGroup',      label: 'Custom Groups',     enabled: true, group: null },
+  { id: 'dynamicName',      label: 'Dynamic Names',     enabled: true, group: null },
+  { id: 'purchaseLocation', label: 'Purchase Location', enabled: true, group: null },
+  { id: 'storageLocation',  label: 'Storage Location',  enabled: true, group: null },
+  { id: 'year',             label: 'Years',             enabled: true, group: null },
+  { id: 'grade',            label: 'Grades',            enabled: true, group: null },
+  { id: 'numistaId',        label: 'Numista IDs',       enabled: true, group: null },
 ];
 
 /**

--- a/js/filters.js
+++ b/js/filters.js
@@ -540,8 +540,7 @@ const renderActiveFilters = () => {
   chips.forEach((f, i) => {
     const chip = document.createElement('span');
     chip.className = 'filter-chip';
-    if (f.isDynamic) chip.classList.add('dynamic-chip');
-    if (f.isCustomGroup) chip.classList.add('custom-chip');
+    // All chip categories render visually identical — no italic/bold distinction
     const firstValue = String(f.value).split(', ')[0];
     let color;
     let textColor;

--- a/js/filters.js
+++ b/js/filters.js
@@ -582,9 +582,9 @@ const renderActiveFilters = () => {
     chip.style.color = textColor || getContrastColor(bg);
 
     // Display simplified value for most chips, but keep full base name for name chips
-    // Custom groups use their display label; dynamic chips are wrapped in quotes
+    // Custom groups use their display label; dynamic chips are italic (via CSS class)
     const displayValue = f.isCustomGroup ? f.displayLabel
-      : f.isDynamic ? `\u201C${f.value}\u201D`
+      : f.isDynamic ? f.value
       : f.field === 'name' ? f.value
       : f.field === 'numistaId' ? `N#${f.value}`
       : simplifyChipValue(f.value, f.field);

--- a/js/settings.js
+++ b/js/settings.js
@@ -560,7 +560,7 @@ const renderFilterChipCategoryTable = () => {
     const groupSelect = document.createElement('select');
     groupSelect.className = 'control-select';
     groupSelect.title = 'Merge group — same letter = chips sort together';
-    groupSelect.style.cssText = 'width:auto;min-width:2.5rem;padding:0.15rem 0.3rem;font-size:0.8rem';
+    groupSelect.style.cssText = 'width:auto;min-width:3.2rem;padding:0.15rem 0.3rem;font-size:0.8rem';
     const groupOptions = ['\u2014', 'A', 'B', 'C', 'D', 'E'];
     groupOptions.forEach(letter => {
       const opt = document.createElement('option');

--- a/js/settings.js
+++ b/js/settings.js
@@ -512,6 +512,19 @@ const renderFilterChipCategoryTable = () => {
 
   const table = document.createElement('table');
   table.className = 'chip-grouping-table';
+
+  // Header row
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['', 'Category', 'Group', ''].forEach(text => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    th.style.cssText = 'font-size:0.75rem;font-weight:normal;opacity:0.6;padding:0.2rem 0.4rem';
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
   const tbody = document.createElement('tbody');
 
   config.forEach((cat, idx) => {
@@ -541,6 +554,33 @@ const renderFilterChipCategoryTable = () => {
     const tdLabel = document.createElement('td');
     tdLabel.textContent = cat.label;
 
+    // Group dropdown cell
+    const tdGroup = document.createElement('td');
+    tdGroup.style.cssText = 'width:3rem;text-align:center';
+    const groupSelect = document.createElement('select');
+    groupSelect.className = 'control-select';
+    groupSelect.title = 'Merge group — same letter = chips sort together';
+    groupSelect.style.cssText = 'width:auto;min-width:2.5rem;padding:0.15rem 0.3rem;font-size:0.8rem';
+    const groupOptions = ['\u2014', 'A', 'B', 'C', 'D', 'E'];
+    groupOptions.forEach(letter => {
+      const opt = document.createElement('option');
+      opt.value = letter === '\u2014' ? '' : letter;
+      opt.textContent = letter;
+      if ((cat.group || '') === opt.value) opt.selected = true;
+      groupSelect.appendChild(opt);
+    });
+    groupSelect.addEventListener('change', () => {
+      const cfg = getFilterChipCategoryConfig();
+      const item = cfg.at(idx);
+      if (item) {
+        item.group = groupSelect.value || null;
+        saveFilterChipCategoryConfig(cfg);
+        renderFilterChipCategoryTable();
+        if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      }
+    });
+    tdGroup.appendChild(groupSelect);
+
     // Arrow buttons cell
     const tdMove = document.createElement('td');
     tdMove.style.cssText = 'width:3.5rem;text-align:right;white-space:nowrap';
@@ -567,7 +607,7 @@ const renderFilterChipCategoryTable = () => {
     tdMove.appendChild(makeBtn('up', idx === 0));
     tdMove.appendChild(makeBtn('down', idx === config.length - 1));
 
-    tr.append(tdCheck, tdLabel, tdMove);
+    tr.append(tdCheck, tdLabel, tdGroup, tdMove);
     tbody.appendChild(tr);
   });
 


### PR DESCRIPTION
## Summary

- **Merge groups**: Categories assigned the same group letter (A-E) pool their chips for cross-category sorting. New Group dropdown column in Settings > Chips table. First group member in drag order = pole position for the merged block
- **Uniform chip styling**: Removed italic (dynamic chips) and bold (custom group chips) visual distinctions — all chip categories now render identically. Colors preserved
- **Curly quotes removed**: Dynamic name chips no longer wrapped in Unicode quotes
- **Dropdown fix**: Group dropdown widened to prevent OS checkmark overlap

## Files changed

| File | Change |
|------|--------|
| `js/constants.js` | Added `group: null` field to `FILTER_CHIP_CATEGORY_DEFAULTS` |
| `js/filters.js` | Refactored to "first-encounter-emits-all" merge pattern with `collectCategoryChips` + `sortChips` helpers. Removed `dynamic-chip` and `custom-chip` CSS class assignments |
| `js/settings.js` | Added Group dropdown (—/A/B/C/D/E) + table header row to category config table |
| `index.html` | Updated settings subtext to describe merge groups |

## Test plan

- [ ] Set Names, Custom Groups, Dynamic Names to Group A — verify their chips interleave when sorted by Name (A-Z)
- [ ] Verify ungrouped categories still sort independently
- [ ] Verify group block renders at the position of its first member in drag order
- [ ] Verify all chips look visually identical (no italic or bold)
- [ ] Verify group dropdown letter + checkmark don't overlap
- [ ] Reload page — verify group assignments persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)