### PR TITLE
v3.24.03 — Fix Goldback melt/retail/weight in Details Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.24.02] - 2026-02-11
+
+### Added — STACK-44: Settings Log Tab Reorganization
+
+- **Added**: Activity Log sub-tabs in Settings — Changelog, Metals, Catalogs, Price History (STACK-44)
+- **Added**: Spot price history table with sortable columns (Timestamp, Metal, Spot Price, Source, Provider)
+- **Added**: Catalog API call history table with failed entries highlighted in red
+- **Added**: Per-item price history table with item name filter and sortable columns
+- **Added**: Clear button with confirmation dialog for each log sub-tab
+- **Added**: Lazy-rendering of sub-tab content on first activation
+
+---
+
 ## [3.24.01] - 2026-02-11
 
 ### Fixed — Codacy code quality cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.24.03] - 2026-02-12
+
+### Fixed — Goldback melt/retail/weight in Details Modal
+
+- **Fixed**: Goldback melt values inflated 1000x in Details Modal — apply `GB_TO_OZT` conversion and denomination retail pricing
+
+---
+
 ## [3.24.02] - 2026-02-11
 
 ### Added — STACK-44: Settings Log Tab Reorganization

--- a/css/styles.css
+++ b/css/styles.css
@@ -7011,6 +7011,117 @@ th {
   padding: 0.15rem 0.45rem;
 }
 
+/* Log sub-tabs (inside Activity Log panel) */
+.settings-log-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--border);
+  margin: 1rem 0 0 0;
+}
+
+.settings-log-tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.settings-log-tab:hover {
+  color: var(--text-primary);
+}
+
+.settings-log-tab.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
+
+.settings-log-panel {
+  padding-top: 1rem;
+}
+
+/* Price history filter + clear row */
+.settings-pricehistory-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: var(--spacing);
+}
+
+.settings-filter-input {
+  flex: 1;
+  max-width: 280px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.8125rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.settings-filter-input:focus {
+  border-color: var(--primary);
+}
+
+/* Shared table styles for all log sub-tab tables */
+#settingsSpotHistoryTable,
+#settingsCatalogHistoryTable,
+#settingsPriceHistoryTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+#settingsSpotHistoryTable thead,
+#settingsCatalogHistoryTable thead,
+#settingsPriceHistoryTable thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-secondary, var(--bg));
+}
+
+#settingsSpotHistoryTable th,
+#settingsCatalogHistoryTable th,
+#settingsPriceHistoryTable th {
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+}
+
+#settingsSpotHistoryTable td,
+#settingsCatalogHistoryTable td,
+#settingsPriceHistoryTable td {
+  padding: 0.3rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
+/* Empty-state message row */
+.settings-log-empty td {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 2rem 0.5rem;
+  font-style: italic;
+}
+
 /* =============================================================================
    BULK EDIT MODAL
    ============================================================================= */

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STACK-44: Activity Log sub-tabs (v3.24.02)**: Settings Log panel reorganized with 4 sub-tabs — Changelog, Metals (spot history), Catalogs (API calls), Price History (per-item). Sortable tables, filter, and clear buttons for each
 - **Codacy code quality cleanup (v3.24.01)**: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved
 - **STACK-50: Multi-Currency Support (v3.24.00)**: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix
 - **STACK-52: Bulk Edit pinned selections (v3.23.02)**: Selected items stay visible at top of table when search changes. Removed dormant prototype files

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **Fix Goldback melt/retail/weight in Details Modal (v3.24.03)**: Goldback melt values no longer inflated 1000x in breakdown modals. Applies GB_TO_OZT conversion and denomination retail pricing
 - **STACK-44: Activity Log sub-tabs (v3.24.02)**: Settings Log panel reorganized with 4 sub-tabs — Changelog, Metals (spot history), Catalogs (API calls), Price History (per-item). Sortable tables, filter, and clear buttons for each
 - **Codacy code quality cleanup (v3.24.01)**: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved
 - **STACK-50: Multi-Currency Support (v3.24.00)**: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix
 - **STACK-52: Bulk Edit pinned selections (v3.23.02)**: Selected items stay visible at top of table when search changes. Removed dormant prototype files
-- **Goldback real-time estimation, Settings reorganization (v3.23.01)**: Goldback price estimation from gold spot with configurable premium. Settings sidebar renamed Theme to Appearance, Tools to System
-- **STACK-42/43/45: UUIDs, Price History, Goldback Pricing (v3.23.00)**: Goldback denomination pricing and type support. Persistent UUID v4 for every item. Silent per-item price history recording
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -2160,28 +2160,111 @@
               </div>
             </div>
 
-            <!-- ===== CHANGE LOG ===== -->
+            <!-- ===== ACTIVITY LOG ===== -->
             <div class="settings-section-panel" id="settingsPanel_changelog" style="display: none">
-              <h3>Change Log</h3>
-              <p class="settings-subtext">Recent inventory changes. Click a row to edit the item, or undo/redo individual changes.</p>
-              <div class="settings-changelog-actions">
-                <button class="btn btn-secondary" id="settingsChangeLogClearBtn" type="button">Clear Log</button>
+              <h3>Activity Log</h3>
+              <p class="settings-subtext">Browse inventory changes, spot price history, catalog lookups, and per-item price tracking.</p>
+
+              <!-- Log sub-tab bar -->
+              <div class="settings-log-tabs">
+                <button class="settings-log-tab active" data-log-tab="changelog" type="button">Changelog</button>
+                <button class="settings-log-tab" data-log-tab="metals" type="button">Metals</button>
+                <button class="settings-log-tab" data-log-tab="catalogs" type="button">Catalogs</button>
+                <button class="settings-log-tab" data-log-tab="pricehistory" type="button">Price History</button>
               </div>
-              <div class="settings-changelog-wrap">
-                <table id="settingsChangeLogTable">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Item</th>
-                      <th>Field</th>
-                      <th>Old Value</th>
-                      <th>New Value</th>
-                      <th>Undo</th>
-                    </tr>
-                  </thead>
-                  <tbody></tbody>
-                </table>
+
+              <!-- Changelog panel (existing) -->
+              <div class="settings-log-panel" id="logPanel_changelog">
+                <p class="settings-subtext">Recent inventory changes. Click a row to edit the item, or undo/redo individual changes.</p>
+                <div class="settings-changelog-actions">
+                  <button class="btn btn-secondary" id="settingsChangeLogClearBtn" type="button">Clear Log</button>
+                </div>
+                <div class="settings-changelog-wrap">
+                  <table id="settingsChangeLogTable">
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Item</th>
+                        <th>Field</th>
+                        <th>Old Value</th>
+                        <th>New Value</th>
+                        <th>Undo</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
               </div>
+
+              <!-- Metals (Spot History) panel -->
+              <div class="settings-log-panel" id="logPanel_metals" style="display: none">
+                <p class="settings-subtext">Spot price updates recorded from API syncs and manual edits.</p>
+                <div class="settings-changelog-actions">
+                  <button class="btn btn-secondary" id="settingsSpotHistoryClearBtn" type="button">Clear Spot History</button>
+                </div>
+                <div class="settings-changelog-wrap">
+                  <table id="settingsSpotHistoryTable">
+                    <thead>
+                      <tr>
+                        <th>Timestamp</th>
+                        <th>Metal</th>
+                        <th>Spot Price</th>
+                        <th>Source</th>
+                        <th>Provider</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+
+              <!-- Catalogs panel -->
+              <div class="settings-log-panel" id="logPanel_catalogs" style="display: none">
+                <p class="settings-subtext">Catalog API call history. Failed lookups are highlighted in red.</p>
+                <div class="settings-changelog-actions">
+                  <button class="btn btn-secondary" id="settingsCatalogHistoryClearBtn" type="button">Clear Catalog History</button>
+                </div>
+                <div class="settings-changelog-wrap">
+                  <table id="settingsCatalogHistoryTable">
+                    <thead>
+                      <tr>
+                        <th>Time</th>
+                        <th>Action</th>
+                        <th>Query</th>
+                        <th>Result</th>
+                        <th>Items</th>
+                        <th>Provider</th>
+                        <th>Duration</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+
+              <!-- Price History panel -->
+              <div class="settings-log-panel" id="logPanel_pricehistory" style="display: none">
+                <p class="settings-subtext">Per-item price snapshots recorded on add, edit, and spot price sync.</p>
+                <div class="settings-pricehistory-controls">
+                  <input class="settings-filter-input" id="priceHistoryFilterInput" placeholder="Filter by item name..." type="text">
+                  <button class="btn btn-secondary" id="settingsPriceHistoryClearBtn" type="button">Clear Price History</button>
+                </div>
+                <div class="settings-changelog-wrap">
+                  <table id="settingsPriceHistoryTable">
+                    <thead>
+                      <tr>
+                        <th>Timestamp</th>
+                        <th>Item Name</th>
+                        <th>Retail</th>
+                        <th>Spot</th>
+                        <th>Melt</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+
             </div>
 
           </div><!-- .settings-content-area -->

--- a/js/about.js
+++ b/js/about.js
@@ -272,12 +272,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.24.03 &ndash; Fix Goldback melt/retail/weight in Details Modal</strong>: Goldback melt values no longer inflated 1000x in breakdown modals. Applies GB_TO_OZT conversion and denomination retail pricing</li>
     <li><strong>v3.24.02 &ndash; STACK-44: Activity Log sub-tabs</strong>: Settings Log panel reorganized with 4 sub-tabs &mdash; Changelog, Metals, Catalogs, Price History. Sortable tables, filter, and clear buttons</li>
     <li><strong>v3.24.01 &ndash; Codacy code quality cleanup</strong>: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved</li>
     <li><strong>v3.24.00 &ndash; STACK-50: Multi-Currency Support</strong>: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix</li>
     <li><strong>v3.23.02 &ndash; STACK-52: Bulk Edit pinned selections</strong>: Selected items stay visible at top of table when search changes. Removed dormant prototype files</li>
-    <li><strong>v3.23.01 &ndash; Goldback real-time estimation, Settings reorganization</strong>: Goldback price estimation from gold spot with configurable premium. Settings sidebar renamed Theme to Appearance, Tools to System</li>
-    <li><strong>v3.23.00 &ndash; STACK-42/43/45: UUIDs, Price History, Goldback Pricing</strong>: Goldback denomination pricing and type support. Persistent UUID v4 for every item. Silent per-item price history recording</li>
   `;
 };
 

--- a/js/about.js
+++ b/js/about.js
@@ -122,8 +122,8 @@ const loadAnnouncements = async () => {
     const text = await res.text();
 
     const section = (name) => {
-      // nosemgrep: javascript.dos.rule-non-literal-regexp
-      const regex = new RegExp(`##\\s+${name}\\n([\\s\\S]*?)(?=##|$)`, "i");
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(`##\\s+${escaped}\\n([\\s\\S]*?)(?=##|$)`, "i");
       const match = text.match(regex);
       return match ? match[1] : "";
     };

--- a/js/about.js
+++ b/js/about.js
@@ -272,6 +272,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.24.02 &ndash; STACK-44: Activity Log sub-tabs</strong>: Settings Log panel reorganized with 4 sub-tabs &mdash; Changelog, Metals, Catalogs, Price History. Sortable tables, filter, and clear buttons</li>
     <li><strong>v3.24.01 &ndash; Codacy code quality cleanup</strong>: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved</li>
     <li><strong>v3.24.00 &ndash; STACK-50: Multi-Currency Support</strong>: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix</li>
     <li><strong>v3.23.02 &ndash; STACK-52: Bulk Edit pinned selections</strong>: Selected items stay visible at top of table when search changes. Removed dormant prototype files</li>

--- a/js/api.js
+++ b/js/api.js
@@ -915,6 +915,7 @@ const fetchLatestPrices = async (provider, apiKey, selectedMetals) => {
       const headers = { "Content-Type": "application/json" };
       if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
+      // Safe: URL constructed from hardcoded API_PROVIDERS config (latestBatchEndpoint)
       const response = await fetch(url, { method: "GET", headers, mode: "cors" });
       if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -940,6 +941,17 @@ const fetchLatestPrices = async (provider, apiKey, selectedMetals) => {
       const base = custom.baseUrl || "";
       const pattern = custom.endpoint || "";
       const format = custom.format || "symbol";
+
+      // Validate custom API base URL before use
+      try {
+        const validated = new URL(base);
+        if (validated.protocol !== 'https:') {
+          throw new Error('Custom API base must use HTTPS');
+        }
+      } catch (urlErr) {
+        debugLog('warn', 'Invalid custom API base URL:', base, urlErr.message);
+        return results;
+      }
       const metalCodes = {
         silver: format === "symbol" ? "XAG" : "silver",
         gold: format === "symbol" ? "XAU" : "gold",
@@ -965,6 +977,7 @@ const fetchLatestPrices = async (provider, apiKey, selectedMetals) => {
         const endpoint = providerConfig.endpoints[metal];
         if (!endpoint) continue;
         try {
+          // Safe: URL constructed from hardcoded API_PROVIDERS config (baseUrl + endpoints)
           const url = `${providerConfig.baseUrl}${endpoint.replace("{API_KEY}", apiKey)}`;
           const headers = { "Content-Type": "application/json" };
           if (provider === "METALS_DEV" && apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
@@ -1231,6 +1244,7 @@ const fetchHistoryBatched = async (provider, apiKey, selectedMetals, totalDays) 
       }
 
       try {
+        // Safe: URL constructed from hardcoded API_PROVIDERS config (baseUrl + batchEndpoint + templated dates/metals)
         const response = await fetch(url, { method: "GET", headers, mode: "cors" });
         if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-11 - STACK-44: Settings Log tab reorganization with sub-tabs
  */
 
-const APP_VERSION = "3.24.02";
+const APP_VERSION = "3.24.03";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/constants.js
+++ b/js/constants.js
@@ -251,10 +251,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-09 - Patch: Edit custom grouping rules, relocate chip threshold
+ * Updated: 2026-02-11 - STACK-44: Settings Log tab reorganization with sub-tabs
  */
 
-const APP_VERSION = "3.24.01";
+const APP_VERSION = "3.24.02";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -29,14 +29,19 @@ const getBreakdownData = (metal) => {
 
   metalItems.forEach(item => {
     const qty = Number(item.qty) || 1;
-    const itemWeight = qty * (parseFloat(item.weight) || 0);
+    const weight = parseFloat(item.weight) || 0;
+    const weightOz = (item.weightUnit === 'gb') ? weight * GB_TO_OZT : weight;
+    const itemWeight = qty * weightOz;
     const purchasePrice = parseFloat(item.price) || 0;
     const purchaseTotal = qty * purchasePrice;
     const purity = parseFloat(item.purity) || 1.0;
     const meltValue = itemWeight * currentSpot * purity;
+    const gbDenomPrice = (typeof getGoldbackRetailPrice === 'function') ? getGoldbackRetailPrice(item) : null;
     const rawMarket = parseFloat(item.marketValue) || 0;
-    const isManualRetail = rawMarket > 0;
-    const retailTotal = isManualRetail ? rawMarket * qty : meltValue;
+    const isManualRetail = !gbDenomPrice && rawMarket > 0;
+    const retailTotal = gbDenomPrice   ? gbDenomPrice * qty
+                      : isManualRetail ? rawMarket * qty
+                      : meltValue;
     const gainLoss = retailTotal - purchaseTotal;
 
     // Type breakdown
@@ -83,15 +88,20 @@ const getAllMetalsBreakdownData = () => {
 
   inventory.forEach(item => {
     const qty = Number(item.qty) || 1;
-    const itemWeight = qty * (parseFloat(item.weight) || 0);
+    const weight = parseFloat(item.weight) || 0;
+    const weightOz = (item.weightUnit === 'gb') ? weight * GB_TO_OZT : weight;
+    const itemWeight = qty * weightOz;
     const purchasePrice = parseFloat(item.price) || 0;
     const purchaseTotal = qty * purchasePrice;
     const currentSpot = spotPrices[item.metal.toLowerCase()] || 0;
     const purity = parseFloat(item.purity) || 1.0;
     const meltValue = itemWeight * currentSpot * purity;
+    const gbDenomPrice = (typeof getGoldbackRetailPrice === 'function') ? getGoldbackRetailPrice(item) : null;
     const rawMv2 = parseFloat(item.marketValue) || 0;
-    const isManualRetail = rawMv2 > 0;
-    const retailTotal = isManualRetail ? rawMv2 * qty : meltValue;
+    const isManualRetail = !gbDenomPrice && rawMv2 > 0;
+    const retailTotal = gbDenomPrice   ? gbDenomPrice * qty
+                      : isManualRetail ? rawMv2 * qty
+                      : meltValue;
     const gainLoss = retailTotal - purchaseTotal;
 
     // Metal breakdown

--- a/js/events.js
+++ b/js/events.js
@@ -75,21 +75,21 @@ const setupColumnResizing = () => {
       headerTextSpan = document.createElement('span');
       headerTextSpan.className = 'header-text';
     }
-    
+
     // Check if the span is empty or needs text
     if (!headerTextSpan.textContent.trim()) {
       // Find the text content (excluding SVG and existing elements)
-      const textNodes = Array.from(header.childNodes).filter(node => 
+      const textNodes = Array.from(header.childNodes).filter(node =>
         node.nodeType === Node.TEXT_NODE && node.textContent.trim()
       );
-      
+
       if (textNodes.length > 0) {
         // Move text content into the span
         headerTextSpan.textContent = textNodes.map(node => node.textContent.trim()).join(' ');
-        
+
         // Remove original text nodes
         textNodes.forEach(node => node.remove());
-        
+
         // Insert the span after the SVG icon (if present) if it's not already in the DOM
         if (!header.contains(headerTextSpan)) {
           const svg = header.querySelector('svg');
@@ -261,6 +261,1289 @@ const setupResponsiveColumns = () => {
   );
 };
 
+// SUB-FUNCTIONS FOR EVENT LISTENER SETUP
+// =============================================================================
+
+/**
+ * Sets up search input and chip-related listeners
+ */
+const setupSearchAndChipListeners = () => {
+  // Search Input
+  if (elements.searchInput) {
+    const debouncedSearch = debounce(() => {
+      searchQuery = elements.searchInput.value.replace(/[<>]/g, "").trim();
+      renderTable();
+      if (typeof renderActiveFilters === "function") {
+        renderActiveFilters();
+      }
+    }, 300);
+    safeAttachListener(elements.searchInput, "input", debouncedSearch, "Search Input");
+  }
+
+  // Chip minimum count dropdown (inline)
+  const chipMinCountEl = document.getElementById('chipMinCount');
+  if (chipMinCountEl) {
+    safeAttachListener(
+      chipMinCountEl,
+      'change',
+      (e) => {
+        const minCount = parseInt(e.target.value, 10);
+        localStorage.setItem('chipMinCount', minCount.toString());
+        // Sync settings modal control
+        const settingsChipMin = document.getElementById('settingsChipMinCount');
+        if (settingsChipMin) settingsChipMin.value = minCount.toString();
+        if (typeof renderActiveFilters === 'function') {
+          renderActiveFilters();
+        }
+      },
+      'Chip minimum count dropdown'
+    );
+  }
+
+  // Grouped name chips toggle (inline)
+  const groupNameChipsEl = document.getElementById('groupNameChips');
+  if (groupNameChipsEl && window.featureFlags) {
+    // Set initial state from feature flag
+    const initVal = window.featureFlags.isEnabled('GROUPED_NAME_CHIPS') ? 'yes' : 'no';
+    groupNameChipsEl.querySelectorAll('.chip-sort-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.val === initVal);
+    });
+
+    groupNameChipsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip-sort-btn');
+      if (!btn) return;
+      const isEnabled = btn.dataset.val === 'yes';
+      if (isEnabled) {
+        window.featureFlags.enable('GROUPED_NAME_CHIPS');
+      } else {
+        window.featureFlags.disable('GROUPED_NAME_CHIPS');
+      }
+      // Update active state
+      groupNameChipsEl.querySelectorAll('.chip-sort-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.val === btn.dataset.val);
+      });
+      // Sync settings modal toggle
+      const settingsGroup = document.getElementById('settingsGroupNameChips');
+      if (settingsGroup) {
+        settingsGroup.querySelectorAll('.chip-sort-btn').forEach(b => {
+          b.classList.toggle('active', b.dataset.val === btn.dataset.val);
+        });
+      }
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+    });
+  }
+
+  // Chip sort order inline toggle
+  const chipSortEl = document.getElementById('chipSortOrder');
+  if (chipSortEl) {
+    // Restore saved value on setup (migrate 'default' → 'alpha')
+    const savedSort = localStorage.getItem('chipSortOrder');
+    const activeSort = (savedSort === 'count') ? 'count' : 'alpha';
+    chipSortEl.querySelectorAll('.chip-sort-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.sort === activeSort);
+    });
+
+    chipSortEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip-sort-btn');
+      if (!btn) return;
+      const val = btn.dataset.sort;
+      localStorage.setItem('chipSortOrder', val);
+      // Update active state
+      chipSortEl.querySelectorAll('.chip-sort-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.sort === val);
+      });
+      // Sync settings modal toggle
+      const settingsSort = document.getElementById('settingsChipSortOrder');
+      if (settingsSort) {
+        settingsSort.querySelectorAll('.chip-sort-btn').forEach(b => {
+          b.classList.toggle('active', b.dataset.sort === val);
+        });
+      }
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+    });
+  }
+};
+
+/**
+ * Sets up header button listeners (logo, settings, about, details)
+ */
+const setupHeaderButtonListeners = () => {
+  // CRITICAL HEADER BUTTONS
+  debugLog("Setting up header buttons...");
+
+  // App Logo
+  if (elements.appLogo) {
+    safeAttachListener(
+      elements.appLogo,
+      "click",
+      () => window.location.reload(),
+      "App Logo",
+    );
+  }
+
+  // Settings Button
+  if (elements.settingsBtn) {
+    safeAttachListener(
+      elements.settingsBtn,
+      "click",
+      (e) => {
+        e.preventDefault();
+        debugLog("Settings button clicked");
+        if (typeof showSettingsModal === "function") {
+          showSettingsModal();
+        }
+      },
+      "Settings Button",
+    );
+  }
+
+  // About Button
+  if (elements.aboutBtn) {
+    safeAttachListener(
+      elements.aboutBtn,
+      "click",
+      (e) => {
+        e.preventDefault();
+        if (typeof showAboutModal === "function") {
+          showAboutModal();
+        }
+      },
+      "About Button",
+    );
+  }
+
+
+  // Details modal triggers
+  if (elements.totalTitles && elements.totalTitles.length) {
+    elements.totalTitles.forEach((title) => {
+      safeAttachListener(
+        title,
+        "click",
+        () => {
+          const metal = title.dataset.metal;
+          if (typeof showDetailsModal === "function") {
+            showDetailsModal(metal);
+          }
+        },
+        `Totals title (${title.dataset.metal})`,
+      );
+    });
+  }
+
+  if (elements.detailsCloseBtn) {
+    safeAttachListener(
+      elements.detailsCloseBtn,
+      "click",
+      () => {
+        if (typeof closeDetailsModal === "function") {
+          closeDetailsModal();
+        }
+      },
+      "Close details modal",
+    );
+  }
+};
+
+/**
+ * Sets up table header sorting and Goldback denomination picker
+ */
+const setupTableSortListeners = () => {
+  // TABLE HEADER SORTING
+  debugLog("Setting up table sorting...");
+  const inventoryTable = document.getElementById("inventoryTable");
+  if (inventoryTable) {
+    const headers = inventoryTable.querySelectorAll("th");
+    headers.forEach((header, index) => {
+      // Skip the Actions column (last column)
+      if (index >= headers.length - 1) {
+        return;
+      }
+
+      header.style.cursor = "pointer";
+
+      safeAttachListener(
+        header,
+        "click",
+        (e) => {
+          if (e.shiftKey) return;
+          // Toggle sort direction if same column, otherwise set to new column with asc
+          if (sortColumn === index) {
+            sortDirection = sortDirection === "asc" ? "desc" : "asc";
+          } else {
+            sortColumn = index;
+            sortDirection = "asc";
+          }
+
+          renderTable();
+        },
+        `Table header ${index}`,
+      );
+    });
+  } else {
+    console.error("Inventory table not found for sorting setup!");
+  }
+
+  // GOLDBACK DENOMINATION PICKER TOGGLE (STACK-45)
+  // Swaps weight text input ↔ denomination select when unit changes to/from 'gb'.
+  // Auto-fills hidden weight value from the selected denomination.
+  window.toggleGbDenomPicker = () => {
+    const isGb = elements.itemWeightUnit && elements.itemWeightUnit.value === 'gb';
+    const weightInput = elements.itemWeight;
+    const denomSelect = elements.itemGbDenom || document.getElementById('itemGbDenom');
+    const weightLabel = document.getElementById('itemWeightLabel');
+
+    if (denomSelect) {
+      denomSelect.style.display = isGb ? '' : 'none';
+    }
+    if (weightInput) {
+      weightInput.style.display = isGb ? 'none' : '';
+      if (isGb && denomSelect) {
+        weightInput.value = denomSelect.value;
+      }
+    }
+    if (weightLabel) {
+      weightLabel.textContent = isGb ? 'Denomination' : 'Weight';
+    }
+  };
+};
+
+/**
+ * Sets up item form submission and related button listeners
+ */
+const setupItemFormListeners = () => {
+  // UNIFIED FORM SUBMISSION (Add + Edit via single #itemModal)
+  debugLog("Setting up unified item form...");
+  if (elements.inventoryForm) {
+    safeAttachListener(
+      elements.inventoryForm,
+      "submit",
+      function (e) {
+        e.preventDefault();
+
+        const isEditing = editingIndex !== null;
+        const existingItem = isEditing ? { ...inventory[editingIndex] } : {};
+
+        // Read all fields (same for both modes)
+        const composition = getCompositionFirstWords(elements.itemMetal.value);
+        const metal = parseNumistaMetal(composition);
+
+        const nameInput = elements.itemName.value.trim();
+        const name = isEditing ? (nameInput || existingItem.name || '') : nameInput;
+
+        const qtyInput = elements.itemQty.value.trim();
+        const qty = qtyInput === '' ? (isEditing ? (existingItem.qty || 1) : 1) : parseInt(qtyInput, 10);
+
+        const type = elements.itemType.value || (isEditing ? existingItem.type : '');
+
+        // Weight: uses real <select>, supports fraction input (e.g. "1/1000", "1 1/2")
+        const weightUnit = elements.itemWeightUnit.value;
+        const denomSelect = elements.itemGbDenom || document.getElementById('itemGbDenom');
+        const weightRaw = (weightUnit === 'gb' && denomSelect) ? denomSelect.value : elements.itemWeight.value;
+        let weight;
+        if (isEditing && weightRaw === '') {
+          weight = typeof existingItem.weight !== 'undefined' ? existingItem.weight : 0;
+        } else {
+          weight = parseFraction(weightRaw);
+          if (weightUnit === 'g') {
+            weight = gramsToOzt(weight);
+          }
+          // gb: weight stays as raw denomination value (conversion happens in computeMeltValue)
+          weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(6));
+        }
+
+        // Price: in edit mode, empty field preserves existing price
+        // User enters in display currency; convert to USD for storage (STACK-50)
+        const priceRaw = elements.itemPrice.value.trim();
+        const fxRate = (typeof getExchangeRate === 'function') ? getExchangeRate() : 1;
+        let price;
+        if (isEditing && priceRaw === '') {
+          price = typeof existingItem.price !== 'undefined' ? existingItem.price : 0;
+        } else {
+          let enteredPrice = priceRaw === '' ? 0 : parseFloat(priceRaw);
+          enteredPrice = isNaN(enteredPrice) || enteredPrice < 0 ? 0 : enteredPrice;
+          price = fxRate !== 1 ? enteredPrice / fxRate : enteredPrice;
+        }
+
+        const purchaseLocation = elements.purchaseLocation.value.trim() || (isEditing ? (existingItem.purchaseLocation || '') : '');
+        const storageLocation = elements.storageLocation.value.trim() || (isEditing ? (existingItem.storageLocation || 'Unknown') : 'Unknown');
+        const serialNumber = (elements.itemSerialNumber || document.getElementById('itemSerialNumber'))?.value?.trim() || (isEditing ? (existingItem.serialNumber || '') : '');
+        const notes = elements.itemNotes.value.trim() || (isEditing ? (existingItem.notes || '') : '');
+        const date = elements.itemDate.value || (isEditing ? (existingItem.date || '') : todayStr());
+
+        const catalog = elements.itemCatalog ? elements.itemCatalog.value.trim() : '';
+        const year = (elements.itemYear || document.getElementById('itemYear'))?.value?.trim() || '';
+        const grade = (elements.itemGrade || document.getElementById('itemGrade'))?.value?.trim() || '';
+        const gradingAuthority = (elements.itemGradingAuthority || document.getElementById('itemGradingAuthority'))?.value?.trim() || '';
+        const certNumber = (elements.itemCertNumber || document.getElementById('itemCertNumber'))?.value?.trim() || '';
+        const pcgsNumber = (elements.itemPcgsNumber || document.getElementById('itemPcgsNumber'))?.value?.trim() || '';
+        const marketValueInput = elements.itemMarketValue ? elements.itemMarketValue.value.trim() : '';
+        let marketValue;
+        if (marketValueInput && !isNaN(parseFloat(marketValueInput))) {
+          const enteredMv = parseFloat(marketValueInput);
+          marketValue = fxRate !== 1 ? enteredMv / fxRate : enteredMv;
+        } else {
+          marketValue = isEditing ? (existingItem.marketValue || 0) : 0;
+        }
+
+        // Purity: read from select or custom input
+        let purity = 1.0;
+        const puritySelect = elements.itemPuritySelect || document.getElementById('itemPuritySelect');
+        if (puritySelect && puritySelect.value === 'custom') {
+          const purityInput = elements.itemPurity || document.getElementById('itemPurity');
+          purity = purityInput ? (parseFloat(purityInput.value) || 1.0) : 1.0;
+        } else if (puritySelect) {
+          purity = parseFloat(puritySelect.value) || 1.0;
+        }
+        if (isEditing && !puritySelect) {
+          purity = existingItem.purity || 1.0;
+        }
+
+        // Validate mandatory fields
+        if (
+          !name ||
+          !date ||
+          !type ||
+          !metal ||
+          isNaN(weight) ||
+          weight <= 0 ||
+          isNaN(qty) ||
+          qty < 1 ||
+          !Number.isInteger(qty)
+        ) {
+          return alert("Please enter valid values for Name, Date, Type, Metal, Weight, and Quantity.");
+        }
+
+        if (isEditing) {
+          // --- EDIT MODE ---
+          const oldItem = { ...inventory[editingIndex] };
+          const serial = oldItem.serial;
+
+          inventory[editingIndex] = {
+            ...oldItem,
+            metal,
+            composition,
+            name,
+            qty,
+            type,
+            weight,
+            weightUnit,
+            price,
+            marketValue,
+            date,
+            purchaseLocation,
+            storageLocation,
+            serialNumber,
+            notes,
+            year,
+            grade,
+            gradingAuthority,
+            certNumber,
+            pcgsNumber,
+            purity,
+            isCollectable: false,
+            numistaId: catalog,
+            currency: displayCurrency,
+          };
+
+          addCompositionOption(composition);
+
+          try {
+            if (window.catalogManager && inventory[editingIndex].numistaId) {
+              catalogManager.setCatalogId(serial, inventory[editingIndex].numistaId);
+            }
+          } catch (catErr) {
+            console.warn('Failed to update catalog mapping:', catErr);
+          }
+
+          saveInventory();
+
+          // Record price data point if price-related fields changed (STACK-43)
+          if (typeof recordSingleItemPrice === 'function') {
+            const cur = inventory[editingIndex];
+            const priceChanged = oldItem.marketValue !== cur.marketValue
+              || oldItem.price !== cur.price || oldItem.weight !== cur.weight
+              || oldItem.qty !== cur.qty || oldItem.metal !== cur.metal
+              || oldItem.purity !== cur.purity;
+            if (priceChanged) recordSingleItemPrice(cur, 'edit');
+          }
+
+          renderTable();
+          renderActiveFilters();
+          logItemChanges(oldItem, inventory[editingIndex]);
+
+          editingIndex = null;
+          editingChangeLogIndex = null;
+        } else {
+          // --- ADD MODE ---
+          const metalKey = metal.toLowerCase();
+          const spotPriceAtPurchase = spotPrices[metalKey] ?? 0;
+          const serial = getNextSerial();
+
+          inventory.push({
+            metal,
+            composition,
+            name,
+            qty,
+            type,
+            weight,
+            weightUnit,
+            price,
+            marketValue,
+            date,
+            purchaseLocation,
+            storageLocation,
+            serialNumber,
+            notes,
+            year,
+            grade,
+            gradingAuthority,
+            certNumber,
+            pcgsNumber,
+            pcgsVerified: false,
+            purity,
+            spotPriceAtPurchase,
+            premiumPerOz: 0,
+            totalPremium: 0,
+            isCollectable: false,
+            serial,
+            uuid: generateUUID(),
+            numistaId: catalog,
+            currency: displayCurrency,
+          });
+
+          typeof registerName === "function" && registerName(name);
+          addCompositionOption(composition);
+
+          if (window.catalogManager && catalog) {
+            catalogManager.setCatalogId(serial, catalog);
+          }
+
+          saveInventory();
+
+          // Record initial price data point (STACK-43)
+          if (typeof recordSingleItemPrice === 'function') {
+            recordSingleItemPrice(inventory[inventory.length - 1], 'add');
+          }
+
+          renderTable();
+          this.reset();
+          elements.itemWeightUnit.value = "oz";
+          elements.itemDate.value = todayStr();
+        }
+
+        // Close modal
+        try {
+          if (typeof closeModalById === 'function') {
+            closeModalById('itemModal');
+          } else if (elements.itemModal) {
+            elements.itemModal.style.display = 'none';
+            document.body.style.overflow = '';
+          }
+        } catch (closeErr) {
+          console.warn('Failed to close item modal:', closeErr);
+        }
+
+        // Update filter chips after inventory mutation
+        if (typeof renderActiveFilters === 'function') {
+          renderActiveFilters();
+        }
+      },
+      "Unified item form",
+    );
+  } else {
+    console.error("Main inventory form not found!");
+  }
+
+  // UNDO CHANGE BUTTON
+  if (elements.undoChangeBtn) {
+    safeAttachListener(
+      elements.undoChangeBtn,
+      "click",
+      (e) => {
+        if (e && typeof e.preventDefault === 'function') e.preventDefault();
+        if (editingChangeLogIndex !== null) {
+          toggleChange(editingChangeLogIndex);
+          try { if (typeof closeModalById === 'function') closeModalById('itemModal'); } catch(undoErr) {}
+          editingIndex = null;
+          editingChangeLogIndex = null;
+          renderChangeLog();
+        }
+      },
+      "Undo change button",
+    );
+  }
+
+  // ITEM MODAL CLOSE / CANCEL BUTTONS
+  if (elements.cancelItemBtn) {
+    safeAttachListener(
+      elements.cancelItemBtn,
+      "click",
+      function (e) {
+        if (e && typeof e.preventDefault === 'function') e.preventDefault();
+        if (e && typeof e.stopPropagation === 'function') e.stopPropagation();
+        try { if (typeof closeModalById === 'function') closeModalById('itemModal'); } catch(closeErr) {}
+        editingIndex = null;
+        editingChangeLogIndex = null;
+      },
+      "Cancel item button",
+    );
+  }
+
+  if (elements.itemCloseBtn) {
+    safeAttachListener(
+      elements.itemCloseBtn,
+      "click",
+      (e) => {
+        if (e && typeof e.preventDefault === 'function') e.preventDefault();
+        if (e && typeof e.stopPropagation === 'function') e.stopPropagation();
+        try { if (typeof closeModalById === 'function') closeModalById('itemModal'); } catch(closeErr) {}
+        editingIndex = null;
+        editingChangeLogIndex = null;
+      },
+      "Item modal close button",
+    );
+  }
+
+  // SEARCH NUMISTA BUTTON — lookup by N# or search by name
+  if (elements.searchNumistaBtn) {
+    safeAttachListener(
+      elements.searchNumistaBtn,
+      "click",
+      async () => {
+        const catalogVal = (elements.itemCatalog || document.getElementById('itemCatalog'))?.value.trim() || '';
+        const nameVal = (elements.itemName || document.getElementById('itemName'))?.value.trim() || '';
+
+        if (!catalogVal && !nameVal) {
+          alert('Enter a Name or Catalog N# to search.');
+          return;
+        }
+
+        if (!catalogAPI || !catalogAPI.activeProvider) {
+          alert('Configure Numista API key in Settings first.');
+          return;
+        }
+
+        const btn = elements.searchNumistaBtn;
+        const originalHTML = btn.innerHTML;
+        btn.textContent = 'Searching...';
+        btn.disabled = true;
+
+        // Type → Numista category mapping for smarter search results
+        const TYPE_TO_NUMISTA_CATEGORY = {
+          'Coin': 'coin',
+          'Bar': 'exonumia',
+          'Round': 'exonumia',
+          'Note': 'banknote',
+          // Aurum omitted — Goldbacks are "Embedded-asset notes" on Numista,
+          // which isn't a valid API category. Uncategorized search finds them.
+          // Set omitted — Numista sets use a different URL scheme (set.php)
+          // and are not searchable via the /types API endpoint.
+        };
+
+        try {
+          if (catalogVal) {
+            // Direct N# lookup → single result
+            const result = await catalogAPI.lookupItem(catalogVal);
+            showNumistaResults(result ? [result] : [], true, catalogVal);
+          } else {
+            // Name search → multiple results with smart category/metal filtering
+            const typeVal = (elements.itemType || document.getElementById('itemType'))?.value || '';
+            const metalVal = (elements.itemMetal || document.getElementById('itemMetal'))?.value || '';
+
+            const searchFilters = { limit: 20 };
+            const numistaCategory = TYPE_TO_NUMISTA_CATEGORY[typeVal];
+            if (numistaCategory) searchFilters.category = numistaCategory;
+
+            // Prepend metal to query for better results (avoid doubling e.g. "Silver Silver Eagle")
+            const searchQuery = metalVal && !nameVal.toLowerCase().includes(metalVal.toLowerCase())
+              ? `${metalVal} ${nameVal}` : nameVal;
+
+            const results = await catalogAPI.searchItems(searchQuery, searchFilters);
+            showNumistaResults(results, false, searchQuery);
+          }
+        } catch (error) {
+          console.error('Numista search error:', error);
+          alert('Search failed: ' + error.message);
+        } finally {
+          // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
+          btn.innerHTML = originalHTML;
+          btn.disabled = false;
+        }
+      },
+      "Search Numista button",
+    );
+  }
+
+  // LOOKUP PCGS BUTTON — verify by Cert# or look up by PCGS#
+  if (elements.lookupPcgsBtn) {
+    safeAttachListener(
+      elements.lookupPcgsBtn,
+      "click",
+      async () => {
+        if (typeof lookupPcgsFromForm !== 'function') {
+          alert('PCGS lookup is not available.');
+          return;
+        }
+
+        const btn = elements.lookupPcgsBtn;
+        const originalHTML = btn.innerHTML;
+        btn.textContent = 'Looking up...';
+        btn.disabled = true;
+
+        try {
+          const result = await lookupPcgsFromForm();
+
+          if (!result.verified) {
+            alert(result.error || 'PCGS lookup failed.');
+            return;
+          }
+
+          // Show field picker modal instead of auto-filling
+          if (typeof showPcgsFieldPicker === 'function') {
+            showPcgsFieldPicker(result);
+          } else {
+            alert('PCGS field picker not available.');
+          }
+        } catch (error) {
+          console.error('PCGS lookup error:', error);
+          alert('PCGS lookup failed: ' + error.message);
+        } finally {
+          btn.innerHTML = originalHTML;
+          btn.disabled = false;
+        }
+      },
+      "Lookup PCGS button",
+    );
+  }
+};
+
+/**
+ * Sets up notes modal, debug modal, bulk edit, changelog, and settings clear button listeners
+ */
+const setupNoteAndModalListeners = () => {
+  // NOTES MODAL BUTTONS
+  if (elements.saveNotesBtn) {
+    safeAttachListener(
+      elements.saveNotesBtn,
+      "click",
+      () => {
+        if (notesIndex === null) return;
+        const textareaElement =
+          elements.notesTextarea || document.getElementById("notesTextarea");
+        const text = textareaElement ? textareaElement.value.trim() : "";
+
+        const oldItem = { ...inventory[notesIndex] };
+        inventory[notesIndex].notes = text;
+        saveInventory();
+        renderTable();
+        logItemChanges(oldItem, inventory[notesIndex]);
+
+        const modalElement =
+          elements.notesModal || document.getElementById("notesModal");
+        if (modalElement) {
+          modalElement.style.display = "none";
+        }
+        notesIndex = null;
+      },
+      "Save notes button",
+    );
+  }
+
+  if (elements.cancelNotesBtn) {
+    safeAttachListener(
+      elements.cancelNotesBtn,
+      "click",
+      () => {
+        const modalElement =
+          elements.notesModal || document.getElementById("notesModal");
+        if (modalElement) {
+          modalElement.style.display = "none";
+        }
+        notesIndex = null;
+      },
+      "Cancel notes button",
+    );
+  }
+
+  if (elements.notesCloseBtn) {
+    safeAttachListener(
+      elements.notesCloseBtn,
+      "click",
+      () => {
+        const modalElement =
+          elements.notesModal || document.getElementById("notesModal");
+        if (modalElement) {
+          modalElement.style.display = "none";
+        }
+        notesIndex = null;
+      },
+      "Notes modal close button",
+    );
+  }
+
+  if (elements.debugCloseBtn) {
+    safeAttachListener(
+      elements.debugCloseBtn,
+      "click",
+      () => {
+        if (typeof hideDebugModal === "function") {
+          hideDebugModal();
+        }
+      },
+      "Debug modal close button",
+    );
+  }
+
+  // Bulk Edit modal open/close
+  if (elements.bulkEditBtn) {
+    safeAttachListener(
+      elements.bulkEditBtn,
+      "click",
+      () => {
+        if (typeof openBulkEdit === "function") openBulkEdit();
+      },
+      "Bulk edit open button",
+    );
+  }
+  if (elements.bulkEditCloseBtn) {
+    safeAttachListener(
+      elements.bulkEditCloseBtn,
+      "click",
+      () => {
+        if (typeof closeBulkEdit === "function") closeBulkEdit();
+      },
+      "Bulk edit close button",
+    );
+  }
+
+    if (elements.changeLogBtn) {
+      safeAttachListener(
+        elements.changeLogBtn,
+        "click",
+        (e) => {
+          e.preventDefault();
+          if (typeof showSettingsModal === "function") {
+            showSettingsModal("changelog");
+          }
+        },
+        "Change log button",
+      );
+    }
+
+    // Settings panel Change Log clear button
+    if (elements.settingsChangeLogClearBtn) {
+      safeAttachListener(
+        elements.settingsChangeLogClearBtn,
+        "click",
+        () => {
+          if (typeof clearChangeLog === "function") clearChangeLog();
+        },
+        "Settings change log clear button",
+      );
+    }
+
+    // Settings Spot History clear button (STACK-44)
+    if (elements.settingsSpotHistoryClearBtn) {
+      safeAttachListener(
+        elements.settingsSpotHistoryClearBtn,
+        "click",
+        () => {
+          if (typeof clearSpotHistory === "function") clearSpotHistory();
+        },
+        "Settings spot history clear button",
+      );
+    }
+
+    // Settings Catalog History clear button (STACK-44)
+    if (elements.settingsCatalogHistoryClearBtn) {
+      safeAttachListener(
+        elements.settingsCatalogHistoryClearBtn,
+        "click",
+        () => {
+          if (typeof clearCatalogHistory === "function") clearCatalogHistory();
+        },
+        "Settings catalog history clear button",
+      );
+    }
+
+    // Settings Price History clear button (STACK-44)
+    if (elements.settingsPriceHistoryClearBtn) {
+      safeAttachListener(
+        elements.settingsPriceHistoryClearBtn,
+        "click",
+        () => {
+          if (typeof clearItemPriceHistory === "function") clearItemPriceHistory();
+        },
+        "Settings price history clear button",
+      );
+    }
+
+    // Price History filter input (STACK-44)
+    if (elements.priceHistoryFilterInput) {
+      safeAttachListener(
+        elements.priceHistoryFilterInput,
+        "input",
+        () => {
+          if (typeof filterItemPriceHistoryTable === "function") filterItemPriceHistoryTable();
+        },
+        "Price history filter input",
+      );
+    }
+
+    if (elements.backupReminder) {
+      safeAttachListener(
+        elements.backupReminder,
+        "click",
+        (e) => {
+          e.preventDefault();
+          if (typeof showSettingsModal === "function") {
+            showSettingsModal('files');
+          }
+        },
+        "Backup reminder link",
+      );
+    }
+
+    if (elements.storageReportLink) {
+      safeAttachListener(
+        elements.storageReportLink,
+        "click",
+        (e) => {
+          e.preventDefault();
+          if (typeof openStorageReportPopup === "function") {
+            openStorageReportPopup();
+          }
+        },
+        "Storage report link",
+      );
+    }
+
+  if (elements.changeLogCloseBtn) {
+    safeAttachListener(
+      elements.changeLogCloseBtn,
+      "click",
+      () => {
+        if (elements.changeLogModal) {
+          if (window.closeModalById) closeModalById('changeLogModal');
+          else {
+            elements.changeLogModal.style.display = "none";
+            document.body.style.overflow = "";
+          }
+        }
+      },
+      "Change log close button",
+    );
+  }
+
+  if (elements.changeLogClearBtn) {
+    safeAttachListener(
+      elements.changeLogClearBtn,
+      "click",
+      () => {
+        if (typeof clearChangeLog === "function") {
+          clearChangeLog();
+        }
+      },
+      "Change log clear button",
+    );
+  }
+};
+
+/**
+ * Sets up spot price sync icons, range dropdowns, and inline editing
+ */
+const setupSpotPriceListeners = () => {
+  // SPOT PRICE EVENT LISTENERS — Sparkline card redesign
+  debugLog("Setting up spot price listeners...");
+  Object.values(METALS).forEach((metalConfig) => {
+    const metalKey = metalConfig.key;
+    const metalName = metalConfig.name;
+
+    // Sync icon button
+    const syncIcon = document.getElementById(`syncIcon${metalName}`);
+    if (syncIcon) {
+      safeAttachListener(
+        syncIcon,
+        "click",
+        () => {
+          debugLog(`Sync icon clicked for ${metalName}`);
+          if (typeof syncSpotPricesFromApi === "function") {
+            syncSpotPricesFromApi(true);
+          } else {
+            alert(
+              "API sync functionality requires Metals API configuration. Please configure an API provider first.",
+            );
+          }
+        },
+        `Sync spot price for ${metalName}`,
+      );
+    }
+
+    // Range dropdown change → re-render sparkline + save preference
+    const rangeSelect = document.getElementById(`spotRange${metalName}`);
+    if (rangeSelect) {
+      // Restore saved preference
+      const saved = typeof loadTrendRanges === "function" ? loadTrendRanges() : {};
+      if (saved[metalKey]) {
+        rangeSelect.value = String(saved[metalKey]);
+      }
+
+      safeAttachListener(
+        rangeSelect,
+        "change",
+        () => {
+          const days = parseInt(rangeSelect.value, 10);
+          if (typeof saveTrendRange === "function") saveTrendRange(metalKey, days);
+          if (typeof updateSparkline === "function") updateSparkline(metalKey);
+        },
+        `Trend range for ${metalName}`,
+      );
+    }
+  });
+
+  // Shift+click capture handler for inline spot price editing
+  document.addEventListener(
+    "click",
+    (e) => {
+      if (!e.shiftKey) return;
+      const valueEl = e.target.closest(".spot-card-value");
+      if (!valueEl) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const card = valueEl.closest(".spot-card");
+      if (!card || !card.dataset.metal) return;
+
+      if (typeof startSpotInlineEdit === "function") {
+        startSpotInlineEdit(valueEl, card.dataset.metal);
+      }
+    },
+    true,
+  );
+};
+
+/**
+ * Sets up import/export event listeners (CSV, JSON, Numista, PDF, Vault, etc.)
+ */
+const setupImportExportListeners = () => {
+  // IMPORT/EXPORT EVENT LISTENERS
+  debugLog("Setting up import/export listeners...");
+
+  let csvImportOverride = false;
+  if (elements.importCsvOverride && elements.importCsvFile) {
+    safeAttachListener(
+      elements.importCsvOverride,
+      "click",
+      () => {
+        if (
+          confirm(
+            "Importing CSV will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
+          )
+        ) {
+          csvImportOverride = true;
+          elements.importCsvFile.click();
+        }
+      },
+      "CSV override button",
+    );
+  }
+  if (elements.importCsvMerge && elements.importCsvFile) {
+    safeAttachListener(
+      elements.importCsvMerge,
+      "click",
+      () => {
+        csvImportOverride = false;
+        elements.importCsvFile.click();
+      },
+      "CSV merge button",
+    );
+  }
+  if (elements.importCsvFile) {
+    safeAttachListener(
+      elements.importCsvFile,
+      "change",
+      function (e) {
+        if (e.target.files.length > 0) {
+
+          const file = e.target.files[0];
+          if (!checkFileSize(file)) {
+            alert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
+          } else {
+            importCsv(file, csvImportOverride);
+          }
+
+        }
+        this.value = "";
+      },
+      "CSV import",
+    );
+  }
+
+  let jsonImportOverride = false;
+  if (elements.importJsonOverride && elements.importJsonFile) {
+    safeAttachListener(
+      elements.importJsonOverride,
+      "click",
+      () => {
+        if (
+          confirm(
+            "Importing JSON will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
+          )
+        ) {
+          jsonImportOverride = true;
+          elements.importJsonFile.click();
+        }
+      },
+      "JSON override button",
+    );
+  }
+  if (elements.importJsonMerge && elements.importJsonFile) {
+    safeAttachListener(
+      elements.importJsonMerge,
+      "click",
+      () => {
+        jsonImportOverride = false;
+        elements.importJsonFile.click();
+      },
+      "JSON merge button",
+    );
+  }
+  if (elements.importJsonFile) {
+    safeAttachListener(
+      elements.importJsonFile,
+      "change",
+      function (e) {
+        if (e.target.files.length > 0) {
+
+          const file = e.target.files[0];
+          if (!checkFileSize(file)) {
+            alert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
+          } else {
+            importJson(file, jsonImportOverride);
+          }
+
+        }
+        this.value = "";
+      },
+      "JSON import",
+    );
+  }
+
+  let numistaOverride = false;
+  const importNumistaBtn = document.getElementById("importNumistaBtn");
+  const mergeNumistaBtn = document.getElementById("mergeNumistaBtn");
+  if (importNumistaBtn && elements.numistaImportFile) {
+    safeAttachListener(
+      importNumistaBtn,
+      "click",
+      () => {
+        if (
+          confirm(
+            "Importing Numista CSV will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
+          )
+        ) {
+          numistaOverride = true;
+          elements.numistaImportFile.click();
+        }
+      },
+      "Import Numista CSV button",
+    );
+  }
+  if (mergeNumistaBtn && elements.numistaImportFile) {
+    safeAttachListener(
+      mergeNumistaBtn,
+      "click",
+      () => {
+        numistaOverride = false;
+        elements.numistaImportFile.click();
+      },
+      "Merge Numista CSV button",
+    );
+  }
+    if (elements.numistaImportFile) {
+      safeAttachListener(
+        elements.numistaImportFile,
+        "change",
+        function (e) {
+          if (e.target.files.length > 0) {
+
+          const file = e.target.files[0];
+          if (!checkFileSize(file)) {
+            alert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
+          } else {
+            importNumistaCsv(file, numistaOverride);
+          }
+        }
+        this.value = "";
+      },
+        "Numista CSV import",
+      );
+    }
+
+    // Export buttons
+    if (elements.exportCsvBtn) {
+      safeAttachListener(
+      elements.exportCsvBtn,
+      "click",
+      exportCsv,
+      "CSV export",
+    );
+  }
+  if (elements.exportJsonBtn) {
+    safeAttachListener(
+      elements.exportJsonBtn,
+      "click",
+      exportJson,
+      "JSON export",
+    );
+  }
+  if (elements.exportPdfBtn) {
+    safeAttachListener(
+      elements.exportPdfBtn,
+      "click",
+      exportPdf,
+      "PDF export",
+    );
+  }
+  if (elements.cloudSyncBtn) {
+    safeAttachListener(
+      elements.cloudSyncBtn,
+      "click",
+      () => {
+        if (elements.cloudSyncModal) {
+          if (window.openModalById) openModalById('cloudSyncModal');
+          else elements.cloudSyncModal.style.display = "flex";
+        }
+      },
+      "Cloud Sync button",
+    );
+  }
+  const cloudSyncCloseBtn = document.getElementById("cloudSyncCloseBtn");
+  if (cloudSyncCloseBtn && elements.cloudSyncModal) {
+    safeAttachListener(
+      cloudSyncCloseBtn,
+      "click",
+      () => {
+        if (window.closeModalById) closeModalById('cloudSyncModal');
+        else elements.cloudSyncModal.style.display = "none";
+      },
+      "Cloud Sync close",
+    );
+  }
+
+  // Vault Encrypted Backup Buttons
+  if (elements.vaultExportBtn) {
+    safeAttachListener(
+      elements.vaultExportBtn,
+      "click",
+      function () {
+        openVaultModal("export");
+      },
+      "Vault export button",
+    );
+  }
+
+  if (elements.vaultImportBtn) {
+    safeAttachListener(
+      elements.vaultImportBtn,
+      "click",
+      function () {
+        if (elements.vaultImportFile) elements.vaultImportFile.click();
+      },
+      "Vault import button",
+    );
+  }
+
+  if (elements.vaultImportFile) {
+    safeAttachListener(
+      elements.vaultImportFile,
+      "change",
+      function (e) {
+        var file = e.target.files && e.target.files[0];
+        if (file) {
+          openVaultModal("import", file);
+          // Reset input so the same file can be selected again
+          e.target.value = "";
+        }
+      },
+      "Vault import file input",
+    );
+  }
+
+  // Vault modal live password events
+  (function () {
+    var pw = document.getElementById("vaultPassword");
+    var cpw = document.getElementById("vaultConfirmPassword");
+    if (pw) {
+      pw.addEventListener("input", function () {
+        updateStrengthBar(pw.value);
+        if (cpw) updateMatchIndicator(pw.value, cpw.value);
+      });
+    }
+    if (cpw) {
+      cpw.addEventListener("input", function () {
+        if (pw) updateMatchIndicator(pw.value, cpw.value);
+      });
+    }
+  })();
+
+  // Remove Inventory Data Button
+  if (elements.removeInventoryDataBtn) {
+    safeAttachListener(
+      elements.removeInventoryDataBtn,
+      "click",
+      function () {
+        if (confirm("Remove all inventory items? This cannot be undone.")) {
+          localStorage.removeItem(LS_KEY);
+          loadInventory();
+          renderTable();
+          renderActiveFilters();
+          alert("Inventory data cleared.");
+        }
+      },
+      "Remove inventory data button",
+    );
+  }
+
+  // Boating Accident Button
+  if (elements.boatingAccidentBtn) {
+    safeAttachListener(
+      elements.boatingAccidentBtn,
+      "click",
+      function () {
+        if (
+          confirm(
+            "Did you really lose it all in a boating accident? This will wipe all local data.",
+          )
+        ) {
+          localStorage.removeItem(LS_KEY);
+          localStorage.removeItem(SPOT_HISTORY_KEY);
+          localStorage.removeItem(API_KEY_STORAGE_KEY);
+          localStorage.removeItem(API_CACHE_KEY);
+          Object.values(METALS).forEach((metalConfig) => {
+            localStorage.removeItem(metalConfig.localStorageKey);
+          });
+          sessionStorage.clear();
+
+          loadInventory();
+          renderTable();
+          renderActiveFilters();
+          loadSpotHistory();
+          fetchSpotPrice();
+
+          apiConfig = { provider: "", keys: {} };
+          apiCache = null;
+          updateSyncButtonStates();
+
+          alert("All data has been erased. Hope your scuba gear is ready!");
+        }
+      },
+      "Boating accident button",
+    );
+  }
+};
+
 // MAIN EVENT LISTENERS SETUP
 // =============================================================================
 
@@ -271,1271 +1554,14 @@ const setupEventListeners = () => {
   console.log(`Setting up event listeners (v${APP_VERSION})...`);
 
   try {
-    // Search Input
-    if (elements.searchInput) {
-      const debouncedSearch = debounce(() => {
-        searchQuery = elements.searchInput.value.replace(/[<>]/g, "").trim();
-        renderTable();
-        if (typeof renderActiveFilters === "function") {
-          renderActiveFilters();
-        }
-      }, 300);
-      safeAttachListener(elements.searchInput, "input", debouncedSearch, "Search Input");
-    }
-
-    // Ensure debounce utility is used for search input events
-    const searchInput = document.getElementById('searchInput');
-    if (searchInput) {
-      const debouncedSearchHandler = debounce((event) => {
-        const query = event.target.value;
-        searchQuery = query;
-        filterInventory();
-      }, 300);
-
-      safeAttachListener(
-        searchInput,
-        'input',
-        debouncedSearchHandler,
-        'Debounced search input handler'
-      );
-    }
-
-    // Responsive column handling
+    setupSearchAndChipListeners();
     setupResponsiveColumns();
-
-
-    // CRITICAL HEADER BUTTONS
-    debugLog("Setting up header buttons...");
-
-    // App Logo
-    if (elements.appLogo) {
-      safeAttachListener(
-        elements.appLogo,
-        "click",
-        () => window.location.reload(),
-        "App Logo",
-      );
-    }
-
-    // Settings Button
-    if (elements.settingsBtn) {
-      safeAttachListener(
-        elements.settingsBtn,
-        "click",
-        (e) => {
-          e.preventDefault();
-          debugLog("Settings button clicked");
-          if (typeof showSettingsModal === "function") {
-            showSettingsModal();
-          }
-        },
-        "Settings Button",
-      );
-    }
-
-    // About Button
-    if (elements.aboutBtn) {
-      safeAttachListener(
-        elements.aboutBtn,
-        "click",
-        (e) => {
-          e.preventDefault();
-          if (typeof showAboutModal === "function") {
-            showAboutModal();
-          }
-        },
-        "About Button",
-      );
-    }
-
-
-    // Details modal triggers
-    if (elements.totalTitles && elements.totalTitles.length) {
-      elements.totalTitles.forEach((title) => {
-        safeAttachListener(
-          title,
-          "click",
-          () => {
-            const metal = title.dataset.metal;
-            if (typeof showDetailsModal === "function") {
-              showDetailsModal(metal);
-            }
-          },
-          `Totals title (${title.dataset.metal})`,
-        );
-      });
-    }
-
-    // Chip minimum count dropdown (inline)
-    const chipMinCountEl = document.getElementById('chipMinCount');
-    if (chipMinCountEl) {
-      safeAttachListener(
-        chipMinCountEl,
-        'change',
-        (e) => {
-          const minCount = parseInt(e.target.value, 10);
-          localStorage.setItem('chipMinCount', minCount.toString());
-          // Sync settings modal control
-          const settingsChipMin = document.getElementById('settingsChipMinCount');
-          if (settingsChipMin) settingsChipMin.value = minCount.toString();
-          if (typeof renderActiveFilters === 'function') {
-            renderActiveFilters();
-          }
-        },
-        'Chip minimum count dropdown'
-      );
-    }
-
-    // Grouped name chips toggle (inline)
-    const groupNameChipsEl = document.getElementById('groupNameChips');
-    if (groupNameChipsEl && window.featureFlags) {
-      // Set initial state from feature flag
-      const initVal = window.featureFlags.isEnabled('GROUPED_NAME_CHIPS') ? 'yes' : 'no';
-      groupNameChipsEl.querySelectorAll('.chip-sort-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.val === initVal);
-      });
-
-      groupNameChipsEl.addEventListener('click', (e) => {
-        const btn = e.target.closest('.chip-sort-btn');
-        if (!btn) return;
-        const isEnabled = btn.dataset.val === 'yes';
-        if (isEnabled) {
-          window.featureFlags.enable('GROUPED_NAME_CHIPS');
-        } else {
-          window.featureFlags.disable('GROUPED_NAME_CHIPS');
-        }
-        // Update active state
-        groupNameChipsEl.querySelectorAll('.chip-sort-btn').forEach(b => {
-          b.classList.toggle('active', b.dataset.val === btn.dataset.val);
-        });
-        // Sync settings modal toggle
-        const settingsGroup = document.getElementById('settingsGroupNameChips');
-        if (settingsGroup) {
-          settingsGroup.querySelectorAll('.chip-sort-btn').forEach(b => {
-            b.classList.toggle('active', b.dataset.val === btn.dataset.val);
-          });
-        }
-        if (typeof renderActiveFilters === 'function') renderActiveFilters();
-      });
-    }
-
-    // Chip sort order inline toggle
-    const chipSortEl = document.getElementById('chipSortOrder');
-    if (chipSortEl) {
-      // Restore saved value on setup (migrate 'default' → 'alpha')
-      const savedSort = localStorage.getItem('chipSortOrder');
-      const activeSort = (savedSort === 'count') ? 'count' : 'alpha';
-      chipSortEl.querySelectorAll('.chip-sort-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.sort === activeSort);
-      });
-
-      chipSortEl.addEventListener('click', (e) => {
-        const btn = e.target.closest('.chip-sort-btn');
-        if (!btn) return;
-        const val = btn.dataset.sort;
-        localStorage.setItem('chipSortOrder', val);
-        // Update active state
-        chipSortEl.querySelectorAll('.chip-sort-btn').forEach(b => {
-          b.classList.toggle('active', b.dataset.sort === val);
-        });
-        // Sync settings modal toggle
-        const settingsSort = document.getElementById('settingsChipSortOrder');
-        if (settingsSort) {
-          settingsSort.querySelectorAll('.chip-sort-btn').forEach(b => {
-            b.classList.toggle('active', b.dataset.sort === val);
-          });
-        }
-        if (typeof renderActiveFilters === 'function') renderActiveFilters();
-      });
-    }
-
-    if (elements.detailsCloseBtn) {
-      safeAttachListener(
-        elements.detailsCloseBtn,
-        "click",
-        () => {
-          if (typeof closeDetailsModal === "function") {
-            closeDetailsModal();
-          }
-        },
-        "Close details modal",
-      );
-    }
-
-    // TABLE HEADER SORTING
-    debugLog("Setting up table sorting...");
-    const inventoryTable = document.getElementById("inventoryTable");
-    if (inventoryTable) {
-      const headers = inventoryTable.querySelectorAll("th");
-      headers.forEach((header, index) => {
-        // Skip the Actions column (last column)
-        if (index >= headers.length - 1) {
-          return;
-        }
-
-        header.style.cursor = "pointer";
-
-        safeAttachListener(
-          header,
-          "click",
-          (e) => {
-            if (e.shiftKey) return;
-            // Toggle sort direction if same column, otherwise set to new column with asc
-            if (sortColumn === index) {
-              sortDirection = sortDirection === "asc" ? "desc" : "asc";
-            } else {
-              sortColumn = index;
-              sortDirection = "asc";
-            }
-
-            renderTable();
-          },
-          `Table header ${index}`,
-        );
-      });
-    } else {
-      console.error("Inventory table not found for sorting setup!");
-    }
-
-    // GOLDBACK DENOMINATION PICKER TOGGLE (STACK-45)
-    // Swaps weight text input ↔ denomination select when unit changes to/from 'gb'.
-    // Auto-fills hidden weight value from the selected denomination.
-    window.toggleGbDenomPicker = () => {
-      const isGb = elements.itemWeightUnit && elements.itemWeightUnit.value === 'gb';
-      const weightInput = elements.itemWeight;
-      const denomSelect = elements.itemGbDenom || document.getElementById('itemGbDenom');
-      const weightLabel = document.getElementById('itemWeightLabel');
-
-      if (denomSelect) {
-        denomSelect.style.display = isGb ? '' : 'none';
-      }
-      if (weightInput) {
-        weightInput.style.display = isGb ? 'none' : '';
-        if (isGb && denomSelect) {
-          weightInput.value = denomSelect.value;
-        }
-      }
-      if (weightLabel) {
-        weightLabel.textContent = isGb ? 'Denomination' : 'Weight';
-      }
-    };
-
-    // UNIFIED FORM SUBMISSION (Add + Edit via single #itemModal)
-    debugLog("Setting up unified item form...");
-    if (elements.inventoryForm) {
-      safeAttachListener(
-        elements.inventoryForm,
-        "submit",
-        function (e) {
-          e.preventDefault();
-
-          const isEditing = editingIndex !== null;
-          const existingItem = isEditing ? { ...inventory[editingIndex] } : {};
-
-          // Read all fields (same for both modes)
-          const composition = getCompositionFirstWords(elements.itemMetal.value);
-          const metal = parseNumistaMetal(composition);
-
-          const nameInput = elements.itemName.value.trim();
-          const name = isEditing ? (nameInput || existingItem.name || '') : nameInput;
-
-          const qtyInput = elements.itemQty.value.trim();
-          const qty = qtyInput === '' ? (isEditing ? (existingItem.qty || 1) : 1) : parseInt(qtyInput, 10);
-
-          const type = elements.itemType.value || (isEditing ? existingItem.type : '');
-
-          // Weight: uses real <select>, supports fraction input (e.g. "1/1000", "1 1/2")
-          const weightUnit = elements.itemWeightUnit.value;
-          const denomSelect = elements.itemGbDenom || document.getElementById('itemGbDenom');
-          const weightRaw = (weightUnit === 'gb' && denomSelect) ? denomSelect.value : elements.itemWeight.value;
-          let weight;
-          if (isEditing && weightRaw === '') {
-            weight = typeof existingItem.weight !== 'undefined' ? existingItem.weight : 0;
-          } else {
-            weight = parseFraction(weightRaw);
-            if (weightUnit === 'g') {
-              weight = gramsToOzt(weight);
-            }
-            // gb: weight stays as raw denomination value (conversion happens in computeMeltValue)
-            weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(6));
-          }
-
-          // Price: in edit mode, empty field preserves existing price
-          // User enters in display currency; convert to USD for storage (STACK-50)
-          const priceRaw = elements.itemPrice.value.trim();
-          const fxRate = (typeof getExchangeRate === 'function') ? getExchangeRate() : 1;
-          let price;
-          if (isEditing && priceRaw === '') {
-            price = typeof existingItem.price !== 'undefined' ? existingItem.price : 0;
-          } else {
-            let enteredPrice = priceRaw === '' ? 0 : parseFloat(priceRaw);
-            enteredPrice = isNaN(enteredPrice) || enteredPrice < 0 ? 0 : enteredPrice;
-            price = fxRate !== 1 ? enteredPrice / fxRate : enteredPrice;
-          }
-
-          const purchaseLocation = elements.purchaseLocation.value.trim() || (isEditing ? (existingItem.purchaseLocation || '') : '');
-          const storageLocation = elements.storageLocation.value.trim() || (isEditing ? (existingItem.storageLocation || 'Unknown') : 'Unknown');
-          const serialNumber = (elements.itemSerialNumber || document.getElementById('itemSerialNumber'))?.value?.trim() || (isEditing ? (existingItem.serialNumber || '') : '');
-          const notes = elements.itemNotes.value.trim() || (isEditing ? (existingItem.notes || '') : '');
-          const date = elements.itemDate.value || (isEditing ? (existingItem.date || '') : todayStr());
-
-          const catalog = elements.itemCatalog ? elements.itemCatalog.value.trim() : '';
-          const year = (elements.itemYear || document.getElementById('itemYear'))?.value?.trim() || '';
-          const grade = (elements.itemGrade || document.getElementById('itemGrade'))?.value?.trim() || '';
-          const gradingAuthority = (elements.itemGradingAuthority || document.getElementById('itemGradingAuthority'))?.value?.trim() || '';
-          const certNumber = (elements.itemCertNumber || document.getElementById('itemCertNumber'))?.value?.trim() || '';
-          const pcgsNumber = (elements.itemPcgsNumber || document.getElementById('itemPcgsNumber'))?.value?.trim() || '';
-          const marketValueInput = elements.itemMarketValue ? elements.itemMarketValue.value.trim() : '';
-          let marketValue;
-          if (marketValueInput && !isNaN(parseFloat(marketValueInput))) {
-            const enteredMv = parseFloat(marketValueInput);
-            marketValue = fxRate !== 1 ? enteredMv / fxRate : enteredMv;
-          } else {
-            marketValue = isEditing ? (existingItem.marketValue || 0) : 0;
-          }
-
-          // Purity: read from select or custom input
-          let purity = 1.0;
-          const puritySelect = elements.itemPuritySelect || document.getElementById('itemPuritySelect');
-          if (puritySelect && puritySelect.value === 'custom') {
-            const purityInput = elements.itemPurity || document.getElementById('itemPurity');
-            purity = purityInput ? (parseFloat(purityInput.value) || 1.0) : 1.0;
-          } else if (puritySelect) {
-            purity = parseFloat(puritySelect.value) || 1.0;
-          }
-          if (isEditing && !puritySelect) {
-            purity = existingItem.purity || 1.0;
-          }
-
-          // Validate mandatory fields
-          if (
-            !name ||
-            !date ||
-            !type ||
-            !metal ||
-            isNaN(weight) ||
-            weight <= 0 ||
-            isNaN(qty) ||
-            qty < 1 ||
-            !Number.isInteger(qty)
-          ) {
-            return alert("Please enter valid values for Name, Date, Type, Metal, Weight, and Quantity.");
-          }
-
-          if (isEditing) {
-            // --- EDIT MODE ---
-            const oldItem = { ...inventory[editingIndex] };
-            const serial = oldItem.serial;
-
-            inventory[editingIndex] = {
-              ...oldItem,
-              metal,
-              composition,
-              name,
-              qty,
-              type,
-              weight,
-              weightUnit,
-              price,
-              marketValue,
-              date,
-              purchaseLocation,
-              storageLocation,
-              serialNumber,
-              notes,
-              year,
-              grade,
-              gradingAuthority,
-              certNumber,
-              pcgsNumber,
-              purity,
-              isCollectable: false,
-              numistaId: catalog,
-              currency: displayCurrency,
-            };
-
-            addCompositionOption(composition);
-
-            try {
-              if (window.catalogManager && inventory[editingIndex].numistaId) {
-                catalogManager.setCatalogId(serial, inventory[editingIndex].numistaId);
-              }
-            } catch (catErr) {
-              console.warn('Failed to update catalog mapping:', catErr);
-            }
-
-            saveInventory();
-
-            // Record price data point if price-related fields changed (STACK-43)
-            if (typeof recordSingleItemPrice === 'function') {
-              const cur = inventory[editingIndex];
-              const priceChanged = oldItem.marketValue !== cur.marketValue
-                || oldItem.price !== cur.price || oldItem.weight !== cur.weight
-                || oldItem.qty !== cur.qty || oldItem.metal !== cur.metal
-                || oldItem.purity !== cur.purity;
-              if (priceChanged) recordSingleItemPrice(cur, 'edit');
-            }
-
-            renderTable();
-            renderActiveFilters();
-            logItemChanges(oldItem, inventory[editingIndex]);
-
-            editingIndex = null;
-            editingChangeLogIndex = null;
-          } else {
-            // --- ADD MODE ---
-            const metalKey = metal.toLowerCase();
-            const spotPriceAtPurchase = spotPrices[metalKey] ?? 0;
-            const serial = getNextSerial();
-
-            inventory.push({
-              metal,
-              composition,
-              name,
-              qty,
-              type,
-              weight,
-              weightUnit,
-              price,
-              marketValue,
-              date,
-              purchaseLocation,
-              storageLocation,
-              serialNumber,
-              notes,
-              year,
-              grade,
-              gradingAuthority,
-              certNumber,
-              pcgsNumber,
-              pcgsVerified: false,
-              purity,
-              spotPriceAtPurchase,
-              premiumPerOz: 0,
-              totalPremium: 0,
-              isCollectable: false,
-              serial,
-              uuid: generateUUID(),
-              numistaId: catalog,
-              currency: displayCurrency,
-            });
-
-            typeof registerName === "function" && registerName(name);
-            addCompositionOption(composition);
-
-            if (window.catalogManager && catalog) {
-              catalogManager.setCatalogId(serial, catalog);
-            }
-
-            saveInventory();
-
-            // Record initial price data point (STACK-43)
-            if (typeof recordSingleItemPrice === 'function') {
-              recordSingleItemPrice(inventory[inventory.length - 1], 'add');
-            }
-
-            renderTable();
-            this.reset();
-            elements.itemWeightUnit.value = "oz";
-            elements.itemDate.value = todayStr();
-          }
-
-          // Close modal
-          try {
-            if (typeof closeModalById === 'function') {
-              closeModalById('itemModal');
-            } else if (elements.itemModal) {
-              elements.itemModal.style.display = 'none';
-              document.body.style.overflow = '';
-            }
-          } catch (closeErr) {
-            console.warn('Failed to close item modal:', closeErr);
-          }
-
-          // Update filter chips after inventory mutation
-          if (typeof renderActiveFilters === 'function') {
-            renderActiveFilters();
-          }
-        },
-        "Unified item form",
-      );
-    } else {
-      console.error("Main inventory form not found!");
-    }
-
-    // UNDO CHANGE BUTTON
-    if (elements.undoChangeBtn) {
-      safeAttachListener(
-        elements.undoChangeBtn,
-        "click",
-        (e) => {
-          if (e && typeof e.preventDefault === 'function') e.preventDefault();
-          if (editingChangeLogIndex !== null) {
-            toggleChange(editingChangeLogIndex);
-            try { if (typeof closeModalById === 'function') closeModalById('itemModal'); } catch(undoErr) {}
-            editingIndex = null;
-            editingChangeLogIndex = null;
-            renderChangeLog();
-          }
-        },
-        "Undo change button",
-      );
-    }
-
-    // ITEM MODAL CLOSE / CANCEL BUTTONS
-    if (elements.cancelItemBtn) {
-      safeAttachListener(
-        elements.cancelItemBtn,
-        "click",
-        function (e) {
-          if (e && typeof e.preventDefault === 'function') e.preventDefault();
-          if (e && typeof e.stopPropagation === 'function') e.stopPropagation();
-          try { if (typeof closeModalById === 'function') closeModalById('itemModal'); } catch(closeErr) {}
-          editingIndex = null;
-          editingChangeLogIndex = null;
-        },
-        "Cancel item button",
-      );
-    }
-
-    if (elements.itemCloseBtn) {
-      safeAttachListener(
-        elements.itemCloseBtn,
-        "click",
-        (e) => {
-          if (e && typeof e.preventDefault === 'function') e.preventDefault();
-          if (e && typeof e.stopPropagation === 'function') e.stopPropagation();
-          try { if (typeof closeModalById === 'function') closeModalById('itemModal'); } catch(closeErr) {}
-          editingIndex = null;
-          editingChangeLogIndex = null;
-        },
-        "Item modal close button",
-      );
-    }
-
-    // SEARCH NUMISTA BUTTON — lookup by N# or search by name
-    if (elements.searchNumistaBtn) {
-      safeAttachListener(
-        elements.searchNumistaBtn,
-        "click",
-        async () => {
-          const catalogVal = (elements.itemCatalog || document.getElementById('itemCatalog'))?.value.trim() || '';
-          const nameVal = (elements.itemName || document.getElementById('itemName'))?.value.trim() || '';
-
-          if (!catalogVal && !nameVal) {
-            alert('Enter a Name or Catalog N# to search.');
-            return;
-          }
-
-          if (!catalogAPI || !catalogAPI.activeProvider) {
-            alert('Configure Numista API key in Settings first.');
-            return;
-          }
-
-          const btn = elements.searchNumistaBtn;
-          const originalHTML = btn.innerHTML;
-          btn.textContent = 'Searching...';
-          btn.disabled = true;
-
-          // Type → Numista category mapping for smarter search results
-          const TYPE_TO_NUMISTA_CATEGORY = {
-            'Coin': 'coin',
-            'Bar': 'exonumia',
-            'Round': 'exonumia',
-            'Note': 'banknote',
-            // Aurum omitted — Goldbacks are "Embedded-asset notes" on Numista,
-            // which isn't a valid API category. Uncategorized search finds them.
-            // Set omitted — Numista sets use a different URL scheme (set.php)
-            // and are not searchable via the /types API endpoint.
-          };
-
-          try {
-            if (catalogVal) {
-              // Direct N# lookup → single result
-              const result = await catalogAPI.lookupItem(catalogVal);
-              showNumistaResults(result ? [result] : [], true, catalogVal);
-            } else {
-              // Name search → multiple results with smart category/metal filtering
-              const typeVal = (elements.itemType || document.getElementById('itemType'))?.value || '';
-              const metalVal = (elements.itemMetal || document.getElementById('itemMetal'))?.value || '';
-
-              const searchFilters = { limit: 20 };
-              const numistaCategory = TYPE_TO_NUMISTA_CATEGORY[typeVal];
-              if (numistaCategory) searchFilters.category = numistaCategory;
-
-              // Prepend metal to query for better results (avoid doubling e.g. "Silver Silver Eagle")
-              const searchQuery = metalVal && !nameVal.toLowerCase().includes(metalVal.toLowerCase())
-                ? `${metalVal} ${nameVal}` : nameVal;
-
-              const results = await catalogAPI.searchItems(searchQuery, searchFilters);
-              showNumistaResults(results, false, searchQuery);
-            }
-          } catch (error) {
-            console.error('Numista search error:', error);
-            alert('Search failed: ' + error.message);
-          } finally {
-            // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
-            btn.innerHTML = originalHTML;
-            btn.disabled = false;
-          }
-        },
-        "Search Numista button",
-      );
-    }
-
-    // LOOKUP PCGS BUTTON — verify by Cert# or look up by PCGS#
-    if (elements.lookupPcgsBtn) {
-      safeAttachListener(
-        elements.lookupPcgsBtn,
-        "click",
-        async () => {
-          if (typeof lookupPcgsFromForm !== 'function') {
-            alert('PCGS lookup is not available.');
-            return;
-          }
-
-          const btn = elements.lookupPcgsBtn;
-          const originalHTML = btn.innerHTML;
-          btn.textContent = 'Looking up...';
-          btn.disabled = true;
-
-          try {
-            const result = await lookupPcgsFromForm();
-
-            if (!result.verified) {
-              alert(result.error || 'PCGS lookup failed.');
-              return;
-            }
-
-            // Show field picker modal instead of auto-filling
-            if (typeof showPcgsFieldPicker === 'function') {
-              showPcgsFieldPicker(result);
-            } else {
-              alert('PCGS field picker not available.');
-            }
-          } catch (error) {
-            console.error('PCGS lookup error:', error);
-            alert('PCGS lookup failed: ' + error.message);
-          } finally {
-            btn.innerHTML = originalHTML;
-            btn.disabled = false;
-          }
-        },
-        "Lookup PCGS button",
-      );
-    }
-
-    // NOTES MODAL BUTTONS
-    if (elements.saveNotesBtn) {
-      safeAttachListener(
-        elements.saveNotesBtn,
-        "click",
-        () => {
-          if (notesIndex === null) return;
-          const textareaElement =
-            elements.notesTextarea || document.getElementById("notesTextarea");
-          const text = textareaElement ? textareaElement.value.trim() : "";
-
-          const oldItem = { ...inventory[notesIndex] };
-          inventory[notesIndex].notes = text;
-          saveInventory();
-          renderTable();
-          logItemChanges(oldItem, inventory[notesIndex]);
-
-          const modalElement =
-            elements.notesModal || document.getElementById("notesModal");
-          if (modalElement) {
-            modalElement.style.display = "none";
-          }
-          notesIndex = null;
-        },
-        "Save notes button",
-      );
-    }
-
-    if (elements.cancelNotesBtn) {
-      safeAttachListener(
-        elements.cancelNotesBtn,
-        "click",
-        () => {
-          const modalElement =
-            elements.notesModal || document.getElementById("notesModal");
-          if (modalElement) {
-            modalElement.style.display = "none";
-          }
-          notesIndex = null;
-        },
-        "Cancel notes button",
-      );
-    }
-
-    if (elements.notesCloseBtn) {
-      safeAttachListener(
-        elements.notesCloseBtn,
-        "click",
-        () => {
-          const modalElement =
-            elements.notesModal || document.getElementById("notesModal");
-          if (modalElement) {
-            modalElement.style.display = "none";
-          }
-          notesIndex = null;
-        },
-        "Notes modal close button",
-      );
-    }
-
-    if (elements.debugCloseBtn) {
-      safeAttachListener(
-        elements.debugCloseBtn,
-        "click",
-        () => {
-          if (typeof hideDebugModal === "function") {
-            hideDebugModal();
-          }
-        },
-        "Debug modal close button",
-      );
-    }
-
-    // Bulk Edit modal open/close
-    if (elements.bulkEditBtn) {
-      safeAttachListener(
-        elements.bulkEditBtn,
-        "click",
-        () => {
-          if (typeof openBulkEdit === "function") openBulkEdit();
-        },
-        "Bulk edit open button",
-      );
-    }
-    if (elements.bulkEditCloseBtn) {
-      safeAttachListener(
-        elements.bulkEditCloseBtn,
-        "click",
-        () => {
-          if (typeof closeBulkEdit === "function") closeBulkEdit();
-        },
-        "Bulk edit close button",
-      );
-    }
-
-      if (elements.changeLogBtn) {
-        safeAttachListener(
-          elements.changeLogBtn,
-          "click",
-          (e) => {
-            e.preventDefault();
-            if (typeof showSettingsModal === "function") {
-              showSettingsModal("changelog");
-            }
-          },
-          "Change log button",
-        );
-      }
-
-      // Settings panel Change Log clear button
-      if (elements.settingsChangeLogClearBtn) {
-        safeAttachListener(
-          elements.settingsChangeLogClearBtn,
-          "click",
-          () => {
-            if (typeof clearChangeLog === "function") clearChangeLog();
-          },
-          "Settings change log clear button",
-        );
-      }
-
-      // Settings Spot History clear button (STACK-44)
-      if (elements.settingsSpotHistoryClearBtn) {
-        safeAttachListener(
-          elements.settingsSpotHistoryClearBtn,
-          "click",
-          () => {
-            if (typeof clearSpotHistory === "function") clearSpotHistory();
-          },
-          "Settings spot history clear button",
-        );
-      }
-
-      // Settings Catalog History clear button (STACK-44)
-      if (elements.settingsCatalogHistoryClearBtn) {
-        safeAttachListener(
-          elements.settingsCatalogHistoryClearBtn,
-          "click",
-          () => {
-            if (typeof clearCatalogHistory === "function") clearCatalogHistory();
-          },
-          "Settings catalog history clear button",
-        );
-      }
-
-      // Settings Price History clear button (STACK-44)
-      if (elements.settingsPriceHistoryClearBtn) {
-        safeAttachListener(
-          elements.settingsPriceHistoryClearBtn,
-          "click",
-          () => {
-            if (typeof clearItemPriceHistory === "function") clearItemPriceHistory();
-          },
-          "Settings price history clear button",
-        );
-      }
-
-      // Price History filter input (STACK-44)
-      if (elements.priceHistoryFilterInput) {
-        safeAttachListener(
-          elements.priceHistoryFilterInput,
-          "input",
-          () => {
-            if (typeof filterItemPriceHistoryTable === "function") filterItemPriceHistoryTable();
-          },
-          "Price history filter input",
-        );
-      }
-
-      if (elements.backupReminder) {
-        safeAttachListener(
-          elements.backupReminder,
-          "click",
-          (e) => {
-            e.preventDefault();
-            if (typeof showSettingsModal === "function") {
-              showSettingsModal('files');
-            }
-          },
-          "Backup reminder link",
-        );
-      }
-
-      if (elements.storageReportLink) {
-        safeAttachListener(
-          elements.storageReportLink,
-          "click",
-          (e) => {
-            e.preventDefault();
-            if (typeof openStorageReportPopup === "function") {
-              openStorageReportPopup();
-            }
-          },
-          "Storage report link",
-        );
-      }
-
-    if (elements.changeLogCloseBtn) {
-      safeAttachListener(
-        elements.changeLogCloseBtn,
-        "click",
-        () => {
-          if (elements.changeLogModal) {
-            if (window.closeModalById) closeModalById('changeLogModal');
-            else {
-              elements.changeLogModal.style.display = "none";
-              document.body.style.overflow = "";
-            }
-          }
-        },
-        "Change log close button",
-      );
-    }
-
-    if (elements.changeLogClearBtn) {
-      safeAttachListener(
-        elements.changeLogClearBtn,
-        "click",
-        () => {
-          if (typeof clearChangeLog === "function") {
-            clearChangeLog();
-          }
-        },
-        "Change log clear button",
-      );
-    }
-
-    // SPOT PRICE EVENT LISTENERS — Sparkline card redesign
-    debugLog("Setting up spot price listeners...");
-    Object.values(METALS).forEach((metalConfig) => {
-      const metalKey = metalConfig.key;
-      const metalName = metalConfig.name;
-
-      // Sync icon button
-      const syncIcon = document.getElementById(`syncIcon${metalName}`);
-      if (syncIcon) {
-        safeAttachListener(
-          syncIcon,
-          "click",
-          () => {
-            debugLog(`Sync icon clicked for ${metalName}`);
-            if (typeof syncSpotPricesFromApi === "function") {
-              syncSpotPricesFromApi(true);
-            } else {
-              alert(
-                "API sync functionality requires Metals API configuration. Please configure an API provider first.",
-              );
-            }
-          },
-          `Sync spot price for ${metalName}`,
-        );
-      }
-
-      // Range dropdown change → re-render sparkline + save preference
-      const rangeSelect = document.getElementById(`spotRange${metalName}`);
-      if (rangeSelect) {
-        // Restore saved preference
-        const saved = typeof loadTrendRanges === "function" ? loadTrendRanges() : {};
-        if (saved[metalKey]) {
-          rangeSelect.value = String(saved[metalKey]);
-        }
-
-        safeAttachListener(
-          rangeSelect,
-          "change",
-          () => {
-            const days = parseInt(rangeSelect.value, 10);
-            if (typeof saveTrendRange === "function") saveTrendRange(metalKey, days);
-            if (typeof updateSparkline === "function") updateSparkline(metalKey);
-          },
-          `Trend range for ${metalName}`,
-        );
-      }
-    });
-
-    // Shift+click capture handler for inline spot price editing
-    document.addEventListener(
-      "click",
-      (e) => {
-        if (!e.shiftKey) return;
-        const valueEl = e.target.closest(".spot-card-value");
-        if (!valueEl) return;
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        const card = valueEl.closest(".spot-card");
-        if (!card || !card.dataset.metal) return;
-
-        if (typeof startSpotInlineEdit === "function") {
-          startSpotInlineEdit(valueEl, card.dataset.metal);
-        }
-      },
-      true,
-    );
-
-    // IMPORT/EXPORT EVENT LISTENERS
-    debugLog("Setting up import/export listeners...");
-
-    let csvImportOverride = false;
-    if (elements.importCsvOverride && elements.importCsvFile) {
-      safeAttachListener(
-        elements.importCsvOverride,
-        "click",
-        () => {
-          if (
-            confirm(
-              "Importing CSV will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
-            )
-          ) {
-            csvImportOverride = true;
-            elements.importCsvFile.click();
-          }
-        },
-        "CSV override button",
-      );
-    }
-    if (elements.importCsvMerge && elements.importCsvFile) {
-      safeAttachListener(
-        elements.importCsvMerge,
-        "click",
-        () => {
-          csvImportOverride = false;
-          elements.importCsvFile.click();
-        },
-        "CSV merge button",
-      );
-    }
-    if (elements.importCsvFile) {
-      safeAttachListener(
-        elements.importCsvFile,
-        "change",
-        function (e) {
-          if (e.target.files.length > 0) {
-
-            const file = e.target.files[0];
-            if (!checkFileSize(file)) {
-              alert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
-            } else {
-              importCsv(file, csvImportOverride);
-            }
-
-          }
-          this.value = "";
-        },
-        "CSV import",
-      );
-    }
-
-    let jsonImportOverride = false;
-    if (elements.importJsonOverride && elements.importJsonFile) {
-      safeAttachListener(
-        elements.importJsonOverride,
-        "click",
-        () => {
-          if (
-            confirm(
-              "Importing JSON will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
-            )
-          ) {
-            jsonImportOverride = true;
-            elements.importJsonFile.click();
-          }
-        },
-        "JSON override button",
-      );
-    }
-    if (elements.importJsonMerge && elements.importJsonFile) {
-      safeAttachListener(
-        elements.importJsonMerge,
-        "click",
-        () => {
-          jsonImportOverride = false;
-          elements.importJsonFile.click();
-        },
-        "JSON merge button",
-      );
-    }
-    if (elements.importJsonFile) {
-      safeAttachListener(
-        elements.importJsonFile,
-        "change",
-        function (e) {
-          if (e.target.files.length > 0) {
-
-            const file = e.target.files[0];
-            if (!checkFileSize(file)) {
-              alert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
-            } else {
-              importJson(file, jsonImportOverride);
-            }
-
-          }
-          this.value = "";
-        },
-        "JSON import",
-      );
-    }
-
-    let numistaOverride = false;
-    const importNumistaBtn = document.getElementById("importNumistaBtn");
-    const mergeNumistaBtn = document.getElementById("mergeNumistaBtn");
-    if (importNumistaBtn && elements.numistaImportFile) {
-      safeAttachListener(
-        importNumistaBtn,
-        "click",
-        () => {
-          if (
-            confirm(
-              "Importing Numista CSV will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
-            )
-          ) {
-            numistaOverride = true;
-            elements.numistaImportFile.click();
-          }
-        },
-        "Import Numista CSV button",
-      );
-    }
-    if (mergeNumistaBtn && elements.numistaImportFile) {
-      safeAttachListener(
-        mergeNumistaBtn,
-        "click",
-        () => {
-          numistaOverride = false;
-          elements.numistaImportFile.click();
-        },
-        "Merge Numista CSV button",
-      );
-    }
-      if (elements.numistaImportFile) {
-        safeAttachListener(
-          elements.numistaImportFile,
-          "change",
-          function (e) {
-            if (e.target.files.length > 0) {
-
-            const file = e.target.files[0];
-            if (!checkFileSize(file)) {
-              alert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
-            } else {
-              importNumistaCsv(file, numistaOverride);
-            }
-          }
-          this.value = "";
-        },
-          "Numista CSV import",
-        );
-      }
-
-      // Export buttons
-      if (elements.exportCsvBtn) {
-        safeAttachListener(
-        elements.exportCsvBtn,
-        "click",
-        exportCsv,
-        "CSV export",
-      );
-    }
-    if (elements.exportJsonBtn) {
-      safeAttachListener(
-        elements.exportJsonBtn,
-        "click",
-        exportJson,
-        "JSON export",
-      );
-    }
-    if (elements.exportPdfBtn) {
-      safeAttachListener(
-        elements.exportPdfBtn,
-        "click",
-        exportPdf,
-        "PDF export",
-      );
-    }
-    if (elements.cloudSyncBtn) {
-      safeAttachListener(
-        elements.cloudSyncBtn,
-        "click",
-        () => {
-          if (elements.cloudSyncModal) {
-            if (window.openModalById) openModalById('cloudSyncModal');
-            else elements.cloudSyncModal.style.display = "flex";
-          }
-        },
-        "Cloud Sync button",
-      );
-    }
-    const cloudSyncCloseBtn = document.getElementById("cloudSyncCloseBtn");
-    if (cloudSyncCloseBtn && elements.cloudSyncModal) {
-      safeAttachListener(
-        cloudSyncCloseBtn,
-        "click",
-        () => {
-          if (window.closeModalById) closeModalById('cloudSyncModal');
-          else elements.cloudSyncModal.style.display = "none";
-        },
-        "Cloud Sync close",
-      );
-    }
-
-    // Vault Encrypted Backup Buttons
-    if (elements.vaultExportBtn) {
-      safeAttachListener(
-        elements.vaultExportBtn,
-        "click",
-        function () {
-          openVaultModal("export");
-        },
-        "Vault export button",
-      );
-    }
-
-    if (elements.vaultImportBtn) {
-      safeAttachListener(
-        elements.vaultImportBtn,
-        "click",
-        function () {
-          if (elements.vaultImportFile) elements.vaultImportFile.click();
-        },
-        "Vault import button",
-      );
-    }
-
-    if (elements.vaultImportFile) {
-      safeAttachListener(
-        elements.vaultImportFile,
-        "change",
-        function (e) {
-          var file = e.target.files && e.target.files[0];
-          if (file) {
-            openVaultModal("import", file);
-            // Reset input so the same file can be selected again
-            e.target.value = "";
-          }
-        },
-        "Vault import file input",
-      );
-    }
-
-    // Vault modal live password events
-    (function () {
-      var pw = document.getElementById("vaultPassword");
-      var cpw = document.getElementById("vaultConfirmPassword");
-      if (pw) {
-        pw.addEventListener("input", function () {
-          updateStrengthBar(pw.value);
-          if (cpw) updateMatchIndicator(pw.value, cpw.value);
-        });
-      }
-      if (cpw) {
-        cpw.addEventListener("input", function () {
-          if (pw) updateMatchIndicator(pw.value, cpw.value);
-        });
-      }
-    })();
-
-    // Remove Inventory Data Button
-    if (elements.removeInventoryDataBtn) {
-      safeAttachListener(
-        elements.removeInventoryDataBtn,
-        "click",
-        function () {
-          if (confirm("Remove all inventory items? This cannot be undone.")) {
-            localStorage.removeItem(LS_KEY);
-            loadInventory();
-            renderTable();
-            renderActiveFilters();
-            alert("Inventory data cleared.");
-          }
-        },
-        "Remove inventory data button",
-      );
-    }
-
-    // Boating Accident Button
-    if (elements.boatingAccidentBtn) {
-      safeAttachListener(
-        elements.boatingAccidentBtn,
-        "click",
-        function () {
-          if (
-            confirm(
-              "Did you really lose it all in a boating accident? This will wipe all local data.",
-            )
-          ) {
-            localStorage.removeItem(LS_KEY);
-            localStorage.removeItem(SPOT_HISTORY_KEY);
-            localStorage.removeItem(API_KEY_STORAGE_KEY);
-            localStorage.removeItem(API_CACHE_KEY);
-            Object.values(METALS).forEach((metalConfig) => {
-              localStorage.removeItem(metalConfig.localStorageKey);
-            });
-            sessionStorage.clear();
-
-            loadInventory();
-            renderTable();
-            renderActiveFilters();
-            loadSpotHistory();
-            fetchSpotPrice();
-
-            apiConfig = { provider: "", keys: {} };
-            apiCache = null;
-            updateSyncButtonStates();
-
-            alert("All data has been erased. Hope your scuba gear is ready!");
-          }
-        },
-        "Boating accident button",
-      );
-    }
+    setupHeaderButtonListeners();
+    setupTableSortListeners();
+    setupItemFormListeners();
+    setupNoteAndModalListeners();
+    setupSpotPriceListeners();
+    setupImportExportListeners();
 
     // API MODAL EVENT LISTENERS
     debugLog("Setting up API modal listeners...");
@@ -1550,7 +1576,7 @@ const setupEventListeners = () => {
     debugLog("✓ All event listeners setup complete");
   } catch (error) {
     console.error("❌ Error setting up event listeners:", error);
-    throw error; // Re-throw to trigger fallback in init.js
+    throw error;
   }
 };
 

--- a/js/events.js
+++ b/js/events.js
@@ -1046,6 +1046,54 @@ const setupEventListeners = () => {
         );
       }
 
+      // Settings Spot History clear button (STACK-44)
+      if (elements.settingsSpotHistoryClearBtn) {
+        safeAttachListener(
+          elements.settingsSpotHistoryClearBtn,
+          "click",
+          () => {
+            if (typeof clearSpotHistory === "function") clearSpotHistory();
+          },
+          "Settings spot history clear button",
+        );
+      }
+
+      // Settings Catalog History clear button (STACK-44)
+      if (elements.settingsCatalogHistoryClearBtn) {
+        safeAttachListener(
+          elements.settingsCatalogHistoryClearBtn,
+          "click",
+          () => {
+            if (typeof clearCatalogHistory === "function") clearCatalogHistory();
+          },
+          "Settings catalog history clear button",
+        );
+      }
+
+      // Settings Price History clear button (STACK-44)
+      if (elements.settingsPriceHistoryClearBtn) {
+        safeAttachListener(
+          elements.settingsPriceHistoryClearBtn,
+          "click",
+          () => {
+            if (typeof clearItemPriceHistory === "function") clearItemPriceHistory();
+          },
+          "Settings price history clear button",
+        );
+      }
+
+      // Price History filter input (STACK-44)
+      if (elements.priceHistoryFilterInput) {
+        safeAttachListener(
+          elements.priceHistoryFilterInput,
+          "input",
+          () => {
+            if (typeof filterItemPriceHistoryTable === "function") filterItemPriceHistoryTable();
+          },
+          "Price history filter input",
+        );
+      }
+
       if (elements.backupReminder) {
         safeAttachListener(
           elements.backupReminder,

--- a/js/init.js
+++ b/js/init.js
@@ -198,6 +198,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Settings change log panel
     elements.settingsChangeLogClearBtn = safeGetElement("settingsChangeLogClearBtn");
 
+    // Settings Activity Log sub-tab elements (STACK-44)
+    elements.settingsSpotHistoryClearBtn = safeGetElement("settingsSpotHistoryClearBtn");
+    elements.settingsCatalogHistoryClearBtn = safeGetElement("settingsCatalogHistoryClearBtn");
+    elements.settingsPriceHistoryClearBtn = safeGetElement("settingsPriceHistoryClearBtn");
+    elements.priceHistoryFilterInput = safeGetElement("priceHistoryFilterInput");
+
     // Pagination elements
     debugLog("Phase 5: Initializing pagination elements...");
     elements.itemsPerPage = safeGetElement("itemsPerPage");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -2154,8 +2154,7 @@ const exportNumistaCsv = () => {
     const year = item.year || item.issuedYear || '';
     let title = item.name || '';
     if (year) {
-      // nosemgrep: javascript.dos.rule-non-literal-regexp
-      const yearRegex = new RegExp(`\\s*${year}\\b`);
+      const yearRegex = new RegExp(`\\s*${String(year).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
       title = title.replace(yearRegex, '').trim();
     }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -57,9 +57,11 @@ const switchSettingsSection = (name) => {
     populateApiSection();
   }
 
-  // Populate change log when switching to changelog section
-  if (name === 'changelog' && typeof renderChangeLog === 'function') {
-    renderChangeLog();
+  // Render the active log sub-tab when switching to the changelog section
+  if (name === 'changelog') {
+    const activeTab = document.querySelector('.settings-log-tab.active');
+    const activeKey = activeTab ? activeTab.dataset.logTab : 'changelog';
+    switchLogTab(activeKey);
   }
 };
 
@@ -81,6 +83,59 @@ const switchProviderTab = (key) => {
   document.querySelectorAll('.settings-provider-tab').forEach(tab => {
     tab.classList.toggle('active', tab.dataset.provider === key);
   });
+};
+
+/**
+ * Switches the visible log sub-tab in the Activity Log panel.
+ * Lazy-renders each sub-tab on first activation via data-rendered attribute.
+ * @param {string} key - Sub-tab key: 'changelog', 'metals', 'catalogs', 'pricehistory'
+ */
+const switchLogTab = (key) => {
+  // Hide all log panels
+  document.querySelectorAll('.settings-log-panel').forEach(panel => {
+    panel.style.display = 'none';
+  });
+
+  // Show target panel
+  const target = document.getElementById(`logPanel_${key}`);
+  if (target) target.style.display = 'block';
+
+  // Update active tab
+  document.querySelectorAll('.settings-log-tab').forEach(tab => {
+    tab.classList.toggle('active', tab.dataset.logTab === key);
+  });
+
+  // Lazy-render on first activation
+  if (target && !target.dataset.rendered) {
+    renderLogTab(key);
+    target.dataset.rendered = '1';
+  }
+
+  // Always re-render changelog (existing behavior — it may have changed)
+  if (key === 'changelog') {
+    renderLogTab(key);
+  }
+};
+
+/**
+ * Dispatches to the appropriate render function for a log sub-tab.
+ * @param {string} key - Sub-tab key
+ */
+const renderLogTab = (key) => {
+  switch (key) {
+    case 'changelog':
+      if (typeof renderChangeLog === 'function') renderChangeLog();
+      break;
+    case 'metals':
+      if (typeof renderSpotHistoryTable === 'function') renderSpotHistoryTable();
+      break;
+    case 'catalogs':
+      if (typeof renderCatalogHistoryForSettings === 'function') renderCatalogHistoryForSettings();
+      break;
+    case 'pricehistory':
+      if (typeof renderItemPriceHistoryTable === 'function') renderItemPriceHistoryTable();
+      break;
+  }
 };
 
 /**
@@ -230,6 +285,13 @@ const setupSettingsEventListeners = () => {
   document.querySelectorAll('.settings-provider-tab').forEach(tab => {
     tab.addEventListener('click', () => {
       switchProviderTab(tab.dataset.provider);
+    });
+  });
+
+  // Log sub-tabs
+  document.querySelectorAll('[data-log-tab]').forEach(tab => {
+    tab.addEventListener('click', () => {
+      switchLogTab(tab.dataset.logTab);
     });
   });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -602,6 +602,7 @@ const saveExchangeRates = (rates) => {
  */
 const fetchExchangeRates = async () => {
   try {
+    // Safe: URL from hardcoded constant EXCHANGE_RATE_API_URL or fallback literal
     const url = typeof EXCHANGE_RATE_API_URL !== 'undefined'
       ? EXCHANGE_RATE_API_URL
       : 'https://open.er-api.com/v6/latest/USD';

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -93,6 +93,9 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.24.03": `
+      <li><strong>Fixed</strong>: Goldback melt values inflated 1000x in Details Modal &mdash; apply GB_TO_OZT conversion and denomination retail pricing</li>
+    `,
     "3.24.02": `
       <li><strong>Added</strong>: Activity Log sub-tabs in Settings &mdash; Changelog, Metals, Catalogs, Price History (STACK-44)</li>
       <li><strong>Added</strong>: Sortable spot price history, catalog API call log, and per-item price history tables</li>

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -93,6 +93,11 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.24.02": `
+      <li><strong>Added</strong>: Activity Log sub-tabs in Settings &mdash; Changelog, Metals, Catalogs, Price History (STACK-44)</li>
+      <li><strong>Added</strong>: Sortable spot price history, catalog API call log, and per-item price history tables</li>
+      <li><strong>Added</strong>: Filter and clear buttons for each log sub-tab with confirmation dialogs</li>
+    `,
     "3.24.01": `
       <li><strong>Fixed</strong>: Convert innerHTML to textContent for plain-text currency formatting</li>
       <li><strong>Changed</strong>: Add PMD, ESLint, and Semgrep configuration to resolve 90 Codacy issues</li>


### PR DESCRIPTION
## Summary

- **Fixed**: Goldback melt values inflated 1000x in Details Modal — `detailsModal.js` computed melt as `weight * spot * purity` without applying the `GB_TO_OZT` (0.001) conversion that `computeMeltValue()` correctly uses
- **Fixed**: Weight display showed raw denomination totals (e.g., 11.50 oz) instead of actual troy ounces (~0.01 oz)
- **Fixed**: Goldback denomination retail pricing (`getGoldbackRetailPrice`) now applied in both single-metal and all-metals breakdown views
- **Fixed**: Codacy remediation — RegExp escaping, URL validation, complexity reduction

## Files Updated

- `js/detailsModal.js` — Apply GB_TO_OZT conversion and Goldback retail pricing in `getBreakdownData()` and `getAllMetalsBreakdownData()`
- `js/constants.js` — APP_VERSION → 3.24.03
- `CHANGELOG.md` — New section for 3.24.03
- `docs/announcements.md` — New What's New entry
- `js/versionCheck.js` — Embedded changelog fallback
- `js/about.js` — Embedded What's New fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)