### PR TITLE
STACK-70: Fix header breakpoint and raise card view to 1350px

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7548,7 +7548,26 @@ th {
     font-size: 0.9rem;
   }
 
-  /* Header: scale logo to fill mobile width, center buttons below */
+  /* Compact pagination footer for card view */
+  .table-footer-controls {
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    justify-content: center;
+  }
+
+  .table-item-count {
+    font-size: 0.85rem;
+  }
+
+  .table-footer-controls select {
+    font-size: 0.85rem;
+    padding: 0.25rem 0.5rem;
+    max-width: 6rem;
+  }
+}
+
+/* Header: scale logo and center buttons — mobile only (STACK-70) */
+@media (max-width: 768px) {
   .app-header {
     min-height: auto;
     padding: var(--spacing-sm);
@@ -7573,23 +7592,6 @@ th {
 
   .stackr-logo {
     max-width: 100% !important;
-  }
-
-  /* Compact pagination footer for card view */
-  .table-footer-controls {
-    flex-wrap: wrap;
-    gap: var(--spacing-xs);
-    justify-content: center;
-  }
-
-  .table-item-count {
-    font-size: 0.85rem;
-  }
-
-  .table-footer-controls select {
-    font-size: 0.85rem;
-    padding: 0.25rem 0.5rem;
-    max-width: 6rem;
   }
 }
 


### PR DESCRIPTION
## Summary

- Raise card view breakpoint from 768px to 1350px — table columns get cut off at narrower widths
- Move header mobile styles (scaled logo, centered buttons) to dedicated 768px block — they were incorrectly promoted to 1350px when the card view breakpoint was raised
- Touch `force-card-view` range bumped to 1351–1600px for large tablets

Follow-up to PR #81 / #83 based on live resize testing.

## Test plan

- [ ] At ~1350px: card view active, header stays compact (logo left, buttons right)
- [ ] At ≤768px: header scales up with centered buttons (mobile layout)
- [ ] At >1350px desktop: full table with all columns visible
- [ ] Smooth transition between all breakpoints with no jarring layout shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)