### PR TITLE
v3.25.02 — STACK-68: Goldback spot lookup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.25.02] - 2026-02-12
+
+### Fixed — STACK-68: Goldback spot lookup fix
+
+- **Fixed**: Spot price lookup now applies Goldback formula (`2 × (goldSpot / 1000) × modifier × denomination`) instead of raw gold spot for purchase price (STACK-68)
+
+---
+
 ## [3.25.01] - 2026-02-12
 
 ### Fixed — STACK-64: Version splash content source

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,13 +24,17 @@ Multi-currency is shipped (STACK-50). These items are unblocked and ready for th
 
 ---
 
-## Medium-Term — BYO-Backend (Supabase Cloud Sync)
+## Medium-Term — Cloud Sync (Supabase + GitHub Sponsors)
 
-Zero-cost, zero-server architecture. App stays static; users who want cloud sync bring their own free Supabase project.
+Encrypted cloud sync for sponsors ($3/month). Zero-knowledge architecture — data encrypted client-side (AES-256-GCM) before upload, decrypted client-side after download. Server never sees plaintext. Self-hostable for users who want their own Supabase instance.
 
 | Issue | Title | Priority | Depends On |
 |-------|-------|----------|------------|
-| [STACK-30](https://linear.app/hextrackr/issue/STACK-30) | BYO-Backend: Supabase cloud sync | Medium | — |
+| [STACK-30](https://linear.app/hextrackr/issue/STACK-30) | BYO-Backend: Supabase cloud sync (self-host) | Medium | — |
+| DEVS-5 | Cloud Sync — Supabase-backed encrypted sync for sponsors (epic) | High | — |
+| DEVS-6 | M1: Supabase schema, RLS policies & self-host docs | Medium | — |
+| DEVS-7 | M2: Client-side sync UI & upload/download logic | Medium | DEVS-6 |
+| DEVS-8 | M3: GitHub Action — automated sponsor key lifecycle | Medium | DEVS-6 |
 
 ---
 
@@ -78,6 +82,8 @@ Explicitly out of scope until prerequisites are met.
 <details>
 <summary>Shipped features (click to expand)</summary>
 
+- **v3.25.01** — STACK-64/67: Version splash fix (friendly announcements), footer version badge with remote update check, sponsor badges
+- **v3.25.00** — STACK-54/65/66: Appearance settings (header buttons, layout toggles), spot lookup fix, sparkline improvements
 - **v3.24.00** — STACK-50: Multi-currency support with 17-currency display, daily exchange rate conversion, dynamic formatting
 - **v3.23.02** — STACK-52: Bulk Edit pinned selections, dormant prototype cleanup
 - **v3.23.01** — Goldback real-time estimation, Settings reorganization

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **STACK-68: Goldback spot lookup fix (v3.25.02)**: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula
 - **STACK-64, STACK-67: Version splash fix & update badge (v3.25.01)**: Version splash now shows friendly "What's New" content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache
 - **STACK-54, STACK-66: Appearance settings & sparkline improvements (v3.25.00)**: Header quick-access buttons for theme and currency. Layout visibility toggles. 1-day sparkline with daily-averaged trend. Spot lookup now fills visible price field. 15/30-minute API cache options
 - **STACK-56: Complexity reduction (v3.24.06)**: Refactored 6 functions to reduce cyclomatic complexity — dispatch maps, extracted helpers, optionalListener utility. −301 lines from events.js
 - **STACK-55: Bulk Editor clean selection (v3.24.04)**: Bulk Editor now resets selection on every open. Removed stale localStorage persistence
-- **STACK-44: Activity Log sub-tabs (v3.24.02)**: Settings Log panel reorganized with 4 sub-tabs — Changelog, Metals (spot history), Catalogs (API calls), Price History (per-item). Sortable tables, filter, and clear buttons for each
-- **STACK-50: Multi-Currency Support (v3.24.00)**: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -274,12 +274,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.25.02 &ndash; STACK-68: Goldback spot lookup fix</strong>: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula</li>
     <li><strong>v3.25.01 &ndash; STACK-64, STACK-67: Version splash fix &amp; update badge</strong>: Version splash now shows friendly &ldquo;What&rsquo;s New&rdquo; content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache</li>
     <li><strong>v3.25.00 &ndash; STACK-54, STACK-66: Appearance settings &amp; sparkline improvements</strong>: Header quick-access buttons for theme and currency. Layout visibility toggles. 1-day sparkline with daily-averaged trend. Spot lookup now fills visible price field. 15/30-minute API cache options</li>
     <li><strong>v3.24.06 &ndash; STACK-56: Complexity reduction</strong>: Refactored 6 functions below Lizard CCN threshold &mdash; dispatch maps, extracted helpers, optionalListener utility. &minus;301 lines from events.js</li>
     <li><strong>v3.24.04 &ndash; STACK-55: Bulk Editor clean selection</strong>: Bulk Editor now resets selection on every open. Removed stale localStorage persistence</li>
-    <li><strong>v3.24.02 &ndash; STACK-44: Activity Log sub-tabs</strong>: Settings Log panel reorganized with 4 sub-tabs &mdash; Changelog, Metals, Catalogs, Price History. Sortable tables, filter, and clear buttons</li>
-    <li><strong>v3.24.00 &ndash; STACK-50: Multi-Currency Support</strong>: 17-currency display with daily exchange rate conversion. Dynamic currency symbols across modals, Goldback settings, and exports. Dynamic Gain/Loss labels on totals cards. Sticky header fix</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-55: Bulk Editor clean selection, code cleanup
  */
 
-const APP_VERSION = "3.25.01";
+const APP_VERSION = "3.25.02";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -397,7 +397,20 @@ const useSpotPrice = (spotPrice, timestamp) => {
   // Populate visible Purchase Price field (convert USD → display currency)
   if (elements.itemPrice) {
     const fxRate = (typeof getExchangeRate === 'function') ? getExchangeRate() : 1;
-    const displayPrice = (spotPrice * fxRate).toFixed(2);
+
+    // Goldback: convert gold spot → per-unit Goldback price (STACK-68)
+    let priceUSD = spotPrice;
+    if (elements.itemWeightUnit && elements.itemWeightUnit.value === 'gb'
+        && typeof computeGoldbackEstimatedRate === 'function') {
+      const gbRate = computeGoldbackEstimatedRate(spotPrice);
+      const denom = parseFloat(
+        (elements.itemGbDenom && elements.itemGbDenom.value) ||
+        (elements.itemWeight && elements.itemWeight.value) || 1
+      );
+      priceUSD = gbRate * denom;
+    }
+
+    const displayPrice = (priceUSD * fxRate).toFixed(2);
     elements.itemPrice.value = displayPrice;
 
     // Brief visual highlight on the price field for confirmation

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.25.01",
+  "version": "3.25.02",
   "releaseDate": "2026-02-12",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: Spot price lookup now applies Goldback formula instead of raw gold spot for purchase price (STACK-68)
- Updated roadmap with cloud sync sponsor model and shipped version history

## Files Updated

- `js/spotLookup.js` — Goldback detection in `useSpotPrice()` with formula conversion
- `js/constants.js` — APP_VERSION → 3.25.02
- `CHANGELOG.md` — new v3.25.02 section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint
- `ROADMAP.md` — cloud sync sponsor model, shipped versions

## Linear Issues

- [STACK-68: Spot Price Lookup — Goldbacks](https://linear.app/hextrackr/issue/STACK-68/spot-price-lookup-goldbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)