### PR TITLE
v3.26.01 — Fuzzy Autocomplete Settings Toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.26.01] - 2026-02-13
+
+### Added — Fuzzy Autocomplete Settings Toggle
+
+- **Added**: Fuzzy autocomplete On/Off toggle in Settings > Filter Chips panel
+- **Fixed**: Autocomplete feature flag not discoverable — persisted disabled state had no UI to re-enable
+
+---
+
 ## [3.26.00] - 2026-02-13
 
 ### Added — STACK-62: Autocomplete & Fuzzy Search Pipeline

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Fuzzy Autocomplete Settings Toggle (v3.26.01)**: Added On/Off toggle for fuzzy autocomplete in Settings > Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled
 - **STACK-62: Autocomplete & Fuzzy Search Pipeline (v3.26.00)**: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix
 - **STACK-71: Details modal QoL (v3.25.05)**: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors
 - **STACK-70: Mobile-optimized modals (v3.25.04)**: Full-screen modals on mobile with 100dvh, settings 5×2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769–1024px, bulk edit stacking
 - **STACK-38/STACK-31: Responsive card view & mobile layout (v3.25.03)**: Inventory table converts to touch-friendly cards at ≤768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at ≤640px
-- **STACK-68: Goldback spot lookup fix (v3.25.02)**: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -1704,6 +1704,15 @@
               </div>
 
               <div class="settings-group">
+                <div class="settings-group-label">Fuzzy autocomplete</div>
+                <p class="settings-subtext">Show smart suggestions when typing in the Name, Purchase Location, and Storage Location fields.</p>
+                <div class="chip-sort-toggle" id="settingsFuzzyAutocomplete">
+                  <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
+                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
+                </div>
+              </div>
+
+              <div class="settings-group">
                 <div class="settings-group-label">Chip sort order</div>
                 <p class="settings-subtext">Sort chips within each category by name or quantity.</p>
                 <div class="chip-sort-toggle" id="settingsChipSortOrder">

--- a/js/about.js
+++ b/js/about.js
@@ -274,11 +274,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.26.01 &ndash; Fuzzy Autocomplete Settings Toggle</strong>: Added On/Off toggle for fuzzy autocomplete in Settings &gt; Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled</li>
     <li><strong>v3.26.00 &ndash; STACK-62: Autocomplete &amp; Fuzzy Search Pipeline</strong>: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix</li>
     <li><strong>v3.25.05 &ndash; STACK-71: Details modal QoL</strong>: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors</li>
     <li><strong>v3.25.04 &ndash; STACK-70: Mobile-optimized modals</strong>: Full-screen modals on mobile with 100dvh, settings 5&times;2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769&ndash;1024px, bulk edit stacking</li>
     <li><strong>v3.25.03 &ndash; STACK-38/STACK-31: Responsive card view &amp; mobile layout</strong>: Inventory table converts to touch-friendly cards at &le;768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at &le;640px</li>
-    <li><strong>v3.25.02 &ndash; STACK-68: Goldback spot lookup fix</strong>: Spot price lookup now converts gold spot to Goldback denomination price instead of using raw gold formula</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.26.00";
+const APP_VERSION = "3.26.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/settings.js
+++ b/js/settings.js
@@ -185,6 +185,15 @@ const syncSettingsUI = () => {
     });
   }
 
+  // Fuzzy autocomplete — sync toggle with feature flag
+  const autocompleteSetting = document.getElementById('settingsFuzzyAutocomplete');
+  if (autocompleteSetting && window.featureFlags) {
+    const aVal = featureFlags.isEnabled('FUZZY_AUTOCOMPLETE') ? 'yes' : 'no';
+    autocompleteSetting.querySelectorAll('.chip-sort-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.val === aVal);
+    });
+  }
+
   // Chip grouping tables and dropdown
   if (typeof window.populateBlacklistDropdown === 'function') window.populateBlacklistDropdown();
   if (typeof window.renderBlacklistTable === 'function') window.renderBlacklistTable();
@@ -453,6 +462,28 @@ const setupSettingsEventListeners = () => {
         b.classList.toggle('active', b.dataset.val === btn.dataset.val);
       });
       if (typeof renderActiveFilters === 'function') renderActiveFilters();
+    });
+  }
+
+  // Fuzzy autocomplete toggle
+  const autocompleteSettingEl = document.getElementById('settingsFuzzyAutocomplete');
+  if (autocompleteSettingEl) {
+    autocompleteSettingEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip-sort-btn');
+      if (!btn) return;
+      const isEnabled = btn.dataset.val === 'yes';
+      if (window.featureFlags) {
+        if (isEnabled) featureFlags.enable('FUZZY_AUTOCOMPLETE');
+        else featureFlags.disable('FUZZY_AUTOCOMPLETE');
+      }
+      // Update active state
+      autocompleteSettingEl.querySelectorAll('.chip-sort-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.val === btn.dataset.val);
+      });
+      // Re-initialize or tear down autocomplete live
+      if (isEnabled && typeof initializeAutocomplete === 'function') {
+        initializeAutocomplete(inventory);
+      }
     });
   }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.26.00",
+  "version": "3.26.01",
   "releaseDate": "2026-02-13",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Added**: Fuzzy autocomplete On/Off toggle in Settings > Filter Chips panel
- **Fixed**: Autocomplete feature flag not discoverable — persisted disabled state had no UI to re-enable

## Files Updated

- `js/constants.js` — APP_VERSION → 3.26.01
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint
- `index.html` — new settings toggle HTML
- `js/settings.js` — toggle sync + click handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)