### PR TITLE
STACK-60: Fix Source/Storage click-to-filter for empty values

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,7 @@ Multi-currency is shipped (STACK-50). These items are unblocked and ready for th
 | [STACK-49](https://linear.app/hextrackr/issue/STACK-49) | Spot Price Lookup by Date on Add/Edit Form | Low | — |
 | [STACK-51](https://linear.app/hextrackr/issue/STACK-51) | Custom CSV import mapper with header mapping UI and saved profiles | Medium | — |
 | [STACK-53](https://linear.app/hextrackr/issue/STACK-53) | [RFC] Community spot price history CDN via GitHub with manifest-based selective import | Medium | — |
+| [STACK-60](https://linear.app/hextrackr/issue/STACK-60) | Source "—" click-to-filter returns no results for empty source items | Low | — |
 
 ---
 

--- a/js/filters.js
+++ b/js/filters.js
@@ -720,13 +720,17 @@ const filterInventoryAdvanced = () => {
           break;
         case 'purchaseLocation':
           result = result.filter(item => {
-            const match = values.includes(item.purchaseLocation);
+            const loc = item.purchaseLocation;
+            const normalized = (!loc || loc === 'Unknown' || loc === 'Numista Import') ? '—' : loc;
+            const match = values.includes(normalized);
             return exclude ? !match : match;
           });
           break;
         case 'storageLocation':
           result = result.filter(item => {
-            const match = values.includes(item.storageLocation);
+            const loc = item.storageLocation;
+            const normalized = (!loc || loc === 'Unknown' || loc === 'Numista Import') ? '—' : loc;
+            const match = values.includes(normalized);
             return exclude ? !match : match;
           });
           break;


### PR DESCRIPTION
## Summary
- Clicking "—" in the Source or Storage Location columns triggered a filter that returned **zero results** instead of showing items with no source/storage
- Root cause: display logic converts empty/null/"Unknown"/"Numista Import" to "—", but the filter compared against the raw stored value (empty string)
- Fix normalizes stored values to "—" before filter comparison, matching the display logic

## Test plan
- [ ] Click "—" in Source column → should show all items with no purchase location
- [ ] Click "—" in Storage column → should show all items with no storage location
- [ ] Click a real source/storage value → should still filter correctly
- [ ] Exclude filter (right-click "—") → should hide empty-source items
- [ ] Items with "Unknown" or "Numista Import" source → should match "—" filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)