### PR TITLE
v3.24.04 — STACK-55: Bulk Editor clean selection on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.24.04] - 2026-02-12
+
+### Fixed — STACK-55: Bulk Editor retains selected items after close/reopen
+
+- **Fixed**: Bulk Editor now starts with a clean selection every time it opens (STACK-55)
+- **Removed**: `bulkEditSelection` localStorage persistence — selection no longer carries across sessions
+
+---
+
 ## [3.24.03] - 2026-02-12
 
 ### Fixed — Goldback melt/retail/weight in Details Modal

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **STACK-55: Bulk Editor clean selection (v3.24.04)**: Bulk Editor now resets selection on every open. Removed stale localStorage persistence
 - **Fix Goldback melt/retail/weight in Details Modal (v3.24.03)**: Goldback melt values no longer inflated 1000x in breakdown modals. Applies GB_TO_OZT conversion and denomination retail pricing
 - **STACK-44: Activity Log sub-tabs (v3.24.02)**: Settings Log panel reorganized with 4 sub-tabs — Changelog, Metals (spot history), Catalogs (API calls), Price History (per-item). Sortable tables, filter, and clear buttons for each
 - **Codacy code quality cleanup (v3.24.01)**: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved
 - **STACK-50: Multi-Currency Support (v3.24.00)**: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix
-- **STACK-52: Bulk Edit pinned selections (v3.23.02)**: Selected items stay visible at top of table when search changes. Removed dormant prototype files
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -272,11 +272,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.24.04 &ndash; STACK-55: Bulk Editor clean selection</strong>: Bulk Editor now resets selection on every open. Removed stale localStorage persistence</li>
     <li><strong>v3.24.03 &ndash; Fix Goldback melt/retail/weight in Details Modal</strong>: Goldback melt values no longer inflated 1000x in breakdown modals. Applies GB_TO_OZT conversion and denomination retail pricing</li>
     <li><strong>v3.24.02 &ndash; STACK-44: Activity Log sub-tabs</strong>: Settings Log panel reorganized with 4 sub-tabs &mdash; Changelog, Metals, Catalogs, Price History. Sortable tables, filter, and clear buttons</li>
     <li><strong>v3.24.01 &ndash; Codacy code quality cleanup</strong>: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved</li>
     <li><strong>v3.24.00 &ndash; STACK-50: Multi-Currency Support</strong>: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix</li>
-    <li><strong>v3.23.02 &ndash; STACK-52: Bulk Edit pinned selections</strong>: Selected items stay visible at top of table when search changes. Removed dormant prototype files</li>
   `;
 };
 

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -101,24 +101,8 @@ const openBulkEdit = () => {
   const modal = safeGetElement('bulkEditModal');
   if (!modal) return;
 
-  // Restore persisted selection
-  try {
-    const saved = localStorage.getItem('bulkEditSelection');
-    if (saved) {
-      const arr = JSON.parse(saved);
-      if (Array.isArray(arr)) bulkSelection = new Set(arr.map(String));
-    }
-  } catch (e) {
-    debugLog('bulkEdit: failed to restore selection', e);
-  }
-
-  // Prune selection — remove serials that no longer exist in inventory
-  if (typeof inventory !== 'undefined' && Array.isArray(inventory)) {
-    const validSerials = new Set(inventory.map(item => String(item.serial)));
-    bulkSelection.forEach(s => {
-      if (!validSerials.has(s)) bulkSelection.delete(s);
-    });
-  }
+  // Always start with a clean selection (STACK-55)
+  bulkSelection = new Set();
 
   modal.style.display = 'flex';
   document.body.style.overflow = 'hidden';
@@ -135,13 +119,6 @@ const openBulkEdit = () => {
 const closeBulkEdit = () => {
   const modal = safeGetElement('bulkEditModal');
   if (!modal) return;
-
-  // Persist selection
-  try {
-    localStorage.setItem('bulkEditSelection', JSON.stringify([...bulkSelection]));
-  } catch (e) {
-    debugLog('bulkEdit: failed to persist selection', e);
-  }
 
   // Clear Numista callback
   window._bulkEditNumistaCallback = null;

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-11 - STACK-44: Settings Log tab reorganization with sub-tabs
  */
 
-const APP_VERSION = "3.24.03";
+const APP_VERSION = "3.24.04";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -556,7 +556,6 @@ const ALLOWED_STORAGE_KEYS = [
   "apiProviderOrder",
   "filterChipCategoryConfig",
   "chipSortOrder",
-  "bulkEditSelection",
   GOLDBACK_PRICES_KEY,
   GOLDBACK_PRICE_HISTORY_KEY,
   GOLDBACK_ENABLED_KEY,

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -93,6 +93,10 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.24.04": `
+      <li><strong>Fixed</strong>: Bulk Editor now starts with a clean selection every time it opens (STACK-55)</li>
+      <li><strong>Removed</strong>: <code>bulkEditSelection</code> localStorage persistence</li>
+    `,
     "3.24.03": `
       <li><strong>Fixed</strong>: Goldback melt values inflated 1000x in Details Modal &mdash; apply GB_TO_OZT conversion and denomination retail pricing</li>
     `,


### PR DESCRIPTION
## Summary

- **Fixed**: Bulk Editor now resets selection to empty every time it opens — no more stale checkboxes from previous sessions (STACK-55)
- **Removed**: `bulkEditSelection` localStorage persistence and `ALLOWED_STORAGE_KEYS` entry

## Files Updated

- `js/bulkEdit.js` — Replace 15-line restore/prune + 6-line persist with `bulkSelection = new Set()`
- `js/constants.js` — APP_VERSION → 3.24.04, remove `bulkEditSelection` from storage whitelist
- `CHANGELOG.md` — New section for 3.24.04
- `docs/announcements.md` — New What's New entry
- `js/versionCheck.js` — Embedded changelog fallback
- `js/about.js` — Embedded What's New fallback

## Linear Issues

- STACK-55: Bulk Editor retains selected items after close/reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)