### PR TITLE
STACK-70: Raise card view breakpoint to 1350px

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7340,7 +7340,7 @@ th {
    data-label attributes on <td> elements via ::before pseudo-elements.
    ============================================================================= */
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   /* Hide table header — card labels replace column headers */
   #inventoryTable thead {
     display: none;
@@ -7985,8 +7985,8 @@ body.force-card-view .table-footer-controls select {
   max-width: 6rem;
 }
 
-/* Portrait ≤768px in landscape orientation: 2-column card grid */
-@media (max-width: 768px) and (orientation: landscape) {
+/* Landscape orientation: 2-column card grid */
+@media (max-width: 1024px) and (orientation: landscape) {
   #inventoryTable tbody {
     display: grid !important;
     grid-template-columns: 1fr 1fr;

--- a/css/styles.css
+++ b/css/styles.css
@@ -7340,7 +7340,7 @@ th {
    data-label attributes on <td> elements via ::before pseudo-elements.
    ============================================================================= */
 
-@media (max-width: 1024px) {
+@media (max-width: 1350px) {
   /* Hide table header — card labels replace column headers */
   #inventoryTable thead {
     display: none;
@@ -7986,7 +7986,7 @@ body.force-card-view .table-footer-controls select {
 }
 
 /* Landscape orientation: 2-column card grid */
-@media (max-width: 1024px) and (orientation: landscape) {
+@media (max-width: 1350px) and (orientation: landscape) {
   #inventoryTable tbody {
     display: grid !important;
     grid-template-columns: 1fr 1fr;

--- a/js/events.js
+++ b/js/events.js
@@ -243,13 +243,13 @@ const setupColumnResizing = () => {
 const updateColumnVisibility = () => {
   const width = window.innerWidth;
   const isTouch = window.matchMedia('(pointer: coarse)').matches;
-  const forceCards = isTouch && width > 768 && width <= 1024;
+  const forceCards = isTouch && width > 1024 && width <= 1280;
 
   document.body.classList.toggle('force-card-view', forceCards);
 
-  // Card view handles all column visibility via CSS at ≤768px (STACK-31)
-  // or via .force-card-view for landscape touch devices (STACK-70)
-  if (width <= 768 || forceCards) return;
+  // Card view handles all column visibility via CSS at ≤1024px (STACK-70)
+  // or via .force-card-view for landscape touch tablets (STACK-70)
+  if (width <= 1024 || forceCards) return;
   const hidden = new Set();
 
   const breakpoints = [

--- a/js/events.js
+++ b/js/events.js
@@ -243,13 +243,13 @@ const setupColumnResizing = () => {
 const updateColumnVisibility = () => {
   const width = window.innerWidth;
   const isTouch = window.matchMedia('(pointer: coarse)').matches;
-  const forceCards = isTouch && width > 1024 && width <= 1280;
+  const forceCards = isTouch && width > 1350 && width <= 1600;
 
   document.body.classList.toggle('force-card-view', forceCards);
 
-  // Card view handles all column visibility via CSS at ≤1024px (STACK-70)
-  // or via .force-card-view for landscape touch tablets (STACK-70)
-  if (width <= 1024 || forceCards) return;
+  // Card view handles all column visibility via CSS at ≤1350px (STACK-70)
+  // or via .force-card-view for large touch tablets (STACK-70)
+  if (width <= 1350 || forceCards) return;
   const hidden = new Set();
 
   const breakpoints = [

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -15,9 +15,9 @@ const updatePortalHeight = () => {
   const portalScroll = document.querySelector('.portal-scroll');
   if (!portalScroll) return;
 
-  // Card view at ≤768px or landscape touch (STACK-31 / STACK-70):
+  // Card view at ≤1024px or landscape touch tablets (STACK-31 / STACK-70):
   // cards scroll naturally in the page
-  if (window.innerWidth <= 768 || document.body.classList.contains('force-card-view')) {
+  if (window.innerWidth <= 1024 || document.body.classList.contains('force-card-view')) {
     portalScroll.style.maxHeight = '';
     return;
   }

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -15,9 +15,9 @@ const updatePortalHeight = () => {
   const portalScroll = document.querySelector('.portal-scroll');
   if (!portalScroll) return;
 
-  // Card view at ≤1024px or landscape touch tablets (STACK-31 / STACK-70):
+  // Card view at ≤1350px or large touch tablets (STACK-31 / STACK-70):
   // cards scroll naturally in the page
-  if (window.innerWidth <= 1024 || document.body.classList.contains('force-card-view')) {
+  if (window.innerWidth <= 1350 || document.body.classList.contains('force-card-view')) {
     portalScroll.style.maxHeight = '';
     return;
   }


### PR DESCRIPTION
## Summary

- Raise card view breakpoint from 768px to 1350px — table content gets cut off before card view kicks in at lower thresholds
- Touch `force-card-view` range bumped to 1351–1600px for large tablets
- JS guards in `events.js` and `pagination.js` updated to match

Follow-up to PR #81 (v3.25.04) based on live testing.

## Test plan

- [ ] At 1350px width: card view active, no table columns cut off
- [ ] At 1351px+ width: table view with progressive column hiding
- [ ] Touch devices >1350px: `force-card-view` active up to 1600px
- [ ] Desktop >1400px: full table with all columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)