### PR TITLE
STACK-54: Appearance settings — header shortcuts & layout visibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1301,6 +1301,65 @@ input[type="submit"] {
   font-size: 0.9rem;
 }
 
+/* Header toggle buttons (STACK-54) */
+.header-toggle-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Settings checkbox labels (STACK-54) */
+.settings-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  cursor: pointer;
+  font-size: 0.9375rem;
+}
+
+.settings-checkbox-label input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
+/* Header currency dropdown (STACK-54) */
+.header-currency-dropdown {
+  position: fixed;
+  z-index: 9999;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow);
+  max-height: 320px;
+  overflow-y: auto;
+  min-width: 220px;
+  padding: 0.25rem 0;
+}
+
+.header-currency-item {
+  display: block;
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.header-currency-item:hover {
+  background: var(--bg-elev-1);
+}
+
+.header-currency-item.active {
+  color: var(--primary);
+  font-weight: 600;
+}
+
 .theme-buttons {
   display: flex;
   gap: 1rem;

--- a/index.html
+++ b/index.html
@@ -188,7 +188,39 @@
         </h1>
       </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
-        <button class="btn theme-btn" id="aboutBtn" title="About" aria-label="About">📖</button>
+        <!-- Theme cycle button (STACK-54) -->
+        <button class="btn theme-btn header-toggle-btn" id="headerThemeBtn"
+                title="Cycle theme" aria-label="Cycle theme">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+        </button>
+        <!-- Currency toggle button (STACK-54) -->
+        <button class="btn theme-btn header-toggle-btn" id="headerCurrencyBtn"
+                title="Toggle currency" aria-label="Toggle currency">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="12" y1="1" x2="12" y2="23"/>
+            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+          </svg>
+        </button>
+        <button class="btn theme-btn" id="aboutBtn" title="About" aria-label="About">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="12" y1="16" x2="12" y2="12"/>
+            <line x1="12" y1="8" x2="12.01" y2="8"/>
+          </svg>
+        </button>
         <button class="btn theme-btn" id="settingsBtn" title="Settings" aria-label="Settings">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
         </button>
@@ -206,7 +238,7 @@
          
          Spot prices are used for premium calculations and profit/loss analysis
          ============================================================================= -->
-      <section class="spot-prices">
+      <section class="spot-prices" id="spotPricesSection">
         <div
           class="grid"
           style="
@@ -328,7 +360,7 @@
          All calculations are performed by updateSummary() in inventory.js
          Values are updated automatically when inventory changes
          ============================================================================= -->
-      <section class="totals-section">
+      <section class="totals-section" id="totalsSectionEl">
         <div class="totals">
           <!-- Silver totals card -->
           <div class="total-card silver">
@@ -548,7 +580,7 @@
            Search is case-insensitive and supports partial matches
            Implementation in search.js with filterInventory() function
            ============================================================================= -->
-        <section class="search-section">
+        <section class="search-section" id="searchSectionEl">
           <div class="search-container">
             <button
               class="btn search-action-btn add-btn"
@@ -640,7 +672,7 @@
         Table rendering handled by renderTable() in inventory.js
          Portal view shows all items in a scrollable table with sticky headers
          ============================================================================= -->
-        <section class="table-section">
+        <section class="table-section" id="tableSectionEl">
           <div class="portal-scroll">
           <table id="inventoryTable">
           <thead>
@@ -1475,6 +1507,15 @@
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="19" cy="13" r="2.5"/><circle cx="16" cy="20" r="2.5"/><circle cx="7" cy="20" r="2.5"/><circle cx="4" cy="13" r="2.5"/><circle cx="12" cy="13" r="3"/></svg>
               Appearance
             </button>
+            <button class="settings-nav-item" data-section="layout">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                   stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+                <line x1="3" y1="9" x2="21" y2="9"/>
+                <line x1="9" y1="21" x2="9" y2="9"/>
+              </svg>
+              Layout
+            </button>
             <button class="settings-nav-item" data-section="system">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
               System
@@ -1531,11 +1572,45 @@
                 <select id="settingsDisplayCurrency"></select>
               </div>
 
+              <!-- Header shortcuts (STACK-54) -->
+              <div class="settings-group">
+                <div class="settings-group-label">Header shortcuts</div>
+                <p class="settings-subtext">Show quick-access buttons in the app header.</p>
+                <label class="settings-checkbox-label">
+                  <input type="checkbox" id="settingsHeaderThemeBtn" checked> Theme cycle button
+                </label>
+                <label class="settings-checkbox-label">
+                  <input type="checkbox" id="settingsHeaderCurrencyBtn" checked> Currency toggle button
+                </label>
+              </div>
+
               <div class="settings-placeholder" style="margin-top: 1.5rem;">
                 <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="19" cy="13" r="2.5"/><circle cx="16" cy="20" r="2.5"/><circle cx="7" cy="20" r="2.5"/><circle cx="4" cy="13" r="2.5"/><circle cx="12" cy="13" r="3"/></svg>
                 <p>Custom themes coming soon.</p>
               </div>
 
+            </div>
+
+            <!-- ===== LAYOUT SETTINGS (STACK-54) ===== -->
+            <div class="settings-section-panel" id="settingsPanel_layout" style="display: none">
+              <h3>Layout</h3>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Visible sections</div>
+                <p class="settings-subtext">Toggle major page sections on or off. Hidden sections are still functional — just not visible.</p>
+                <label class="settings-checkbox-label">
+                  <input type="checkbox" id="layoutSpotPrices" checked> Spot price cards
+                </label>
+                <label class="settings-checkbox-label">
+                  <input type="checkbox" id="layoutTotals" checked> Summary totals
+                </label>
+                <label class="settings-checkbox-label">
+                  <input type="checkbox" id="layoutSearch" checked> Search & filter bar
+                </label>
+                <label class="settings-checkbox-label">
+                  <input type="checkbox" id="layoutTable" checked> Inventory table
+                </label>
+              </div>
             </div>
 
             <!-- ===== TABLE SETTINGS ===== -->

--- a/js/constants.js
+++ b/js/constants.js
@@ -563,6 +563,9 @@ const ALLOWED_STORAGE_KEYS = [
   GB_ESTIMATE_MODIFIER_KEY,
   DISPLAY_CURRENCY_KEY,
   EXCHANGE_RATES_KEY,
+  "headerThemeBtnVisible",    // boolean string: "true"/"false" (STACK-54)
+  "headerCurrencyBtnVisible", // boolean string: "true"/"false" (STACK-54)
+  "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54)
 ];
 
 // =============================================================================

--- a/js/init.js
+++ b/js/init.js
@@ -118,6 +118,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.settingsBtn = safeGetElement("settingsBtn", true);
     elements.aboutBtn = safeGetElement("aboutBtn");
 
+    // STACK-54 header toggles
+    elements.headerThemeBtn = safeGetElement("headerThemeBtn");
+    elements.headerCurrencyBtn = safeGetElement("headerCurrencyBtn");
+
+    // STACK-54 layout sections
+    elements.spotPricesSection = safeGetElement("spotPricesSection");
+    elements.totalsSectionEl = safeGetElement("totalsSectionEl");
+    elements.searchSectionEl = safeGetElement("searchSectionEl");
+    elements.tableSectionEl = safeGetElement("tableSectionEl");
+
     // Check if critical buttons exist
     debugLog(
       "Settings Button found:",
@@ -407,6 +417,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     } else if (earlyTheme === 'sepia') {
       document.documentElement.setAttribute('data-theme', 'sepia');
     }
+
+    // Apply header toggle & layout visibility from saved prefs (STACK-54)
+    if (typeof applyHeaderToggleVisibility === 'function') applyHeaderToggleVisibility();
+    if (typeof applyLayoutVisibility === 'function') applyLayoutVisibility();
 
     // Phase 13: Initial Rendering
     debugLog("Phase 13: Rendering initial display...");

--- a/js/settings.js
+++ b/js/settings.js
@@ -353,7 +353,7 @@ const setupSettingsEventListeners = () => {
         const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
         saved[key] = cb.checked;
         localStorage.setItem('layoutVisibility', JSON.stringify(saved));
-        applyLayoutVisibility(saved);
+        applyLayoutVisibility();
       });
     }
   });
@@ -1144,18 +1144,16 @@ const syncLayoutVisibilityUI = () => {
     if (cb) cb.checked = state[key];
   }
 
-  applyLayoutVisibility(state);
+  applyLayoutVisibility();
 };
 
 /**
  * Shows/hides major page sections based on layout visibility state.
  * @param {Object} [state] - Optional visibility state object; reads from localStorage if omitted.
  */
-const applyLayoutVisibility = (state) => {
-  if (!state) {
-    const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
-    state = { spotPrices: true, totals: true, search: true, table: true, ...saved };
-  }
+const applyLayoutVisibility = () => {
+  const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+  const state = { spotPrices: true, totals: true, search: true, table: true, ...saved };
 
   const sectionMap = {
     spotPrices: elements.spotPricesSection,
@@ -1224,10 +1222,8 @@ const toggleCurrencyDropdown = () => {
   // Align right edge of dropdown with right edge of button
   dropdown.style.right = (window.innerWidth - rect.right) + 'px';
 
-  // Close on outside click (next tick to avoid the current click)
-  requestAnimationFrame(() => {
-    document.addEventListener('click', closeCurrencyDropdownOnOutside);
-  });
+  // Close on outside click; header button click already stops propagation
+  document.addEventListener('click', closeCurrencyDropdownOnOutside);
 };
 
 /** Closes the currency dropdown and removes the outside-click listener. */

--- a/js/settings.js
+++ b/js/settings.js
@@ -350,9 +350,9 @@ const setupSettingsEventListeners = () => {
     const cb = document.getElementById(id);
     if (cb) {
       cb.addEventListener('change', () => {
-        const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+        const saved = loadDataSync('layoutVisibility', {});
         saved[key] = cb.checked;
-        localStorage.setItem('layoutVisibility', JSON.stringify(saved));
+        saveDataSync('layoutVisibility', saved);
         applyLayoutVisibility();
       });
     }
@@ -1129,7 +1129,7 @@ window.applyHeaderToggleVisibility = applyHeaderToggleVisibility;
  * Syncs layout visibility checkboxes in Settings with stored state.
  */
 const syncLayoutVisibilityUI = () => {
-  const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+  const saved = loadDataSync('layoutVisibility', {});
   const defaults = { spotPrices: true, totals: true, search: true, table: true };
   const state = { ...defaults, ...saved };
 
@@ -1149,10 +1149,10 @@ const syncLayoutVisibilityUI = () => {
 
 /**
  * Shows/hides major page sections based on layout visibility state.
- * @param {Object} [state] - Optional visibility state object; reads from localStorage if omitted.
+ * Always reads from localStorage and merges with defaults.
  */
 const applyLayoutVisibility = () => {
-  const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+  const saved = loadDataSync('layoutVisibility', {});
   const state = { spotPrices: true, totals: true, search: true, table: true, ...saved };
 
   const sectionMap = {
@@ -1173,7 +1173,7 @@ window.applyLayoutVisibility = applyLayoutVisibility;
  * Creates the dropdown lazily on first use; subsequent calls toggle visibility.
  */
 const toggleCurrencyDropdown = () => {
-  const btn = elements.headerCurrencyBtn;
+  const btn = document.getElementById('headerCurrencyBtn');
   if (!btn) return;
 
   // If dropdown already open, close it

--- a/js/settings.js
+++ b/js/settings.js
@@ -234,6 +234,11 @@ const syncSettingsUI = () => {
     syncGoldbackSettingsUI();
   }
 
+  // Header shortcuts (STACK-54)
+  syncHeaderToggleUI();
+  // Layout visibility (STACK-54)
+  syncLayoutVisibilityUI();
+
   // Set first provider tab active if none visible — default to Numista
   const anyVisible = document.querySelector('.settings-provider-panel[style*="display: block"]');
   if (!anyVisible) {
@@ -319,6 +324,59 @@ const setupSettingsEventListeners = () => {
       if (typeof updateAllSparklines === 'function') updateAllSparklines();
       // Update Goldback denomination symbols (STACK-50)
       if (typeof syncGoldbackSettingsUI === 'function') syncGoldbackSettingsUI();
+    });
+  }
+
+  // Header shortcuts (STACK-54)
+  const headerThemeCb = document.getElementById('settingsHeaderThemeBtn');
+  if (headerThemeCb) {
+    headerThemeCb.addEventListener('change', () => {
+      localStorage.setItem('headerThemeBtnVisible', headerThemeCb.checked ? 'true' : 'false');
+      applyHeaderToggleVisibility();
+    });
+  }
+
+  const headerCurrencyCb = document.getElementById('settingsHeaderCurrencyBtn');
+  if (headerCurrencyCb) {
+    headerCurrencyCb.addEventListener('change', () => {
+      localStorage.setItem('headerCurrencyBtnVisible', headerCurrencyCb.checked ? 'true' : 'false');
+      applyHeaderToggleVisibility();
+    });
+  }
+
+  // Layout visibility (STACK-54)
+  ['spotPrices', 'totals', 'search', 'table'].forEach(key => {
+    const id = 'layout' + key.charAt(0).toUpperCase() + key.slice(1);
+    const cb = document.getElementById(id);
+    if (cb) {
+      cb.addEventListener('change', () => {
+        const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+        saved[key] = cb.checked;
+        localStorage.setItem('layoutVisibility', JSON.stringify(saved));
+        applyLayoutVisibility(saved);
+      });
+    }
+  });
+
+  // Theme cycle header button (STACK-54)
+  if (elements.headerThemeBtn) {
+    elements.headerThemeBtn.addEventListener('click', () => {
+      if (typeof toggleTheme === 'function') toggleTheme();
+      if (typeof updateThemeButton === 'function') updateThemeButton();
+      // Sync settings picker if open
+      const currentTheme = localStorage.getItem(THEME_KEY) || 'light';
+      document.querySelectorAll('.theme-option').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.theme === currentTheme);
+      });
+    });
+  }
+
+  // Currency picker header button (STACK-54)
+  // Opens a floating dropdown to switch display currency directly from the header.
+  if (elements.headerCurrencyBtn) {
+    elements.headerCurrencyBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleCurrencyDropdown();
     });
   }
 
@@ -1031,6 +1089,163 @@ const syncGoldbackSettingsUI = () => {
   }
 };
 
+// =============================================================================
+// HEADER TOGGLE & LAYOUT VISIBILITY (STACK-54)
+// =============================================================================
+
+/**
+ * Syncs the header shortcut checkboxes in Settings with stored state.
+ */
+const syncHeaderToggleUI = () => {
+  const themeVisible = localStorage.getItem('headerThemeBtnVisible') !== 'false';
+  const currencyVisible = localStorage.getItem('headerCurrencyBtnVisible') !== 'false';
+
+  const themeCb = document.getElementById('settingsHeaderThemeBtn');
+  const currencyCb = document.getElementById('settingsHeaderCurrencyBtn');
+  if (themeCb) themeCb.checked = themeVisible;
+  if (currencyCb) currencyCb.checked = currencyVisible;
+
+  applyHeaderToggleVisibility();
+};
+
+/**
+ * Shows/hides the header shortcut buttons based on stored preferences.
+ * Default is visible (true) unless explicitly set to 'false'.
+ */
+const applyHeaderToggleVisibility = () => {
+  const themeVisible = localStorage.getItem('headerThemeBtnVisible') !== 'false';
+  const currencyVisible = localStorage.getItem('headerCurrencyBtnVisible') !== 'false';
+
+  if (elements.headerThemeBtn) {
+    elements.headerThemeBtn.style.display = themeVisible ? '' : 'none';
+  }
+  if (elements.headerCurrencyBtn) {
+    elements.headerCurrencyBtn.style.display = currencyVisible ? '' : 'none';
+  }
+};
+window.applyHeaderToggleVisibility = applyHeaderToggleVisibility;
+
+/**
+ * Syncs layout visibility checkboxes in Settings with stored state.
+ */
+const syncLayoutVisibilityUI = () => {
+  const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+  const defaults = { spotPrices: true, totals: true, search: true, table: true };
+  const state = { ...defaults, ...saved };
+
+  const map = {
+    spotPrices: 'layoutSpotPrices',
+    totals: 'layoutTotals',
+    search: 'layoutSearch',
+    table: 'layoutTable',
+  };
+  for (const [key, id] of Object.entries(map)) {
+    const cb = document.getElementById(id);
+    if (cb) cb.checked = state[key];
+  }
+
+  applyLayoutVisibility(state);
+};
+
+/**
+ * Shows/hides major page sections based on layout visibility state.
+ * @param {Object} [state] - Optional visibility state object; reads from localStorage if omitted.
+ */
+const applyLayoutVisibility = (state) => {
+  if (!state) {
+    const saved = JSON.parse(localStorage.getItem('layoutVisibility') || '{}');
+    state = { spotPrices: true, totals: true, search: true, table: true, ...saved };
+  }
+
+  const sectionMap = {
+    spotPrices: elements.spotPricesSection,
+    totals: elements.totalsSectionEl,
+    search: elements.searchSectionEl,
+    table: elements.tableSectionEl,
+  };
+
+  for (const [key, el] of Object.entries(sectionMap)) {
+    if (el) el.style.display = state[key] ? '' : 'none';
+  }
+};
+window.applyLayoutVisibility = applyLayoutVisibility;
+
+/**
+ * Toggles the floating currency picker dropdown anchored to the header button.
+ * Creates the dropdown lazily on first use; subsequent calls toggle visibility.
+ */
+const toggleCurrencyDropdown = () => {
+  const btn = elements.headerCurrencyBtn;
+  if (!btn) return;
+
+  // If dropdown already open, close it
+  const existing = document.getElementById('headerCurrencyDropdown');
+  if (existing) {
+    closeCurrencyDropdown();
+    return;
+  }
+
+  // Build dropdown
+  const dropdown = document.createElement('div');
+  dropdown.id = 'headerCurrencyDropdown';
+  dropdown.className = 'header-currency-dropdown';
+
+  const currentCode = displayCurrency || 'USD';
+
+  SUPPORTED_CURRENCIES.forEach(c => {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'header-currency-item';
+    if (c.code === currentCode) item.classList.add('active');
+
+    const symbol = getCurrencySymbol(c.code);
+    item.textContent = `${symbol}  ${c.code} — ${c.name}`;
+
+    item.addEventListener('click', (e) => {
+      e.stopPropagation();
+      saveDisplayCurrency(c.code);
+      if (typeof renderTable === 'function') renderTable();
+      if (typeof updateSummary === 'function') updateSummary();
+      if (typeof updateAllSparklines === 'function') updateAllSparklines();
+      if (typeof syncGoldbackSettingsUI === 'function') syncGoldbackSettingsUI();
+      // Sync settings dropdown if open
+      const sel = document.getElementById('settingsDisplayCurrency');
+      if (sel) sel.value = c.code;
+      closeCurrencyDropdown();
+    });
+
+    dropdown.appendChild(item);
+  });
+
+  // Position below button
+  document.body.appendChild(dropdown);
+  const rect = btn.getBoundingClientRect();
+  dropdown.style.top = (rect.bottom + 4) + 'px';
+  // Align right edge of dropdown with right edge of button
+  dropdown.style.right = (window.innerWidth - rect.right) + 'px';
+
+  // Close on outside click (next tick to avoid the current click)
+  requestAnimationFrame(() => {
+    document.addEventListener('click', closeCurrencyDropdownOnOutside);
+  });
+};
+
+/** Closes the currency dropdown and removes the outside-click listener. */
+const closeCurrencyDropdown = () => {
+  const el = document.getElementById('headerCurrencyDropdown');
+  if (el) el.remove();
+  document.removeEventListener('click', closeCurrencyDropdownOnOutside);
+};
+
+/** Click-outside handler for the currency dropdown. */
+const closeCurrencyDropdownOnOutside = (e) => {
+  const dropdown = document.getElementById('headerCurrencyDropdown');
+  const btn = elements.headerCurrencyBtn;
+  if (dropdown && !dropdown.contains(e.target) && e.target !== btn) {
+    closeCurrencyDropdown();
+  }
+};
+
 // Expose globally
 if (typeof window !== 'undefined') {
   window.showSettingsModal = showSettingsModal;
@@ -1045,4 +1260,6 @@ if (typeof window !== 'undefined') {
   window.saveProviderTabOrder = saveProviderTabOrder;
   window.syncGoldbackSettingsUI = syncGoldbackSettingsUI;
   window.syncCurrencySettingsUI = syncCurrencySettingsUI;
+  window.syncHeaderToggleUI = syncHeaderToggleUI;
+  window.syncLayoutVisibilityUI = syncLayoutVisibilityUI;
 }

--- a/js/state.js
+++ b/js/state.js
@@ -175,6 +175,16 @@ const elements = {
   ackModal: null,
   ackAcceptBtn: null,
 
+  // Header toggle buttons (STACK-54)
+  headerThemeBtn: null,
+  headerCurrencyBtn: null,
+
+  // Layout section containers (STACK-54)
+  spotPricesSection: null,
+  totalsSectionEl: null,
+  searchSectionEl: null,
+  tableSectionEl: null,
+
   // Settings modal elements
   settingsBtn: null,
   settingsModal: null,


### PR DESCRIPTION
## Summary
- Adds theme cycle and currency picker buttons to the app header (enabled by default, toggleable via Settings > Appearance)
- Currency picker opens a floating dropdown with all 17 supported currencies — selection persists and syncs with Settings
- Adds Layout settings panel with toggles to show/hide spot price cards, summary totals, search bar, and inventory table
- Replaces About button emoji (📖) with SVG info-circle icon for uniform header styling
- 3 new localStorage keys: `headerThemeBtnVisible`, `headerCurrencyBtnVisible`, `layoutVisibility`

## Test plan
- [ ] Default state: theme + currency buttons visible in header on fresh install
- [ ] Theme button cycles light → sepia → dark; Settings theme picker stays synced
- [ ] Currency dropdown shows all 17 currencies with symbols; selection updates all prices and persists
- [ ] Layout toggles independently control each section's visibility; persists across reload
- [ ] Disabling header buttons via Settings > Appearance hides them from header
- [ ] All 4 header buttons are visually uniform (SVG icons, same size)
- [ ] Verify in all 3 themes (light/dark/sepia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)