### PR TITLE
v3.25.04 — STACK-70: Mobile-optimized modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.25.04] - 2026-02-12
+
+### Added — STACK-70: Mobile-optimized modals
+
+- **Added**: Full-screen modals at ≤768px using `100dvh` with `100vh` fallback — all primary modals fill the viewport on mobile (STACK-70)
+- **Added**: Settings sidebar 5×2 tab grid replacing horizontal scroll — all 10 tabs visible simultaneously (STACK-70)
+- **Added**: Touch-sized inputs (44px min-height) and stacked action buttons in add/edit item modal (STACK-70)
+- **Added**: Landscape card view for touch devices 769–1024px via `pointer: coarse` detection and `body.force-card-view` class (STACK-70)
+- **Added**: 2-column card grid for portrait ≤768px in landscape orientation (STACK-70)
+- **Changed**: Pie charts and metric toggle hidden on mobile in details modal — Chart.js creation skipped entirely for performance (STACK-70)
+- **Changed**: Bulk edit modal stacks vertically with full-screen integration and touch-sized inputs (STACK-70)
+- **Changed**: `updateColumnVisibility()` extended to apply `.force-card-view` for landscape touch devices (STACK-70)
+- **Changed**: `updatePortalHeight()` clears max-height for `.force-card-view` card layout (STACK-70)
+- **Fixed**: Small utility modals (notes, API info, storage options, cloud sync) remain as centered popups, not full-screen (STACK-70)
+
+---
+
 ## [3.25.03] - 2026-02-12
 
 ### Added — STACK-38/STACK-31: Responsive card view & mobile layout

--- a/css/styles.css
+++ b/css/styles.css
@@ -2024,44 +2024,45 @@ input[type="submit"] {
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
 }
 
-/* Mobile: sidebar becomes horizontal strip */
+/* Mobile: sidebar becomes 5×2 grid — all 10 tabs visible (STACK-70) */
 @media (max-width: 768px) {
-  .modal-content.settings-modal-content {
-    width: 98vw;
-    height: 95vh;
-    max-height: 95vh;
-  }
-
-  .settings-modal-layout {
-    flex-direction: column;
-  }
+  .settings-modal-layout { flex-direction: column; }
 
   .settings-sidebar {
     width: 100%;
     min-width: unset;
-    flex-direction: row;
-    overflow-x: auto;
-    overflow-y: hidden;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    overflow: visible;
     border-right: none;
     border-bottom: 1px solid var(--border);
-    padding: 0;
+    padding: var(--spacing-xs);
+    gap: 2px;
     flex-shrink: 0;
   }
 
   .settings-nav-item {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.15rem;
+    padding: 0.35rem 0.25rem;
+    font-size: 0.65rem;
+    text-align: center;
     white-space: nowrap;
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8125rem;
+    min-height: 44px;
+    border-radius: var(--radius);
   }
+
+  .settings-nav-item svg { width: 14px; height: 14px; }
 
   .settings-nav-item.active {
     border-left: none;
-    border-bottom: 3px solid var(--primary);
+    background: var(--primary);
+    color: #f8fafc;
   }
 
-  .settings-content-area {
-    padding: var(--spacing);
-  }
+  .settings-content-area { padding: var(--spacing); }
 }
 
 
@@ -7665,5 +7666,330 @@ th {
   .grid-2,
   .grid-purity-row {
     grid-template-columns: 1fr;
+  }
+}
+
+/* =============================================================================
+   MOBILE-OPTIMIZED MODALS  (STACK-70)
+   Full-screen modals, touch-sized inputs, hidden charts, landscape card view.
+   ============================================================================= */
+
+/* --- Phase 1: Full-screen modal base ------------------------------------ */
+@media (max-width: 768px) {
+  .modal { padding: 0; }
+
+  .modal-content {
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100vh; height: 100dvh;
+    max-height: 100vh; max-height: 100dvh;
+    margin: 0;
+    border-radius: 0;
+    animation: none;
+  }
+
+  /* Specificity overrides for modals that set their own width */
+  .modal-content.settings-modal-content,
+  #itemModal .modal-content,
+  #detailsModal .modal-content,
+  .bulk-edit-content,
+  .about-modal-content {
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100vh; height: 100dvh;
+    max-height: 100vh; max-height: 100dvh;
+    margin: 0;
+    border-radius: 0;
+  }
+
+  /* Remove header border-radius on fullscreen modals */
+  .modal-content .modal-header,
+  .about-modal-header,
+  .bulk-edit-content .modal-header { border-radius: 0; }
+
+  .modal-content::before { border-radius: 0; }
+
+  /* Exempt small utility modals — keep as centered popups */
+  #apiInfoModal .modal-content,
+  #notesModal .modal-content,
+  #notesViewModal .modal-content,
+  #storageOptionsModal .modal-content,
+  #cloudSyncModal .modal-content {
+    width: 95vw !important;
+    max-width: 400px !important;
+    height: auto;
+    max-height: 90vh; max-height: 90dvh;
+    border-radius: var(--radius-lg);
+  }
+
+  /* --- Phase 3: Item modal — touch-friendly inputs & stacked actions ---- */
+  #itemModal .modal-content { display: flex; flex-direction: column; }
+  #itemModal .modal-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--spacing);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Touch-sized inputs: 44px min height (Apple HIG) */
+  #itemModal input,
+  #itemModal select,
+  #itemModal textarea {
+    min-height: 44px;
+    font-size: 1rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  #itemModal .btn { min-height: 44px; font-size: 0.9rem; }
+
+  /* Stack action rows: Save/Cancel on top, lookup buttons below */
+  .item-modal-actions {
+    flex-direction: column;
+    gap: var(--spacing);
+    padding-top: var(--spacing);
+    border-top: 1px solid var(--border);
+  }
+  .item-modal-actions-left { justify-content: center; order: 2; }
+  .item-modal-actions-right { width: 100%; }
+  .item-modal-actions-right .btn { flex: 1; }
+
+  /* --- Phase 4: Details modal — hide charts, stack panels --------------- */
+  .chart-canvas-container { display: none !important; }
+  .chart-metric-toggle { display: none; }
+
+  .details-grid { grid-template-columns: 1fr; gap: var(--spacing); }
+  .details-panel { padding: var(--spacing); }
+  #detailsModal .modal-body { overflow-y: auto; flex: 1; }
+
+  /* Breakdown grid: keep 2-col for compact financial data */
+  .breakdown-grid { grid-template-columns: 1fr 1fr; gap: 0.125rem 0.5rem; }
+
+  /* --- Phase 6: Bulk edit modal — full-screen stacking ------------------ */
+  .bulk-edit-content { display: flex; flex-direction: column; }
+  .bulk-edit-body {
+    flex-direction: column;
+    flex: 1;
+    overflow-y: auto;
+  }
+  .bulk-edit-fields {
+    width: 100%;
+    max-height: none;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+  .bulk-edit-fields input,
+  .bulk-edit-fields select { min-height: 44px; }
+  .bulk-edit-items { flex: 1; overflow-y: auto; }
+}
+
+/* --- Phase 5: Landscape card view (STACK-70) ----------------------------
+   Touch devices between 769–1024px get card view via JS-applied
+   body.force-card-view class. Rules mirror the ≤768px card block
+   (STACK-31, lines ~7342–7593) — keep both in sync during edits.
+   ----------------------------------------------------------------------- */
+
+/* Landscape touch: 2-column card grid */
+body.force-card-view #inventoryTable thead { display: none; }
+
+body.force-card-view #inventoryTable,
+body.force-card-view #inventoryTable tbody {
+  display: block;
+  width: 100%;
+  border-spacing: 0;
+}
+
+body.force-card-view #inventoryTable tbody {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+body.force-card-view #inventoryTable tbody tr {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 0.75rem;
+  cursor: pointer;
+}
+
+body.force-card-view #inventoryTable tbody td,
+body.force-card-view #inventoryTable tbody td.shrink,
+body.force-card-view #inventoryTable tbody td.expand,
+body.force-card-view #inventoryTable tbody td.icon-col {
+  display: flex !important;
+  justify-content: space-between;
+  align-items: baseline;
+  flex: 0 0 50% !important;
+  box-sizing: border-box;
+  padding: 0.2rem 0.35rem;
+  border: none;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  width: unset !important;
+  max-width: none !important;
+  min-width: 0 !important;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+body.force-card-view #inventoryTable tbody td::before {
+  content: attr(data-label);
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-right: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* Name — full-width card title */
+body.force-card-view #inventoryTable tbody td[data-column="name"] {
+  flex: 0 0 100% !important;
+  order: -2;
+  font-size: 1.05rem;
+  font-weight: 600;
+  justify-content: flex-start;
+  padding-bottom: 0.25rem;
+  text-align: left;
+}
+body.force-card-view #inventoryTable tbody td[data-column="name"]::before { display: none; }
+
+/* Metal — full-width subtitle */
+body.force-card-view #inventoryTable tbody td[data-column="metal"] {
+  flex: 0 0 100% !important;
+  order: -1;
+  font-size: 0.9rem;
+  justify-content: flex-start;
+  padding-bottom: 0.35rem;
+  margin-bottom: 0.25rem;
+  border-bottom: 1px solid var(--border);
+}
+body.force-card-view #inventoryTable tbody td[data-column="metal"]::before { display: none; }
+
+/* Actions — full-width bottom row */
+body.force-card-view #inventoryTable tbody td[data-column="actions"],
+body.force-card-view #inventoryTable tbody td.icon-col[data-column="actions"] {
+  flex: 0 0 100% !important;
+  width: unset !important;
+  max-width: none !important;
+  justify-content: center;
+  padding-top: 0.35rem;
+  margin-top: 0.25rem;
+  border-top: 1px solid var(--border);
+}
+body.force-card-view #inventoryTable tbody td[data-column="actions"]::before { display: none; }
+
+/* Hide lower-priority fields */
+body.force-card-view #inventoryTable tbody td[data-column="date"],
+body.force-card-view #inventoryTable tbody td[data-column="type"],
+body.force-card-view #inventoryTable tbody td[data-column="purchaseLocation"] {
+  display: none !important;
+}
+
+/* Override hideEmptyColumns() for visible card fields */
+body.force-card-view #inventoryTable tbody td[data-column="name"],
+body.force-card-view #inventoryTable tbody td[data-column="metal"],
+body.force-card-view #inventoryTable tbody td[data-column="qty"],
+body.force-card-view #inventoryTable tbody td[data-column="weight"],
+body.force-card-view #inventoryTable tbody td[data-column="purchasePrice"],
+body.force-card-view #inventoryTable tbody td[data-column="meltValue"],
+body.force-card-view #inventoryTable tbody td[data-column="retailPrice"],
+body.force-card-view #inventoryTable tbody td[data-column="gainLoss"],
+body.force-card-view #inventoryTable tbody td[data-column="actions"] {
+  display: flex !important;
+}
+
+/* eBay search SVG icons: hide in card view */
+body.force-card-view #inventoryTable tbody td .ebay-search-svg { display: none; }
+
+/* Action row layout inside card */
+body.force-card-view #inventoryTable tbody td[data-column="actions"] .actions-row {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  width: 100%;
+}
+
+/* Touch-friendly action buttons (44px minimum) */
+body.force-card-view #inventoryTable tbody td[data-column="actions"] .icon-btn {
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0.4rem;
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+
+body.force-card-view #inventoryTable tbody td[data-column="actions"] .icon-svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* Cards scroll naturally — remove portal max-height */
+body.force-card-view .portal-scroll {
+  max-height: none !important;
+  overflow: visible;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Name cell: name on line 1, chips wrap on line 2 */
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .filter-text {
+  flex: 0 0 100%;
+  overflow: visible;
+  white-space: normal;
+  text-overflow: clip;
+  font-size: 1.05rem;
+}
+
+/* Chips: horizontal row, touch-friendly */
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .year-tag,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .numista-tag,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .pcgs-tag,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .grade-tag,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .serial-tag,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .storage-tag,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .notes-indicator,
+body.force-card-view #inventoryTable tbody td[data-column="name"] .name-cell-content > .purity-tag {
+  flex-shrink: 0;
+  font-size: 0.8rem !important;
+  padding: 0.2rem 0.5rem !important;
+  min-height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Compact pagination footer for card view */
+body.force-card-view .table-footer-controls {
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  justify-content: center;
+}
+
+body.force-card-view .table-item-count { font-size: 0.85rem; }
+
+body.force-card-view .table-footer-controls select {
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+  max-width: 6rem;
+}
+
+/* Portrait ≤768px in landscape orientation: 2-column card grid */
+@media (max-width: 768px) and (orientation: landscape) {
+  #inventoryTable tbody {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
   }
 }

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STACK-70: Mobile-optimized modals (v3.25.04)**: Full-screen modals on mobile with 100dvh, settings 5×2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769–1024px, bulk edit stacking
 - **STACK-38/STACK-31: Responsive card view & mobile layout (v3.25.03)**: Inventory table converts to touch-friendly cards at ≤768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at ≤640px
 - **STACK-68: Goldback spot lookup fix (v3.25.02)**: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula
 - **STACK-64, STACK-67: Version splash fix & update badge (v3.25.01)**: Version splash now shows friendly "What's New" content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache
@@ -12,4 +13,4 @@
 - **Chart Overhaul (STACK-48)**: Migrate to ApexCharts with time-series trend views
 - **Custom CSV Mapper (STACK-51)**: Header mapping UI with saved import profiles
 - ~~**Table CSS Hardening (STACK-38)**: Responsive audit and CSS cleanup~~ ✓ Shipped v3.25.03
-- **Mobile Modals (STACK-70)**: Full-screen edit/add modal, touch-sized inputs, swipe gestures on cards
+- ~~**Mobile Modals (STACK-70)**: Full-screen edit/add modal, touch-sized inputs~~ ✓ Shipped v3.25.04

--- a/js/about.js
+++ b/js/about.js
@@ -274,6 +274,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.25.04 &ndash; STACK-70: Mobile-optimized modals</strong>: Full-screen modals on mobile with 100dvh, settings 5&times;2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769&ndash;1024px, bulk edit stacking</li>
     <li><strong>v3.25.03 &ndash; STACK-38/STACK-31: Responsive card view &amp; mobile layout</strong>: Inventory table converts to touch-friendly cards at &le;768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at &le;640px</li>
     <li><strong>v3.25.02 &ndash; STACK-68: Goldback spot lookup fix</strong>: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula</li>
     <li><strong>v3.25.01 &ndash; STACK-64, STACK-67: Version splash fix &amp; update badge</strong>: Version splash now shows friendly &ldquo;What&rsquo;s New&rdquo; content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.25.03";
+const APP_VERSION = "3.25.04";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -253,8 +253,12 @@ const showDetailsModal = (metal) => {
     rightBreakdown = metalData.locationBreakdown;
   }
 
+  // Charts hidden via CSS on mobile — skip creation entirely (STACK-70)
+  const isMobile = window.innerWidth <= 768;
+
   // Helper: render charts with current metric
   const renderCharts = () => {
+    if (isMobile) return;
     destroyCharts();
     if (Object.keys(leftBreakdown).length > 0) {
       chartInstances.typeChart = createPieChart(
@@ -279,33 +283,35 @@ const showDetailsModal = (metal) => {
   let existingToggle = elements.detailsModal.querySelector('.chart-metric-toggle');
   if (existingToggle) existingToggle.remove();
 
-  const toggleBar = document.createElement('div');
-  toggleBar.className = 'chart-metric-toggle';
-  const metrics = [
-    { key: 'purchase', label: 'Purchase' },
-    { key: 'melt',     label: 'Melt' },
-    { key: 'retail',   label: 'Retail' },
-    { key: 'gainLoss', label: 'Gain/Loss' }
-  ];
-  metrics.forEach(m => {
-    const btn = document.createElement('button');
-    btn.className = 'chart-metric-btn' + (m.key === detailsChartMetric ? ' active' : '');
-    btn.textContent = m.label;
-    btn.type = 'button';
-    btn.addEventListener('click', () => {
-      detailsChartMetric = m.key;
-      toggleBar.querySelectorAll('.chart-metric-btn').forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      renderCharts();
+  if (!isMobile) {
+    const toggleBar = document.createElement('div');
+    toggleBar.className = 'chart-metric-toggle';
+    const metrics = [
+      { key: 'purchase', label: 'Purchase' },
+      { key: 'melt',     label: 'Melt' },
+      { key: 'retail',   label: 'Retail' },
+      { key: 'gainLoss', label: 'Gain/Loss' }
+    ];
+    metrics.forEach(m => {
+      const btn = document.createElement('button');
+      btn.className = 'chart-metric-btn' + (m.key === detailsChartMetric ? ' active' : '');
+      btn.textContent = m.label;
+      btn.type = 'button';
+      btn.addEventListener('click', () => {
+        detailsChartMetric = m.key;
+        toggleBar.querySelectorAll('.chart-metric-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        renderCharts();
+      });
+      toggleBar.appendChild(btn);
     });
-    toggleBar.appendChild(btn);
-  });
 
-  if (detailsGrid) {
-    detailsGrid.parentNode.insertBefore(toggleBar, detailsGrid);
+    if (detailsGrid) {
+      detailsGrid.parentNode.insertBefore(toggleBar, detailsGrid);
+    }
   }
 
-  // Initial chart render
+  // Initial chart render (no-op on mobile)
   renderCharts();
 
   // Build color maps matching pie chart segment order (by insertion order)

--- a/js/events.js
+++ b/js/events.js
@@ -242,8 +242,14 @@ const setupColumnResizing = () => {
  */
 const updateColumnVisibility = () => {
   const width = window.innerWidth;
+  const isTouch = window.matchMedia('(pointer: coarse)').matches;
+  const forceCards = isTouch && width > 768 && width <= 1024;
+
+  document.body.classList.toggle('force-card-view', forceCards);
+
   // Card view handles all column visibility via CSS at ≤768px (STACK-31)
-  if (width <= 768) return;
+  // or via .force-card-view for landscape touch devices (STACK-70)
+  if (width <= 768 || forceCards) return;
   const hidden = new Set();
 
   const breakpoints = [

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -15,8 +15,9 @@ const updatePortalHeight = () => {
   const portalScroll = document.querySelector('.portal-scroll');
   if (!portalScroll) return;
 
-  // Card view at ≤768px: cards scroll naturally in the page (STACK-31)
-  if (window.innerWidth <= 768) {
+  // Card view at ≤768px or landscape touch (STACK-31 / STACK-70):
+  // cards scroll naturally in the page
+  if (window.innerWidth <= 768 || document.body.classList.contains('force-card-view')) {
     portalScroll.style.maxHeight = '';
     return;
   }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.25.03",
+  "version": "3.25.04",
   "releaseDate": "2026-02-12",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Full-screen modals at ≤768px using `100dvh` with `100vh` fallback for all primary modals
- Settings sidebar converts from horizontal scroll to 5×2 grid — all 10 tabs visible
- Touch-sized inputs (44px min-height per Apple HIG) and stacked action buttons in add/edit modal
- Pie charts hidden on mobile in details modal — Chart.js creation skipped entirely for performance
- Landscape card view for touch devices 769–1024px via `pointer: coarse` detection
- 2-column card grid for portrait ≤768px in landscape orientation
- Bulk edit modal stacks vertically with full-screen integration
- Small utility modals (notes, API info, etc.) remain as centered popups

## Test plan

- [ ] Desktop 1920×1080: all modals render as before, table layout normal
- [ ] Portrait phone (390×844): all modals full-screen, settings 5×2 tab grid, 44px inputs, cards 1-col
- [ ] Landscape phone (844×390): 2-column card grid (not table), modals full-screen
- [ ] iPad portrait (768×1024): card view active, modals full-screen
- [ ] iPad landscape (1024×768): 2-column card grid via `.force-card-view`
- [ ] All 4 themes (light/dark/sepia/system): full-screen modals render correctly
- [ ] Small utility modals: notes, API info stay as centered popups
- [ ] `file://` protocol: no new fetches or imports — pure CSS + minimal JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)