### PR TITLE
v3.25.05 — STACK-71: Details modal QoL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.25.05] - 2026-02-13
+
+### Added — STACK-71: Details modal QoL — responsive charts, slice labels, scrollable breakdown
+
+- **Added**: Pie chart percentage labels via chartjs-plugin-datalabels — slices ≥5% show percentage directly on the chart (STACK-71)
+- **Added**: Sticky metric toggle (Purchase/Melt/Retail/Gain-Loss) stays visible while scrolling the modal body (STACK-71)
+- **Fixed**: Details modal overflow cascade — breakdowns no longer clipped off-screen at any viewport size (STACK-71)
+- **Fixed**: Chart container uses `aspect-ratio: 1` for circular pie charts instead of rigid 300px height (STACK-71)
+- **Fixed**: ResizeObserver memory leak — observer now disconnected on modal close (STACK-71)
+- **Fixed**: Sepia theme chart colors — tooltips now use correct background/text colors for all 4 themes (STACK-71)
+- **Fixed**: Allow clearing optional form fields on edit
+- **Removed**: Dead CSS chart-height rules at ≤768px/≤640px/≤480px (already hidden by STACK-70)
+
+---
+
 ## [3.25.04] - 2026-02-12
 
 ### Added — STACK-70: Mobile-optimized modals

--- a/css/styles.css
+++ b/css/styles.css
@@ -2142,7 +2142,8 @@ input[type="submit"] {
   padding: 0;
   overflow: hidden;
   width: 90%;
-  max-width: 1000px;
+  max-width: 1200px;
+  max-height: 90vh;
 }
 
 #changeLogModal .modal-content {
@@ -2192,7 +2193,7 @@ input[type="submit"] {
 #detailsModal .modal-body {
   padding: var(--spacing-xl);
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -3470,8 +3471,8 @@ a.about-badge:hover {
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-xl);
   margin-bottom: var(--spacing-lg);
-  flex: 1;
-  overflow: hidden;
+  flex: 0 0 auto;
+  overflow: visible;
 }
 
 .details-panel {
@@ -3482,12 +3483,12 @@ a.about-badge:hover {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .details-breakdown {
-  flex: 1;
-  overflow: auto;
+  flex: 0 0 auto;
+  overflow: visible;
   padding-right: var(--spacing-sm);
 }
 
@@ -3572,10 +3573,12 @@ a.about-badge:hover {
 
 .chart-canvas-container {
   position: relative;
-  height: 300px;
   width: 100%;
+  max-width: 300px;
+  max-height: 300px;
+  aspect-ratio: 1;
   margin: 0 auto;
-  flex: 0 0 300px;
+  flex: 0 0 auto;
 }
 
 .chart-canvas {
@@ -3587,24 +3590,36 @@ a.about-badge:hover {
   display: flex;
   justify-content: center;
   gap: 0;
-  margin: 0.75rem auto;
+  margin: 0 auto 0.75rem;
   border-radius: var(--radius);
-  overflow: hidden;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border);
   width: fit-content;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg-primary);
+  padding: 0.5rem 0;
 }
 .chart-metric-btn {
-  padding: 0.35rem 0.85rem;
-  font-size: 0.8rem;
-  font-weight: 500;
+  padding: 0.5rem 1.25rem;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
   border: none;
   background: var(--bg-secondary);
   color: var(--text-primary);
   transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+.chart-metric-btn:first-child {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+.chart-metric-btn:last-child {
+  border-radius: 0 var(--radius) var(--radius) 0;
 }
 .chart-metric-btn:not(:last-child) {
-  border-right: 1px solid var(--border-color);
+  border-right: 1px solid var(--border);
 }
 .chart-metric-btn:hover {
   background: var(--bg-hover);
@@ -4485,6 +4500,13 @@ input:disabled + .slider {
    - Optimized table display with column adjustments
    ============================================================================= */
 
+/* STACK-71: Single-column details at tablet widths, aligned with card-view breakpoint */
+@media (max-width: 1350px) {
+  .details-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 1200px) {
   .totals {
     grid-template-columns: repeat(3, 1fr);
@@ -4492,10 +4514,6 @@ input:disabled + .slider {
 
   #detailsModal .modal-content {
     max-width: 900px;
-  }
-
-  .details-grid {
-    grid-template-columns: 1fr;
   }
 }
 
@@ -4505,7 +4523,7 @@ input:disabled + .slider {
   }
 
   #detailsModal .modal-content {
-    max-width: 700px;
+    max-width: 900px;
   }
 }
 
@@ -4596,14 +4614,6 @@ input:disabled + .slider {
   .action-buttons {
     grid-template-columns: 1fr;
   }
-
-  .chart-canvas-container {
-    height: 250px;
-  }
-
-  .chart-canvas {
-    max-height: 250px !important;
-  }
 }
 
 @media (max-width: 480px) {
@@ -4622,14 +4632,6 @@ input:disabled + .slider {
 
   .spot-input {
     padding: var(--spacing);
-  }
-
-  .chart-canvas-container {
-    height: 200px;
-  }
-
-  .chart-canvas {
-    max-height: 200px !important;
   }
 }
 
@@ -7616,15 +7618,6 @@ th {
   .breakdown-grid {
     grid-template-columns: 1fr;
     gap: 0.125rem;
-  }
-
-  .chart-canvas-container {
-    height: 150px;
-    flex: 0 0 150px;
-  }
-
-  .chart-canvas {
-    max-height: 150px !important;
   }
 
   /* Reduce breakdown font sizes */

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,16 +1,13 @@
 ## What's New
 
+- **STACK-71: Details modal QoL (v3.25.05)**: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors
 - **STACK-70: Mobile-optimized modals (v3.25.04)**: Full-screen modals on mobile with 100dvh, settings 5×2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769–1024px, bulk edit stacking
 - **STACK-38/STACK-31: Responsive card view & mobile layout (v3.25.03)**: Inventory table converts to touch-friendly cards at ≤768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at ≤640px
 - **STACK-68: Goldback spot lookup fix (v3.25.02)**: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula
 - **STACK-64, STACK-67: Version splash fix & update badge (v3.25.01)**: Version splash now shows friendly "What's New" content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache
-- **STACK-54, STACK-66: Appearance settings & sparkline improvements (v3.25.00)**: Header quick-access buttons for theme and currency. Layout visibility toggles. 1-day sparkline with daily-averaged trend. Spot lookup now fills visible price field. 15/30-minute API cache options
-- **STACK-56: Complexity reduction (v3.24.06)**: Refactored 6 functions to reduce cyclomatic complexity — dispatch maps, extracted helpers, optionalListener utility. −301 lines from events.js
-- **STACK-55: Bulk Editor clean selection (v3.24.04)**: Bulk Editor now resets selection on every open. Removed stale localStorage persistence
 
 ## Development Roadmap
 
 - **Chart Overhaul (STACK-48)**: Migrate to ApexCharts with time-series trend views
 - **Custom CSV Mapper (STACK-51)**: Header mapping UI with saved import profiles
-- ~~**Table CSS Hardening (STACK-38)**: Responsive audit and CSS cleanup~~ ✓ Shipped v3.25.03
-- ~~**Mobile Modals (STACK-70)**: Full-screen edit/add modal, touch-sized inputs~~ ✓ Shipped v3.25.04
+- **Autocomplete & Fuzzy Search (STACK-62)**: Wire up existing autocomplete/fuzzy-search infrastructure into search and form inputs

--- a/index.html
+++ b/index.html
@@ -55,6 +55,11 @@
       defer=""
       src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"
     ></script>
+    <!-- Chart.js datalabels plugin for pie chart percentage labels (STACK-71) -->
+    <script
+      defer=""
+      src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js"
+    ></script>
     <!-- JSZip for backup functionality -->
     <script
       defer=""

--- a/js/about.js
+++ b/js/about.js
@@ -274,13 +274,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.25.05 &ndash; STACK-71: Details modal QoL</strong>: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors</li>
     <li><strong>v3.25.04 &ndash; STACK-70: Mobile-optimized modals</strong>: Full-screen modals on mobile with 100dvh, settings 5&times;2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769&ndash;1024px, bulk edit stacking</li>
     <li><strong>v3.25.03 &ndash; STACK-38/STACK-31: Responsive card view &amp; mobile layout</strong>: Inventory table converts to touch-friendly cards at &le;768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at &le;640px</li>
     <li><strong>v3.25.02 &ndash; STACK-68: Goldback spot lookup fix</strong>: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula</li>
     <li><strong>v3.25.01 &ndash; STACK-64, STACK-67: Version splash fix &amp; update badge</strong>: Version splash now shows friendly &ldquo;What&rsquo;s New&rdquo; content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache</li>
-    <li><strong>v3.25.00 &ndash; STACK-54, STACK-66: Appearance settings &amp; sparkline improvements</strong>: Header quick-access buttons for theme and currency. Layout visibility toggles. 1-day sparkline with daily-averaged trend. Spot lookup now fills visible price field. 15/30-minute API cache options</li>
-    <li><strong>v3.24.06 &ndash; STACK-56: Complexity reduction</strong>: Refactored 6 functions below Lizard CCN threshold &mdash; dispatch maps, extracted helpers, optionalListener utility. &minus;301 lines from events.js</li>
-    <li><strong>v3.24.04 &ndash; STACK-55: Bulk Editor clean selection</strong>: Bulk Editor now resets selection on every open. Removed stale localStorage persistence</li>
   `;
 };
 
@@ -292,7 +290,7 @@ const getEmbeddedRoadmap = () => {
   return `
     <li><strong>Chart Overhaul (STACK-48)</strong>: Migrate to ApexCharts with time-series trend views</li>
     <li><strong>Custom CSV Mapper (STACK-51)</strong>: Header mapping UI with saved import profiles</li>
-    <li><strong>Table CSS Hardening (STACK-38)</strong>: Responsive audit and CSS cleanup</li>
+    <li><strong>Autocomplete &amp; Fuzzy Search (STACK-62)</strong>: Wire up existing autocomplete/fuzzy-search infrastructure into search and form inputs</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.25.04";
+const APP_VERSION = "3.25.05";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.25.04",
-  "releaseDate": "2026-02-12",
+  "version": "3.25.05",
+  "releaseDate": "2026-02-13",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Pie chart datalabels**: Percentage labels on slices ≥5% via chartjs-plugin-datalabels (CDN, per-chart registration)
- **Scrollable modal body**: Fixed `overflow: hidden` cascade that clipped breakdowns off-screen
- **Sticky metric toggle**: Purchase/Melt/Retail/Gain-Loss tabs stay visible while scrolling
- **Chart aspect-ratio**: Circular pie charts via `aspect-ratio: 1` instead of rigid 300px height
- **ResizeObserver leak fix**: Observer disconnected on modal close
- **Sepia theme colors**: Chart tooltips now correct for all 4 themes
- **Form fix**: Allow clearing optional fields on edit

## Files Updated

- `index.html` — chartjs-plugin-datalabels v2.2.0 CDN script
- `css/styles.css` — overflow fixes, chart constraints, sticky toggle, 1350px breakpoint, dead code cleanup
- `js/charts.js` — datalabels plugin config, sepia theme fix
- `js/detailsModal.js` — ResizeObserver leak fix, scroll-to-top on open
- `js/constants.js` — APP_VERSION → 3.25.05
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry, roadmap cleanup
- `js/about.js` — embedded What's New + Roadmap fallback sync
- `version.json` — remote version check endpoint

## Linear Issues

- STACK-71: Details modal QoL — responsive charts, slice labels, scrollable breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)