### PR TITLE
Fix dynamic name chips ignoring minCount threshold

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -211,7 +211,7 @@ const generateCategorySummary = (inventory) => {
     Object.entries(numistaIds).filter(([key, count]) => count >= minCount)
   );
   const filteredDynamicNames = Object.fromEntries(
-    Object.entries(dynamicNames).filter(([key, count]) => count >= minCount)
+    Object.entries(dynamicNames).filter(([key, count]) => count >= nameMinCount)
   );
 
   // Apply blacklist filter to auto-generated name chips and dynamic chips


### PR DESCRIPTION
## Summary

- **Bug**: Dynamic name chips (text extracted from parentheses/quotes in item names) ignored the user's chip threshold setting when filters or search were active. Setting "3+" still showed chips like "Fancy" (2 matches) and "The Royal Fortune" (1 match)
- **Root cause**: `filteredDynamicNames` used `minCount` (which drops to 1 when any filter is active for structural categories) instead of `nameMinCount` (which preserves the user's threshold)
- **Fix**: One-line change in `js/filters.js:214` — `minCount` → `nameMinCount`

Structural categories (Metal, Type, Year, Grade) and custom group labels (e.g., "Black Flag") continue to always show when filtered. Only name-based chips (smart grouping + dynamic names) honor the threshold.

## Test plan

- [ ] Filter by a custom group (e.g., "Black Flag") with threshold set to 3+ → only chips with 3+ matches show (no "Fancy", "The Kingston", "The Royal Fortune", etc.)
- [ ] Change threshold to 2+ → chips with 2+ matches appear (Fancy, The Kingston, The Rising Sun, Queen Anne's Revenge) but not The Royal Fortune (1 match)
- [ ] Metal, Type, Year, Grade, and custom group label chips still always appear regardless of threshold
- [ ] Behavior consistent with Smart Grouping on and off

🤖 Generated with [Claude Code](https://claude.com/claude-code)