### PR TITLE
Add Codacy badge to footer and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A powerful, privacy-first precious metals portfolio tracker for Silver, Gold, Pl
 
 **Live site:** [www.staktrakr.com](https://www.staktrakr.com)
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8)](https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+
 ![StakTrakr Screenshot](ScreenshotStakTrakr.png)
 
 ---

--- a/css/styles.css
+++ b/css/styles.css
@@ -437,6 +437,18 @@ section {
   color: var(--text-secondary);
 }
 
+.footer-badges {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.footer-badges img {
+  vertical-align: middle;
+}
+
 .storage-line a {
   margin-left: var(--spacing-sm);
 }

--- a/index.html
+++ b/index.html
@@ -1202,7 +1202,13 @@
     <footer class="app-footer">
       <div class="storage-line">Storage: <span id="storageUsage"></span> <progress id="storageUsageBar" max="5120" value="0"></progress> <a href="#" id="storageReportLink">Storage report</a></div>
       <div class="footer-meta">
-        <span>Thank you for using <span id="footerBrand">StakTrakr</span> (<span id="footerVersion"></span>). &copy; 2025-2026 <span id="footerDomain">staktrakr.com</span>. Created with love on Apple Silicon.<br>If you are having issues, report them on <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener">GitHub</a> or join our <a href="https://www.reddit.com/r/stackrtrackr/" target="_blank" rel="noopener">community</a>. This project is <a href="https://github.com/lbruton/StackTrackr" target="_blank" rel="noopener">open source</a>. MIT License.</span>
+        <span>Thank you for using <span id="footerBrand">StakTrakr</span> (<span id="footerVersion"></span>). &copy; 2025-2026 <span id="footerDomain">staktrakr.com</span>. Created with love on Apple Silicon.</span>
+        <div class="footer-badges">
+          <a href="https://github.com/lbruton/StackTrackr" target="_blank" rel="noopener"><img src="https://img.shields.io/github/license/lbruton/StackTrackr?style=flat-square" alt="MIT License" height="20"></a>
+          <a href="https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
+          <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StackTrackr?style=flat-square" alt="GitHub Issues" height="20"></a>
+          <a href="https://www.reddit.com/r/stackrtrackr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/stackrtrackr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
+        </div>
       </div>
     </footer>
     <!-- =============================================================================


### PR DESCRIPTION
## Summary

- Replace footer text links with inline shield badges (license, Codacy grade, issues, community)
- Add `footer-badges` CSS for flex layout
- Add Codacy badge to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)