### PR TITLE
Update Reddit links to r/staktrakr

### DIFF
--- a/index.html
+++ b/index.html
@@ -1207,7 +1207,7 @@
           <a href="https://github.com/lbruton/StackTrackr" target="_blank" rel="noopener"><img src="https://img.shields.io/github/license/lbruton/StackTrackr?style=flat-square" alt="MIT License" height="20"></a>
           <a href="https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
           <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StackTrackr?style=flat-square" alt="GitHub Issues" height="20"></a>
-          <a href="https://www.reddit.com/r/stackrtrackr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/stackrtrackr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
+          <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
         </div>
       </div>
     </footer>
@@ -1318,7 +1318,7 @@
                 <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
                 Source
               </a>
-              <a href="https://www.reddit.com/r/stackrtrackr/" target="_blank" rel="noopener" class="about-badge">
+              <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener" class="about-badge">
                 <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
                 Community
               </a>


### PR DESCRIPTION
## Summary
- Updated footer badge link and shields.io subscriber badge from `r/stackrtrackr` to `r/staktrakr`
- Updated About modal community badge link from `r/stackrtrackr` to `r/staktrakr`

## Test plan
- [ ] Footer badge loads subscriber count from shields.io for `r/staktrakr`
- [ ] Footer badge links to `https://www.reddit.com/r/staktrakr/`
- [ ] About modal Community badge links to `https://www.reddit.com/r/staktrakr/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)