### PR TITLE
Move history import/export to modal + provider sync mode toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -809,6 +809,26 @@ input[type="submit"] {
 .spot-down { color: var(--danger); }
 .spot-unchanged { color: var(--warning); }
 
+.spot-card-change {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 2px 0;
+  position: relative;
+  z-index: 2;
+  min-height: 1.1em;
+}
+.spot-change-up { color: var(--success); }
+.spot-change-down { color: var(--danger); }
+
+/* Portfolio card gain/loss percentage — subtle prefix left of value */
+.gain-loss-pct {
+  font-size: 0.7rem;
+  font-weight: 400;
+  opacity: 0.7;
+  margin-right: 0.35em;
+}
+
 .spot-card-timestamp {
   position: relative;
   z-index: 1;
@@ -883,11 +903,56 @@ input[type="submit"] {
 
 .provider-header {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 0.25rem;
   font-weight: 600;
-  gap: 0.25rem;
+  gap: 0.5rem;
+}
+
+.provider-doc-link {
+  font-size: 0.8rem;
+  font-weight: 400;
+  opacity: 0.7;
+  text-decoration: none;
+  color: var(--primary);
+}
+.provider-doc-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.provider-history-pull {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+.provider-history-pull label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin: 0;
+}
+.provider-history-select {
+  width: 110px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+}
+.api-history-btn {
+  font-size: 0.8rem;
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+.history-pull-cost {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
 }
 
 
@@ -1339,6 +1404,14 @@ input[type="submit"] {
   padding: var(--spacing-xl);
   overflow: auto;
   flex: 1;
+}
+
+.api-history-footer {
+  padding: var(--spacing);
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-end;
 }
 
 .api-history-body {

--- a/index.html
+++ b/index.html
@@ -222,7 +222,9 @@
                 <div class="spot-card-label">Silver Spot Price</div>
                 <div class="spot-card-controls">
                   <select class="spot-range-select" id="spotRangeSilver" title="Trend period">
+                    <option value="1">1d</option>
                     <option value="7">7d</option>
+                    <option value="14">14d</option>
                     <option value="30">30d</option>
                     <option value="60">60d</option>
                     <option value="90" selected>90d</option>
@@ -233,6 +235,7 @@
                 </div>
               </div>
               <div class="spot-card-value" id="spotPriceDisplaySilver" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-change" id="spotChangeSilver"></div>
               <div class="spot-card-timestamp" id="spotTimestampSilver">No data</div>
             </div>
           </div>
@@ -244,7 +247,9 @@
                 <div class="spot-card-label">Gold Spot Price</div>
                 <div class="spot-card-controls">
                   <select class="spot-range-select" id="spotRangeGold" title="Trend period">
+                    <option value="1">1d</option>
                     <option value="7">7d</option>
+                    <option value="14">14d</option>
                     <option value="30">30d</option>
                     <option value="60">60d</option>
                     <option value="90" selected>90d</option>
@@ -255,6 +260,7 @@
                 </div>
               </div>
               <div class="spot-card-value" id="spotPriceDisplayGold" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-change" id="spotChangeGold"></div>
               <div class="spot-card-timestamp" id="spotTimestampGold">No data</div>
             </div>
           </div>
@@ -266,7 +272,9 @@
                 <div class="spot-card-label">Platinum Spot Price</div>
                 <div class="spot-card-controls">
                   <select class="spot-range-select" id="spotRangePlatinum" title="Trend period">
+                    <option value="1">1d</option>
                     <option value="7">7d</option>
+                    <option value="14">14d</option>
                     <option value="30">30d</option>
                     <option value="60">60d</option>
                     <option value="90" selected>90d</option>
@@ -277,6 +285,7 @@
                 </div>
               </div>
               <div class="spot-card-value" id="spotPriceDisplayPlatinum" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-change" id="spotChangePlatinum"></div>
               <div class="spot-card-timestamp" id="spotTimestampPlatinum">No data</div>
             </div>
           </div>
@@ -288,7 +297,9 @@
                 <div class="spot-card-label">Palladium Spot Price</div>
                 <div class="spot-card-controls">
                   <select class="spot-range-select" id="spotRangePalladium" title="Trend period">
+                    <option value="1">1d</option>
                     <option value="7">7d</option>
+                    <option value="14">14d</option>
                     <option value="30">30d</option>
                     <option value="60">60d</option>
                     <option value="90" selected>90d</option>
@@ -299,6 +310,7 @@
                 </div>
               </div>
               <div class="spot-card-value" id="spotPriceDisplayPalladium" title="Shift+click to edit">$ -</div>
+              <div class="spot-card-change" id="spotChangePalladium"></div>
               <div class="spot-card-timestamp" id="spotTimestampPalladium">No data</div>
             </div>
           </div>
@@ -1662,6 +1674,7 @@
                 <div class="api-provider" data-provider="METALS_DEV">
                   <div class="provider-header">
                     <span class="provider-name">Metals.dev</span>
+                    <a href="https://metals.dev/documentation" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="API Documentation">Docs</a>
                   </div>
                   <div class="api-key-row">
                     <label for="apiKey_METALS_DEV">API Key:</label>
@@ -1680,12 +1693,21 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label for="historyDays_METALS_DEV">History Days:</label>
-                      <input type="number" id="historyDays_METALS_DEV" class="provider-history-input" min="1" max="30" value="29" placeholder="1-30">
+                      <label>Sync Mode:</label>
+                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_METALS_DEV" data-provider="METALS_DEV">
+                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
+                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
+                      </div>
                     </div>
-                    <div class="provider-setting-row">
-                      <label for="historyTimes_METALS_DEV">Times per Day:</label>
-                      <input type="text" id="historyTimes_METALS_DEV" class="provider-history-input" placeholder="08:00,20:00">
+                    <div class="provider-history-pull">
+                      <label for="historyPullDays_METALS_DEV">Pull History:</label>
+                      <select id="historyPullDays_METALS_DEV" class="provider-history-select">
+                        <option value="7">7 days</option>
+                        <option value="14">14 days</option>
+                        <option value="30" selected>30 days</option>
+                      </select>
+                      <button type="button" class="btn api-history-btn" data-provider="METALS_DEV">Pull History</button>
+                      <span class="history-pull-cost" id="historyPullCost_METALS_DEV"></span>
                     </div>
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
@@ -1717,6 +1739,7 @@
                 <div class="api-provider" data-provider="METALS_API">
                   <div class="provider-header">
                     <span class="provider-name">Metals-API.com</span>
+                    <a href="https://metals-api.com/documentation" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="API Documentation">Docs</a>
                   </div>
                   <div class="api-key-row">
                     <label for="apiKey_METALS_API">API Key:</label>
@@ -1735,12 +1758,25 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label for="historyDays_METALS_API">History Days:</label>
-                      <input type="number" id="historyDays_METALS_API" class="provider-history-input" min="1" max="365" value="30" placeholder="1-365">
+                      <label>Sync Mode:</label>
+                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_METALS_API" data-provider="METALS_API">
+                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
+                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
+                      </div>
                     </div>
-                    <div class="provider-setting-row">
-                      <label for="historyTimes_METALS_API">Times per Day:</label>
-                      <input type="text" id="historyTimes_METALS_API" class="provider-history-input" placeholder="08:00,20:00">
+                    <div class="provider-history-pull">
+                      <label for="historyPullDays_METALS_API">Pull History:</label>
+                      <select id="historyPullDays_METALS_API" class="provider-history-select">
+                        <option value="7">7 days</option>
+                        <option value="14">14 days</option>
+                        <option value="30" selected>30 days</option>
+                        <option value="60">60 days</option>
+                        <option value="90">90 days</option>
+                        <option value="180">180 days</option>
+                        <option value="365">365 days</option>
+                      </select>
+                      <button type="button" class="btn api-history-btn" data-provider="METALS_API">Pull History</button>
+                      <span class="history-pull-cost" id="historyPullCost_METALS_API"></span>
                     </div>
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
@@ -1772,6 +1808,7 @@
                 <div class="api-provider" data-provider="METAL_PRICE_API">
                   <div class="provider-header">
                     <span class="provider-name">MetalPriceAPI.com</span>
+                    <a href="https://metalpriceapi.com/documentation" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="API Documentation">Docs</a>
                   </div>
                   <div class="api-key-row">
                     <label for="apiKey_METAL_PRICE_API">API Key:</label>
@@ -1790,12 +1827,25 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label for="historyDays_METAL_PRICE_API">History Days:</label>
-                      <input type="number" id="historyDays_METAL_PRICE_API" class="provider-history-input" min="1" max="365" value="30" placeholder="1-365">
+                      <label>Sync Mode:</label>
+                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_METAL_PRICE_API" data-provider="METAL_PRICE_API">
+                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
+                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
+                      </div>
                     </div>
-                    <div class="provider-setting-row">
-                      <label for="historyTimes_METAL_PRICE_API">Times per Day:</label>
-                      <input type="text" id="historyTimes_METAL_PRICE_API" class="provider-history-input" placeholder="08:00,20:00">
+                    <div class="provider-history-pull">
+                      <label for="historyPullDays_METAL_PRICE_API">Pull History:</label>
+                      <select id="historyPullDays_METAL_PRICE_API" class="provider-history-select">
+                        <option value="7">7 days</option>
+                        <option value="14">14 days</option>
+                        <option value="30" selected>30 days</option>
+                        <option value="60">60 days</option>
+                        <option value="90">90 days</option>
+                        <option value="180">180 days</option>
+                        <option value="365">365 days</option>
+                      </select>
+                      <button type="button" class="btn api-history-btn" data-provider="METAL_PRICE_API">Pull History</button>
+                      <span class="history-pull-cost" id="historyPullCost_METAL_PRICE_API"></span>
                     </div>
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
@@ -1860,13 +1910,13 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label for="historyDays_CUSTOM">History Days:</label>
-                      <input type="number" id="historyDays_CUSTOM" class="provider-history-input" min="1" max="365" value="30" placeholder="1-365">
+                      <label>Sync Mode:</label>
+                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_CUSTOM" data-provider="CUSTOM">
+                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
+                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
+                      </div>
                     </div>
-                    <div class="provider-setting-row">
-                      <label for="historyTimes_CUSTOM">Times per Day:</label>
-                      <input type="text" id="historyTimes_CUSTOM" class="provider-history-input" placeholder="08:00,20:00">
-                    </div>
+                    <!-- Custom providers: no history pull (batch not supported) -->
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
                       <div class="metal-checkboxes">
@@ -2176,9 +2226,14 @@
             </div>
           </div>
         </div>
+        <div class="modal-footer api-history-footer">
+          <button type="button" class="btn" id="exportSpotHistoryBtn">Export History</button>
+          <button type="button" class="btn" id="importSpotHistoryBtn">Import History</button>
+          <input type="file" id="importSpotHistoryFile" accept=".csv,.json" style="display:none">
+        </div>
       </div>
     </div>
-    
+
     <!-- =============================================================================
        CATALOG HISTORY MODAL
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -22,8 +22,23 @@ const API_PROVIDERS = {
       platinum: "/metal/spot?api_key={API_KEY}&metal=platinum&currency=USD",
       palladium: "/metal/spot?api_key={API_KEY}&metal=palladium&currency=USD",
     },
+    latestBatchEndpoint: "/latest?api_key={API_KEY}&currency=USD&unit=toz",
     parseResponse: (data) => data.rate?.price || null,
+    parseLatestBatchResponse: (data) => {
+      const current = {};
+      if (data?.metals) {
+        Object.entries(data.metals).forEach(([metal, price]) => {
+          if (typeof price === "number" && price > 0) {
+            current[metal.toLowerCase()] = price;
+          }
+        });
+      }
+      return current;
+    },
     documentation: "https://www.metals.dev/docs",
+    maxHistoryDays: 30,
+    symbolsPerRequest: "all",
+    docUrl: "https://metals.dev/documentation",
     batchSupported: true,
     batchEndpoint: "/timeseries?api_key={API_KEY}&start_date={START_DATE}&end_date={END_DATE}",
     parseBatchResponse: (data) => {
@@ -75,6 +90,9 @@ const API_PROVIDERS = {
       return rate ? 1 / rate : null; // Convert from metal per USD to USD per ounce
     },
     documentation: "https://metals-api.com/documentation",
+    maxHistoryDays: 30,
+    symbolsPerRequest: 1,
+    docUrl: "https://metals-api.com/documentation",
     batchSupported: true,
     batchEndpoint: "/timeseries?access_key={API_KEY}&start_date={START_DATE}&end_date={END_DATE}&base=USD&symbols={SYMBOLS}",
     parseBatchResponse: (data) => {
@@ -141,6 +159,9 @@ const API_PROVIDERS = {
       return rate ? 1 / rate : null; // Convert from metal per USD to USD per ounce
     },
     documentation: "https://metalpriceapi.com/documentation",
+    maxHistoryDays: 365,
+    symbolsPerRequest: "all",
+    docUrl: "https://metalpriceapi.com/documentation",
     batchSupported: true,
     batchEndpoint: "/timeframe?api_key={API_KEY}&start_date={START_DATE}&end_date={END_DATE}&base=USD&currencies={CURRENCIES}",
     parseBatchResponse: (data) => {

--- a/js/events.js
+++ b/js/events.js
@@ -1868,9 +1868,13 @@ const setupApiEvents = () => {
         syncAllBtn,
         "click",
         async () => {
-          if (typeof syncAllProviders === "function") {
-            const count = await syncAllProviders();
-            alert(`${count} records updated.`);
+          if (typeof syncProviderChain === "function") {
+            const { updatedCount, results } = await syncProviderChain({ showProgress: true, forceSync: true });
+            const summary = Object.entries(results)
+              .filter(([_, status]) => status !== "skipped")
+              .map(([prov, status]) => `${API_PROVIDERS[prov]?.name || prov}: ${status}`)
+              .join("\n");
+            alert(`Synced ${updatedCount} prices.\n\n${summary}`);
           }
         },
         "Sync all providers button",

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1239,7 +1239,10 @@ const updateSummary = () => {
     if (els.value) els.value.innerHTML = formatCurrency(totals.totalMeltValue || 0);
     if (els.purchased) els.purchased.innerHTML = formatCurrency(totals.totalPurchased || 0);
     if (els.retailValue) els.retailValue.innerHTML = formatCurrency(totals.totalRetailValue || 0);
-    if (els.lossProfit) els.lossProfit.innerHTML = formatLossProfit(totals.totalGainLoss || 0);
+    if (els.lossProfit) {
+      const gainLossPct = totals.totalPurchased > 0 ? (totals.totalGainLoss / totals.totalPurchased) * 100 : 0;
+      els.lossProfit.innerHTML = formatLossProfit(totals.totalGainLoss || 0, gainLossPct);
+    }
     if (els.avgCostPerOz) {
       const avgCost = totals.totalWeight > 0 ? totals.totalPurchased / totals.totalWeight : 0;
       els.avgCostPerOz.innerHTML = formatCurrency(avgCost);
@@ -1272,7 +1275,10 @@ const updateSummary = () => {
     if (elements.totals.all.value) elements.totals.all.value.innerHTML = formatCurrency(allTotals.totalMeltValue || 0);
     if (elements.totals.all.purchased) elements.totals.all.purchased.innerHTML = formatCurrency(allTotals.totalPurchased || 0);
     if (elements.totals.all.retailValue) elements.totals.all.retailValue.innerHTML = formatCurrency(allTotals.totalRetailValue || 0);
-    if (elements.totals.all.lossProfit) elements.totals.all.lossProfit.innerHTML = formatLossProfit(allTotals.totalGainLoss || 0);
+    if (elements.totals.all.lossProfit) {
+      const allGainLossPct = allTotals.totalPurchased > 0 ? (allTotals.totalGainLoss / allTotals.totalPurchased) * 100 : 0;
+      elements.totals.all.lossProfit.innerHTML = formatLossProfit(allTotals.totalGainLoss || 0, allGainLossPct);
+    }
     if (elements.totals.all.avgCostPerOz) {
       const avgCost = allTotals.totalWeight > 0 ? allTotals.totalPurchased / allTotals.totalWeight : 0;
       elements.totals.all.avgCostPerOz.innerHTML = formatCurrency(avgCost);

--- a/js/pcgs-api.js
+++ b/js/pcgs-api.js
@@ -245,8 +245,8 @@ const renderPcgsFieldCheckboxes = (result) => {
   const container = document.getElementById('pcgsFieldCheckboxes');
   if (!container) return;
 
-  // Check if grade value matches a dropdown option
-  const gradeStr = (result.grade || '').toUpperCase().replace(/\s+/g, '-');
+  // Normalize grade: PCGS returns "MS70", our dropdown uses "MS-70"
+  const gradeStr = (result.grade || '').toUpperCase().replace(/\s+/g, '-').replace(/^([A-Z]+)(\d)/, '$1-$2');
   const gradeEl = document.getElementById('itemGrade');
   let gradeValid = false;
   if (gradeEl && gradeStr) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -475,14 +475,18 @@ const formatCurrency = (value, currency = DEFAULT_CURRENCY) => {
  * @param {number} value - Profit/loss value
  * @returns {string} HTML string with appropriate color styling
  */
-const formatLossProfit = (value) => {
+const formatLossProfit = (value, percent) => {
   const formatted = formatCurrency(value);
+  const pctHtml =
+    percent !== undefined && percent !== 0
+      ? `<span class="gain-loss-pct">${percent > 0 ? "+" : ""}${percent.toFixed(1)}%</span>`
+      : "";
   if (value > 0) {
-    return `<span style="color: var(--success);">${formatted}</span>`;
+    return `<span style="color: var(--success);">${pctHtml}${formatted}</span>`;
   } else if (value < 0) {
-    return `<span style="color: var(--danger);">${formatted}</span>`;
+    return `<span style="color: var(--danger);">${pctHtml}${formatted}</span>`;
   }
-  return formatted;
+  return pctHtml + formatted;
 };
 
 /**


### PR DESCRIPTION
## Summary
- **Relocated spot history Export/Import buttons** from the API settings section into the Metals History modal footer, placing controls next to the data they operate on
- **Added per-provider sync mode toggle** (Always/Backup) to all 4 provider panels, with a new `syncProviderChain()` engine that runs providers in priority order and skips backup providers when an "Always" provider succeeds
- **Refactored sync orchestration** — `syncAllProviders()`, `syncSpotPricesFromApi()`, and `autoSyncSpotPrices()` now delegate to the unified chain, eliminating duplicated fetch/update/cache logic

## Test plan
- [ ] Open Metals History modal → Export/Import buttons appear in footer → Export downloads CSV → Import adds entries and table refreshes immediately
- [ ] Verify API settings section no longer shows export/import buttons
- [ ] Each provider panel shows Always/Backup toggle, persists on reload
- [ ] First provider with key defaults to "Always", rest to "Backup"
- [ ] Click sync on spot card → "Always" providers run → if all fail, "Backup" providers run in order → stops at first backup success
- [ ] "Sync Metals" button shows per-provider status summary
- [ ] Auto-sync on load uses chain with per-provider cache checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)