### PR TITLE
Fix spot lookup price fill & retail price melt revert

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -635,7 +635,7 @@ const parseItemFormFields = (isEditing, existingItem) => {
     const enteredMv = parseFloat(marketValueInput);
     marketValue = fxRate !== 1 ? enteredMv / fxRate : enteredMv;
   } else {
-    marketValue = isEditing ? (existingItem.marketValue || 0) : 0;
+    marketValue = 0;
   }
 
   return {

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -389,16 +389,22 @@ const renderSpotLookupEmpty = (container, metalName, dateStr) => {
  * @param {string} timestamp - Timestamp of the selected entry (for reference)
  */
 const useSpotPrice = (spotPrice, timestamp) => {
+  // Store in hidden field for spotPriceAtPurchase (melt value calculation)
   if (elements.itemSpotPrice) {
     elements.itemSpotPrice.value = spotPrice;
   }
 
-  // Brief visual highlight on the date field for confirmation
-  if (elements.itemDate) {
-    elements.itemDate.style.transition = 'background-color 0.3s';
-    elements.itemDate.style.backgroundColor = 'var(--accent, #fbbf24)';
+  // Populate visible Purchase Price field (convert USD → display currency)
+  if (elements.itemPrice) {
+    const fxRate = (typeof getExchangeRate === 'function') ? getExchangeRate() : 1;
+    const displayPrice = fxRate !== 1 ? (spotPrice * fxRate).toFixed(2) : spotPrice;
+    elements.itemPrice.value = displayPrice;
+
+    // Brief visual highlight on the price field for confirmation
+    elements.itemPrice.style.transition = 'background-color 0.3s';
+    elements.itemPrice.style.backgroundColor = 'var(--accent, #fbbf24)';
     setTimeout(() => {
-      elements.itemDate.style.backgroundColor = '';
+      elements.itemPrice.style.backgroundColor = '';
     }, 800);
   }
 


### PR DESCRIPTION
## Summary
- **Spot lookup "Use" button now updates the visible Purchase Price field** with the looked-up spot price (converted to display currency), instead of only setting a hidden field with no visible feedback
- **Clearing the Retail Price field during editing now correctly reverts to melt value** instead of silently preserving the old value

## Details
### Bug 1 — Spot lookup (`js/spotLookup.js`)
`useSpotPrice()` previously only set the hidden `itemSpotPrice` field (used for `spotPriceAtPurchase` at save time). The visible Purchase Price field was never updated, so clicking "Use" appeared to do nothing. Now it populates the price field with the spot price (USD→display currency converted) and flashes it yellow as confirmation.

### Bug 2 — Retail price revert (`js/events.js`)
In `parseItemFormFields()`, when the Retail Price field was empty during editing, the code fell back to `existingItem.marketValue || 0` — preserving the old value. Changed to unconditionally return `0`, which triggers the melt value fallback used throughout the app.

Closes #67

## Test plan
- [ ] Open edit modal for any item, click Spot button, select a price, click "Use" → Purchase Price field updates and flashes yellow
- [ ] Verify spot price is correctly converted to display currency (if non-USD)
- [ ] Edit an item with a Retail Price, clear the field, save → retail column shows melt value instead of old price
- [ ] Edit an item, keep Retail Price populated, save → value preserved correctly
- [ ] Verify in all 3 themes (light/dark/sepia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)