### PR TITLE
PCGS lookup button, name chip fallback fix, modal button cleanup

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5577,6 +5577,13 @@ th {
   gap: 0.5rem;
 }
 
+.item-modal-actions-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .item-modal-actions-right {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -961,14 +961,24 @@
             </div>
             <!-- Form action buttons -->
             <div class="item-modal-actions">
-              <button class="btn secondary" id="searchNumistaBtn" type="button"
-                      title="Search Numista catalog using the Name or N# field">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                     stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-                     style="vertical-align: -2px; margin-right: 0.3rem;">
-                  <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
-                </svg>Search Numista
-              </button>
+              <div class="item-modal-actions-left">
+                <button class="btn secondary" id="searchNumistaBtn" type="button"
+                        title="Search Numista catalog using the Name or N# field">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                       stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+                       style="vertical-align: -2px; margin-right: 0.3rem;">
+                    <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
+                  </svg>Search Numista
+                </button>
+                <button class="btn secondary" id="lookupPcgsBtn" type="button"
+                        title="Look up coin via PCGS Cert# or PCGS# field">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                       stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+                       style="vertical-align: -2px; margin-right: 0.3rem;">
+                    <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
+                  </svg>Lookup PCGS
+                </button>
+              </div>
               <div class="item-modal-actions-right">
                 <button class="btn" id="undoChangeBtn" type="button" style="display:none">Undo</button>
                 <button class="btn" id="cancelItem" type="button">Cancel</button>

--- a/index.html
+++ b/index.html
@@ -968,7 +968,7 @@
                        stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
                        style="vertical-align: -2px; margin-right: 0.3rem;">
                     <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
-                  </svg>Search Numista
+                  </svg>Numista
                 </button>
                 <button class="btn secondary" id="lookupPcgsBtn" type="button"
                         title="Look up coin via PCGS Cert# or PCGS# field">
@@ -976,7 +976,7 @@
                        stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
                        style="vertical-align: -2px; margin-right: 0.3rem;">
                     <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
-                  </svg>Lookup PCGS
+                  </svg>PCGS
                 </button>
               </div>
               <div class="item-modal-actions-right">

--- a/js/api.js
+++ b/js/api.js
@@ -26,6 +26,15 @@ const renderApiStatusSummary = () => {
   } catch (e) { /* ignore */ }
   items.push({ name: "Numista", status: numistaStatus, provider: "NUMISTA" });
 
+  // PCGS status
+  let pcgsStatus = "disconnected";
+  try {
+    if (typeof catalogConfig !== "undefined" && catalogConfig.isPcgsEnabled) {
+      pcgsStatus = catalogConfig.isPcgsEnabled() ? "connected" : "disconnected";
+    }
+  } catch (e) { /* ignore */ }
+  items.push({ name: "PCGS", status: pcgsStatus, provider: "PCGS" });
+
   // Metals providers
   Object.keys(API_PROVIDERS).forEach((prov) => {
     const status = Object.hasOwn(providerStatuses, prov) ? providerStatuses[prov] : "disconnected"; // eslint-disable-line security/detect-object-injection
@@ -1535,6 +1544,25 @@ const populateApiSection = () => {
       } else {
         numistaStatusEl.classList.add("status-disconnected");
         const text = numistaStatusEl.querySelector(".status-text");
+        if (text) text.textContent = "Disconnected";
+      }
+    }
+  }
+
+  // Populate PCGS tab status
+  if (typeof catalogConfig !== "undefined" && catalogConfig.isPcgsEnabled) {
+    const pcgsStatusEl = document.getElementById("pcgsProviderStatus");
+    if (pcgsStatusEl) {
+      pcgsStatusEl.classList.remove("status-connected", "status-disconnected");
+      if (catalogConfig.isPcgsEnabled()) {
+        pcgsStatusEl.classList.add("status-connected");
+        const dot = pcgsStatusEl.querySelector(".status-dot");
+        const text = pcgsStatusEl.querySelector(".status-text");
+        if (dot) dot.style.background = "";
+        if (text) text.textContent = "Connected";
+      } else {
+        pcgsStatusEl.classList.add("status-disconnected");
+        const text = pcgsStatusEl.querySelector(".status-text");
         if (text) text.textContent = "Disconnected";
       }
     }

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1706,6 +1706,14 @@ document.addEventListener('DOMContentLoaded', function() {
       }
       catalogConfig.setPcgsConfig(token);
       if (pcgsStatus) pcgsStatus.textContent = 'Token saved.';
+      // Update provider status indicator and header status row
+      const statusEl = document.getElementById('pcgsProviderStatus');
+      if (statusEl) {
+        statusEl.querySelector('.status-dot')?.classList.add('connected');
+        const txt = statusEl.querySelector('.status-text');
+        if (txt) txt.textContent = 'Connected';
+      }
+      if (typeof renderApiStatusSummary === 'function') renderApiStatusSummary();
       alert('PCGS bearer token saved.');
     });
   }
@@ -1751,6 +1759,14 @@ document.addEventListener('DOMContentLoaded', function() {
         catalogConfig.clearPcgsToken();
         if (pcgsTokenInput) pcgsTokenInput.value = '';
         if (pcgsStatus) pcgsStatus.textContent = 'Token cleared.';
+        // Update provider status indicator and header status row
+        const statusEl = document.getElementById('pcgsProviderStatus');
+        if (statusEl) {
+          statusEl.querySelector('.status-dot')?.classList.remove('connected');
+          const txt = statusEl.querySelector('.status-text');
+          if (txt) txt.textContent = 'Disconnected';
+        }
+        if (typeof renderApiStatusSummary === 'function') renderApiStatusSummary();
       }
     });
   }

--- a/js/filters.js
+++ b/js/filters.js
@@ -418,7 +418,12 @@ const renderActiveFilters = () => {
     // BUT: if no summary chip was rendered for this field (all below minCount),
     // fall through so the user can still see and remove their active filter
     if (categoryFields.has(field)) {
-      const hasSummaryChip = chips.some(c => c.field === field && c.count !== undefined);
+      let hasSummaryChip = chips.some(c => c.field === field && c.count !== undefined);
+      // For 'name' filters, customGroup/dynamicName chips provide visual coverage
+      // so suppress the individual name fallback when those chips are present
+      if (field === 'name' && !hasSummaryChip) {
+        hasSummaryChip = chips.some(c => (c.field === 'customGroup' || c.field === 'dynamicName') && c.count !== undefined);
+      }
       if (hasSummaryChip) return;
     }
     

--- a/js/filters.js
+++ b/js/filters.js
@@ -98,9 +98,13 @@ const generateCategorySummary = (inventory) => {
   }
 
   // When the user has active filters or a search query, drop minCount to 1
-  // so all descriptive chips for the filtered subset are visible
+  // for descriptive categories (metal, type, year, grade, location, groups)
+  // so the filtered subset's attributes are always visible.
+  // Name chips keep the user's threshold (min 2) to avoid flooding the chip
+  // bar with every unique item name in the filtered set.
   const hasActiveFilters = Object.keys(activeFilters).length > 0;
   const hasSearchQuery = typeof searchQuery === 'string' && searchQuery.trim().length > 0;
+  const nameMinCount = Math.max(2, minCount);
   if (hasActiveFilters || hasSearchQuery) {
     minCount = 1;
   }
@@ -195,7 +199,7 @@ const generateCategorySummary = (inventory) => {
     Object.entries(storageLocations).filter(([key, count]) => count >= minCount)
   );
   let filteredNames = Object.fromEntries(
-    Object.entries(names).filter(([key, count]) => count >= minCount)
+    Object.entries(names).filter(([key, count]) => count >= nameMinCount)
   );
   const filteredYears = Object.fromEntries(
     Object.entries(years).filter(([key, count]) => count >= minCount)

--- a/js/init.js
+++ b/js/init.js
@@ -115,6 +115,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.itemPcgsNumber = safeGetElement("itemPcgsNumber");
     elements.itemSerialNumber = safeGetElement("itemSerialNumber");
     elements.searchNumistaBtn = safeGetElement("searchNumistaBtn");
+    elements.lookupPcgsBtn = safeGetElement("lookupPcgsBtn");
 
     // Header buttons - CRITICAL
     debugLog("Phase 2: Initializing header buttons...");

--- a/js/pcgs-api.js
+++ b/js/pcgs-api.js
@@ -1,95 +1,100 @@
-// PCGS API — Cert Verification
+// PCGS API — Cert Verification & Coin Lookup
 // =============================================================================
-// Provides one-click PCGS cert verification via the PCGS Public API.
-// Requires a bearer token configured in Settings > API > PCGS.
+// Provides one-click PCGS cert verification and PCGS# lookup via the PCGS
+// Public API. Requires a bearer token configured in Settings > API > PCGS.
+
+/**
+ * Shared pre-flight checks for all PCGS API calls.
+ * @returns {Object|null} Error result if checks fail, null if OK
+ */
+const pcgsPreflightCheck = () => {
+  if (window.location.protocol === 'file:') {
+    return { verified: false, error: 'PCGS API requires HTTPS. Unavailable on file:// protocol.' };
+  }
+  if (typeof catalogConfig === 'undefined' || !catalogConfig.isPcgsEnabled()) {
+    return { verified: false, error: 'PCGS API not configured. Add your bearer token in Settings > API > PCGS.' };
+  }
+  if (!catalogConfig.canMakePcgsRequest()) {
+    return { verified: false, error: 'PCGS daily rate limit reached (1,000 requests/day). Try again tomorrow.' };
+  }
+  return null;
+};
+
+/**
+ * Shared fetch wrapper for PCGS API calls.
+ * @param {string} url - Full API URL
+ * @returns {Promise<Object>} Parsed JSON or error result
+ */
+const pcgsFetch = async (url) => {
+  const config = catalogConfig.getPcgsConfig();
+  catalogConfig.incrementPcgsUsage();
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Authorization': `bearer ${config.bearerToken}`,
+      'Accept': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      return { _error: true, verified: false, error: 'Invalid or expired PCGS bearer token.' };
+    }
+    if (response.status === 404) {
+      return { _error: true, verified: false, error: 'Not found in PCGS database.' };
+    }
+    return { _error: true, verified: false, error: `PCGS API error: HTTP ${response.status}` };
+  }
+
+  return response.json();
+};
+
+/**
+ * Parse a PCGS API coin detail response into a standardized result object.
+ * @param {Object} data - Raw PCGS API response
+ * @returns {Object} Parsed coin details
+ */
+const parsePcgsResponse = (data) => {
+  if (!data || (!data.PCGSNo && !data.CertNo)) {
+    return { verified: false, error: 'Coin not found in PCGS database.' };
+  }
+
+  const gradeNum = data.Grade || '';
+  const pcgsNo = String(data.PCGSNo || '');
+  const coinFactsUrl = pcgsNo
+    ? `https://www.pcgs.com/coinfacts/coin/detail/${pcgsNo}/${gradeNum}`
+    : '';
+
+  return {
+    verified: true,
+    pcgsNumber: pcgsNo,
+    grade: data.GradeString || `${data.GradePrefix || ''}${gradeNum}`,
+    population: data.Pop || 0,
+    popHigher: data.PopHigher || 0,
+    priceGuide: data.PriceGuideValue || 0,
+    coinFactsUrl,
+    name: data.Name || '',
+    year: String(data.Year || ''),
+    designation: data.Designation || ''
+  };
+};
 
 /**
  * Verify a PCGS certification number via the PCGS Public API.
  *
  * @param {string} certNumber - PCGS certification number to verify
- * @returns {Promise<Object>} Verification result
- * @returns {boolean} result.verified - Whether the cert was found
- * @returns {string}  result.pcgsNumber - PCGS catalog number
- * @returns {string}  result.grade - Full grade string (e.g. "MS-69")
- * @returns {number}  result.population - Total graded at this grade
- * @returns {number}  result.popHigher - Total graded higher
- * @returns {number}  result.priceGuide - PCGS price guide value in USD
- * @returns {string}  result.coinFactsUrl - Direct URL to CoinFacts page
- * @returns {string}  result.error - Error message if verification failed
+ * @returns {Promise<Object>} Verification result with coin details
  */
 const verifyPcgsCert = async (certNumber) => {
-  // Protocol check — PCGS API requires HTTPS, won't work on file://
-  if (window.location.protocol === 'file:') {
-    return {
-      verified: false,
-      error: 'PCGS API requires HTTPS. Cert verification is unavailable on file:// protocol.'
-    };
-  }
-
-  // Config check
-  if (typeof catalogConfig === 'undefined' || !catalogConfig.isPcgsEnabled()) {
-    return {
-      verified: false,
-      error: 'PCGS API not configured. Add your bearer token in Settings > API > PCGS.'
-    };
-  }
-
-  // Rate limit check
-  if (!catalogConfig.canMakePcgsRequest()) {
-    return {
-      verified: false,
-      error: 'PCGS daily rate limit reached (1,000 requests/day). Try again tomorrow.'
-    };
-  }
-
-  const config = catalogConfig.getPcgsConfig();
-  const url = `https://api.pcgs.com/publicapi/coindetail/GetCoinFactsByCertNo/${encodeURIComponent(certNumber)}`;
+  const check = pcgsPreflightCheck();
+  if (check) return check;
 
   try {
-    catalogConfig.incrementPcgsUsage();
-
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'Authorization': `bearer ${config.bearerToken}`,
-        'Accept': 'application/json'
-      }
-    });
-
-    if (!response.ok) {
-      if (response.status === 401) {
-        return { verified: false, error: 'Invalid or expired PCGS bearer token.' };
-      }
-      if (response.status === 404) {
-        return { verified: false, error: `Cert #${certNumber} not found in PCGS database.` };
-      }
-      return { verified: false, error: `PCGS API error: HTTP ${response.status}` };
-    }
-
-    const data = await response.json();
-
-    // PCGS API returns coin details when found
-    if (!data || (!data.PCGSNo && !data.CertNo)) {
-      return { verified: false, error: `Cert #${certNumber} not found.` };
-    }
-
-    const gradeNum = data.Grade || '';
-    const pcgsNo = String(data.PCGSNo || '');
-    const coinFactsUrl = pcgsNo
-      ? `https://www.pcgs.com/coinfacts/coin/detail/${pcgsNo}/${gradeNum}`
-      : '';
-
-    return {
-      verified: true,
-      pcgsNumber: pcgsNo,
-      grade: data.GradeString || `${data.GradePrefix || ''}${gradeNum}`,
-      population: data.Pop || 0,
-      popHigher: data.PopHigher || 0,
-      priceGuide: data.PriceGuideValue || 0,
-      coinFactsUrl,
-      name: data.Name || '',
-      year: data.Year || ''
-    };
+    const url = `https://api.pcgs.com/publicapi/coindetail/GetCoinFactsByCertNo/${encodeURIComponent(certNumber)}`;
+    const data = await pcgsFetch(url);
+    if (data._error) return data;
+    return parsePcgsResponse(data);
   } catch (error) {
     if (error.name === 'TypeError' && error.message.includes('fetch')) {
       return { verified: false, error: 'Network error — check your internet connection.' };
@@ -98,7 +103,65 @@ const verifyPcgsCert = async (certNumber) => {
   }
 };
 
+/**
+ * Look up a coin by PCGS catalog number via the PCGS Public API.
+ *
+ * @param {string} pcgsNumber - PCGS catalog number (e.g. "786060")
+ * @param {string} [gradeNumber] - Optional grade number for specific grade lookup
+ * @returns {Promise<Object>} Lookup result with coin details
+ */
+const lookupPcgsByNumber = async (pcgsNumber, gradeNumber) => {
+  const check = pcgsPreflightCheck();
+  if (check) return check;
+
+  try {
+    const grade = gradeNumber || '0';
+    const url = `https://api.pcgs.com/publicapi/coindetail/GetCoinFactsByPCGSNo/${encodeURIComponent(pcgsNumber)}/${encodeURIComponent(grade)}`;
+    const data = await pcgsFetch(url);
+    if (data._error) return data;
+    return parsePcgsResponse(data);
+  } catch (error) {
+    if (error.name === 'TypeError' && error.message.includes('fetch')) {
+      return { verified: false, error: 'Network error — check your internet connection.' };
+    }
+    return { verified: false, error: error.message || 'Unknown error during PCGS lookup.' };
+  }
+};
+
+/**
+ * Smart PCGS lookup — tries Cert# first, then PCGS#.
+ * Reads values from the item form fields.
+ *
+ * @returns {Promise<Object>} Lookup result with coin details
+ */
+const lookupPcgsFromForm = async () => {
+  const certEl = document.getElementById('itemCertNumber');
+  const pcgsEl = document.getElementById('itemPcgsNumber');
+  const certNumber = (certEl?.value || '').trim();
+  const pcgsNumber = (pcgsEl?.value || '').trim();
+
+  if (!certNumber && !pcgsNumber) {
+    return { verified: false, error: 'Enter a PCGS Cert# or PCGS# to look up.' };
+  }
+
+  // Try cert number first (more specific), then PCGS catalog number
+  if (certNumber) {
+    const result = await verifyPcgsCert(certNumber);
+    if (result.verified) return result;
+    // If cert lookup fails and we also have a PCGS#, try that
+    if (pcgsNumber) {
+      const fallback = await lookupPcgsByNumber(pcgsNumber);
+      if (fallback.verified) return fallback;
+    }
+    return result; // Return the cert error
+  }
+
+  return lookupPcgsByNumber(pcgsNumber);
+};
+
 // Expose globally
 if (typeof window !== 'undefined') {
   window.verifyPcgsCert = verifyPcgsCert;
+  window.lookupPcgsByNumber = lookupPcgsByNumber;
+  window.lookupPcgsFromForm = lookupPcgsFromForm;
 }

--- a/js/state.js
+++ b/js/state.js
@@ -72,6 +72,7 @@ const elements = {
   itemGradingAuthority: null,
   itemCertNumber: null,
   searchNumistaBtn: null,
+  lookupPcgsBtn: null,
 
   // Spot price sync icons (per-metal)
   syncIconSilver: null,


### PR DESCRIPTION
## Summary
- **PCGS Lookup button** on item modal (next to Numista) — tries cert# first, falls back to PCGS#, populates grade/year/authority fields
- **PCGS status indicator** in API settings header row (connected/disconnected dot)
- **Shortened modal buttons** — removed redundant "Search"/"Lookup" verbs since search icon conveys intent
- **Name chip minCount fix** — descriptive categories (metal, type, year, groups) drop to minCount=1 when filtered; name chips keep 2+ to prevent flooding
- **Fallback suppression fix** — when customGroup/dynamicName chips provide visual coverage for names, suppress individual name chip fallback at high minCount settings

## Test plan
- [ ] Add PCGS bearer token in Settings > API > PCGS, verify connected status dot
- [ ] Open item modal, click PCGS button with cert# or PCGS# entered — fields populate
- [ ] Click Goldback custom group chip at various minCount levels (2+, 10+, 100+) — no individual name chip flooding
- [ ] Click individual item filter — descriptive chips still show (metal, type, year)
- [ ] Verify Numista and PCGS buttons show as just "Numista" and "PCGS" with search icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)