### PR TITLE
Add sponsor badges and FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [lbruton]

--- a/index.html
+++ b/index.html
@@ -1248,7 +1248,7 @@
           <a href="https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
           <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StackTrackr?style=flat-square" alt="GitHub Issues" height="20"></a>
           <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
-          <iframe src="https://github.com/sponsors/lbruton/button" title="Sponsor lbruton" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
+          <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/sponsor-♡-ea4aaa?style=flat-square" alt="Sponsor" height="20"></a>
         </div>
       </div>
     </footer>
@@ -1366,6 +1366,10 @@
               <a href="https://github.com/lbruton/StackTrackr/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="about-badge">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
                 MIT License
+              </a>
+              <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener" class="about-badge">
+                <svg viewBox="0 0 24 24" fill="#ea4aaa" stroke="none"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+                Sponsor
               </a>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -1248,6 +1248,7 @@
           <a href="https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
           <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StackTrackr?style=flat-square" alt="GitHub Issues" height="20"></a>
           <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
+          <iframe src="https://github.com/sponsors/lbruton/button" title="Sponsor lbruton" height="32" width="114" style="border: 0; border-radius: 6px;"></iframe>
         </div>
       </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -1248,7 +1248,7 @@
           <a href="https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
           <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StackTrackr?style=flat-square" alt="GitHub Issues" height="20"></a>
           <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
-          <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/sponsor-♡-ea4aaa?style=flat-square" alt="Sponsor" height="20"></a>
+          <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/sponsor-%E2%99%A1-ea4aaa?style=flat-square" alt="Sponsor" height="20"></a>
         </div>
       </div>
     </footer>
@@ -1368,7 +1368,7 @@
                 MIT License
               </a>
               <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener" class="about-badge">
-                <svg viewBox="0 0 24 24" fill="#ea4aaa" stroke="none"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
                 Sponsor
               </a>
             </div>


### PR DESCRIPTION
## Summary

- Add GitHub Sponsors shield badge to footer (matches existing badge style)
- Add Sponsor badge with heart icon to About modal (matches existing about-badge style)
- Add `.github/FUNDING.yml` to enable Sponsor button on repo page

## Test plan

- [ ] Footer sponsor badge renders at same height as other badges
- [ ] Footer sponsor badge links to GitHub Sponsors page
- [ ] About modal sponsor badge renders consistently with other badges
- [ ] Verify across light/dark/sepia themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)