### PR TITLE
STACK-42: Persistent UUIDs + v3.22.x releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to StakTrakr will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — STACK-42: Persistent UUIDs for inventory items
+
+- **Added**: Stable UUID v4 field on every inventory item — survives delete, reorder, and sort
+- **Added**: `generateUUID()` helper with `crypto.randomUUID()` and RFC 4122 fallback for `file://`
+- **Added**: Automatic UUID migration for existing items on load (no data loss)
+- **Changed**: CSV, JSON, ZIP, and PDF exports now include UUID column
+- **Changed**: CSV, JSON imports preserve existing UUIDs, generate for items without
+- **Changed**: Bulk copy and add-item assign new UUIDs; edit preserves existing UUID
+- **Fixed**: `sanitizeImportedItem()` safety net ensures no item lacks a UUID
+
+---
+
 ## [3.22.01] - 2026-02-10
 
 ### Added — Form layout, bulk edit dropdowns, purity chips

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,41 +6,54 @@ Project direction and planned work. Each item links to its full Linear issue for
 
 ---
 
-## Near-Term (UI Focus)
+## Near-Term — Price History Foundation
 
-Visual polish and usability improvements — no backend changes required.
+The UUID → silent recording → log tabs → charts pipeline. STACK-42 is the critical path that unblocks the rest.
 
-### Active Backlog
-
-| Issue | Title | Priority | Label |
-|-------|-------|----------|-------|
-| [STACK-26](https://linear.app/hextrackr/issue/STACK-26) | Batch rename/normalize tool (Numista-powered) | Medium | Feature |
-| [STACK-28](https://linear.app/hextrackr/issue/STACK-28) | Chart.js dashboard improvements | Low | Feature |
-| [STACK-29](https://linear.app/hextrackr/issue/STACK-29) | Custom tagging system | Low | Feature |
+| Issue | Title | Priority | Depends On |
+|-------|-------|----------|------------|
+| [STACK-42](https://linear.app/hextrackr/issue/STACK-42) | Assign persistent UUIDs to all inventory items | **High** | — |
+| [STACK-41](https://linear.app/hextrackr/issue/STACK-41) | Per-item retail price history for trend charts | Medium | STACK-42 |
+| [STACK-43](https://linear.app/hextrackr/issue/STACK-43) | Silent per-item price history recording | Medium | STACK-42 |
+| [STACK-44](https://linear.app/hextrackr/issue/STACK-44) | Settings Log tab reorganization with sub-tabs | Medium | STACK-43 |
 
 ---
 
-## Medium-Term (BYO-Backend — Supabase Cloud Sync)
+## Near-Term — Features & UI
+
+Independent feature work that can proceed in parallel with the price history pipeline.
+
+| Issue | Title | Priority | Depends On |
+|-------|-------|----------|------------|
+| [STACK-45](https://linear.app/hextrackr/issue/STACK-45) | Goldback denomination pricing & type support | Medium | — |
+| [STACK-46](https://linear.app/hextrackr/issue/STACK-46) | Configurable spot & portfolio card grid with drag-to-reorder | Medium | STACK-45 (for Goldback card) |
+| [STACK-48](https://linear.app/hextrackr/issue/STACK-48) | Chart system overhaul: migrate to ApexCharts, add time-series trends | Medium | STACK-43 (for time-series data) |
+
+---
+
+## Medium-Term — BYO-Backend (Supabase Cloud Sync)
 
 Zero-cost, zero-server architecture. App stays static; users who want cloud sync bring their own free Supabase project.
 
-| Issue | Title | Priority | Label |
-|-------|-------|----------|-------|
-| [STACK-30](https://linear.app/hextrackr/issue/STACK-30) | BYO-Backend: Supabase cloud sync | Medium | Feature |
+| Issue | Title | Priority | Depends On |
+|-------|-------|----------|------------|
+| [STACK-30](https://linear.app/hextrackr/issue/STACK-30) | BYO-Backend: Supabase cloud sync | Medium | — |
 
 ---
 
-## Long-Term (Polish & Distribution)
+## Long-Term — Polish & Distribution
 
-Enhanced UX, mobile support, and deployment options.
+Enhanced UX, mobile support, deployment options, and the v4 vision.
 
-| Issue | Title | Priority | Label | Blocked By |
-|-------|-------|----------|-------|------------|
-| [STACK-31](https://linear.app/hextrackr/issue/STACK-31) | Mobile-responsive card view | Low | Feature | — |
-| [STACK-32](https://linear.app/hextrackr/issue/STACK-32) | User photo upload for inventory items | Low | Feature | STACK-30 |
-| [STACK-33](https://linear.app/hextrackr/issue/STACK-33) | Mobile camera capture in add/edit modal | Low | Feature | STACK-31, STACK-32 |
-| [STACK-34](https://linear.app/hextrackr/issue/STACK-34) | Docker build & image for self-hosting | Low | Feature | — |
-| [STACK-35](https://linear.app/hextrackr/issue/STACK-35) | Proxmox LXC setup guide | Low | Feature | STACK-34 |
+| Issue | Title | Priority | Depends On |
+|-------|-------|----------|------------|
+| [STACK-47](https://linear.app/hextrackr/issue/STACK-47) | v4.00.00 — Multi-asset wealth dashboard (Stocks, Crypto, Collectibles, Real Estate) | Low | STACK-42, STACK-43, STACK-45, STACK-46 |
+| [STACK-31](https://linear.app/hextrackr/issue/STACK-31) | Mobile-responsive card view | Low | — |
+| [STACK-32](https://linear.app/hextrackr/issue/STACK-32) | User photo upload for inventory items | Low | STACK-30 |
+| [STACK-33](https://linear.app/hextrackr/issue/STACK-33) | Mobile camera capture in add/edit modal | Low | STACK-31, STACK-32 |
+| [STACK-34](https://linear.app/hextrackr/issue/STACK-34) | Docker build & image for self-hosting | Low | — |
+| [STACK-35](https://linear.app/hextrackr/issue/STACK-35) | Proxmox LXC setup guide | Low | STACK-34 |
+| [STACK-37](https://linear.app/hextrackr/issue/STACK-37) | Numista image & API caching | Low | STACK-30 |
 
 ---
 
@@ -48,13 +61,22 @@ Enhanced UX, mobile support, and deployment options.
 
 Explicitly out of scope until prerequisites are met.
 
-| Issue | Title | Priority | Label | Blocked By |
-|-------|-------|----------|-------|------------|
-| [STACK-36](https://linear.app/hextrackr/issue/STACK-36) | Encryption at rest for Supabase data | Low | Feature | STACK-30 |
-| [STACK-37](https://linear.app/hextrackr/issue/STACK-37) | Numista image caching (CC-licensed only) | Low | Feature | STACK-30 |
-| [STACK-38](https://linear.app/hextrackr/issue/STACK-38) | Table CSS hardening & responsive audit | Low | Improvement | — |
-| [STACK-39](https://linear.app/hextrackr/issue/STACK-39) | Full UI review walkthrough | Low | Improvement | — |
-| [STACK-40](https://linear.app/hextrackr/issue/STACK-40) | eBay API integration for retail estimates | Low | Feature | STACK-30 |
+| Issue | Title | Priority | Depends On |
+|-------|-------|----------|------------|
+| [STACK-36](https://linear.app/hextrackr/issue/STACK-36) | Encryption at rest for Supabase data | Low | STACK-30 |
+| [STACK-38](https://linear.app/hextrackr/issue/STACK-38) | Table CSS hardening & responsive audit | Low | — |
+| [STACK-39](https://linear.app/hextrackr/issue/STACK-39) | Full UI review walkthrough | Low | — |
+| [STACK-40](https://linear.app/hextrackr/issue/STACK-40) | eBay API integration for retail estimates | Low | STACK-30 |
+
+---
+
+## Canceled
+
+| Issue | Title | Reason |
+|-------|-------|--------|
+| STACK-26 | Batch rename/normalize tool | Covered by existing Bulk Edit + Numista search |
+| STACK-28 | Chart.js dashboard improvements | Superseded by STACK-48 (ApexCharts migration) |
+| STACK-29 | Custom tagging system | Canceled |
 
 ---
 
@@ -63,6 +85,7 @@ Explicitly out of scope until prerequisites are met.
 <details>
 <summary>Shipped features (click to expand)</summary>
 
+- **v3.22.01** — Form layout, bulk edit dropdowns, purity chips
 - **v3.22.00** — STACK-22/24/25/27: Purity field & melt formula, PCGS quota bar, pie chart metric toggle, test-loader extraction
 - **v3.21.03** — STACK-23: Search matches custom chip group labels
 - **v3.21.02** — Seed data & first-time UX: 720 seed spot history entries, 8 sample inventory items, README overhaul

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STACK-42: Persistent UUIDs**: Every inventory item now has a stable UUID v4 identifier that never changes regardless of array position. Foundation for per-item price history, trend charts, and cloud sync. Existing items auto-migrate on load. All export/import formats updated
 - **Form layout, bulk edit dropdowns, purity chips (v3.22.01)**: Purity form layout: Weight/Purity/Qty on single row. Bulk Edit: Purity, Grade, Grading Authority as dropdowns. Purity/fineness filter chips (enabled) and inline chips (disabled). Purity inline chip shows numerical value only
 - **STACK-22/24/25/27: Purity, PCGS quota, chart toggle, extraction (v3.22.00)**: Added: Purity (fineness) field — adjusts melt value formula across all calculation sites (STACK-22). Added: PCGS API daily quota usage bar in Settings (STACK-24). Added: Pie chart metric toggle — switch between Purchase, Melt, Retail, and Gain/Loss views (STACK-27). Changed: Extracted inline test loader to js/test-loader.js (STACK-25). Changed: CSV, PDF, and ZIP exports now include Purity column. Changed: Seed data includes realistic purity values for sample items
 - **STACK-23: Search matches custom chip group labels (v3.21.03)**: Fixed: Search now matches items belonging to custom chip groups when searching by group label (STACK-23)

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -614,6 +614,7 @@ const copySelectedItems = () => {
     // Deep clone
     const clone = JSON.parse(JSON.stringify(item));
     clone.serial = getNextSerial();
+    clone.uuid = generateUUID();
 
     inventory.push(clone);
 

--- a/js/events.js
+++ b/js/events.js
@@ -668,6 +668,7 @@ const setupEventListeners = () => {
               totalPremium: 0,
               isCollectable: false,
               serial,
+              uuid: generateUUID(),
               numistaId: catalog,
             });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -18,6 +18,26 @@ const debugLog = (...args) => {
     console.log(...args);
   }
 };
+
+/**
+ * Generates a UUID v4 string for stable item identification.
+ * Uses crypto.randomUUID() where available, with a Math.random() RFC 4122 v4 fallback
+ * for environments (e.g. file:// protocol) that lack crypto.randomUUID.
+ *
+ * @returns {string} A UUID v4 string (e.g. "550e8400-e29b-41d4-a716-446655440000")
+ */
+const generateUUID = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // RFC 4122 v4 fallback
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};
+
 /**
  * Gets the active branding name considering domain overrides
  *
@@ -911,6 +931,9 @@ const sanitizeImportedItem = (item) => {
     sanitized.premiumPerOz = 0;
     sanitized.totalPremium = 0;
   }
+
+  // Ensure every item has a stable UUID
+  if (!sanitized.uuid) sanitized.uuid = generateUUID();
 
   return sanitizeObjectFields(sanitized);
 };
@@ -2727,5 +2750,6 @@ if (typeof module !== 'undefined' && module.exports) {
     computeMeltValue,
     getContrastColor,
     debounce,
+    generateUUID,
   };
 }


### PR DESCRIPTION
## Summary

- **STACK-42**: Every inventory item now has a stable UUID v4 that survives delete, reorder, and sort. Foundation for per-item price history (STACK-43), trend charts (STACK-41), and Supabase sync (STACK-30)
- **v3.22.01**: Form layout improvements, bulk edit dropdowns, purity chips
- **v3.22.00**: Purity field & melt formula (STACK-22), PCGS quota bar (STACK-24), pie chart metric toggle (STACK-27), test-loader extraction (STACK-25)
- **v3.21.03**: Search matches custom chip group labels (STACK-23)

## Test plan

- [ ] Existing items have UUID after page load (check console: `inventory[0].uuid`)
- [ ] New item gets UUID on creation
- [ ] Edit preserves UUID; duplicate/bulk copy get new UUIDs
- [ ] CSV/JSON/ZIP/PDF exports include UUID column
- [ ] CSV/JSON imports preserve existing UUIDs, generate for items without
- [ ] Works on `file://` protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)