### PR TITLE
v3.26.00 — STACK-62: Autocomplete & Fuzzy Search Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.26.00] - 2026-02-13
+
+### Added — STACK-62: Autocomplete & Fuzzy Search Pipeline
+
+- **Added**: Autocomplete dropdown on Name, Purchase Location, and Storage Location form inputs — suggestions from inventory + prebuilt coin database (STACK-62)
+- **Added**: Abbreviation expansion in search — "ASE", "AGE", "kook", "krug" etc. match full coin names (STACK-62)
+- **Added**: Fuzzy search fallback — approximate matches shown with indicator banner when exact search returns no results (STACK-62)
+- **Added**: `registerName()` dynamically adds new item names to autocomplete suggestions (STACK-62)
+- **Fixed**: Firefox autocomplete suppression using non-standard attribute value (STACK-62)
+- **Fixed**: Autocomplete cache invalidated on inventory save, clear, and boating accident (STACK-62)
+- **Changed**: `FUZZY_AUTOCOMPLETE` feature flag promoted to stable (STACK-62)
+
+---
+
 ## [3.25.05] - 2026-02-13
 
 ### Added — STACK-71: Details modal QoL — responsive charts, slice labels, scrollable breakdown

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,9 @@ Multi-currency is shipped (STACK-50). These items are unblocked and ready for th
 | [STACK-51](https://linear.app/hextrackr/issue/STACK-51) | Custom CSV import mapper with header mapping UI and saved profiles | Medium | — |
 | [STACK-53](https://linear.app/hextrackr/issue/STACK-53) | [RFC] Community spot price history CDN via GitHub with manifest-based selective import | Medium | — |
 | [STACK-60](https://linear.app/hextrackr/issue/STACK-60) | Source "—" click-to-filter returns no results for empty source items | Low | — |
+| [STACK-73](https://linear.app/hextrackr/issue/STACK-73) | Date Run Checklist: track collecting goals with auto-matched year sets | Medium | — |
+| [STACK-74](https://linear.app/hextrackr/issue/STACK-74) | PWA support: manifest, service worker, installable app experience | Medium | — |
+| [STACK-76](https://linear.app/hextrackr/issue/STACK-76) | Numismatics expansion: paper notes, non-melt collectibles, asset class field | Medium | — |
 
 ---
 
@@ -45,6 +48,9 @@ Enhanced UX, mobile support, deployment options, and the v4 vision.
 | Issue | Title | Priority | Depends On |
 |-------|-------|----------|------------|
 | [STACK-47](https://linear.app/hextrackr/issue/STACK-47) | v4.00.00 — Multi-asset wealth dashboard (Stocks, Crypto, Collectibles, Real Estate) | Low | STACK-42, STACK-43, STACK-45, STACK-46 |
+| [STACK-75](https://linear.app/hextrackr/issue/STACK-75) | Desktop wrapper research: Tauri vs Electron for native installers | Low | STACK-74 |
+| [STACK-77](https://linear.app/hextrackr/issue/STACK-77) | Stocks & Crypto module: ticker-based pricing with portfolio tracking | Low | STACK-76 |
+| [STACK-78](https://linear.app/hextrackr/issue/STACK-78) | Mobile native app: Capacitor/Tauri wrapper with Supabase sync | Low | STACK-30, STACK-74, STACK-75 |
 | [STACK-31](https://linear.app/hextrackr/issue/STACK-31) | Mobile-responsive card view | Low | — |
 | [STACK-32](https://linear.app/hextrackr/issue/STACK-32) | User photo upload for inventory items | Low | STACK-30 |
 | [STACK-33](https://linear.app/hextrackr/issue/STACK-33) | Mobile camera capture in add/edit modal | Low | STACK-31, STACK-32 |

--- a/css/styles.css
+++ b/css/styles.css
@@ -3864,15 +3864,12 @@ a.about-badge:hover {
 }
 
 .autocomplete-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
+  position: fixed;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow);
-  z-index: 1000;
+  z-index: 10100;
   max-height: 12rem;
   overflow-y: auto;
 }
@@ -3885,6 +3882,19 @@ a.about-badge:hover {
 .autocomplete-item.active,
 .autocomplete-item:hover {
   background: var(--bg-secondary);
+}
+
+.autocomplete-item mark {
+  background: transparent;
+  color: var(--info);
+  font-weight: 600;
+}
+
+.fuzzy-indicator {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  padding: var(--spacing-xs) 0;
+  font-style: italic;
 }
 
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,13 +1,13 @@
 ## What's New
 
+- **STACK-62: Autocomplete & Fuzzy Search Pipeline (v3.26.00)**: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix
 - **STACK-71: Details modal QoL (v3.25.05)**: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors
 - **STACK-70: Mobile-optimized modals (v3.25.04)**: Full-screen modals on mobile with 100dvh, settings 5×2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769–1024px, bulk edit stacking
 - **STACK-38/STACK-31: Responsive card view & mobile layout (v3.25.03)**: Inventory table converts to touch-friendly cards at ≤768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at ≤640px
 - **STACK-68: Goldback spot lookup fix (v3.25.02)**: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula
-- **STACK-64, STACK-67: Version splash fix & update badge (v3.25.01)**: Version splash now shows friendly "What's New" content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache
 
 ## Development Roadmap
 
 - **Chart Overhaul (STACK-48)**: Migrate to ApexCharts with time-series trend views
 - **Custom CSV Mapper (STACK-51)**: Header mapping UI with saved import profiles
-- **Autocomplete & Fuzzy Search (STACK-62)**: Wire up existing autocomplete/fuzzy-search infrastructure into search and form inputs
+- **PWA Support (STACK-74)**: Manifest, service worker, installable app experience

--- a/js/about.js
+++ b/js/about.js
@@ -274,11 +274,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.26.00 &ndash; STACK-62: Autocomplete &amp; Fuzzy Search Pipeline</strong>: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix</li>
     <li><strong>v3.25.05 &ndash; STACK-71: Details modal QoL</strong>: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors</li>
     <li><strong>v3.25.04 &ndash; STACK-70: Mobile-optimized modals</strong>: Full-screen modals on mobile with 100dvh, settings 5&times;2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769&ndash;1024px, bulk edit stacking</li>
     <li><strong>v3.25.03 &ndash; STACK-38/STACK-31: Responsive card view &amp; mobile layout</strong>: Inventory table converts to touch-friendly cards at &le;768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at &le;640px</li>
     <li><strong>v3.25.02 &ndash; STACK-68: Goldback spot lookup fix</strong>: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula</li>
-    <li><strong>v3.25.01 &ndash; STACK-64, STACK-67: Version splash fix &amp; update badge</strong>: Version splash now shows friendly &ldquo;What&rsquo;s New&rdquo; content. Footer version badge links to GitHub releases; on hosted sites, checks for updates with 24hr cache</li>
   `;
 };
 
@@ -290,7 +290,7 @@ const getEmbeddedRoadmap = () => {
   return `
     <li><strong>Chart Overhaul (STACK-48)</strong>: Migrate to ApexCharts with time-series trend views</li>
     <li><strong>Custom CSV Mapper (STACK-51)</strong>: Header mapping UI with saved import profiles</li>
-    <li><strong>Autocomplete &amp; Fuzzy Search (STACK-62)</strong>: Wire up existing autocomplete/fuzzy-search infrastructure into search and form inputs</li>
+    <li><strong>PWA Support (STACK-74)</strong>: Manifest, service worker, installable app experience</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.25.05";
+const APP_VERSION = "3.26.00";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -835,11 +835,11 @@ if (typeof window !== "undefined") {
  */
 const FEATURE_FLAGS = {
   FUZZY_AUTOCOMPLETE: {
-    enabled: false,
+    enabled: true,
     urlOverride: true,
     userToggle: true,
     description: "Fuzzy search autocomplete for item names and locations",
-    phase: "testing"
+    phase: "stable"
   },
   DEBUG_UI: {
     enabled: false,

--- a/js/events.js
+++ b/js/events.js
@@ -1272,6 +1272,8 @@ const setupDataManagementListeners = () => {
   optionalListener(elements.removeInventoryDataBtn, "click", () => {
     if (confirm("Remove all inventory items? This cannot be undone.")) {
       localStorage.removeItem(LS_KEY);
+      // STACK-62: Clear stale autocomplete cache so it rebuilds from fresh inventory
+      if (typeof clearLookupCache === 'function') clearLookupCache();
       loadInventory();
       renderTable();
       renderActiveFilters();
@@ -1288,6 +1290,8 @@ const setupDataManagementListeners = () => {
       Object.values(METALS).forEach((metalConfig) => {
         localStorage.removeItem(metalConfig.localStorageKey);
       });
+      // STACK-62: Clear autocomplete cache with everything else
+      if (typeof clearLookupCache === 'function') clearLookupCache();
       sessionStorage.clear();
 
       loadInventory();

--- a/js/init.js
+++ b/js/init.js
@@ -437,6 +437,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         updateStorageStats();
       }
 
+    // STACK-62: Initialize autocomplete/fuzzy search system
+    if (typeof initializeAutocomplete === 'function') {
+      initializeAutocomplete(inventory);
+    }
+
     // Automatically sync prices if cache is stale and API keys are available
     if (typeof autoSyncSpotPrices === "function") {
       autoSyncSpotPrices();

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -512,6 +512,8 @@ window.getNextSerial = getNextSerial;
 const saveInventory = () => {
   saveData(LS_KEY, inventory);
   // CatalogManager handles its own saving, no need to explicitly save catalogMap
+  // STACK-62: Invalidate autocomplete cache so lookup table rebuilds with current inventory
+  if (typeof clearLookupCache === 'function') clearLookupCache();
 };
 
 /**

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.25.05",
+  "version": "3.26.00",
   "releaseDate": "2026-02-13",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Autocomplete dropdowns** on Name, Purchase Location, and Storage Location form inputs — suggestions drawn from inventory + prebuilt coin database
- **Abbreviation expansion** in search — "ASE", "AGE", "kook", "krug", "phil", "buff" etc. match full coin names
- **Fuzzy search fallback** — approximate matches shown with indicator banner when exact search returns no results
- **registerName()** dynamically adds new item names to autocomplete suggestions on save
- **Firefox compatibility** — non-standard autocomplete attribute suppresses browser form history
- **Cache invalidation** — autocomplete lookup cache cleared on inventory save, clear, and boating accident
- **Feature flag** — `FUZZY_AUTOCOMPLETE` promoted from testing to stable

## Files Updated

- `js/autocomplete.js` — Expanded abbreviations, registerName(), attachAutocomplete() dropdown UI, initializeAutocomplete()
- `js/filters.js` — Abbreviation expansion + fuzzy fallback in filterInventoryAdvanced()
- `js/search.js` — Abbreviation expansion + fuzzy fallback in legacy path, fuzzy indicator
- `js/constants.js` — APP_VERSION → 3.26.00, FUZZY_AUTOCOMPLETE flag → stable
- `js/events.js` — clearLookupCache() on inventory clear/boating accident
- `js/inventory.js` — clearLookupCache() on saveInventory()
- `js/init.js` — initializeAutocomplete() call during startup
- `css/styles.css` — Portal dropdown positioning, fuzzy indicator, match highlighting
- `CHANGELOG.md` — New v3.26.00 section
- `docs/announcements.md` — New What's New entry, STACK-62 removed from roadmap
- `js/about.js` — Embedded fallbacks synced with announcements.md
- `version.json` — Version + release date
- `ROADMAP.md` — Updated

## Linear Issues

- STACK-62: Autocomplete & Fuzzy Search Pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)