### PR TITLE
v3.24.05 — Code cleanup: debugLog, dead parameter, version comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.24.05] - 2026-02-12
+
+### Fixed — Code cleanup and minor fixes
+
+- **Fixed**: `debugLog('warn', ...)` in custom API validation now uses `console.warn()` (debugLog has no level support)
+- **Removed**: Unused `columns` parameter from `buildBulkItemRow()` in Bulk Edit
+- **Fixed**: Stale `Updated:` comment on APP_VERSION docblock
+
+---
+
 ## [3.24.04] - 2026-02-12
 
 ### Fixed — STACK-55: Bulk Editor retains selected items after close/reopen

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Code cleanup (v3.24.05)**: Fix debugLog warn level, remove dead parameter, update version comment
 - **STACK-55: Bulk Editor clean selection (v3.24.04)**: Bulk Editor now resets selection on every open. Removed stale localStorage persistence
 - **Fix Goldback melt/retail/weight in Details Modal (v3.24.03)**: Goldback melt values no longer inflated 1000x in breakdown modals. Applies GB_TO_OZT conversion and denomination retail pricing
 - **STACK-44: Activity Log sub-tabs (v3.24.02)**: Settings Log panel reorganized with 4 sub-tabs — Changelog, Metals (spot history), Catalogs (API calls), Price History (per-item). Sortable tables, filter, and clear buttons for each
-- **Codacy code quality cleanup (v3.24.01)**: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved
 - **STACK-50: Multi-Currency Support (v3.24.00)**: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix
 
 ## Development Roadmap

--- a/js/about.js
+++ b/js/about.js
@@ -272,10 +272,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.24.05 &ndash; Code cleanup</strong>: Fix debugLog warn level, remove dead parameter, update version comment</li>
     <li><strong>v3.24.04 &ndash; STACK-55: Bulk Editor clean selection</strong>: Bulk Editor now resets selection on every open. Removed stale localStorage persistence</li>
     <li><strong>v3.24.03 &ndash; Fix Goldback melt/retail/weight in Details Modal</strong>: Goldback melt values no longer inflated 1000x in breakdown modals. Applies GB_TO_OZT conversion and denomination retail pricing</li>
     <li><strong>v3.24.02 &ndash; STACK-44: Activity Log sub-tabs</strong>: Settings Log panel reorganized with 4 sub-tabs &mdash; Changelog, Metals, Catalogs, Price History. Sortable tables, filter, and clear buttons</li>
-    <li><strong>v3.24.01 &ndash; Codacy code quality cleanup</strong>: innerHTML-to-textContent fixes, PMD/ESLint/Semgrep configuration. 90 issues resolved</li>
     <li><strong>v3.24.00 &ndash; STACK-50: Multi-Currency Support</strong>: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix</li>
   `;
 };

--- a/js/api.js
+++ b/js/api.js
@@ -949,7 +949,7 @@ const fetchLatestPrices = async (provider, apiKey, selectedMetals) => {
           throw new Error('Custom API base must use HTTPS');
         }
       } catch (urlErr) {
-        debugLog('warn', 'Invalid custom API base URL:', base, urlErr.message);
+        console.warn('Invalid custom API base URL:', base, urlErr.message);
         return results;
       }
       const metalCodes = {

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -192,10 +192,9 @@ const coerceFieldValue = (fieldId, value) => {
  * Builds a table row element for a single inventory item in the bulk edit table.
  * @param {Object} item - The inventory item
  * @param {boolean} isPinned - Whether the row is in the pinned section
- * @param {Array} columns - Column definitions array
  * @returns {HTMLTableRowElement} The constructed row
  */
-const buildBulkItemRow = (item, isPinned, columns) => {
+const buildBulkItemRow = (item, isPinned) => {
   const serial = String(item.serial);
   const tr = document.createElement('tr');
   tr.setAttribute('data-serial', serial);
@@ -527,7 +526,7 @@ const renderBulkTableBody = () => {
 
     // Pinned rows
     pinnedItems.forEach(item => {
-      tbody.appendChild(buildBulkItemRow(item, true, columns));
+      tbody.appendChild(buildBulkItemRow(item, true));
     });
 
     // Divider
@@ -541,7 +540,7 @@ const renderBulkTableBody = () => {
 
   // Filtered rows
   filtered.forEach(item => {
-    tbody.appendChild(buildBulkItemRow(item, false, columns));
+    tbody.appendChild(buildBulkItemRow(item, false));
   });
 
   table.appendChild(tbody);

--- a/js/constants.js
+++ b/js/constants.js
@@ -251,10 +251,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-11 - STACK-44: Settings Log tab reorganization with sub-tabs
+ * Updated: 2026-02-12 - STACK-55: Bulk Editor clean selection, code cleanup
  */
 
-const APP_VERSION = "3.24.04";
+const APP_VERSION = "3.24.05";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -93,6 +93,11 @@ const populateVersionModal = (version, html) => {
  */
 const getEmbeddedChangelog = (version) => {
   const changelogs = {
+    "3.24.05": `
+      <li><strong>Fixed</strong>: <code>debugLog('warn', ...)</code> now uses <code>console.warn()</code></li>
+      <li><strong>Removed</strong>: Unused <code>columns</code> parameter from <code>buildBulkItemRow()</code></li>
+      <li><strong>Fixed</strong>: Stale version comment on APP_VERSION docblock</li>
+    `,
     "3.24.04": `
       <li><strong>Fixed</strong>: Bulk Editor now starts with a clean selection every time it opens (STACK-55)</li>
       <li><strong>Removed</strong>: <code>bulkEditSelection</code> localStorage persistence</li>


### PR DESCRIPTION
## Summary

- **Fixed**: `debugLog('warn', ...)` in custom API URL validation now uses `console.warn()` — `debugLog` doesn't support log levels
- **Removed**: Unused `columns` parameter from `buildBulkItemRow()` and both call sites in Bulk Edit
- **Fixed**: Stale `Updated:` comment on APP_VERSION docblock (now references STACK-55 / 2026-02-12)

## Files Updated

- `js/api.js` — `debugLog('warn', ...)` → `console.warn(...)`
- `js/bulkEdit.js` — Remove `columns` param from function signature and 2 call sites
- `js/constants.js` — APP_VERSION → 3.24.05, updated docblock comment
- `CHANGELOG.md` — New section for 3.24.05
- `docs/announcements.md` — New What's New entry
- `js/versionCheck.js` — Embedded changelog fallback
- `js/about.js` — Embedded What's New fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)