### PR TITLE
v3.26.03 — STACK-79, STACK-80: XSS & HTML Injection Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.26.03] - 2026-02-13
+
+### Fixed — STACK-79, STACK-80: XSS & HTML Injection Hardening
+
+- **Fixed**: DOM XSS in Price History table — item names now escaped via `escapeHtml()` before innerHTML interpolation (STACK-79)
+- **Fixed**: HTML injection in Spot History table — metal, source, and provider fields now escaped (STACK-80)
+- **Fixed**: HTML injection in Spot Lookup modal — source and data attributes now escaped (STACK-80)
+- **Added**: Shared `escapeHtml()` utility in `utils.js` for consistent XSS prevention across modules
+
+---
+
 ## [3.26.02] - 2026-02-13
 
 ### Fixed — Autocomplete Migration & Version Check CORS

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **STACK-79, STACK-80: XSS & HTML Injection Hardening (v3.26.03)**: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility
 - **Autocomplete Migration & Version Check CORS (v3.26.02)**: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect
 - **Fuzzy Autocomplete Settings Toggle (v3.26.01)**: Added On/Off toggle for fuzzy autocomplete in Settings > Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled
 - **STACK-62: Autocomplete & Fuzzy Search Pipeline (v3.26.00)**: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix
-- **STACK-71: Details modal QoL (v3.25.05)**: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.26.03 &ndash; STACK-79, STACK-80: XSS &amp; HTML Injection Hardening</strong>: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility</li>
     <li><strong>v3.26.02 &ndash; Autocomplete Migration &amp; Version Check CORS</strong>: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect</li>
     <li><strong>v3.26.01 &ndash; Fuzzy Autocomplete Settings Toggle</strong>: Added On/Off toggle for fuzzy autocomplete in Settings &gt; Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled</li>
     <li><strong>v3.26.00 &ndash; STACK-62: Autocomplete &amp; Fuzzy Search Pipeline</strong>: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix</li>
-    <li><strong>v3.25.05 &ndash; STACK-71: Details modal QoL</strong>: Pie chart percentage labels on slices, sticky metric toggle, scrollable modal body fixes overflow cascade, circular chart aspect-ratio, ResizeObserver leak fix, sepia theme chart colors</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.26.02";
+const APP_VERSION = "3.26.03";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/priceHistory.js
+++ b/js/priceHistory.js
@@ -304,7 +304,7 @@ const renderItemPriceHistoryTable = () => {
   const fmt = (v) => typeof formatCurrency === 'function' ? formatCurrency(v) : `$${Number(v).toFixed(2)}`;
   const htmlRows = data.map(r => {
     const ts = new Date(r.ts).toLocaleString();
-    return `<tr><td>${ts}</td><td>${r.name}</td><td>${fmt(r.retail)}</td><td>${fmt(r.spot)}</td><td>${fmt(r.melt)}</td></tr>`;
+    return `<tr><td>${ts}</td><td>${escapeHtml(r.name)}</td><td>${fmt(r.retail)}</td><td>${fmt(r.spot)}</td><td>${fmt(r.melt)}</td></tr>`;
   });
 
   // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml

--- a/js/spot.js
+++ b/js/spot.js
@@ -938,7 +938,7 @@ const renderSpotHistoryTable = () => {
     const price = typeof formatCurrency === 'function' ? formatCurrency(e.spot) : `$${Number(e.spot).toFixed(2)}`;
     const source = e.source || '';
     const provider = e.provider || '';
-    return `<tr><td>${ts}</td><td>${metal}</td><td>${price}</td><td>${source}</td><td>${provider}</td></tr>`;
+    return `<tr><td>${ts}</td><td>${escapeHtml(metal)}</td><td>${price}</td><td>${escapeHtml(source)}</td><td>${escapeHtml(provider)}</td></tr>`;
   });
 
   // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -357,10 +357,10 @@ const renderSpotLookupResults = (container, results, metalName, dateStr) => {
     html += '<tr>';
     html += `<td>${ts}</td>`;
     html += `<td><strong>${price}</strong></td>`;
-    html += `<td>${source}</td>`;
+    html += `<td>${escapeHtml(source)}</td>`;
     html += `<td><span class="spot-lookup-offset${exactClass}">${offsetLabel}</span></td>`;
     html += `<td><button class="btn spot-lookup-use-btn" type="button" `
-         + `data-spot="${entry.spot}" data-ts="${entry.timestamp || ''}">Use</button></td>`;
+         + `data-spot="${escapeHtml(entry.spot)}" data-ts="${escapeHtml(entry.timestamp || '')}">Use</button></td>`;
     html += '</tr>';
   });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -9,6 +9,14 @@ const LZString = {
 // UTILITY FUNCTIONS
 
 /**
+ * Escape HTML special characters to prevent XSS when interpolating into innerHTML.
+ * @param {*} str - Value to escape (coerced to string)
+ * @returns {string} Escaped HTML-safe string
+ */
+const escapeHtml = (str) =>
+  String(str ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+/**
  * Logs messages to console when DEBUG flag is enabled
  *
  * @param {...any} args - Values to log when debugging

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.26.02",
+  "version": "3.26.03",
   "releaseDate": "2026-02-13",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **STACK-79**: Escaped item names in Price History table to prevent DOM XSS via crafted `item.name` values
- **STACK-80**: Escaped metal, source, provider fields in Spot History table and source + data attributes in Spot Lookup modal
- **Added**: Shared `escapeHtml()` utility in `js/utils.js` — regex-based, no DOM allocation, available globally

## Files Updated

- `js/utils.js` — new `escapeHtml()` utility function
- `js/priceHistory.js` — escape `r.name` in innerHTML interpolation
- `js/spot.js` — escape `metal`, `source`, `provider` in innerHTML interpolation
- `js/spotLookup.js` — escape `source` and `data-*` attributes in innerHTML interpolation
- `js/constants.js` — APP_VERSION → 3.26.03
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback synced
- `version.json` — remote version check endpoint

## Linear Issues

- STACK-79: DOM XSS in Price History table → Done
- STACK-80: HTML injection in spot-history and spot-lookup rendering → Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)