### PR TITLE
v3.25.03 — STACK-38/STACK-31: Responsive card view + mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.25.03] - 2026-02-12
+
+### Added — STACK-38/STACK-31: Responsive card view & mobile layout
+
+- **Added**: CSS card view at ≤768px — inventory table converts to flexbox cards with name title, horizontal chips, metal subtitle, 2-column financial grid, and centered touch-friendly action buttons (44px targets per Apple HIG) (STACK-31)
+- **Added**: `data-label` attributes on all `<td>` elements for card view `::before` labels (STACK-31)
+- **Added**: Card tap-to-edit — tapping card body opens edit modal; buttons/links work normally (STACK-31)
+- **Added**: Details modal fixes at ≤640px — single-column breakdown grid, 150px chart, stacked panels (STACK-38)
+- **Added**: Short-viewport portal scroll cap at ≤500px height for 300% zoom scenarios (STACK-38)
+- **Changed**: Consolidated 3 duplicate responsive table CSS sections into single canonical block (STACK-38)
+- **Changed**: `updateColumnVisibility()` skips at ≤768px — card CSS handles visibility (STACK-38)
+- **Changed**: `updatePortalHeight()` clears max-height at ≤768px — cards scroll naturally (STACK-38)
+- **Fixed**: Footer badges wrap on mobile instead of overflowing card
+- **Fixed**: Filter chips stay horizontal and wrap instead of stacking vertically at narrow widths
+- **Fixed**: Header logo scales to fill mobile width with centered action buttons below
+
+---
+
 ## [3.25.02] - 2026-02-12
 
 ### Fixed — STACK-68: Goldback spot lookup fix

--- a/css/styles.css
+++ b/css/styles.css
@@ -441,6 +441,7 @@ section {
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
   margin-top: 6px;
 }
@@ -2709,198 +2710,9 @@ tr:hover {
 }
 
 
-/* Enhanced Mobile Responsive Design with Auto-Scaling */
-
-/* Progressive column hiding for responsive design (legacy section — see portfolio overrides below) */
-@media (max-width: 1200px) {
-  #inventoryTable th[data-column="gainLoss"],
-  #inventoryTable td[data-column="gainLoss"] {
-    display: none;
-  }
-}
-
-@media (max-width: 1024px) {
-  #inventoryTable th[data-column="purchaseLocation"],
-  #inventoryTable td[data-column="purchaseLocation"] {
-    display: none;
-  }
-  
-  #inventoryTable {
-    font-size: 0.8rem;
-  }
-  
-  #inventoryTable th,
-  #inventoryTable td {
-    padding: 0.3rem 0.2rem;
-  }
-}
-
-@media (max-width: 768px) {
-  #inventoryTable {
-    width: 100%;
-    min-width: 0;
-    table-layout: fixed;
-    font-size: 0.75rem;
-  }
-
-  #inventoryTable th,
-  #inventoryTable td {
-    padding: 0.25rem 0.15rem;
-    white-space: normal;
-    overflow: hidden;
-    text-overflow: clip;
-    word-break: break-word;
-    line-height: 1.2;
-  }
-  
-  /* Auto-scale column widths for mobile with improved distribution */
-  #inventoryTable th[data-column="date"],
-  #inventoryTable td[data-column="date"] {
-    width: 10%;
-    font-size: 0.7rem;
-  }
-  
-  #inventoryTable th[data-column="metal"],
-  #inventoryTable td[data-column="metal"] {
-    width: 8%;
-    font-size: 0.7rem;
-  }
-  
-  #inventoryTable th[data-column="name"],
-  #inventoryTable td[data-column="name"] {
-    width: 30%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  
-  #inventoryTable th[data-column="qty"],
-  #inventoryTable td[data-column="qty"] {
-    width: 6%;
-  }
-  
-  #inventoryTable th[data-column="weight"],
-  #inventoryTable td[data-column="weight"] {
-    width: 10%;
-  }
-  
-  #inventoryTable th[data-column="purchasePrice"],
-  #inventoryTable td[data-column="purchasePrice"] {
-    width: 12%;
-  }
-  
-  /* Icon columns get minimal width but remain functional */
-  #inventoryTable th.icon-col,
-  #inventoryTable td.icon-col {
-    width: 6%;
-    min-width: 2.5rem;
-    padding: 0.2rem 0.1rem;
-  }
-
-  /* Enhanced responsive text handling */
-  .shrink {
-    width: auto;
-    min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  
-  .expand {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    white-space: normal;
-  }
-}
-
-@media (max-width: 600px) {
-  #inventoryTable {
-    font-size: 0.7rem;
-  }
-  
-  #inventoryTable th,
-  #inventoryTable td {
-    padding: 0.2rem 0.1rem;
-  }
-  
-  /* Progressive column hiding for better mobile experience */
-  #inventoryTable th[data-column="weight"],
-  #inventoryTable td[data-column="weight"],
-  #inventoryTable th[data-column="date"],
-  #inventoryTable td[data-column="date"] {
-    display: none;
-  }
-  
-  /* Redistribute space for remaining columns */
-  #inventoryTable th[data-column="name"],
-  #inventoryTable td[data-column="name"] {
-    width: 40%;
-  }
-  
-  #inventoryTable th[data-column="weight"],
-  #inventoryTable td[data-column="weight"] {
-    width: 12%;
-  }
-  
-  #inventoryTable th[data-column="purchasePrice"],
-  #inventoryTable td[data-column="purchasePrice"] {
-    width: 15%;
-  }
-  
-  #inventoryTable th[data-column="qty"],
-  #inventoryTable td[data-column="qty"] {
-    width: 8%;
-  }
-}
-
-@media (max-width: 480px) {
-  #inventoryTable {
-    font-size: 0.65rem;
-  }
-  
-  #inventoryTable th,
-  #inventoryTable td {
-    padding: 0.15rem 0.05rem;
-  }
-  
-  /* Further column hiding for very small screens */
-  #inventoryTable th[data-column="type"],
-  #inventoryTable td[data-column="type"],
-  #inventoryTable th[data-column="metal"],
-  #inventoryTable td[data-column="metal"] {
-    display: none;
-  }
-  
-  /* Maximize space for essential columns */
-  #inventoryTable th[data-column="name"],
-  #inventoryTable td[data-column="name"] {
-    width: 50%;
-  }
-  
-  #inventoryTable th[data-column="weight"],
-  #inventoryTable td[data-column="weight"] {
-    width: 15%;
-  }
-  
-  #inventoryTable th[data-column="purchasePrice"],
-  #inventoryTable td[data-column="purchasePrice"] {
-    width: 15%;
-  }
-  
-  /* Icon columns remain functional but compact */
-  #inventoryTable th.icon-col,
-  #inventoryTable td.icon-col {
-    width: 8%;
-    min-width: 1.8rem;
-    padding: 0.1rem;
-  }
-  
-  /* Reduce icon sizes for mobile */
-  #inventoryTable td.icon-col .action-icon,
-  #inventoryTable th.icon-col svg {
-    width: 0.9rem;
-    height: 0.9rem;
-  }
-}
+/* Legacy "Enhanced Mobile Responsive Design" section removed —
+   consolidated into canonical responsive block below line 5127 and
+   card-view rules at end of file.  See STACK-38 / STACK-31. */
 
 /* Clickable name cell styling */
 .name-cell {
@@ -4820,52 +4632,7 @@ input:disabled + .slider {
   }
 }
 
-/* Additional mobile table adjustments */
-@media (max-width: 768px) {
-  th {
-    font-size: 0.7rem;
-    padding: 0.25rem 0.125rem;
-  }
-
-  td {
-    font-size: 0.7rem;
-    padding: 0.2rem;
-  }
-}
-
-@media (max-width: 480px) {
-  th {
-    font-size: 0.65rem;
-    padding: 0.2rem 0.1rem;
-  }
-
-  .header-text {
-    font-size: 0.6rem;
-    margin-top: 0.1rem;
-  }
-
-  .icon-col {
-    min-width: 3rem;
-  }
-
-  td {
-    font-size: 0.65rem;
-    padding: 0.15rem;
-  }
-
-  td .btn {
-    padding: 0.2rem 0.3rem;
-    font-size: 0.65rem;
-    min-height: 1.5rem;
-  }
-  td .action-btn {
-    width: 4rem;
-  }
-  td .action-icon {
-    width: 4rem;
-  }
-
-}
+/* Additional mobile table adjustments — removed ≤768px rules (card view handles them) */
 
 @media (min-width: 600px) {
   .grid-2 {
@@ -5124,38 +4891,24 @@ input:disabled + .slider {
 .edit-svg { color: inherit; }
 .delete-svg { color: inherit; }
 
-/* MOBILE PRIORITY RULES — Portfolio layout
-   Keep Name, Purchase, Melt, Retail visible on tight screens. */
-@media (max-width: 768px) {
-  #inventoryTable th[data-column="type"],
-  #inventoryTable td[data-column="type"] {
+/* CANONICAL RESPONSIVE TABLE RULES — Progressive disclosure + portfolio layout
+   Single source of truth for all inventory table responsive behavior.
+   Card view (≤768px) lives at end of file.  See STACK-38 / STACK-31. */
+
+@media (max-width: 1200px) {
+  #inventoryTable th[data-column="gainLoss"],
+  #inventoryTable td[data-column="gainLoss"] {
     display: none;
   }
-
-  #inventoryTable th[data-column="name"],
-  #inventoryTable td[data-column="name"] { width: 35%; }
-  #inventoryTable th[data-column="purchasePrice"],
-  #inventoryTable td[data-column="purchasePrice"] { width: 15%; }
-  #inventoryTable th[data-column="meltValue"],
-  #inventoryTable td[data-column="meltValue"] { width: 15%; }
-
-  #inventoryTable th, #inventoryTable td { padding: 0.2rem 0.15rem; }
 }
 
-@media (max-width: 480px) {
-  #inventoryTable th[data-column="retailPrice"],
-  #inventoryTable td[data-column="retailPrice"],
-  #inventoryTable th[data-column="metal"],
-  #inventoryTable td[data-column="metal"] {
+@media (max-width: 1024px) {
+  #inventoryTable th[data-column="purchaseLocation"],
+  #inventoryTable td[data-column="purchaseLocation"] {
     display: none;
   }
-
-  #inventoryTable th[data-column="name"],
-  #inventoryTable td[data-column="name"] { width: 50%; }
-  #inventoryTable th[data-column="purchasePrice"],
-  #inventoryTable td[data-column="purchasePrice"] { width: 20%; }
-  #inventoryTable th[data-column="meltValue"],
-  #inventoryTable td[data-column="meltValue"] { width: 20%; }
+  #inventoryTable { font-size: 0.8rem; }
+  #inventoryTable th, #inventoryTable td { padding: 0.3rem 0.2rem; }
 }
 
 /* Sticky icon columns: remove left border so they blend with adjacent cells */
@@ -6843,42 +6596,9 @@ th {
   font-variant-numeric: tabular-nums;
 }
 
-/* Responsive column hiding — progressive disclosure for portfolio layout */
-@media (max-width: 1200px) {
-  #inventoryTable th[data-column="gainLoss"],
-  #inventoryTable td[data-column="gainLoss"] {
-    display: none;
-  }
-}
-
-@media (max-width: 1024px) {
-  #inventoryTable th[data-column="purchaseLocation"],
-  #inventoryTable td[data-column="purchaseLocation"] {
-    display: none;
-  }
-}
-
-@media (max-width: 768px) {
-  #inventoryTable th[data-column="type"],
-  #inventoryTable td[data-column="type"] {
-    display: none;
-  }
-}
-
-@media (max-width: 600px) {
-  #inventoryTable th[data-column="weight"],
-  #inventoryTable td[data-column="weight"],
-  #inventoryTable th[data-column="date"],
-  #inventoryTable td[data-column="date"] {
-    display: none;
-  }
-
-  /* Make action buttons smaller on mobile */
-  #inventoryTable td.icon-col .action-icon {
-    width: 1rem;
-    height: 1rem;
-  }
-}
+/* Legacy "Responsive column hiding" section removed —
+   consolidated into canonical responsive block and card-view rules.
+   See STACK-38 / STACK-31. */
 
 /* Smooth table scrolling */
 #inventoryTable {
@@ -7610,5 +7330,340 @@ th {
   .bulk-edit-content {
     width: 98vw;
     max-height: 95vh;
+  }
+}
+
+/* =============================================================================
+   CARD VIEW — Inventory table ≤768px  (STACK-31 / STACK-38)
+   Converts each <tr> into a card via CSS grid. Labels generated from
+   data-label attributes on <td> elements via ::before pseudo-elements.
+   ============================================================================= */
+
+@media (max-width: 768px) {
+  /* Hide table header — card labels replace column headers */
+  #inventoryTable thead {
+    display: none;
+  }
+
+  /* Remove table layout so rows become blocks */
+  #inventoryTable,
+  #inventoryTable tbody {
+    display: block;
+    width: 100%;
+    border-spacing: 0;
+  }
+
+  /* Each row becomes a card (flexbox wrap for reliable spanning) */
+  #inventoryTable tbody tr {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.15rem 0;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    padding: 0.75rem;
+    margin-bottom: 0.5rem;
+    cursor: pointer;
+  }
+
+  /* All cells: half-width by default (2-column pairs).
+     Reset all table-layout width/max-width constraints from .shrink, .expand,
+     .icon-col, and data-column selectors — card view uses flex-basis only. */
+  #inventoryTable tbody td,
+  #inventoryTable tbody td.shrink,
+  #inventoryTable tbody td.expand,
+  #inventoryTable tbody td.icon-col {
+    display: flex !important;
+    justify-content: space-between;
+    align-items: baseline;
+    flex: 0 0 50% !important;
+    box-sizing: border-box;
+    padding: 0.2rem 0.35rem;
+    border: none;
+    font-size: 0.95rem;
+    color: var(--text-primary);
+    width: unset !important;
+    max-width: none !important;
+    min-width: 0 !important;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  /* Label pseudo-element from data-label attribute */
+  #inventoryTable tbody td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-right: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  /* Name — full-width card title, no label */
+  #inventoryTable tbody td[data-column="name"] {
+    flex: 0 0 100% !important;
+    order: -2;
+    font-size: 1.05rem;
+    font-weight: 600;
+    justify-content: flex-start;
+    padding-bottom: 0.25rem;
+    text-align: left;
+  }
+  #inventoryTable tbody td[data-column="name"]::before {
+    display: none;
+  }
+
+  /* Metal — full-width subtitle row */
+  #inventoryTable tbody td[data-column="metal"] {
+    flex: 0 0 100% !important;
+    order: -1;
+    font-size: 0.9rem;
+    justify-content: flex-start;
+    padding-bottom: 0.35rem;
+    margin-bottom: 0.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+  #inventoryTable tbody td[data-column="metal"]::before {
+    display: none;
+  }
+
+  /* Actions — full-width bottom row, centered, no label */
+  #inventoryTable tbody td[data-column="actions"],
+  #inventoryTable tbody td.icon-col[data-column="actions"] {
+    flex: 0 0 100% !important;
+    width: unset !important;
+    max-width: none !important;
+    justify-content: center;
+    padding-top: 0.35rem;
+    margin-top: 0.25rem;
+    border-top: 1px solid var(--border);
+  }
+  #inventoryTable tbody td[data-column="actions"]::before {
+    display: none;
+  }
+
+  /* Hide lower-priority fields in card view */
+  #inventoryTable tbody td[data-column="date"],
+  #inventoryTable tbody td[data-column="type"],
+  #inventoryTable tbody td[data-column="purchaseLocation"] {
+    display: none !important;
+  }
+
+  /* Override hideEmptyColumns() display:none for visible card fields */
+  #inventoryTable tbody td[data-column="name"],
+  #inventoryTable tbody td[data-column="metal"],
+  #inventoryTable tbody td[data-column="qty"],
+  #inventoryTable tbody td[data-column="weight"],
+  #inventoryTable tbody td[data-column="purchasePrice"],
+  #inventoryTable tbody td[data-column="meltValue"],
+  #inventoryTable tbody td[data-column="retailPrice"],
+  #inventoryTable tbody td[data-column="gainLoss"],
+  #inventoryTable tbody td[data-column="actions"] {
+    display: flex !important;
+  }
+
+  /* eBay search SVG icons: hide in card view to save space */
+  #inventoryTable tbody td .ebay-search-svg {
+    display: none;
+  }
+
+  /* Action row layout inside card — centered */
+  #inventoryTable tbody td[data-column="actions"] .actions-row {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    width: 100%;
+  }
+
+  /* Touch-friendly action buttons (44px minimum per Apple HIG) */
+  #inventoryTable tbody td[data-column="actions"] .icon-btn {
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0.4rem;
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+  }
+
+  #inventoryTable tbody td[data-column="actions"] .icon-svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  /* Cards scroll naturally — remove portal max-height */
+  .portal-scroll {
+    max-height: none !important;
+    overflow: visible;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Name cell: name on line 1, all chips wrap horizontally on line 2 */
+  #inventoryTable tbody td[data-column="name"] .name-cell-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+    width: 100%;
+  }
+
+  /* Name text takes full width → forces chips to next line */
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .filter-text {
+    flex: 0 0 100%;
+    overflow: visible;
+    white-space: normal;
+    text-overflow: clip;
+    font-size: 1.05rem;
+  }
+
+  /* Chips: horizontal row, touch-friendly size */
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .year-tag,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .numista-tag,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .pcgs-tag,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .grade-tag,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .serial-tag,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .storage-tag,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .notes-indicator,
+  #inventoryTable tbody td[data-column="name"] .name-cell-content > .purity-tag {
+    flex-shrink: 0;
+    font-size: 0.8rem !important;
+    padding: 0.2rem 0.5rem !important;
+    min-height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Bump card body text sizes for readability */
+  #inventoryTable tbody td {
+    font-size: 0.95rem;
+  }
+
+  #inventoryTable tbody td::before {
+    font-size: 0.8rem;
+  }
+
+  #inventoryTable tbody td[data-column="metal"] {
+    font-size: 0.9rem;
+  }
+
+  /* Header: scale logo to fill mobile width, center buttons below */
+  .app-header {
+    min-height: auto;
+    padding: var(--spacing-sm);
+    align-items: stretch;
+  }
+
+  .app-header > div {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-sm);
+  }
+
+  .app-logo {
+    width: 100%;
+    justify-content: center;
+    transform: scale(1.3);
+    transform-origin: center top;
+    margin-bottom: -1rem;
+  }
+
+  .stackr-logo {
+    max-width: 100% !important;
+  }
+
+  /* Compact pagination footer for card view */
+  .table-footer-controls {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    justify-content: center;
+  }
+
+  .table-item-count {
+    font-size: 0.85rem;
+  }
+
+  .table-footer-controls select {
+    font-size: 0.85rem;
+    padding: 0.25rem 0.5rem;
+    max-width: 6rem;
+  }
+}
+
+/* =============================================================================
+   DETAILS MODAL — Narrow viewport fixes ≤640px  (STACK-38)
+   Stacks panels vertically, single-column breakdown, reduced chart.
+   ============================================================================= */
+
+@media (max-width: 640px) {
+  #detailsModal .modal-content {
+    width: 98vw;
+    max-width: 98vw;
+    max-height: 98vh;
+    padding: var(--spacing-sm);
+  }
+
+  .details-grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-sm);
+  }
+
+  .breakdown-grid {
+    grid-template-columns: 1fr;
+    gap: 0.125rem;
+  }
+
+  .chart-canvas-container {
+    height: 150px;
+    flex: 0 0 150px;
+  }
+
+  .chart-canvas {
+    max-height: 150px !important;
+  }
+
+  /* Reduce breakdown font sizes */
+  .breakdown-label {
+    font-size: 0.8rem;
+  }
+
+  .breakdown-meta {
+    font-size: 0.7rem;
+  }
+
+  .breakdown-grid {
+    font-size: 0.75rem;
+  }
+
+  .breakdown-cell-label {
+    font-size: 0.7rem;
+  }
+}
+
+/* =============================================================================
+   ADDITIONAL SMALL-VIEWPORT FIXES  (STACK-38)
+   Targets zoom-induced short viewports, filter controls, and form grids.
+   ============================================================================= */
+
+/* Short viewport (e.g. 300% zoom on 1080p → ~360px height) */
+@media (max-height: 500px) {
+  .portal-scroll {
+    max-height: 50vh;
+  }
+}
+
+/* Filter controls + form grids at narrow widths */
+@media (max-width: 640px) {
+  .filter-controls {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    justify-content: center;
+  }
+
+  .grid-2,
+  .grid-purity-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -7335,7 +7335,7 @@ th {
 
 /* =============================================================================
    CARD VIEW — Inventory table ≤768px  (STACK-31 / STACK-38)
-   Converts each <tr> into a card via CSS grid. Labels generated from
+   Converts each <tr> into a flexbox-based card. Labels generated from
    data-label attributes on <td> elements via ::before pseudo-elements.
    ============================================================================= */
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STACK-38/STACK-31: Responsive card view & mobile layout (v3.25.03)**: Inventory table converts to touch-friendly cards at ≤768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at ≤640px
 - **STACK-68: Goldback spot lookup fix (v3.25.02)**: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula
 - **STACK-64, STACK-67: Version splash fix & update badge (v3.25.01)**: Version splash now shows friendly "What's New" content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache
 - **STACK-54, STACK-66: Appearance settings & sparkline improvements (v3.25.00)**: Header quick-access buttons for theme and currency. Layout visibility toggles. 1-day sparkline with daily-averaged trend. Spot lookup now fills visible price field. 15/30-minute API cache options
@@ -10,4 +11,5 @@
 
 - **Chart Overhaul (STACK-48)**: Migrate to ApexCharts with time-series trend views
 - **Custom CSV Mapper (STACK-51)**: Header mapping UI with saved import profiles
-- **Table CSS Hardening (STACK-38)**: Responsive audit and CSS cleanup
+- ~~**Table CSS Hardening (STACK-38)**: Responsive audit and CSS cleanup~~ ✓ Shipped v3.25.03
+- **Mobile Modals (STACK-70)**: Full-screen edit/add modal, touch-sized inputs, swipe gestures on cards

--- a/js/about.js
+++ b/js/about.js
@@ -274,6 +274,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.25.03 &ndash; STACK-38/STACK-31: Responsive card view &amp; mobile layout</strong>: Inventory table converts to touch-friendly cards at &le;768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at &le;640px</li>
     <li><strong>v3.25.02 &ndash; STACK-68: Goldback spot lookup fix</strong>: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula</li>
     <li><strong>v3.25.01 &ndash; STACK-64, STACK-67: Version splash fix &amp; update badge</strong>: Version splash now shows friendly &ldquo;What&rsquo;s New&rdquo; content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache</li>
     <li><strong>v3.25.00 &ndash; STACK-54, STACK-66: Appearance settings &amp; sparkline improvements</strong>: Header quick-access buttons for theme and currency. Layout visibility toggles. 1-day sparkline with daily-averaged trend. Spot lookup now fills visible price field. 15/30-minute API cache options</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -251,10 +251,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-02-12 - STACK-55: Bulk Editor clean selection, code cleanup
+ * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.25.02";
+const APP_VERSION = "3.25.03";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -242,6 +242,8 @@ const setupColumnResizing = () => {
  */
 const updateColumnVisibility = () => {
   const width = window.innerWidth;
+  // Card view handles all column visibility via CSS at ≤768px (STACK-31)
+  if (width <= 768) return;
   const hidden = new Set();
 
   const breakpoints = [

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1232,7 +1232,7 @@ const renderTable = () => {
       tbody.addEventListener('click', (e) => {
         if (window.innerWidth > 768) return;
         // Don't intercept clicks on buttons, links, or interactive elements
-        if (e.target.closest('button, a, input, select, textarea, .icon-btn')) return;
+        if (e.target.closest('button, a, input, select, textarea, .icon-btn, .filter-text, [role="button"], .year-tag, .purity-tag')) return;
         const row = e.target.closest('tr[data-idx]');
         if (row) editItem(Number(row.dataset.idx));
       });

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1176,32 +1176,32 @@ const renderTable = () => {
 
   rows.push(`
       <tr data-idx="${originalIdx}">
-  <td class="shrink" data-column="date">${filterLink('date', item.date, 'var(--text-primary)', item.date ? formatDisplayDate(item.date) : '—')}</td>
-      <td class="shrink" data-column="metal" data-metal="${escapeAttribute(item.composition || item.metal || '')}">${filterLink('metal', item.composition || item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)', getDisplayComposition(item.composition || item.metal || 'Silver'))}</td>
-      <td class="shrink" data-column="type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
-      <td class="expand" data-column="name" style="text-align: left;">
+  <td class="shrink" data-column="date" data-label="Date">${filterLink('date', item.date, 'var(--text-primary)', item.date ? formatDisplayDate(item.date) : '—')}</td>
+      <td class="shrink" data-column="metal" data-label="Metal" data-metal="${escapeAttribute(item.composition || item.metal || '')}">${filterLink('metal', item.composition || item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)', getDisplayComposition(item.composition || item.metal || 'Silver'))}</td>
+      <td class="shrink" data-column="type" data-label="Type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
+      <td class="expand" data-column="name" data-label="" style="text-align: left;">
         <div class="name-cell-content">
         ${filterLink('name', item.name, 'var(--text-primary)', undefined, item.name)}${orderedChips}
         </div>
       </td>
-      <td class="shrink" data-column="qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
-      <td class="shrink" data-column="weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight, item.weightUnit), item.weightUnit === 'gb' ? 'Goldback denomination' : item.weight < 1 ? 'Grams (g)' : 'Troy ounces (ozt)')}</td>
-      <td class="shrink" data-column="purchasePrice" title="Purchase Price (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
+      <td class="shrink" data-column="qty" data-label="Qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
+      <td class="shrink" data-column="weight" data-label="Weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight, item.weightUnit), item.weightUnit === 'gb' ? 'Goldback denomination' : item.weight < 1 ? 'Grams (g)' : 'Troy ounces (ozt)')}</td>
+      <td class="shrink" data-column="purchasePrice" data-label="Purchase" title="Purchase Price (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
         <a href="#" class="ebay-buy-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? ' ' + item.year : '') + ' ' + item.name)}" title="Search eBay active listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${formatCurrency(purchasePrice)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>
       </td>
-      <td class="shrink" data-column="meltValue" title="Melt Value (${displayCurrency})" style="color: var(--text-primary);">${meltDisplay}</td>
-      <td class="shrink ${gbDenomPrice ? 'retail-confirmed' : isManualRetail ? 'retail-confirmed' : 'retail-estimated'}" data-column="retailPrice" title="${gbDenomPrice ? 'Goldback denomination price' : isManualRetail ? 'Manual retail price (confirmed)' : 'Estimated — defaults to melt value'} - Click to search eBay sold listings">
+      <td class="shrink" data-column="meltValue" data-label="Melt" title="Melt Value (${displayCurrency})" style="color: var(--text-primary);">${meltDisplay}</td>
+      <td class="shrink ${gbDenomPrice ? 'retail-confirmed' : isManualRetail ? 'retail-confirmed' : 'retail-estimated'}" data-column="retailPrice" data-label="Retail" title="${gbDenomPrice ? 'Goldback denomination price' : isManualRetail ? 'Manual retail price (confirmed)' : 'Estimated — defaults to melt value'} - Click to search eBay sold listings">
         <a href="#" class="ebay-sold-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? ' ' + item.year : '') + ' ' + item.name)}" title="Search eBay sold listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${retailDisplay} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>
       </td>
-      <td class="shrink ${!isManualRetail && gainLoss !== null ? 'gainloss-estimated' : ''}" data-column="gainLoss" title="${isManualRetail ? 'Gain/Loss (confirmed retail)' : 'Gain/Loss (estimated — based on melt value)'}" style="color: ${gainLossColor}; font-weight: ${gainLoss !== null && gainLoss !== 0 && isManualRetail ? '600' : 'normal'};">${gainLoss !== null && gainLossDisplay !== '—' ? gainLossPrefix + gainLossDisplay : '—'}</td>
-      <td class="shrink" data-column="purchaseLocation">
+      <td class="shrink ${!isManualRetail && gainLoss !== null ? 'gainloss-estimated' : ''}" data-column="gainLoss" data-label="Gain/Loss" title="${isManualRetail ? 'Gain/Loss (confirmed retail)' : 'Gain/Loss (estimated — based on melt value)'}" style="color: ${gainLossColor}; font-weight: ${gainLoss !== null && gainLoss !== 0 && isManualRetail ? '600' : 'normal'};">${gainLoss !== null && gainLossDisplay !== '—' ? gainLossPrefix + gainLossDisplay : '—'}</td>
+      <td class="shrink" data-column="purchaseLocation" data-label="Source">
         ${formatPurchaseLocation(item.purchaseLocation)}
       </td>
-      <td class="icon-col actions-cell" data-column="actions"><div class="actions-row">
+      <td class="icon-col actions-cell" data-column="actions" data-label=""><div class="actions-row">
         <button class="icon-btn action-icon edit-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit item">
           <svg class="icon-svg edit-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/></svg>
         </button>
@@ -1225,6 +1225,19 @@ const renderTable = () => {
 
     // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
     tbody.innerHTML = rows.join('');
+
+    // Card-view tap-to-edit: delegate click on tbody rows (≤768px only)
+    if (!tbody._cardTapBound) {
+      tbody._cardTapBound = true;
+      tbody.addEventListener('click', (e) => {
+        if (window.innerWidth > 768) return;
+        // Don't intercept clicks on buttons, links, or interactive elements
+        if (e.target.closest('button, a, input, select, textarea, .icon-btn')) return;
+        const row = e.target.closest('tr[data-idx]');
+        if (row) editItem(Number(row.dataset.idx));
+      });
+    }
+
     hideEmptyColumns();
 
     debugLog('renderTable complete');

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -15,6 +15,12 @@ const updatePortalHeight = () => {
   const portalScroll = document.querySelector('.portal-scroll');
   if (!portalScroll) return;
 
+  // Card view at ≤768px: cards scroll naturally in the page (STACK-31)
+  if (window.innerWidth <= 768) {
+    portalScroll.style.maxHeight = '';
+    return;
+  }
+
   const table = document.getElementById('inventoryTable');
   if (!table) return;
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.25.02",
+  "version": "3.25.03",
   "releaseDate": "2026-02-12",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Card view at ≤768px**: Inventory table converts to flexbox-based touch-friendly cards with name title, horizontal chip row, metal subtitle, 2-column financial grid, and centered 44px action buttons
- **CSS consolidation**: Removed 3 duplicate responsive table sections, consolidated into single canonical block + card view rules
- **JS guards**: Column visibility and portal height management skip at ≤768px — card CSS handles everything
- **Tap-to-edit**: Tapping card body opens edit modal; buttons/links work normally
- **Details modal ≤640px**: Single-column breakdown, 150px chart, stacked panels
- **Small-viewport fixes**: Footer badges wrap, filter chips stay horizontal, header logo scales with centered buttons, compact pagination
- **Desktop unchanged**: Verified at 1920×1080 — all 13 columns, normal table layout

### Files changed
| File | Changes |
|------|---------|
| `css/styles.css` | Card view CSS, consolidated responsive rules, details modal/footer/header fixes |
| `js/inventory.js` | `data-label` attributes on `<td>` elements, card tap-to-edit delegation |
| `js/events.js` | Skip `updateColumnVisibility()` at ≤768px |
| `js/pagination.js` | Clear portal max-height at ≤768px |

### Follow-up
- [STACK-70](https://linear.app/hextrackr/issue/STACK-70): Mobile-optimized modals (edit/add item, swipe gestures)

## Test plan
- [ ] Desktop 1920×1080: normal table layout, all columns visible
- [ ] ≤768px (card view): cards render with title, chips, financials, centered buttons
- [ ] Card tap-to-edit: tapping card body opens edit modal
- [ ] Filter chips wrap horizontally at narrow widths
- [ ] Footer badges wrap inside card on mobile
- [ ] Details modal at ≤640px: single-column breakdown
- [ ] All 4 themes (light/dark/sepia/system): card view renders correctly
- [ ] Pagination controls work in card view

🤖 Generated with [Claude Code](https://claude.com/claude-code)