### PR TITLE
v3.26.02 — Autocomplete Migration & Version Check CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.26.02] - 2026-02-13
+
+### Fixed — Autocomplete Migration & Version Check CORS
+
+- **Fixed**: One-time migration auto-enables `FUZZY_AUTOCOMPLETE` for users who had it silently disabled before the settings toggle existed
+- **Fixed**: Version check CORS failure — `staktrakr.com` 301 redirects to `www.staktrakr.com` without CORS headers; updated URL to skip redirect
+
+---
+
 ## [3.26.01] - 2026-02-13
 
 ### Added — Fuzzy Autocomplete Settings Toggle

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,9 @@
 ## What's New
 
+- **Autocomplete Migration & Version Check CORS (v3.26.02)**: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect
 - **Fuzzy Autocomplete Settings Toggle (v3.26.01)**: Added On/Off toggle for fuzzy autocomplete in Settings > Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled
 - **STACK-62: Autocomplete & Fuzzy Search Pipeline (v3.26.00)**: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix
 - **STACK-71: Details modal QoL (v3.25.05)**: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors
-- **STACK-70: Mobile-optimized modals (v3.25.04)**: Full-screen modals on mobile with 100dvh, settings 5×2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769–1024px, bulk edit stacking
-- **STACK-38/STACK-31: Responsive card view & mobile layout (v3.25.03)**: Inventory table converts to touch-friendly cards at ≤768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at ≤640px
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -274,11 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.26.02 &ndash; Autocomplete Migration &amp; Version Check CORS</strong>: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect</li>
     <li><strong>v3.26.01 &ndash; Fuzzy Autocomplete Settings Toggle</strong>: Added On/Off toggle for fuzzy autocomplete in Settings &gt; Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled</li>
     <li><strong>v3.26.00 &ndash; STACK-62: Autocomplete &amp; Fuzzy Search Pipeline</strong>: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix</li>
     <li><strong>v3.25.05 &ndash; STACK-71: Details modal QoL</strong>: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors</li>
-    <li><strong>v3.25.04 &ndash; STACK-70: Mobile-optimized modals</strong>: Full-screen modals on mobile with 100dvh, settings 5&times;2 tab grid, 44px touch inputs, hidden pie charts, landscape card view for touch devices 769&ndash;1024px, bulk edit stacking</li>
-    <li><strong>v3.25.03 &ndash; STACK-38/STACK-31: Responsive card view &amp; mobile layout</strong>: Inventory table converts to touch-friendly cards at &le;768px with horizontal chips, 2-column financials, centered action buttons. Consolidated responsive CSS, details modal fixes at &le;640px</li>
   `;
 };
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.26.01",
+  "version": "3.26.02",
   "releaseDate": "2026-02-13",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: One-time migration auto-enables `FUZZY_AUTOCOMPLETE` for users who had it silently disabled before the settings toggle existed (v3.26.01)
- **Fixed**: Version check CORS failure — `staktrakr.com` now 301 redirects to `www.staktrakr.com` without CORS headers; updated `VERSION_CHECK_URL` to use `www.` directly

## Files Updated

- `js/constants.js` — APP_VERSION → 3.26.02, VERSION_CHECK_URL → www.staktrakr.com, migration logic + whitelist key
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback synced
- `version.json` — remote version check endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)