### PR TITLE
v3.27.00 — Coin Image Cache & Item View Modal

### DIFF
--- a/.codacy/cli.sh
+++ b/.codacy/cli.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+
+set -e +o pipefail
+
+# Set up paths first
+bin_name="codacy-cli-v2"
+
+# Determine OS-specific paths
+os_name=$(uname)
+arch=$(uname -m)
+
+case "$arch" in
+"x86_64")
+  arch="amd64"
+  ;;
+"x86")
+  arch="386"
+  ;;
+"aarch64"|"arm64")
+  arch="arm64"
+  ;;
+esac
+
+if [ -z "$CODACY_CLI_V2_TMP_FOLDER" ]; then
+    if [ "$(uname)" = "Linux" ]; then
+        CODACY_CLI_V2_TMP_FOLDER="$HOME/.cache/codacy/codacy-cli-v2"
+    elif [ "$(uname)" = "Darwin" ]; then
+        CODACY_CLI_V2_TMP_FOLDER="$HOME/Library/Caches/Codacy/codacy-cli-v2"
+    else
+        CODACY_CLI_V2_TMP_FOLDER=".codacy-cli-v2"
+    fi
+fi
+
+version_file="$CODACY_CLI_V2_TMP_FOLDER/version.yaml"
+
+
+get_version_from_yaml() {
+    if [ -f "$version_file" ]; then
+        local version=$(grep -o 'version: *"[^"]*"' "$version_file" | cut -d'"' -f2)
+        if [ -n "$version" ]; then
+            echo "$version"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+get_latest_version() {
+    local response
+    if [ -n "$GH_TOKEN" ]; then
+        response=$(curl -Lq --header "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/codacy/codacy-cli-v2/releases/latest" 2>/dev/null)
+    else
+        response=$(curl -Lq "https://api.github.com/repos/codacy/codacy-cli-v2/releases/latest" 2>/dev/null)
+    fi
+
+    handle_rate_limit "$response"
+    local version=$(echo "$response" | grep -m 1 tag_name | cut -d'"' -f4)
+    echo "$version"
+}
+
+handle_rate_limit() {
+    local response="$1"
+    if echo "$response" | grep -q "API rate limit exceeded"; then
+          fatal "Error: GitHub API rate limit exceeded. Please try again later"
+    fi
+}
+
+download_file() {
+    local url="$1"
+
+    echo "Downloading from URL: ${url}"
+    if command -v curl > /dev/null 2>&1; then
+        curl -# -LS "$url" -O
+    elif command -v wget > /dev/null 2>&1; then
+        wget "$url"
+    else
+        fatal "Error: Could not find curl or wget, please install one."
+    fi
+}
+
+download() {
+    local url="$1"
+    local output_folder="$2"
+
+    ( cd "$output_folder" && download_file "$url" )
+}
+
+download_cli() {
+    # OS name lower case
+    suffix=$(echo "$os_name" | tr '[:upper:]' '[:lower:]')
+
+    local bin_folder="$1"
+    local bin_path="$2"
+    local version="$3"
+
+    if [ ! -f "$bin_path" ]; then
+        echo "📥 Downloading CLI version $version..."
+
+        remote_file="codacy-cli-v2_${version}_${suffix}_${arch}.tar.gz"
+        url="https://github.com/codacy/codacy-cli-v2/releases/download/${version}/${remote_file}"
+
+        download "$url" "$bin_folder"
+        tar xzfv "${bin_folder}/${remote_file}" -C "${bin_folder}"
+    fi
+}
+
+# Warn if CODACY_CLI_V2_VERSION is set and update is requested
+if [ -n "$CODACY_CLI_V2_VERSION" ] && [ "$1" = "update" ]; then
+    echo "⚠️  Warning: Performing update with forced version $CODACY_CLI_V2_VERSION"
+    echo "    Unset CODACY_CLI_V2_VERSION to use the latest version"
+fi
+
+# Ensure version.yaml exists and is up to date
+if [ ! -f "$version_file" ] || [ "$1" = "update" ]; then
+    echo "ℹ️  Fetching latest version..."
+    version=$(get_latest_version)
+    mkdir -p "$CODACY_CLI_V2_TMP_FOLDER"
+    echo "version: \"$version\"" > "$version_file"
+fi
+
+# Set the version to use
+if [ -n "$CODACY_CLI_V2_VERSION" ]; then
+    version="$CODACY_CLI_V2_VERSION"
+else
+    version=$(get_version_from_yaml)
+fi
+
+
+# Set up version-specific paths
+bin_folder="${CODACY_CLI_V2_TMP_FOLDER}/${version}"
+
+mkdir -p "$bin_folder"
+bin_path="$bin_folder"/"$bin_name"
+
+# Download the tool if not already installed
+download_cli "$bin_folder" "$bin_path" "$version"
+chmod +x "$bin_path"
+
+run_command="$bin_path"
+if [ -z "$run_command" ]; then
+    fatal "Codacy cli v2 binary could not be found."
+fi
+
+if [ "$#" -eq 1 ] && [ "$1" = "download" ]; then
+    echo "Codacy cli v2 download succeeded"
+else
+    eval "$run_command $*"
+fi

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,0 +1,10 @@
+runtimes:
+    - java@17.0.10
+    - node@22.2.0
+    - python@3.11.11
+tools:
+    - eslint@8.57.0
+    - pmd@6.55.0
+    - pylint@3.3.9
+    - semgrep@1.78.0
+    - trivy@0.69.1

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 CLAUDE.md
 TAXONOMY.md
 SPRINT.md
+AGENTS.md
 
 # Internal dev docs (not for public repo)
 docs/CLOUD-SYNC-DESIGN.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.27.00] - 2026-02-13
+
+### Added — Coin Image Cache & Item View Modal
+
+- **Added**: IndexedDB image cache (`js/image-cache.js`) — fetches, resizes, and stores Numista coin images with 50MB quota and graceful `file://` degradation
+- **Added**: Item view modal (`js/viewModal.js`) with coin images, inventory data, valuation, grading, and Numista enrichment — opens via item name click or card tap
+- **Added**: Numista metadata caching with 30-day TTL — denomination, shape, diameter, thickness, orientation, composition, technique, references, rarity, mintage, edge, tags, and commemorative info
+- **Added**: Settings toggles for 15 Numista view modal fields in API settings panel
+- **Added**: View (eye) button in table/card actions, card tap opens view modal on mobile
+- **Added**: Reusable iframe popup modal (1250px) for source URLs, N# Numista links, and external references
+- **Added**: IndexedDB storage reporting in settings footer (LS + IDB) and storage report modal
+- **Added**: Search eBay button in view modal footer
+- **Added**: `COIN_IMAGES` feature flag (beta) gating entire image/view system
+- **Changed**: All popup windows widened from 1200px to 1250px
+- **Changed**: Full-screen view modal on mobile with sticky footer, safe-area insets, and 44px touch targets
+- **Changed**: Rectangular image frames for bars, notes, and Aurum/Goldback items in view modal
+
+---
+
 ## [3.26.03] - 2026-02-13
 
 ### Fixed — STACK-79, STACK-80: XSS & HTML Injection Hardening

--- a/css/styles.css
+++ b/css/styles.css
@@ -3106,6 +3106,520 @@ td input:checked + .slider:before {
 }
 
 /* =============================================================================
+   VIEW ITEM MODAL — Coin showcase card with image display + enriched data
+
+   Glass-morphism card matching existing modal system.
+   Images displayed on a subtle dark field (coin presentation aesthetic).
+   Sections separated by faint gradient dividers.
+   ============================================================================= */
+
+/* --- Modal content shell --- */
+#viewItemModal .modal-content {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  width: 92%;
+  max-width: 820px;
+  max-height: 90vh;
+}
+
+/* --- Header with gradient banner --- */
+#viewItemModal .modal-header {
+  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+  color: #f8fafc;
+  padding: var(--spacing-lg) var(--spacing-xl);
+  padding-right: 2.5rem; /* room for close button */
+  position: relative;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: var(--shadow);
+}
+
+#viewItemModal .modal-header h2 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 1.1rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#viewItemModal .view-modal-catalog-id {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  opacity: 0.85;
+  background: rgba(255, 255, 255, 0.15);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+/* --- Scrollable body --- */
+#viewItemModal .modal-body {
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* --- Image showcase section --- */
+.view-image-section {
+  background: linear-gradient(145deg, #1a1a2e, #16213e);
+  padding: var(--spacing-lg);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: var(--spacing-lg);
+  position: relative;
+}
+
+/* Subtle coin-case texture overlay */
+.view-image-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.3) 100%);
+  pointer-events: none;
+}
+
+.view-image-slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+  position: relative;
+  z-index: 1;
+}
+
+/* Default: round coin frame */
+.view-image-slot img {
+  max-width: 180px;
+  max-height: 180px;
+  object-fit: contain;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+/* Rectangular frame for bars, notes, Aurum/Goldback — auto-fits aspect ratio */
+.view-image-section.view-shape-rect .view-image-slot img {
+  border-radius: var(--radius);
+  max-width: 200px;
+  max-height: 260px;
+  width: auto;
+  height: auto;
+}
+
+.view-image-section.view-shape-rect .view-image-placeholder {
+  border-radius: var(--radius);
+  width: 140px;
+  height: 200px;
+}
+
+.view-image-slot img:hover {
+  transform: scale(1.06);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+}
+
+.view-image-slot .view-image-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.55);
+  font-weight: 500;
+}
+
+/* Placeholder when no image available */
+.view-image-placeholder {
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  color: rgba(255, 255, 255, 0.15);
+}
+
+/* --- Data sections --- */
+.view-detail-section {
+  padding: var(--spacing) var(--spacing-xl);
+  border-bottom: 1px solid var(--border);
+}
+
+.view-detail-section:last-child {
+  border-bottom: none;
+}
+
+.view-section-title {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--primary);
+  margin: 0 0 var(--spacing-sm) 0;
+  padding-bottom: 2px;
+}
+
+.view-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px var(--spacing-lg);
+}
+
+.view-detail-grid.three-col {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.view-detail-item {
+  display: flex;
+  flex-direction: column;
+  padding: 3px 0;
+}
+
+.view-detail-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.view-detail-label {
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.view-detail-value {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.view-detail-value.gain {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.view-detail-value.loss {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.view-detail-value.muted {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* --- Numista enrichment section — distinct separator --- */
+.view-numista-section {
+  padding: var(--spacing) var(--spacing-xl);
+  background: var(--bg-secondary);
+  border-top: 2px solid var(--border);
+  position: relative;
+}
+
+.view-numista-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: var(--spacing-xl);
+  right: var(--spacing-xl);
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--primary), transparent);
+  opacity: 0.3;
+  margin-top: -2px;
+}
+
+.view-numista-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  background: rgba(59, 130, 246, 0.08);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-bottom: var(--spacing-sm);
+}
+
+/* Numista section uses 3 columns by default for compact layout */
+.view-numista-section .view-detail-grid {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+/* Image tooltip for obverse/reverse descriptions */
+.view-image-slot {
+  position: relative;
+}
+
+.view-image-slot[title] img {
+  cursor: help;
+}
+
+/* Rarity bar */
+.view-rarity-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.view-rarity-track {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+  max-width: 120px;
+}
+
+.view-rarity-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--success), var(--warning), var(--danger));
+  transition: width 0.4s ease;
+}
+
+.view-rarity-score {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* --- Notes section --- */
+.view-notes-text {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  font-style: italic;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* --- Footer actions --- */
+.view-modal-footer {
+  padding: var(--spacing) var(--spacing-xl);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.view-footer-left {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.view-footer-right {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.view-modal-footer button {
+  padding: 6px 16px;
+  border-radius: var(--radius);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: var(--transition);
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.view-modal-footer button:hover {
+  background: var(--bg-tertiary);
+}
+
+.view-modal-footer .view-edit-btn {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.view-modal-footer .view-edit-btn:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+}
+
+.view-ebay-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.view-ebay-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+/* --- Iframe Popup Modal --- */
+.iframe-popup-content {
+  width: 95vw;
+  max-width: 1250px;
+  height: 85vh;
+  max-height: 900px;
+}
+
+.iframe-popup-body {
+  height: calc(100% - 60px);
+  padding: 0;
+}
+
+/* Clickable N# badge */
+.view-modal-catalog-id[style*="cursor: pointer"]:hover {
+  filter: brightness(1.2);
+}
+
+/* --- Responsive: mobile view modal (≤768px) --- */
+@media (max-width: 768px) {
+  /* Full-screen modal on phones — no chrome, maximum content */
+  #viewItemModal .modal-content {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100vh;
+    height: 100vh;
+    border-radius: 0;
+    margin: 0;
+  }
+
+  #viewItemModal .modal-header {
+    border-radius: 0;
+    padding: var(--spacing-sm) var(--spacing);
+  }
+
+  #viewItemModal .modal-header h2 {
+    font-size: 0.95rem;
+    line-height: 1.3;
+  }
+
+  /* Images: side-by-side but smaller — keep both visible */
+  .view-image-section {
+    flex-direction: row;
+    justify-content: center;
+    gap: var(--spacing);
+    padding: var(--spacing);
+  }
+
+  .view-image-slot img {
+    max-width: 120px;
+    max-height: 120px;
+  }
+
+  .view-image-placeholder {
+    width: 110px;
+    height: 110px;
+    font-size: 2rem;
+  }
+
+  .view-image-section.view-shape-rect .view-image-slot img {
+    max-width: 110px;
+    max-height: 160px;
+  }
+
+  .view-image-section.view-shape-rect .view-image-placeholder {
+    width: 95px;
+    height: 140px;
+  }
+
+  /* 2-column data grid (down from 3) */
+  .view-detail-grid,
+  .view-detail-grid.three-col {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .view-detail-section {
+    padding: var(--spacing-sm) var(--spacing);
+  }
+
+  .view-numista-section {
+    padding: var(--spacing-sm) var(--spacing);
+  }
+
+  /* Footer: sticky bottom bar with 44px touch targets + safe-area */
+  .view-modal-footer {
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-primary);
+    border-top: 1px solid var(--border);
+    padding: var(--spacing-sm) var(--spacing);
+    padding-bottom: calc(var(--spacing-sm) + env(safe-area-inset-bottom, 0px));
+    z-index: 2;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+  }
+
+  .view-modal-footer button {
+    min-height: 44px;
+    font-size: 0.85rem;
+    padding: 8px 16px;
+  }
+
+  .view-footer-left {
+    order: 2;
+    width: 100%;
+  }
+
+  .view-ebay-btn {
+    width: 100%;
+    min-height: 38px;
+  }
+
+  .view-footer-right {
+    order: 1;
+    width: 100%;
+    display: flex;
+    gap: var(--spacing-sm);
+  }
+
+  .view-footer-right button {
+    flex: 1;
+  }
+
+  /* Iframe popup: full-screen on mobile */
+  .iframe-popup-content {
+    width: 100%;
+    max-width: 100%;
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 0;
+    margin: 0;
+  }
+
+  .iframe-popup-body {
+    height: calc(100vh - 56px);
+  }
+}
+
+/* --- Extra-small phones (≤400px) — single-column data --- */
+@media (max-width: 400px) {
+  .view-detail-grid,
+  .view-detail-grid.three-col {
+    grid-template-columns: 1fr;
+  }
+
+  .view-image-section {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+/* --- Sepia theme adjustments for image showcase --- */
+[data-theme="sepia"] .view-image-section {
+  background: linear-gradient(145deg, #2c1e0e, #3a2a18);
+}
+
+/* =============================================================================
    ABOUT MODAL STYLING - Enhanced splash page design
    ============================================================================= */
 
@@ -4685,6 +5199,14 @@ input:disabled + .slider {
 #inventoryTable td.icon-col .action-icon.edit-icon {
   color: var(--primary);
   font-weight: bold;
+}
+
+#inventoryTable td.icon-col .action-icon.view-icon {
+  color: var(--text-secondary);
+}
+
+#inventoryTable td.icon-col .action-icon.view-icon:hover {
+  color: var(--primary);
 }
 
 /* Actions column styling */
@@ -7505,6 +8027,17 @@ th {
     height: 1.25rem;
   }
 
+  /* View button: primary accent in card view */
+  #inventoryTable tbody td[data-column="actions"] .icon-btn.view-icon {
+    background: var(--primary);
+    border-color: var(--primary);
+    color: #fff;
+  }
+
+  #inventoryTable tbody td[data-column="actions"] .icon-btn.view-icon .icon-svg {
+    fill: #fff;
+  }
+
   /* Cards scroll naturally — remove portal max-height */
   .portal-scroll {
     max-height: none !important;
@@ -7927,6 +8460,17 @@ body.force-card-view #inventoryTable tbody td[data-column="actions"] .icon-btn {
   border-radius: var(--radius);
   background: var(--bg-secondary);
   border: 1px solid var(--border);
+}
+
+/* View button: primary accent in card view */
+body.force-card-view #inventoryTable tbody td[data-column="actions"] .icon-btn.view-icon {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+body.force-card-view #inventoryTable tbody td[data-column="actions"] .icon-btn.view-icon .icon-svg {
+  fill: #fff;
 }
 
 body.force-card-view #inventoryTable tbody td[data-column="actions"] .icon-svg {

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,8 +1,8 @@
 ## What's New
 
+- **Coin Image Cache & Item View Modal (v3.27.00)**: IndexedDB image cache for Numista coin photos with 50MB quota. Card-style view modal with images, inventory data, valuation, grading, and enriched Numista metadata. Settings toggles for 15 fields. View button in table/card actions. Iframe popup for source URLs and Numista pages. eBay search from view modal. Full-screen mobile layout with sticky footer
 - **STACK-79, STACK-80: XSS & HTML Injection Hardening (v3.26.03)**: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility
 - **Autocomplete Migration & Version Check CORS (v3.26.02)**: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect
-- **Fuzzy Autocomplete Settings Toggle (v3.26.01)**: Added On/Off toggle for fuzzy autocomplete in Settings > Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled
 - **STACK-62: Autocomplete & Fuzzy Search Pipeline (v3.26.00)**: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix
 
 ## Development Roadmap

--- a/index.html
+++ b/index.html
@@ -1552,6 +1552,10 @@
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
               Chips
             </button>
+            <button class="settings-nav-item" data-section="search">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              Search
+            </button>
             <button class="settings-nav-item" data-section="api">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/></svg>
               API
@@ -1704,15 +1708,6 @@
               </div>
 
               <div class="settings-group">
-                <div class="settings-group-label">Fuzzy autocomplete</div>
-                <p class="settings-subtext">Show smart suggestions when typing in the Name, Purchase Location, and Storage Location fields.</p>
-                <div class="chip-sort-toggle" id="settingsFuzzyAutocomplete">
-                  <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
-                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
-                </div>
-              </div>
-
-              <div class="settings-group">
                 <div class="settings-group-label">Chip sort order</div>
                 <p class="settings-subtext">Sort chips within each category by name or quantity.</p>
                 <div class="chip-sort-toggle" id="settingsChipSortOrder">
@@ -1745,6 +1740,51 @@
                 </div>
                 <div class="chip-grouping-table-container" id="customGroupTableContainer">
                   <div class="chip-grouping-empty">No custom grouping rules</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- ===== SEARCH ===== -->
+            <div class="settings-section-panel" id="settingsPanel_search" style="display: none">
+              <h3>Search</h3>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Fuzzy autocomplete</div>
+                <p class="settings-subtext">Show smart suggestions when typing in the Name, Purchase Location, and Storage Location fields.</p>
+                <div class="chip-sort-toggle" id="settingsFuzzyAutocomplete">
+                  <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
+                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
+                </div>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Numista name matching</div>
+                <p class="settings-subtext">Rewrite common coin names (e.g. "ASE") into Numista-optimized search queries with direct lookups for known catalog IDs.</p>
+                <div class="chip-sort-toggle" id="settingsNumistaLookup">
+                  <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
+                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
+                </div>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Built-in patterns <span id="seedRuleCount" style="font-size:0.8em;opacity:0.6;margin-left:0.3em;"></span></div>
+                <p class="settings-subtext">Pre-configured lookup rules shipped with StakTrakr. These cannot be edited.</p>
+                <div class="chip-grouping-table-container" id="seedRuleTableContainer" style="max-height:220px;overflow-y:auto;">
+                  <div class="chip-grouping-empty">Loading…</div>
+                </div>
+              </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Custom patterns</div>
+                <p class="settings-subtext">Add your own regex patterns to rewrite Numista search queries. Custom rules override built-in patterns.</p>
+                <div class="chip-grouping-controls">
+                  <input type="text" id="numistaRulePatternInput" class="chip-grouping-input" placeholder="Regex pattern">
+                  <input type="text" id="numistaRuleReplacementInput" class="chip-grouping-input-wide" placeholder="Numista query">
+                  <input type="text" id="numistaRuleIdInput" class="chip-grouping-input" placeholder="N# (optional)" style="width:90px;">
+                  <button type="button" class="btn" id="addNumistaRuleBtn">Add</button>
+                </div>
+                <div class="chip-grouping-table-container" id="customRuleTableContainer">
+                  <div class="chip-grouping-empty">No custom patterns</div>
                 </div>
               </div>
             </div>
@@ -2796,6 +2836,7 @@
   <script defer src="./js/utils.js"></script>
   <script defer src="./js/fuzzy-search.js"></script>
   <script defer src="./js/autocomplete.js"></script>
+  <script defer src="./js/numista-lookup.js"></script>
   <script defer src="./js/versionCheck.js"></script>
   <script defer src="./js/changeLog.js"></script>
     <script defer src="./js/charts.js"></script>

--- a/index.html
+++ b/index.html
@@ -1837,6 +1837,29 @@
                     </div>
                   </div>
                   <div id="numistaStatus" class="api-status" style="margin-top: 0.5rem;"></div>
+
+                  <!-- View Modal Field Toggles -->
+                  <div class="settings-group" style="margin-top: 1rem; border-top: 1px solid var(--border); padding-top: 0.75rem;">
+                    <div class="settings-group-label">View modal fields</div>
+                    <p class="settings-subtext">Choose which Numista data fields appear in the item view modal.</p>
+                    <div id="numistaViewFieldToggles" style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px 1rem;">
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="denomination" checked> Denomination</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="shape" checked> Shape</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="diameter" checked> Diameter</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="thickness" checked> Thickness</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="orientation" checked> Orientation</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="composition" checked> Composition</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="country" checked> Country</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="technique" checked> Technique</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="references" checked> References (KM#)</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="edge" checked> Edge</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="tags" checked> Tags</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="commemorative" checked> Commemorative</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="rarity" checked> Rarity</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="mintage" checked> Mintage</label>
+                      <label class="settings-checkbox-label"><input type="checkbox" data-nf="imageTooltips" checked> Image tooltips</label>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -2247,7 +2270,7 @@
               <p class="settings-subtext">
                 Set market prices for Goldback denominations manually or auto-estimate from gold spot.
                 Check current rates at
-                <a href="#" id="goldbackExchangeRateLink" onclick="window.open('https://www.goldback.com/exchange-rates/', 'goldback_rates', 'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'); return false;">goldback.com/exchange-rates</a>.
+                <a href="#" id="goldbackExchangeRateLink" onclick="window.open('https://www.goldback.com/exchange-rates/', 'goldback_rates', 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'); return false;">goldback.com/exchange-rates</a>.
               </p>
 
               <div class="settings-group">
@@ -2774,6 +2797,39 @@
     </div>
 
     <!-- =============================================================================
+       IFRAME POPUP MODAL — Reusable overlay for external URLs (source, Numista, etc.)
+       ============================================================================= -->
+    <div class="modal" id="iframePopupModal" style="display: none">
+      <div class="modal-content iframe-popup-content">
+        <div class="modal-header">
+          <h2 id="iframePopupTitle"></h2>
+          <button aria-label="Close popup" class="modal-close" id="iframePopupCloseBtn">&times;</button>
+        </div>
+        <div class="modal-body iframe-popup-body">
+          <iframe id="iframePopupFrame" src="about:blank" style="width: 100%; height: 100%; border: none;"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- =============================================================================
+       VIEW ITEM MODAL
+
+       Card-style showcase for viewing a single inventory item with coin images,
+       inventory data, valuation, grading, and Numista enrichment data.
+       Gated behind COIN_IMAGES feature flag.
+       ============================================================================= -->
+    <div class="modal" id="viewItemModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button aria-label="Close modal" class="modal-close" id="viewModalCloseBtn" style="position: absolute; top: var(--spacing-sm); right: var(--spacing-sm);">&times;</button>
+          <h2 id="viewModalTitle"></h2>
+          <span class="view-modal-catalog-id" id="viewModalCatalogId"></span>
+        </div>
+        <div class="modal-body" id="viewModalBody"></div>
+      </div>
+    </div>
+
+    <!-- =============================================================================
        DEBUG LOG MODAL
 
        Displays collected debug output when debug mode is enabled.
@@ -2834,6 +2890,7 @@
   <script defer src="./js/constants.js"></script>
   <script defer src="./js/state.js"></script>
   <script defer src="./js/utils.js"></script>
+  <script defer src="./js/image-cache.js"></script>
   <script defer src="./js/fuzzy-search.js"></script>
   <script defer src="./js/autocomplete.js"></script>
   <script defer src="./js/numista-lookup.js"></script>
@@ -2847,6 +2904,7 @@
     <script defer src="./js/sorting.js"></script>
     <script defer src="./js/pagination.js"></script>
     <script defer src="./js/detailsModal.js"></script>
+    <script defer src="./js/viewModal.js"></script>
     <script defer src="./js/debugModal.js"></script>
     <script defer src="./js/numista-modal.js"></script>
     <script defer src="./js/spot.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -274,9 +274,9 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.27.00 &ndash; Coin Image Cache &amp; Item View Modal</strong>: IndexedDB image cache for Numista coin photos with 50MB quota. Card-style view modal with images, inventory data, valuation, grading, and enriched Numista metadata. Settings toggles for 15 fields. View button in table/card actions. Iframe popup for source URLs and Numista pages. eBay search from view modal. Full-screen mobile layout with sticky footer</li>
     <li><strong>v3.26.03 &ndash; STACK-79, STACK-80: XSS &amp; HTML Injection Hardening</strong>: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility</li>
     <li><strong>v3.26.02 &ndash; Autocomplete Migration &amp; Version Check CORS</strong>: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect</li>
-    <li><strong>v3.26.01 &ndash; Fuzzy Autocomplete Settings Toggle</strong>: Added On/Off toggle for fuzzy autocomplete in Settings &gt; Filter Chips. Fixed autocomplete feature flag not discoverable when persisted as disabled</li>
     <li><strong>v3.26.00 &ndash; STACK-62: Autocomplete &amp; Fuzzy Search Pipeline</strong>: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix</li>
   `;
 };

--- a/js/constants.js
+++ b/js/constants.js
@@ -586,6 +586,7 @@ const ALLOWED_STORAGE_KEYS = [
   LATEST_REMOTE_VERSION_KEY,  // string: cached latest remote version (STACK-67)
   LATEST_REMOTE_URL_KEY,      // string: cached latest remote release URL (STACK-67)
   "ff_migration_fuzzy_autocomplete", // one-time migration flag (v3.26.01)
+  "numistaLookupRules",              // custom Numista search lookup rules (JSON array)
 ];
 
 // =============================================================================
@@ -869,6 +870,13 @@ const FEATURE_FLAGS = {
     userToggle: true,
     description: "Show item count badge on filter chips",
     phase: "stable"
+  },
+  NUMISTA_SEARCH_LOOKUP: {
+    enabled: true,
+    urlOverride: true,
+    userToggle: true,
+    description: "Pattern-based Numista search improvement",
+    phase: "beta"
   }
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.26.03";
+const APP_VERSION = "3.27.00";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -587,6 +587,7 @@ const ALLOWED_STORAGE_KEYS = [
   LATEST_REMOTE_URL_KEY,      // string: cached latest remote release URL (STACK-67)
   "ff_migration_fuzzy_autocomplete", // one-time migration flag (v3.26.01)
   "numistaLookupRules",              // custom Numista search lookup rules (JSON array)
+  "numistaViewFields",               // view modal Numista field visibility config (JSON object)
 ];
 
 // =============================================================================
@@ -788,6 +789,61 @@ const saveLayoutSectionConfig = (config) => {
   }
 };
 
+// =============================================================================
+// NUMISTA VIEW FIELD CONFIG — controls which fields appear in view modal
+// =============================================================================
+
+/**
+ * Default Numista view field visibility. All enabled by default.
+ * @constant {Object<string, boolean>}
+ */
+const NUMISTA_VIEW_FIELD_DEFAULTS = {
+  denomination: true,
+  shape: true,
+  diameter: true,
+  thickness: true,
+  orientation: true,
+  composition: true,
+  country: true,
+  technique: true,
+  references: true,
+  edge: true,
+  tags: true,
+  commemorative: true,
+  rarity: true,
+  mintage: true,
+  imageTooltips: true,
+};
+
+/**
+ * Load Numista view field config from localStorage, merged with defaults.
+ * @returns {Object<string, boolean>}
+ */
+const getNumistaViewFieldConfig = () => {
+  try {
+    const raw = localStorage.getItem('numistaViewFields');
+    if (raw) {
+      const saved = JSON.parse(raw);
+      return { ...NUMISTA_VIEW_FIELD_DEFAULTS, ...saved };
+    }
+  } catch (e) {
+    console.warn('Failed to load Numista view field config:', e);
+  }
+  return { ...NUMISTA_VIEW_FIELD_DEFAULTS };
+};
+
+/**
+ * Save Numista view field config to localStorage.
+ * @param {Object<string, boolean>} config
+ */
+const saveNumistaViewFieldConfig = (config) => {
+  try {
+    localStorage.setItem('numistaViewFields', JSON.stringify(config));
+  } catch (e) {
+    console.warn('Failed to save Numista view field config:', e);
+  }
+};
+
 // Persist current application version for comparison on future loads
 try {
   localStorage.setItem(APP_VERSION_KEY, APP_VERSION);
@@ -876,6 +932,13 @@ const FEATURE_FLAGS = {
     urlOverride: true,
     userToggle: true,
     description: "Pattern-based Numista search improvement",
+    phase: "beta"
+  },
+  COIN_IMAGES: {
+    enabled: true,
+    urlOverride: true,
+    userToggle: true,
+    description: "Coin image caching and item view modal",
     phase: "beta"
   }
 };
@@ -1286,6 +1349,10 @@ if (typeof window !== "undefined") {
   window.GOLDBACK_ESTIMATE_ENABLED_KEY = GOLDBACK_ESTIMATE_ENABLED_KEY;
   window.GB_ESTIMATE_PREMIUM = GB_ESTIMATE_PREMIUM;
   window.GB_ESTIMATE_MODIFIER_KEY = GB_ESTIMATE_MODIFIER_KEY;
+  // Numista view field config
+  window.NUMISTA_VIEW_FIELD_DEFAULTS = NUMISTA_VIEW_FIELD_DEFAULTS;
+  window.getNumistaViewFieldConfig = getNumistaViewFieldConfig;
+  window.saveNumistaViewFieldConfig = saveNumistaViewFieldConfig;
   // Multi-currency support (STACK-50)
   window.SUPPORTED_CURRENCIES = SUPPORTED_CURRENCIES;
   window.DISPLAY_CURRENCY_KEY = DISPLAY_CURRENCY_KEY;

--- a/js/events.js
+++ b/js/events.js
@@ -721,6 +721,8 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       isCollectable: false,
       numistaId: f.catalog,
       currency: f.currency,
+      obverseImageUrl: window.selectedNumistaResult?.imageUrl || oldItem.obverseImageUrl || '',
+      reverseImageUrl: window.selectedNumistaResult?.reverseImageUrl || oldItem.reverseImageUrl || '',
     };
 
     addCompositionOption(f.composition);
@@ -796,6 +798,8 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       uuid: generateUUID(),
       numistaId: f.catalog,
       currency: f.currency,
+      obverseImageUrl: window.selectedNumistaResult?.imageUrl || '',
+      reverseImageUrl: window.selectedNumistaResult?.reverseImageUrl || '',
     });
 
     typeof registerName === "function" && registerName(f.name);

--- a/js/events.js
+++ b/js/events.js
@@ -817,16 +817,25 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
 };
 
 /**
- * Builds a Numista search query, prepending metal if not already in name.
+ * Builds a Numista search query, optionally rewriting via NumistaLookup patterns.
  * @param {string} nameVal - Item name input value
  * @param {string} metalVal - Metal composition value
- * @returns {string} Search query
+ * @returns {{ query: string, numistaId: string|null, matched: boolean }}
  */
 const buildNumistaSearchQuery = (nameVal, metalVal) => {
-  if (metalVal && !nameVal.toLowerCase().includes(metalVal.toLowerCase())) {
-    return `${metalVal} ${nameVal}`;
+  const combined = (metalVal && !nameVal.toLowerCase().includes(metalVal.toLowerCase()))
+    ? `${metalVal} ${nameVal}` : nameVal;
+
+  // Try pattern-based lookup if feature is enabled
+  if (window.NumistaLookup && window.featureFlags && featureFlags.isEnabled('NUMISTA_SEARCH_LOOKUP')) {
+    const match = NumistaLookup.matchQuery(combined);
+    if (match) {
+      return { query: match.replacement, numistaId: match.numistaId, matched: true };
+    }
   }
-  return nameVal;
+
+  // Fallback: original behavior (raw query)
+  return { query: combined, numistaId: null, matched: false };
 };
 
 /**
@@ -977,9 +986,41 @@ const setupItemFormListeners = () => {
             const numistaCategory = TYPE_TO_NUMISTA_CATEGORY[typeVal];
             if (numistaCategory) searchFilters.category = numistaCategory;
 
-            const searchQuery = buildNumistaSearchQuery(nameVal, metalVal);
-            const results = await catalogAPI.searchItems(searchQuery, searchFilters);
-            showNumistaResults(results, false, searchQuery);
+            const searchResult = buildNumistaSearchQuery(nameVal, metalVal);
+
+            if (searchResult.matched) {
+              // Pattern matched — build raw query for fallback results
+              const rawQuery = (metalVal && !nameVal.toLowerCase().includes(metalVal.toLowerCase()))
+                ? `${metalVal} ${nameVal}` : nameVal;
+
+              // Fire all requests in parallel: direct N# + rewritten + raw fallback
+              const promises = [
+                searchResult.numistaId
+                  ? catalogAPI.lookupItem(searchResult.numistaId).catch(() => null)
+                  : Promise.resolve(null),
+                catalogAPI.searchItems(searchResult.query, searchFilters),
+                catalogAPI.searchItems(rawQuery, searchFilters),
+              ];
+              const [directResult, rewrittenResults, rawResults] = await Promise.all(promises);
+
+              // Layer results: pinned direct → rewritten → raw fallback (deduped)
+              const seen = new Set();
+              const merged = [];
+              const addUnique = (item) => {
+                if (item && item.catalogId && !seen.has(item.catalogId)) {
+                  seen.add(item.catalogId);
+                  merged.push(item);
+                }
+              };
+              if (directResult) addUnique(directResult);
+              for (const r of rewrittenResults) addUnique(r);
+              for (const r of rawResults) addUnique(r);
+
+              showNumistaResults(merged, false, searchResult.query);
+            } else {
+              const results = await catalogAPI.searchItems(searchResult.query, searchFilters);
+              showNumistaResults(results, false, searchResult.query);
+            }
           }
         } catch (error) {
           console.error('Numista search error:', error);

--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -1,0 +1,409 @@
+// IMAGE CACHE — IndexedDB storage for coin images and Numista metadata
+// =============================================================================
+
+/**
+ * ImageCache provides persistent IndexedDB storage for coin images (obverse/reverse)
+ * and enriched Numista metadata. Images are resized and compressed to JPEG before storage.
+ *
+ * Schema:
+ *   DB: StakTrakrImages v1
+ *   Store "coinImages"   — keyPath: catalogId (Numista N# string)
+ *   Store "coinMetadata"  — keyPath: catalogId (Numista N# string)
+ *
+ * @class
+ */
+class ImageCache {
+  constructor() {
+    /** @type {IDBDatabase|null} */
+    this._db = null;
+    /** @type {boolean} */
+    this._available = false;
+    /** @type {number} Default storage quota in bytes (50 MB) */
+    this._quotaBytes = 50 * 1024 * 1024;
+    /** @type {number} Max image dimension (px) for resize */
+    this._maxDim = 400;
+    /** @type {number} JPEG quality (0-1) */
+    this._jpegQuality = 0.80;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Open (or create) the IndexedDB database. Safe to call multiple times.
+   * @returns {Promise<boolean>} true if DB opened successfully
+   */
+  async init() {
+    if (this._db) return true;
+
+    if (typeof indexedDB === 'undefined') {
+      console.warn('ImageCache: IndexedDB not available');
+      return false;
+    }
+
+    try {
+      this._db = await new Promise((resolve, reject) => {
+        const req = indexedDB.open('StakTrakrImages', 1);
+
+        req.onupgradeneeded = (e) => {
+          const db = e.target.result;
+          if (!db.objectStoreNames.contains('coinImages')) {
+            db.createObjectStore('coinImages', { keyPath: 'catalogId' });
+          }
+          if (!db.objectStoreNames.contains('coinMetadata')) {
+            db.createObjectStore('coinMetadata', { keyPath: 'catalogId' });
+          }
+        };
+
+        req.onsuccess = (e) => resolve(e.target.result);
+        req.onerror = (e) => reject(e.target.error);
+      });
+
+      this._available = true;
+      debugLog('ImageCache: initialized');
+      return true;
+    } catch (err) {
+      console.warn('ImageCache: failed to open DB', err);
+      this._available = false;
+      return false;
+    }
+  }
+
+  /**
+   * Whether IndexedDB opened successfully.
+   * @returns {boolean}
+   */
+  isAvailable() {
+    return this._available;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Image storage
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch, resize, compress, and store obverse/reverse images for a coin type.
+   * @param {string} catalogId - Numista N# identifier
+   * @param {string} obverseUrl - CDN URL for obverse image
+   * @param {string} reverseUrl - CDN URL for reverse image
+   * @returns {Promise<boolean>} true if at least one image was cached
+   */
+  async cacheImages(catalogId, obverseUrl, reverseUrl) {
+    if (!this._available || !catalogId) return false;
+
+    // Skip if already cached
+    if (await this.hasImages(catalogId)) return true;
+
+    // Check quota before proceeding
+    const usage = await this.getStorageUsage();
+    if (usage.totalBytes >= this._quotaBytes) {
+      console.warn('ImageCache: quota exceeded, skipping cache');
+      return false;
+    }
+
+    const obverseBlob = obverseUrl ? await this._fetchAndResize(obverseUrl) : null;
+    const reverseBlob = reverseUrl ? await this._fetchAndResize(reverseUrl) : null;
+
+    if (!obverseBlob && !reverseBlob) return false;
+
+    const size = (obverseBlob?.size || 0) + (reverseBlob?.size || 0);
+
+    const record = {
+      catalogId,
+      obverse: obverseBlob,
+      reverse: reverseBlob,
+      obverseUrl: obverseUrl || '',
+      reverseUrl: reverseUrl || '',
+      width: this._maxDim,
+      height: this._maxDim,
+      cachedAt: Date.now(),
+      size
+    };
+
+    return this._put('coinImages', record);
+  }
+
+  /**
+   * Store enriched Numista metadata for a coin type.
+   * @param {string} catalogId - Numista N# identifier
+   * @param {Object} numistaResult - Normalized Numista result object
+   * @returns {Promise<boolean>}
+   */
+  async cacheMetadata(catalogId, numistaResult) {
+    if (!this._available || !catalogId || !numistaResult) return false;
+
+    const record = {
+      catalogId,
+      title: numistaResult.name || '',
+      country: numistaResult.country || '',
+      denomination: numistaResult.denomination || '',
+      diameter: numistaResult.diameter || numistaResult.size || 0,
+      thickness: numistaResult.thickness || 0,
+      weight: numistaResult.weight || 0,
+      shape: numistaResult.shape || '',
+      composition: numistaResult.composition || numistaResult.metal || '',
+      orientation: numistaResult.orientation || '',
+      commemorative: !!numistaResult.commemorative,
+      commemorativeDesc: numistaResult.commemorativeDesc || '',
+      rarityIndex: numistaResult.rarityIndex || 0,
+      kmReferences: numistaResult.kmReferences || [],
+      mintageByYear: numistaResult.mintageByYear || [],
+      technique: numistaResult.technique || '',
+      tags: numistaResult.tags || [],
+      obverseDesc: numistaResult.obverseDesc || '',
+      reverseDesc: numistaResult.reverseDesc || '',
+      edgeDesc: numistaResult.edgeDesc || '',
+      cachedAt: Date.now()
+    };
+
+    return this._put('coinMetadata', record);
+  }
+
+  /**
+   * Retrieve the full image record for a coin type.
+   * @param {string} catalogId
+   * @returns {Promise<Object|null>}
+   */
+  async getImages(catalogId) {
+    if (!this._available || !catalogId) return null;
+    return this._get('coinImages', catalogId);
+  }
+
+  /**
+   * Retrieve the metadata record for a coin type.
+   * @param {string} catalogId
+   * @returns {Promise<Object|null>}
+   */
+  async getMetadata(catalogId) {
+    if (!this._available || !catalogId) return null;
+    return this._get('coinMetadata', catalogId);
+  }
+
+  /**
+   * Create an object URL from a cached image blob.
+   * Caller is responsible for revoking via URL.revokeObjectURL().
+   * @param {string} catalogId
+   * @param {'obverse'|'reverse'} side
+   * @returns {Promise<string|null>} Object URL or null
+   */
+  async getImageUrl(catalogId, side) {
+    const record = await this.getImages(catalogId);
+    const blob = record?.[side];
+    if (!blob) return null;
+    return URL.createObjectURL(blob);
+  }
+
+  /**
+   * Quick existence check without loading blobs.
+   * @param {string} catalogId
+   * @returns {Promise<boolean>}
+   */
+  async hasImages(catalogId) {
+    if (!this._available || !catalogId) return false;
+
+    return new Promise((resolve) => {
+      try {
+        const tx = this._db.transaction('coinImages', 'readonly');
+        const req = tx.objectStore('coinImages').count(IDBKeyRange.only(catalogId));
+        req.onsuccess = () => resolve(req.result > 0);
+        req.onerror = () => resolve(false);
+      } catch {
+        resolve(false);
+      }
+    });
+  }
+
+  /**
+   * Remove a single image record.
+   * @param {string} catalogId
+   * @returns {Promise<boolean>}
+   */
+  async deleteImages(catalogId) {
+    if (!this._available || !catalogId) return false;
+    return this._delete('coinImages', catalogId);
+  }
+
+  /**
+   * Clear both object stores.
+   * @returns {Promise<boolean>}
+   */
+  async clearAll() {
+    if (!this._available) return false;
+
+    try {
+      const tx = this._db.transaction(['coinImages', 'coinMetadata'], 'readwrite');
+      tx.objectStore('coinImages').clear();
+      tx.objectStore('coinMetadata').clear();
+      await this._txComplete(tx);
+      debugLog('ImageCache: cleared all stores');
+      return true;
+    } catch (err) {
+      console.warn('ImageCache: clearAll failed', err);
+      return false;
+    }
+  }
+
+  /**
+   * Calculate current storage usage across both stores.
+   * @returns {Promise<{count: number, totalBytes: number, limitBytes: number}>}
+   */
+  async getStorageUsage() {
+    const result = { count: 0, totalBytes: 0, limitBytes: this._quotaBytes };
+    if (!this._available) return result;
+
+    try {
+      const records = await this._getAll('coinImages');
+      result.count = records.length;
+      for (const rec of records) {
+        result.totalBytes += rec.size || 0;
+      }
+    } catch {
+      // ignore
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Image pipeline (private)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch an image URL → resize to max dimension → compress as JPEG blob.
+   * Falls back to Image element if fetch fails (CORS on file://).
+   * @param {string} url
+   * @returns {Promise<Blob|null>}
+   */
+  async _fetchAndResize(url) {
+    if (!url) return null;
+
+    let imgBitmap;
+
+    try {
+      // Primary: fetch as blob
+      const resp = await fetch(url, { mode: 'cors' });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const blob = await resp.blob();
+      imgBitmap = await createImageBitmap(blob);
+    } catch {
+      // Fallback: Image element (works when fetch CORS fails)
+      try {
+        imgBitmap = await this._loadImageElement(url);
+      } catch (e2) {
+        console.warn('ImageCache: failed to load image', url, e2);
+        return null;
+      }
+    }
+
+    // Resize to fit within maxDim × maxDim, preserving aspect ratio
+    let { width, height } = imgBitmap;
+    const scale = Math.min(this._maxDim / width, this._maxDim / height, 1);
+    width = Math.round(width * scale);
+    height = Math.round(height * scale);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(imgBitmap, 0, 0, width, height);
+
+    // Compress to JPEG
+    return new Promise((resolve) => {
+      canvas.toBlob(
+        (blob) => resolve(blob),
+        'image/jpeg',
+        this._jpegQuality
+      );
+    });
+  }
+
+  /**
+   * Load an image via HTMLImageElement (fallback for CORS-restricted fetch).
+   * @param {string} url
+   * @returns {Promise<ImageBitmap>}
+   */
+  _loadImageElement(url) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => {
+        createImageBitmap(img).then(resolve).catch(reject);
+      };
+      img.onerror = () => reject(new Error('Image load failed'));
+      img.src = url;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // IndexedDB helpers (private)
+  // ---------------------------------------------------------------------------
+
+  /** @returns {Promise<boolean>} */
+  async _put(storeName, record) {
+    try {
+      const tx = this._db.transaction(storeName, 'readwrite');
+      tx.objectStore(storeName).put(record);
+      await this._txComplete(tx);
+      return true;
+    } catch (err) {
+      console.warn(`ImageCache: put to ${storeName} failed`, err);
+      return false;
+    }
+  }
+
+  /** @returns {Promise<Object|null>} */
+  _get(storeName, key) {
+    return new Promise((resolve) => {
+      try {
+        const tx = this._db.transaction(storeName, 'readonly');
+        const req = tx.objectStore(storeName).get(key);
+        req.onsuccess = () => resolve(req.result || null);
+        req.onerror = () => resolve(null);
+      } catch {
+        resolve(null);
+      }
+    });
+  }
+
+  /** @returns {Promise<Array>} */
+  _getAll(storeName) {
+    return new Promise((resolve) => {
+      try {
+        const tx = this._db.transaction(storeName, 'readonly');
+        const req = tx.objectStore(storeName).getAll();
+        req.onsuccess = () => resolve(req.result || []);
+        req.onerror = () => resolve([]);
+      } catch {
+        resolve([]);
+      }
+    });
+  }
+
+  /** @returns {Promise<boolean>} */
+  async _delete(storeName, key) {
+    try {
+      const tx = this._db.transaction(storeName, 'readwrite');
+      tx.objectStore(storeName).delete(key);
+      await this._txComplete(tx);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Wait for a transaction to complete. */
+  _txComplete(tx) {
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  }
+}
+
+// Singleton instance exposed globally
+const imageCache = new ImageCache();
+if (typeof window !== 'undefined') {
+  window.imageCache = imageCache;
+}

--- a/js/init.js
+++ b/js/init.js
@@ -437,6 +437,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         updateStorageStats();
       }
 
+    // Load Numista search lookup custom rules
+    if (typeof NumistaLookup !== 'undefined' && typeof NumistaLookup.loadCustomRules === 'function') {
+      NumistaLookup.loadCustomRules();
+    }
+
     // STACK-62: Initialize autocomplete/fuzzy search system
     if (typeof initializeAutocomplete === 'function') {
       initializeAutocomplete(inventory);

--- a/js/init.js
+++ b/js/init.js
@@ -197,6 +197,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.cancelNotesBtn = safeGetElement("cancelNotes");
     elements.notesCloseBtn = safeGetElement("notesCloseBtn");
 
+    // View item modal elements
+    elements.viewItemModal = safeGetElement("viewItemModal");
+    elements.viewModalCloseBtn = safeGetElement("viewModalCloseBtn");
+
     // Debug modal elements
     elements.debugModal = safeGetElement("debugModal");
     elements.debugCloseBtn = safeGetElement("debugCloseBtn");
@@ -418,6 +422,29 @@ document.addEventListener("DOMContentLoaded", async () => {
       document.documentElement.setAttribute('data-theme', 'sepia');
     }
 
+    // Initialize IndexedDB image cache (COIN_IMAGES feature)
+    if (typeof imageCache !== 'undefined' && featureFlags.isEnabled('COIN_IMAGES')) {
+      try {
+        await imageCache.init();
+        debugLog('ImageCache available:', imageCache.isAvailable());
+      } catch (e) {
+        console.warn('ImageCache init failed:', e);
+      }
+    }
+
+    // Wire view modal close button
+    if (elements.viewModalCloseBtn) {
+      elements.viewModalCloseBtn.addEventListener('click', () => {
+        if (typeof closeViewModal === 'function') closeViewModal();
+      });
+    }
+    // Background click dismiss for view modal
+    if (elements.viewItemModal) {
+      elements.viewItemModal.addEventListener('click', (e) => {
+        if (e.target === elements.viewItemModal && typeof closeViewModal === 'function') closeViewModal();
+      });
+    }
+
     // Apply header toggle & layout visibility from saved prefs (STACK-54)
     if (typeof applyHeaderToggleVisibility === 'function') applyHeaderToggleVisibility();
     if (typeof applyLayoutOrder === 'function') applyLayoutOrder();
@@ -584,6 +611,8 @@ function setupBasicEventListeners() {
 window.toggleCollectable = toggleCollectable;
 window.showDetailsModal = showDetailsModal;
 window.closeDetailsModal = closeDetailsModal;
+window.showViewModal = typeof showViewModal !== 'undefined' ? showViewModal : () => {};
+window.closeViewModal = typeof closeViewModal !== 'undefined' ? closeViewModal : () => {};
 window.editItem = editItem;
 window.deleteItem = deleteItem;
 window.showNotes = showNotes;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -770,7 +770,7 @@ const formatPurchaseLocation = (loc) => {
       href = `https://${href}`;
     }
     const safeHref = escapeAttribute(href);
-    return `<a href="#" onclick="event.stopPropagation(); window.open('${safeHref}', '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'); return false;" class="purchase-link" title="${safeHref}">
+    return `<a href="#" onclick="event.stopPropagation(); window.open('${safeHref}', '_blank', 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'); return false;" class="purchase-link" title="${safeHref}">
       <svg class="purchase-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 12px; height: 12px; fill: currentColor; margin-right: 4px;" aria-hidden="true">
         <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"/>
       </svg>
@@ -1183,7 +1183,9 @@ const renderTable = () => {
       <td class="shrink" data-column="type" data-label="Type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
       <td class="expand" data-column="name" data-label="" style="text-align: left;">
         <div class="name-cell-content">
-        ${filterLink('name', item.name, 'var(--text-primary)', undefined, item.name)}${orderedChips}
+        ${featureFlags.isEnabled('COIN_IMAGES')
+          ? `<span class="filter-text" style="color: var(--text-primary); cursor: pointer;" onclick="showViewModal(${originalIdx})" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' ')showViewModal(${originalIdx})" title="View ${escapeAttribute(item.name)}">${sanitizeHtml(item.name)}</span>`
+          : filterLink('name', item.name, 'var(--text-primary)', undefined, item.name)}${orderedChips}
         </div>
       </td>
       <td class="shrink" data-column="qty" data-label="Qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
@@ -1204,6 +1206,9 @@ const renderTable = () => {
         ${formatPurchaseLocation(item.purchaseLocation)}
       </td>
       <td class="icon-col actions-cell" data-column="actions" data-label=""><div class="actions-row">
+        ${featureFlags.isEnabled('COIN_IMAGES') ? `<button class="icon-btn action-icon view-icon" role="button" tabindex="0" onclick="event.stopPropagation(); showViewModal(${originalIdx})" aria-label="View ${sanitizeHtml(item.name)}" title="View item">
+          <svg class="icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>
+        </button>` : ''}
         <button class="icon-btn action-icon edit-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit item">
           <svg class="icon-svg edit-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/></svg>
         </button>
@@ -1228,7 +1233,8 @@ const renderTable = () => {
     // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
     tbody.innerHTML = rows.join('');
 
-    // Card-view tap-to-edit: delegate click on tbody rows (≤768px only)
+    // Card-view tap: delegate click on tbody rows (≤768px only)
+    // Opens view modal if COIN_IMAGES enabled, otherwise edit modal
     if (!tbody._cardTapBound) {
       tbody._cardTapBound = true;
       tbody.addEventListener('click', (e) => {
@@ -1236,7 +1242,14 @@ const renderTable = () => {
         // Don't intercept clicks on buttons, links, or interactive elements
         if (e.target.closest('button, a, input, select, textarea, .icon-btn, .filter-text, [role="button"], .year-tag, .purity-tag')) return;
         const row = e.target.closest('tr[data-idx]');
-        if (row) editItem(Number(row.dataset.idx));
+        if (row) {
+          const idx = Number(row.dataset.idx);
+          if (featureFlags.isEnabled('COIN_IMAGES') && typeof showViewModal === 'function') {
+            showViewModal(idx);
+          } else {
+            editItem(idx);
+          }
+        }
       });
     }
 
@@ -2825,7 +2838,7 @@ document.addEventListener('click', (e) => {
     if (pcgsNo) {
       const url = `https://www.pcgs.com/coinfacts/coin/detail/${encodeURIComponent(pcgsNo)}/${encodeURIComponent(gradeNum)}`;
       const popup = window.open(url, `pcgs_${pcgsNo}`,
-        'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
+        'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
       if (!popup) {
         alert(`Popup blocked! Please allow popups or manually visit:\n${url}`);
       } else {
@@ -2847,7 +2860,7 @@ document.addEventListener('click', (e) => {
       const gradeNum = (gradeTag.dataset.grade || '').match(/\d+/)?.[0] || '';
       url = url.replace('{grade}', encodeURIComponent(gradeNum));
       const popup = window.open(url, `cert_${authority}_${certNum || Date.now()}`,
-        'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
+        'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
       if (!popup) {
         alert(`Popup blocked! Please allow popups or manually visit:\n${url}`);
       } else {

--- a/js/numista-lookup.js
+++ b/js/numista-lookup.js
@@ -1,0 +1,296 @@
+/**
+ * Numista Search Lookup Module
+ * Pattern-based query rewriting for improved Numista search results.
+ * Matches user input against known coin naming patterns and rewrites
+ * queries to use Numista's canonical naming convention.
+ *
+ * Follows the IIFE module pattern used by customMapping.js.
+ */
+
+const NumistaLookup = (() => {
+  // =========================================================================
+  // SEED RULES — shipped with the app, read-only for users
+  // =========================================================================
+
+  /**
+   * Seed rules — verified against the Numista API (Feb 2026).
+   * numistaId values were tested via /v3/types/{id} and confirmed correct.
+   * Coins with yearly-changing designs (Kookaburra, Kangaroo, Panda, etc.)
+   * intentionally use null — Numista has no generic series entry.
+   * @type {Array<{id: string, pattern: string, replacement: string, numistaId: string|null, builtIn: boolean}>}
+   */
+  const SEED_RULES = [
+    // === US Coins (all N# verified 2026-02-13) ===
+    { id: 'us-ase',          pattern: '\\b(american\\s+silver\\s+eagle|\\bASE\\b)',          replacement: '"American Silver Eagle" Bullion', numistaId: '1493', builtIn: true },
+    { id: 'us-ase-new',      pattern: '\\b(ASE\\s+type\\s*2|silver\\s+eagle\\s+type\\s*2)',  replacement: '"American Silver Eagle" New Reverse Bullion', numistaId: '298883', builtIn: true },
+    { id: 'us-age',          pattern: '\\b(american\\s+gold\\s+eagle|\\bAGE\\b)',            replacement: '"American Gold Eagle" Bullion Coinage', numistaId: '23134', builtIn: true },
+    { id: 'us-age-1oz',      pattern: '\\bgold\\s+eagle\\s+1\\s*oz\\b',                     replacement: '50 Dollars "American Gold Eagle" Bullion Coinage', numistaId: '23134', builtIn: true },
+    { id: 'us-age-half',     pattern: '\\bgold\\s+eagle\\s+(1/2|half)\\s*oz\\b',             replacement: '25 Dollars "American Gold Eagle" Bullion Coinage', numistaId: '21899', builtIn: true },
+    { id: 'us-age-quarter',  pattern: '\\bgold\\s+eagle\\s+(1/4|quarter)\\s*oz\\b',          replacement: '10 Dollars "American Gold Eagle" Bullion Coinage', numistaId: '25416', builtIn: true },
+    { id: 'us-age-tenth',    pattern: '\\bgold\\s+eagle\\s+(1/10|tenth)\\s*oz\\b',           replacement: '5 Dollars "American Gold Eagle" Bullion Coinage', numistaId: '10493', builtIn: true },
+    { id: 'us-ape',          pattern: '\\b(american\\s+platinum\\s+eagle|\\bAPE\\b)',        replacement: '100 Dollars "American Platinum Eagle" Bullion Coinage', numistaId: '23137', builtIn: true },
+    { id: 'us-apde',         pattern: '\\b(american\\s+palladium\\s+eagle)',                 replacement: '25 Dollars Palladium Eagle', numistaId: '173899', builtIn: true },
+    { id: 'us-agb',          pattern: '\\b(gold\\s+buffalo|\\bAGB\\b)',                      replacement: '50 Dollars "American Buffalo" Gold Bullion', numistaId: '18451', builtIn: true },
+    { id: 'us-morgan',       pattern: '\\bmorgan\\s+(silver\\s+)?dollar\\b',                 replacement: '1 Dollar "Morgan Dollar"', numistaId: '1492', builtIn: true },
+    { id: 'us-peace',        pattern: '\\bpeace\\s+(silver\\s+)?dollar\\b',                  replacement: '1 Dollar "Peace Dollar"', numistaId: '5580', builtIn: true },
+    { id: 'us-walking-lib',  pattern: '\\bwalking\\s+liberty\\b',                            replacement: '½ Dollar "Walking Liberty Half Dollar"', numistaId: '4455', builtIn: true },
+    { id: 'us-mercury',      pattern: '\\bmercury\\s+dime\\b',                               replacement: '1 Dime "Mercury Dime"', numistaId: '51', builtIn: true },
+    { id: 'us-washington-q',  pattern: '\\bwashington\\s+quarter\\s+silver\\b',              replacement: '¼ Dollar "Washington Silver Quarter"', numistaId: '54', builtIn: true },
+    { id: 'us-roosevelt-d',  pattern: '\\broosevelt\\s+dime\\s+silver\\b',                   replacement: '1 Dime "Roosevelt Silver Dime"', numistaId: '52', builtIn: true },
+    { id: 'us-franklin-h',   pattern: '\\bfranklin\\s+half\\b',                              replacement: '½ Dollar "Franklin Half Dollar"', numistaId: '2835', builtIn: true },
+    { id: 'us-kennedy-h',    pattern: '\\bkennedy\\s+half\\s+silver\\b',                     replacement: '½ Dollar "Kennedy Half Dollar" 90% Silver', numistaId: '943', builtIn: true },
+    { id: 'us-liberty-20',   pattern: '\\bliberty\\s+double\\s+eagle\\b',                    replacement: '20 Dollars Liberty Head Double Eagle', numistaId: '23656', builtIn: true },
+    { id: 'us-saint-g',      pattern: '\\bsaint.?gaudens\\b',                                replacement: '20 Dollars Saint-Gaudens Double Eagle', numistaId: '23126', builtIn: true },
+
+    // === Canada (N# verified 2026-02-13) ===
+    { id: 'ca-sml',    pattern: '\\b(silver\\s+maple\\s+leaf|\\bSML\\b)',                    replacement: '5 Dollars SML Bullion Coinage Canada', numistaId: '18655', builtIn: true },
+    { id: 'ca-gml',    pattern: '\\b(gold\\s+maple\\s+leaf|\\bGML\\b)',                      replacement: '50 Dollars GML Bullion Coinage Canada', numistaId: '32727', builtIn: true },
+    { id: 'ca-pml',    pattern: '\\bplatinum\\s+maple\\s+leaf\\b',                           replacement: '50 Dollars platinum Bullion Coinage Canada Maple', numistaId: '67528', builtIn: true },
+    { id: 'ca-pdml',   pattern: '\\bpalladium\\s+maple\\s+leaf\\b',                          replacement: '50 Dollars palladium Bullion Coinage Canada', numistaId: '36214', builtIn: true },
+    { id: 'ca-predator',pattern: '\\bcanadian?\\s+predator\\b',                              replacement: '"Predator" silver Canada Bullion', numistaId: null, builtIn: true },
+    { id: 'ca-wildlife',pattern: '\\bcanadian?\\s+wildlife\\b',                               replacement: '"Wildlife" silver Canada Bullion', numistaId: null, builtIn: true },
+    { id: 'ca-maple-1g',pattern: '\\bmaple\\s+leaf\\s+maplegram\\b',                         replacement: 'GML bullion Maplegram Canada', numistaId: null, builtIn: true },
+
+    // === Australia (yearly designs — no single N#, query-rewrite only) ===
+    { id: 'au-kook',         pattern: '\\bkookaburra\\b',                                    replacement: '"Australian Kookaburra" silver Bullion', numistaId: null, builtIn: true },
+    { id: 'au-koala',        pattern: '\\bkoala\\b',                                          replacement: '"Koala" silver Bullion Australia', numistaId: null, builtIn: true },
+    { id: 'au-kangaroo',     pattern: '\\b(kangaroo|nugget)\\s*(gold)?\\b',                  replacement: '"Australian Nugget" gold Bullion', numistaId: null, builtIn: true },
+    { id: 'au-kangaroo-s',   pattern: '\\bkangaroo\\s+silver\\b',                            replacement: '"Australian Kangaroo" silver Bullion', numistaId: null, builtIn: true },
+    { id: 'au-lunar-i',      pattern: '\\blunar\\s+(series\\s+)?I\\b',                       replacement: '"Lunar" series I silver Australia', numistaId: null, builtIn: true },
+    { id: 'au-lunar-ii',     pattern: '\\blunar\\s+(series\\s+)?II\\b',                      replacement: '"Lunar" series II silver Australia', numistaId: null, builtIn: true },
+    { id: 'au-lunar-iii',    pattern: '\\blunar\\s+(series\\s+)?III\\b',                     replacement: '"Lunar" series III silver Australia', numistaId: null, builtIn: true },
+    { id: 'au-lunar',        pattern: '\\b(perth|australian?)\\s+lunar\\b',                  replacement: '"Lunar" silver Bullion Australia', numistaId: null, builtIn: true },
+    { id: 'au-swan',         pattern: '\\b(perth\\s+)?swan\\b',                              replacement: '"Swan" silver Australia Perth', numistaId: null, builtIn: true },
+    { id: 'au-emu',          pattern: '\\b(perth\\s+)?emu\\b',                               replacement: '"Emu" silver Australia Perth', numistaId: null, builtIn: true },
+    { id: 'au-platypus',     pattern: '\\bplatypus\\b',                                       replacement: '"Platypus" platinum Australia', numistaId: null, builtIn: true },
+    { id: 'au-dragon-bar',   pattern: '\\bdragon\\s+(silver\\s+)?bar\\b',                    replacement: '"Dragon" rectangular silver Australia', numistaId: null, builtIn: true },
+
+    // === South Africa (yearly/anniversary variants — query-rewrite only) ===
+    { id: 'za-krugerrand',   pattern: '\\bkrugerrand\\b',                                    replacement: 'Krugerrand gold South Africa', numistaId: null, builtIn: true },
+    { id: 'za-krugerrand-s', pattern: '\\bkrugerrand\\s+silver\\b',                          replacement: 'Krugerrand silver South Africa', numistaId: null, builtIn: true },
+
+    // === UK (yearly/variant designs — query-rewrite only) ===
+    { id: 'uk-britannia-s',  pattern: '\\bbritannia\\s*(silver)?\\b',                        replacement: '"Britannia" silver Bullion United Kingdom', numistaId: null, builtIn: true },
+    { id: 'uk-britannia-g',  pattern: '\\bbritannia\\s+gold\\b',                             replacement: '"Britannia" gold Bullion United Kingdom', numistaId: null, builtIn: true },
+    { id: 'uk-sovereign',    pattern: '\\bsovereign\\s+gold\\b',                             replacement: 'Sovereign gold United Kingdom', numistaId: null, builtIn: true },
+
+    // === Austria (N# verified 2026-02-13) ===
+    { id: 'at-philharmonic-s', pattern: '\\bphilharmonic\\s*(silver)?\\b',                   replacement: '1½ Euro Vienna Philharmonic silver', numistaId: '9165', builtIn: true },
+    { id: 'at-philharmonic-g', pattern: '\\bphilharmonic\\s+gold\\b',                       replacement: '100 Euros Vienna Philharmonic gold', numistaId: '23519', builtIn: true },
+
+    // === Mexico (pattern/variant issues — query-rewrite only) ===
+    { id: 'mx-libertad-s',  pattern: '\\blibertad\\s*(silver)?\\b',                          replacement: 'Onza "Libertad" silver Bullion Mexico', numistaId: null, builtIn: true },
+    { id: 'mx-libertad-g',  pattern: '\\blibertad\\s+gold\\b',                               replacement: 'Onza "Libertad" gold Bullion Mexico', numistaId: null, builtIn: true },
+
+    // === China (yearly designs — query-rewrite only) ===
+    { id: 'cn-panda-s',     pattern: '\\bpanda\\s*(silver)?\\b',                             replacement: '10 Yuan Panda silver China', numistaId: null, builtIn: true },
+    { id: 'cn-panda-g',     pattern: '\\bpanda\\s+gold\\b',                                  replacement: '500 Yuan Panda gold China', numistaId: null, builtIn: true },
+
+    // === Armenia (N# verified 2026-02-13) ===
+    { id: 'am-noahs-ark',   pattern: '\\bnoah.?s\\s+ark\\b',                                replacement: '500 Dram Noah\'s Ark silver Armenia', numistaId: '26279', builtIn: true },
+
+    // === Somalia (yearly designs — query-rewrite only) ===
+    { id: 'so-elephant',    pattern: '\\b(somalian?\\s+)?elephant\\b',                       replacement: '100 Shillings Elephant silver Somalia', numistaId: null, builtIn: true },
+
+    // === Generic bullion types ===
+    { id: 'gen-jm-bar',     pattern: '\\bjohnson\\s+matthey\\b',                             replacement: '"Johnson Matthey" silver bar', numistaId: null, builtIn: true },
+    { id: 'gen-engelhard',  pattern: '\\bengelhard\\b',                                       replacement: '"Engelhard" silver bar', numistaId: null, builtIn: true },
+  ];
+
+  // =========================================================================
+  // CUSTOM RULES — user-created, persisted to localStorage
+  // =========================================================================
+
+  /** @type {Array<{id: string, pattern: string, replacement: string, numistaId: string|null, builtIn: boolean}>} */
+  let customRules = [];
+
+  /** Compiled regex cache: id → RegExp */
+  const compiledRegex = new Map();
+
+  /**
+   * Compiles and caches a regex for the given rule.
+   * @param {Object} rule - Rule with pattern string
+   * @returns {RegExp|null} Compiled regex or null on error
+   */
+  const getRegex = (rule) => {
+    if (compiledRegex.has(rule.id)) return compiledRegex.get(rule.id);
+    try {
+      const re = new RegExp(rule.pattern, 'i');
+      compiledRegex.set(rule.id, re);
+      return re;
+    } catch (e) {
+      console.warn('NumistaLookup: invalid regex for rule', rule.id, e);
+      return null;
+    }
+  };
+
+  /**
+   * Compile all seed rule regexes eagerly on load.
+   */
+  const compileSeedRules = () => {
+    for (const rule of SEED_RULES) {
+      getRegex(rule);
+    }
+  };
+
+  // =========================================================================
+  // PUBLIC API
+  // =========================================================================
+
+  /**
+   * Matches user input against all rules (custom first, then seed).
+   * Custom rules take priority so users can override built-in behavior.
+   * @param {string} userInput - Raw search text from the user
+   * @returns {{ rule: Object, replacement: string, numistaId: string|null }|null}
+   */
+  const matchQuery = (userInput) => {
+    if (!userInput || typeof userInput !== 'string') return null;
+    const text = userInput.trim();
+    if (!text) return null;
+
+    // Check custom rules first (user overrides)
+    for (const rule of customRules) {
+      const re = getRegex(rule);
+      if (re && re.test(text)) {
+        return { rule, replacement: rule.replacement, numistaId: rule.numistaId || null };
+      }
+    }
+
+    // Then check seed rules
+    for (const rule of SEED_RULES) {
+      const re = getRegex(rule);
+      if (re && re.test(text)) {
+        return { rule, replacement: rule.replacement, numistaId: rule.numistaId || null };
+      }
+    }
+
+    return null;
+  };
+
+  /**
+   * Adds a custom rule, validates the regex, and persists.
+   * @param {string} pattern - Regex pattern string
+   * @param {string} replacement - Rewritten Numista query
+   * @param {string} [numistaId] - Optional Numista N# for direct lookup
+   * @returns {{ success: boolean, error?: string }}
+   */
+  const addRule = (pattern, replacement, numistaId) => {
+    if (!pattern || !replacement) {
+      return { success: false, error: 'Pattern and replacement are required.' };
+    }
+
+    // Validate regex
+    try {
+      new RegExp(pattern, 'i');
+    } catch (e) {
+      return { success: false, error: 'Invalid regex pattern: ' + e.message };
+    }
+
+    const id = 'custom-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6);
+    const rule = {
+      id,
+      pattern,
+      replacement,
+      numistaId: numistaId || null,
+      builtIn: false,
+    };
+
+    customRules.push(rule);
+    compiledRegex.delete(id); // clear any stale cache
+    getRegex(rule); // eagerly compile
+    saveCustomRules();
+    return { success: true };
+  };
+
+  /**
+   * Removes a custom rule by ID and persists.
+   * @param {string} id - Rule ID to remove
+   */
+  const removeRule = (id) => {
+    customRules = customRules.filter(r => r.id !== id);
+    compiledRegex.delete(id);
+    saveCustomRules();
+  };
+
+  /**
+   * Returns all rules (seed + custom).
+   * @returns {Array}
+   */
+  const listRules = () => [...SEED_RULES, ...customRules];
+
+  /**
+   * Returns only seed (built-in) rules.
+   * @returns {Array}
+   */
+  const listSeedRules = () => [...SEED_RULES];
+
+  /**
+   * Returns only custom (user-created) rules.
+   * @returns {Array}
+   */
+  const listCustomRules = () => [...customRules];
+
+  /**
+   * Persists custom rules to localStorage as JSON.
+   */
+  const saveCustomRules = () => {
+    try {
+      const data = customRules.map(r => ({
+        id: r.id,
+        pattern: r.pattern,
+        replacement: r.replacement,
+        numistaId: r.numistaId,
+        builtIn: false,
+      }));
+      localStorage.setItem('numistaLookupRules', JSON.stringify(data));
+    } catch (e) {
+      console.warn('NumistaLookup: failed to save custom rules:', e);
+    }
+  };
+
+  /**
+   * Loads custom rules from localStorage. Called during app init.
+   */
+  const loadCustomRules = () => {
+    try {
+      const raw = localStorage.getItem('numistaLookupRules');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          customRules = parsed.map(r => ({
+            id: r.id || 'custom-' + Date.now(),
+            pattern: r.pattern || '',
+            replacement: r.replacement || '',
+            numistaId: r.numistaId || null,
+            builtIn: false,
+          }));
+          // Compile custom rule regexes
+          for (const rule of customRules) {
+            getRegex(rule);
+          }
+        }
+      }
+    } catch (e) {
+      console.warn('NumistaLookup: failed to load custom rules:', e);
+      customRules = [];
+    }
+  };
+
+  // Compile seed rules on module load
+  compileSeedRules();
+
+  return {
+    matchQuery,
+    addRule,
+    removeRule,
+    listRules,
+    listSeedRules,
+    listCustomRules,
+    loadCustomRules,
+  };
+})();
+
+// Expose globally
+if (typeof window !== 'undefined') {
+  window.NumistaLookup = NumistaLookup;
+}

--- a/js/numista-modal.js
+++ b/js/numista-modal.js
@@ -22,7 +22,7 @@ function openNumistaModal(numistaId, coinName) {
   const popup = window.open(
     url,
     `numista_${numistaId}`,
-    'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'
+    'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'
   );
 
   if (!popup) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -194,6 +194,19 @@ const syncSettingsUI = () => {
     });
   }
 
+  // Numista name matching — sync toggle with feature flag
+  const numistaLookupSetting = document.getElementById('settingsNumistaLookup');
+  if (numistaLookupSetting && window.featureFlags) {
+    const nlVal = featureFlags.isEnabled('NUMISTA_SEARCH_LOOKUP') ? 'yes' : 'no';
+    numistaLookupSetting.querySelectorAll('.chip-sort-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.val === nlVal);
+    });
+  }
+
+  // Numista lookup rule tables
+  renderSeedRuleTable();
+  renderCustomRuleTable();
+
   // Chip grouping tables and dropdown
   if (typeof window.populateBlacklistDropdown === 'function') window.populateBlacklistDropdown();
   if (typeof window.renderBlacklistTable === 'function') window.renderBlacklistTable();
@@ -484,6 +497,55 @@ const setupSettingsEventListeners = () => {
       if (isEnabled && typeof initializeAutocomplete === 'function') {
         initializeAutocomplete(inventory);
       }
+    });
+  }
+
+  // Numista name matching toggle
+  const numistaLookupSettingEl = document.getElementById('settingsNumistaLookup');
+  if (numistaLookupSettingEl) {
+    numistaLookupSettingEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip-sort-btn');
+      if (!btn) return;
+      const isEnabled = btn.dataset.val === 'yes';
+      if (window.featureFlags) {
+        if (isEnabled) featureFlags.enable('NUMISTA_SEARCH_LOOKUP');
+        else featureFlags.disable('NUMISTA_SEARCH_LOOKUP');
+      }
+      numistaLookupSettingEl.querySelectorAll('.chip-sort-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.val === btn.dataset.val);
+      });
+    });
+  }
+
+  // Add Numista lookup rule button
+  const addNumistaRuleBtn = document.getElementById('addNumistaRuleBtn');
+  if (addNumistaRuleBtn) {
+    addNumistaRuleBtn.addEventListener('click', () => {
+      const patternInput = document.getElementById('numistaRulePatternInput');
+      const replacementInput = document.getElementById('numistaRuleReplacementInput');
+      const idInput = document.getElementById('numistaRuleIdInput');
+      if (!patternInput || !replacementInput) return;
+
+      const pattern = patternInput.value.trim();
+      const replacement = replacementInput.value.trim();
+      const numistaId = idInput ? idInput.value.trim() : '';
+
+      if (!pattern || !replacement) {
+        alert('Pattern and Numista query are required.');
+        return;
+      }
+
+      if (!window.NumistaLookup) return;
+      const result = NumistaLookup.addRule(pattern, replacement, numistaId || null);
+      if (!result.success) {
+        alert(result.error);
+        return;
+      }
+
+      patternInput.value = '';
+      replacementInput.value = '';
+      if (idInput) idInput.value = '';
+      renderCustomRuleTable();
     });
   }
 
@@ -995,6 +1057,132 @@ const renderFilterChipCategoryTable = () => {
 };
 
 /**
+ * Renders the built-in (seed) Numista lookup rules as a read-only table.
+ */
+const renderSeedRuleTable = () => {
+  const container = document.getElementById('seedRuleTableContainer');
+  if (!container || !window.NumistaLookup) return;
+
+  const rules = NumistaLookup.listSeedRules();
+  const countBadge = document.getElementById('seedRuleCount');
+  if (countBadge) countBadge.textContent = `(${rules.length})`;
+
+  container.textContent = '';
+  if (!rules.length) {
+    const empty = document.createElement('div');
+    empty.className = 'chip-grouping-empty';
+    empty.textContent = 'No built-in patterns';
+    container.appendChild(empty);
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'chip-grouping-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Pattern', 'Numista Query', 'N#'].forEach(text => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    th.style.cssText = 'font-size:0.75rem;font-weight:normal;opacity:0.6;padding:0.2rem 0.4rem';
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  const esc = typeof escapeHtml === 'function' ? escapeHtml : (s) => s;
+  for (const rule of rules) {
+    const tr = document.createElement('tr');
+
+    const tdPattern = document.createElement('td');
+    tdPattern.style.cssText = 'font-family:monospace;font-size:0.8rem;word-break:break-all';
+    tdPattern.textContent = rule.pattern;
+
+    const tdReplacement = document.createElement('td');
+    tdReplacement.textContent = rule.replacement;
+
+    const tdId = document.createElement('td');
+    tdId.style.cssText = 'font-size:0.85rem;opacity:0.7;white-space:nowrap';
+    tdId.textContent = rule.numistaId || '\u2014';
+
+    tr.append(tdPattern, tdReplacement, tdId);
+    tbody.appendChild(tr);
+  }
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+};
+
+/**
+ * Renders the custom Numista lookup rules table with delete buttons.
+ */
+const renderCustomRuleTable = () => {
+  const container = document.getElementById('customRuleTableContainer');
+  if (!container || !window.NumistaLookup) return;
+
+  const rules = NumistaLookup.listCustomRules();
+  container.textContent = '';
+
+  if (!rules.length) {
+    const empty = document.createElement('div');
+    empty.className = 'chip-grouping-empty';
+    empty.textContent = 'No custom patterns';
+    container.appendChild(empty);
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'chip-grouping-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['Pattern', 'Numista Query', 'N#', ''].forEach(text => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    th.style.cssText = 'font-size:0.75rem;font-weight:normal;opacity:0.6;padding:0.2rem 0.4rem';
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  for (const rule of rules) {
+    const tr = document.createElement('tr');
+
+    const tdPattern = document.createElement('td');
+    tdPattern.style.cssText = 'font-family:monospace;font-size:0.8rem;word-break:break-all';
+    tdPattern.textContent = rule.pattern;
+
+    const tdReplacement = document.createElement('td');
+    tdReplacement.textContent = rule.replacement;
+
+    const tdId = document.createElement('td');
+    tdId.style.cssText = 'font-size:0.85rem;opacity:0.7;white-space:nowrap';
+    tdId.textContent = rule.numistaId || '\u2014';
+
+    const tdDelete = document.createElement('td');
+    tdDelete.style.cssText = 'width:2rem;text-align:center';
+    const delBtn = document.createElement('button');
+    delBtn.type = 'button';
+    delBtn.className = 'inline-chip-move';
+    delBtn.textContent = '\u2715';
+    delBtn.title = 'Delete rule';
+    delBtn.addEventListener('click', () => {
+      NumistaLookup.removeRule(rule.id);
+      renderCustomRuleTable();
+    });
+    tdDelete.appendChild(delBtn);
+
+    tr.append(tdPattern, tdReplacement, tdId, tdDelete);
+    tbody.appendChild(tr);
+  }
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+};
+
+/**
  * Syncs the display currency dropdown with current state (STACK-50).
  * Populates options from SUPPORTED_CURRENCIES on first call.
  */
@@ -1351,4 +1539,6 @@ if (typeof window !== 'undefined') {
   window.syncCurrencySettingsUI = syncCurrencySettingsUI;
   window.syncHeaderToggleUI = syncHeaderToggleUI;
   window.syncLayoutVisibilityUI = syncLayoutVisibilityUI;
+  window.renderSeedRuleTable = renderSeedRuleTable;
+  window.renderCustomRuleTable = renderCustomRuleTable;
 }

--- a/js/state.js
+++ b/js/state.js
@@ -185,6 +185,10 @@ const elements = {
   searchSectionEl: null,
   tableSectionEl: null,
 
+  // View item modal elements
+  viewItemModal: null,
+  viewModalCloseBtn: null,
+
   // Settings modal elements
   settingsBtn: null,
   settingsModal: null,

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -1,0 +1,694 @@
+// VIEW ITEM MODAL — Card-style showcase with coin images + enriched data
+// =============================================================================
+
+/**
+ * Active object URLs created for the current view modal session.
+ * Revoked on modal close to prevent memory leaks.
+ * @type {string[]}
+ */
+let _viewModalObjectUrls = [];
+
+/** @type {number} Metadata cache TTL: 30 days in ms */
+const VIEW_METADATA_TTL = 30 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Open the view modal for a specific inventory item.
+ * @param {number} index - Index into the global `inventory` array
+ */
+async function showViewModal(index) {
+  const item = inventory[index];
+  if (!item) return;
+
+  const modal = document.getElementById('viewItemModal');
+  if (!modal) return;
+
+  const body = document.getElementById('viewModalBody');
+  if (!body) return;
+
+  // Build modal content
+  body.textContent = '';
+  body.appendChild(buildViewContent(item, index));
+
+  modal.style.display = 'flex';
+
+  // Load images and Numista data asynchronously after modal is visible
+  // Share a single API result to avoid duplicate calls
+  const catalogId = item.numistaId || '';
+  let apiResult = null;
+
+  // Try loading images from cache/item first
+  const imagesLoaded = await loadViewImages(item, body, null);
+
+  // If images or metadata are needed, do a single API lookup
+  if (catalogId && (!imagesLoaded || body.querySelector('#viewNumistaSection'))) {
+    apiResult = await _fetchNumistaResult(catalogId);
+  }
+
+  // Fill images from API result if cache/item didn't have them
+  if (!imagesLoaded && apiResult) {
+    const section = body.querySelector('#viewImageSection');
+    if (section) {
+      const slots = section.querySelectorAll('.view-image-slot');
+      if (apiResult.imageUrl) _setSlotImage(slots[0], apiResult.imageUrl);
+      if (apiResult.reverseImageUrl) _setSlotImage(slots[1], apiResult.reverseImageUrl);
+
+      // Cache for next time
+      if (window.imageCache?.isAvailable()) {
+        imageCache.cacheImages(catalogId, apiResult.imageUrl || '', apiResult.reverseImageUrl || '').catch(() => {});
+      }
+    }
+  }
+
+  // Load Numista enrichment section
+  await loadViewNumistaData(item, body, apiResult);
+}
+
+/**
+ * Close the view modal and clean up resources.
+ */
+function closeViewModal() {
+  const modal = document.getElementById('viewItemModal');
+  if (modal) modal.style.display = 'none';
+
+  // Revoke all object URLs to free memory
+  _viewModalObjectUrls.forEach(url => {
+    try { URL.revokeObjectURL(url); } catch { /* ignore */ }
+  });
+  _viewModalObjectUrls = [];
+}
+
+// ---------------------------------------------------------------------------
+// Content builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the full view modal body as a DocumentFragment.
+ * @param {Object} item - Inventory item
+ * @param {number} index - Item index for edit button
+ * @returns {DocumentFragment}
+ */
+function buildViewContent(item, index) {
+  const frag = document.createDocumentFragment();
+  const metalKey = (item.metal || 'silver').toLowerCase();
+  const currentSpot = spotPrices[metalKey] || 0;
+  const qty = Number(item.qty) || 1;
+  const weight = parseFloat(item.weight) || 0;
+  const purity = parseFloat(item.purity) || 1.0;
+  const isGb = item.weightUnit === 'gb';
+  const weightOz = isGb ? weight * GB_TO_OZT : weight;
+
+  // --- Header info (name + catalog ID) ---
+  const header = document.getElementById('viewModalTitle');
+  if (header) header.textContent = sanitizeHtml(item.name || 'Untitled Item');
+
+  const catalogBadge = document.getElementById('viewModalCatalogId');
+  if (catalogBadge) {
+    const nId = item.numistaId || '';
+    catalogBadge.textContent = nId ? `N#${nId}` : '';
+    catalogBadge.style.display = nId ? '' : 'none';
+    if (nId) {
+      catalogBadge.style.cursor = 'pointer';
+      catalogBadge.title = 'View on Numista';
+      catalogBadge.onclick = (e) => {
+        e.stopPropagation();
+        const isSet = /^S/i.test(nId);
+        const cleanId = nId.replace(/^[NS]?#?\s*/i, '').trim();
+        const url = isSet
+          ? `https://en.numista.com/catalogue/set.php?id=${cleanId}`
+          : `https://en.numista.com/catalogue/pieces${cleanId}.html`;
+        _openIframePopup(url, `Numista — N#${nId}`);
+      };
+    } else {
+      catalogBadge.onclick = null;
+      catalogBadge.style.cursor = '';
+    }
+  }
+
+  // --- Image section (placeholders, populated async) ---
+  // Detect non-round items: bars, notes, Aurum/Goldback, sets → use rectangular frame
+  const itemType = (item.type || '').toLowerCase();
+  const isRectShape = itemType === 'bar' || itemType === 'note' || itemType === 'aurum'
+    || itemType === 'set' || isGb;
+
+  const imgSection = _el('div', 'view-image-section' + (isRectShape ? ' view-shape-rect' : ''));
+  imgSection.id = 'viewImageSection';
+
+  const obvSlot = _imageSlot('obverse', 'Obverse');
+  const revSlot = _imageSlot('reverse', 'Reverse');
+  imgSection.appendChild(obvSlot);
+  imgSection.appendChild(revSlot);
+  frag.appendChild(imgSection);
+
+  // --- Inventory data ---
+  const invSection = _section('Inventory');
+  const invGrid = _el('div', 'view-detail-grid three-col');
+  _addDetail(invGrid, 'Metal', item.composition || item.metal || '—');
+  _addDetail(invGrid, 'Type', item.type || '—');
+  _addDetail(invGrid, 'Year', item.year || '—');
+  _addDetail(invGrid, 'Purity', purity < 1 ? `.${String(purity).replace('0.', '')}` : purity === 1 ? '.999+' : String(purity));
+  _addDetail(invGrid, 'Weight', typeof formatWeight === 'function' ? formatWeight(weight, item.weightUnit) : `${weight} oz`);
+  _addDetail(invGrid, 'Qty', String(qty));
+  invSection.appendChild(invGrid);
+
+  const invGrid2 = _el('div', 'view-detail-grid three-col');
+  _addDetail(invGrid2, 'Purchase', typeof formatCurrency === 'function' ? formatCurrency(parseFloat(item.price) || 0) : `$${item.price}`);
+  _addDetail(invGrid2, 'Date', item.date ? (typeof formatDisplayDate === 'function' ? formatDisplayDate(item.date) : item.date) : '—');
+
+  // Source — render as iframe link if it looks like a URL
+  const srcVal = item.purchaseLocation || '—';
+  const srcUrlPattern = /^(https?:\/\/)?[\w.-]+\.(com|net|org|co|io|us|uk|ca|au|de|fr|shop|store)\b/i;
+  if (srcUrlPattern.test(srcVal)) {
+    const srcItem = _detailItem('Source', '');
+    const valEl = srcItem.querySelector('.view-detail-value');
+    if (valEl) {
+      valEl.textContent = '';
+      const srcLink = document.createElement('a');
+      srcLink.href = '#';
+      let srcHref = srcVal;
+      if (!/^https?:\/\//i.test(srcHref)) srcHref = `https://${srcHref}`;
+      srcLink.title = srcHref;
+      srcLink.style.color = 'var(--primary)';
+      srcLink.style.textDecoration = 'none';
+      // Display: strip protocol and www, truncate domain suffix for readability
+      srcLink.textContent = srcVal.replace(/^(https?:\/\/)?(www\.)?/i, '').replace(/\/(.*)/i, '');
+      srcLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        _openIframePopup(srcHref, 'Source');
+      });
+      valEl.appendChild(srcLink);
+    }
+    invGrid2.appendChild(srcItem);
+  } else {
+    _addDetail(invGrid2, 'Source', srcVal);
+  }
+  invSection.appendChild(invGrid2);
+
+  if (item.storageLocation) {
+    const storGrid = _el('div', 'view-detail-grid');
+    _addDetail(storGrid, 'Storage', item.storageLocation);
+    invSection.appendChild(storGrid);
+  }
+  frag.appendChild(invSection);
+
+  // --- Valuation ---
+  const meltValue = currentSpot > 0 ? weightOz * qty * currentSpot * purity : 0;
+  const purchaseTotal = qty * (parseFloat(item.price) || 0);
+  const marketVal = parseFloat(item.marketValue) || 0;
+  const retailTotal = marketVal > 0 ? qty * marketVal : meltValue;
+  const gainLoss = retailTotal > 0 ? retailTotal - purchaseTotal : null;
+
+  const valSection = _section('Valuation');
+  const valGrid = _el('div', 'view-detail-grid three-col');
+  _addDetail(valGrid, 'Melt Value', currentSpot > 0 ? formatCurrency(meltValue) : '—');
+  _addDetail(valGrid, 'Retail', retailTotal > 0 ? formatCurrency(retailTotal) : '—');
+
+  if (gainLoss !== null && retailTotal > 0) {
+    const glItem = _detailItem('Gain/Loss', (gainLoss >= 0 ? '+' : '') + formatCurrency(gainLoss));
+    const valEl = glItem.querySelector('.view-detail-value');
+    if (valEl) valEl.classList.add(gainLoss >= 0 ? 'gain' : 'loss');
+    valGrid.appendChild(glItem);
+  } else {
+    _addDetail(valGrid, 'Gain/Loss', '—', 'muted');
+  }
+  valSection.appendChild(valGrid);
+  frag.appendChild(valSection);
+
+  // --- Grading (conditional) ---
+  if (item.grade || item.gradingAuthority || item.certNumber) {
+    const gradeSection = _section('Grading');
+    const gradeGrid = _el('div', 'view-detail-grid three-col');
+    _addDetail(gradeGrid, 'Grade', item.grade || '—');
+    _addDetail(gradeGrid, 'Authority', item.gradingAuthority || '—');
+    if (item.certNumber) {
+      const certItem = _detailItem('Cert #', item.certNumber);
+      // Add verification link if authority has a lookup URL
+      if (item.gradingAuthority && typeof CERT_LOOKUP_URLS !== 'undefined' && CERT_LOOKUP_URLS[item.gradingAuthority]) {
+        const url = CERT_LOOKUP_URLS[item.gradingAuthority]
+          .replace(/{certNumber}/g, encodeURIComponent(item.certNumber))
+          .replace(/{grade}/g, encodeURIComponent(item.grade || ''));
+        const valEl = certItem.querySelector('.view-detail-value');
+        if (valEl) {
+          valEl.textContent = '';
+          const link = document.createElement('a');
+          link.href = url;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          link.textContent = item.certNumber;
+          link.style.color = 'var(--primary)';
+          link.title = `Verify on ${item.gradingAuthority}`;
+          valEl.appendChild(link);
+        }
+      }
+      gradeGrid.appendChild(certItem);
+    } else {
+      _addDetail(gradeGrid, 'Cert #', '—');
+    }
+    gradeSection.appendChild(gradeGrid);
+    frag.appendChild(gradeSection);
+  }
+
+  // --- Numista enrichment placeholder (populated async) ---
+  const numistaPlaceholder = _el('div', '');
+  numistaPlaceholder.id = 'viewNumistaSection';
+  frag.appendChild(numistaPlaceholder);
+
+  // --- Notes ---
+  if (item.notes) {
+    const notesSection = _section('Notes');
+    const noteText = _el('div', 'view-notes-text');
+    noteText.textContent = item.notes;
+    notesSection.appendChild(noteText);
+    frag.appendChild(notesSection);
+  }
+
+  // --- Footer ---
+  const footer = _el('div', 'view-modal-footer');
+
+  // Left side — eBay search
+  const footerLeft = _el('div', 'view-footer-left');
+  const ebayBtn = document.createElement('button');
+  ebayBtn.className = 'view-ebay-btn';
+  ebayBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" style="fill:currentColor;margin-right:4px;vertical-align:-2px;"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>Search eBay';
+  ebayBtn.title = 'Search eBay for this item';
+  ebayBtn.addEventListener('click', () => {
+    const searchTerm = (item.metal || '') + (item.year ? ' ' + item.year : '') + ' ' + (item.name || '');
+    if (typeof openEbayBuySearch === 'function') {
+      openEbayBuySearch(searchTerm);
+    } else if (typeof openEbaySoldSearch === 'function') {
+      openEbaySoldSearch(searchTerm);
+    }
+  });
+  footerLeft.appendChild(ebayBtn);
+  footer.appendChild(footerLeft);
+
+  // Right side — Edit + Close
+  const footerRight = _el('div', 'view-footer-right');
+
+  const editBtn = document.createElement('button');
+  editBtn.className = 'view-edit-btn';
+  editBtn.textContent = 'Edit Item';
+  editBtn.addEventListener('click', () => {
+    closeViewModal();
+    if (typeof editItem === 'function') editItem(index);
+  });
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', closeViewModal);
+
+  footerRight.appendChild(editBtn);
+  footerRight.appendChild(closeBtn);
+  footer.appendChild(footerRight);
+  frag.appendChild(footer);
+
+  return frag;
+}
+
+// ---------------------------------------------------------------------------
+// Async loaders
+// ---------------------------------------------------------------------------
+
+/**
+ * Load coin images from IndexedDB cache → CDN URL fallback.
+ * Returns true if images were found from cache or item URLs.
+ * @param {Object} item
+ * @param {HTMLElement} container
+ * @returns {Promise<boolean>} true if images loaded from cache/item
+ */
+async function loadViewImages(item, container) {
+  const section = container.querySelector('#viewImageSection');
+  if (!section) return false;
+
+  const catalogId = item.numistaId || '';
+  const slots = section.querySelectorAll('.view-image-slot');
+  const obvSlot = slots[0];
+  const revSlot = slots[1];
+
+  // Attempt IndexedDB cache first
+  if (catalogId && window.imageCache?.isAvailable()) {
+    const obvUrl = await imageCache.getImageUrl(catalogId, 'obverse');
+    if (obvUrl) {
+      _viewModalObjectUrls.push(obvUrl);
+      _setSlotImage(obvSlot, obvUrl);
+    }
+
+    const revUrl = await imageCache.getImageUrl(catalogId, 'reverse');
+    if (revUrl) {
+      _viewModalObjectUrls.push(revUrl);
+      _setSlotImage(revSlot, revUrl);
+    }
+
+    if (obvUrl || revUrl) return true;
+  }
+
+  // Fallback: CDN URLs stored on the item
+  if (item.obverseImageUrl) _setSlotImage(obvSlot, item.obverseImageUrl);
+  if (item.reverseImageUrl) _setSlotImage(revSlot, item.reverseImageUrl);
+  if (item.obverseImageUrl || item.reverseImageUrl) return true;
+
+  return false;
+}
+
+/**
+ * Load Numista metadata from IndexedDB cache or pre-fetched API result, render enrichment section.
+ * @param {Object} item
+ * @param {HTMLElement} container
+ * @param {Object|null} apiResult - Pre-fetched Numista API result (avoids duplicate call)
+ */
+async function loadViewNumistaData(item, container, apiResult) {
+  const catalogId = item.numistaId || '';
+  if (!catalogId) return;
+
+  const placeholder = container.querySelector('#viewNumistaSection');
+  if (!placeholder) return;
+
+  let meta = null;
+
+  // Check cache
+  if (window.imageCache?.isAvailable()) {
+    meta = await imageCache.getMetadata(catalogId);
+
+    // Stale check
+    if (meta && (Date.now() - (meta.cachedAt || 0)) > VIEW_METADATA_TTL) {
+      meta = null; // Force refresh
+    }
+  }
+
+  // Use pre-fetched API result if no cache hit
+  if (!meta && apiResult) {
+    meta = _extractMetadata(apiResult);
+
+    // Cache for next time
+    if (window.imageCache?.isAvailable()) {
+      imageCache.cacheMetadata(catalogId, apiResult).catch(() => {});
+    }
+  }
+
+  if (!meta) return;
+
+  // Load user's field visibility config
+  const cfg = typeof getNumistaViewFieldConfig === 'function'
+    ? getNumistaViewFieldConfig()
+    : {};
+
+  // Update image frame shape based on Numista data if not already rectangular
+  if (meta.shape) {
+    const imgSection = container.querySelector('#viewImageSection');
+    const shapeStr = meta.shape.toLowerCase();
+    const isNonRound = shapeStr !== 'round' && shapeStr !== 'circular';
+    if (isNonRound && imgSection && !imgSection.classList.contains('view-shape-rect')) {
+      imgSection.classList.add('view-shape-rect');
+    }
+  }
+
+  // Build Numista section
+  const section = _el('div', 'view-numista-section');
+
+  const badge = _el('span', 'view-numista-badge');
+  badge.textContent = 'Numista Data';
+  section.appendChild(badge);
+
+  const grid = _el('div', 'view-detail-grid');
+
+  if (cfg.denomination !== false && meta.denomination) _addDetail(grid, 'Denomination', meta.denomination);
+  if (cfg.shape !== false && meta.shape) _addDetail(grid, 'Shape', meta.shape);
+  if (cfg.diameter !== false && meta.diameter) _addDetail(grid, 'Diameter', `${meta.diameter}mm`);
+  if (cfg.thickness !== false && meta.thickness) _addDetail(grid, 'Thickness', `${meta.thickness}mm`);
+  if (cfg.orientation !== false && meta.orientation) _addDetail(grid, 'Orientation', meta.orientation);
+  if (cfg.composition !== false && meta.composition) _addDetail(grid, 'Composition', meta.composition);
+  if (cfg.country !== false && meta.country) _addDetail(grid, 'Country', meta.country);
+  if (cfg.technique !== false && meta.technique) _addDetail(grid, 'Technique', meta.technique);
+
+  if (cfg.references !== false && meta.kmReferences && meta.kmReferences.length > 0) {
+    _addDetail(grid, 'References', meta.kmReferences.join(', '));
+  }
+
+  section.appendChild(grid);
+
+  // Edge description on its own full-width line (can be long)
+  if (cfg.edge !== false && meta.edgeDesc) {
+    const edgeGrid = _el('div', 'view-detail-grid');
+    const edgeItem = _detailItem('Edge', meta.edgeDesc);
+    edgeItem.classList.add('full-width');
+    edgeGrid.appendChild(edgeItem);
+    section.appendChild(edgeGrid);
+  }
+
+  // Set obverse/reverse descriptions as tooltips on the image slots
+  if (cfg.imageTooltips !== false && (meta.obverseDesc || meta.reverseDesc)) {
+    const imgSection = container.querySelector('#viewImageSection');
+    if (imgSection) {
+      const slots = imgSection.querySelectorAll('.view-image-slot');
+      if (meta.obverseDesc && slots[0]) {
+        slots[0].title = `Obverse: ${meta.obverseDesc}`;
+      }
+      if (meta.reverseDesc && slots[1]) {
+        slots[1].title = `Reverse: ${meta.reverseDesc}`;
+      }
+    }
+  }
+
+  // Tags
+  if (cfg.tags !== false && meta.tags && meta.tags.length > 0) {
+    const tagGrid = _el('div', 'view-detail-grid');
+    const tagItem = _detailItem('Tags', meta.tags.join(', '));
+    tagItem.classList.add('full-width');
+    tagGrid.appendChild(tagItem);
+    section.appendChild(tagGrid);
+  }
+
+  // Commemorative
+  if (cfg.commemorative !== false && meta.commemorative && meta.commemorativeDesc) {
+    const commGrid = _el('div', 'view-detail-grid');
+    const commItem = _detailItem('Commemorative', meta.commemorativeDesc);
+    commItem.classList.add('full-width');
+    commGrid.appendChild(commItem);
+    section.appendChild(commGrid);
+  }
+
+  // Rarity index
+  if (cfg.rarity !== false && meta.rarityIndex > 0) {
+    const rarityRow = _el('div', 'view-detail-item');
+
+    const lbl = _el('span', 'view-detail-label');
+    lbl.textContent = 'Rarity';
+    rarityRow.appendChild(lbl);
+
+    const bar = _el('div', 'view-rarity-bar');
+
+    const track = _el('div', 'view-rarity-track');
+    const fill = _el('div', 'view-rarity-fill');
+    fill.style.width = `${Math.min(meta.rarityIndex, 100)}%`;
+    track.appendChild(fill);
+    bar.appendChild(track);
+
+    const score = _el('span', 'view-rarity-score');
+    score.textContent = String(meta.rarityIndex);
+    bar.appendChild(score);
+
+    rarityRow.appendChild(bar);
+    section.appendChild(rarityRow);
+  }
+
+  // Mintage by year (show first few)
+  if (cfg.mintage !== false && meta.mintageByYear && meta.mintageByYear.length > 0) {
+    const mintGrid = _el('div', 'view-detail-grid');
+    const mintItem = _el('div', 'view-detail-item full-width');
+    const mintLabel = _el('span', 'view-detail-label');
+    mintLabel.textContent = 'Mintage';
+    mintItem.appendChild(mintLabel);
+
+    const mintVal = _el('span', 'view-detail-value');
+    const entries = meta.mintageByYear.slice(0, 5);
+    mintVal.textContent = entries.map(e => {
+      const m = typeof e.mintage === 'number' ? e.mintage.toLocaleString() : e.mintage;
+      return `${e.year}: ${m}${e.remark ? ` (${e.remark})` : ''}`;
+    }).join(' | ');
+    if (meta.mintageByYear.length > 5) mintVal.textContent += ' ...';
+    mintItem.appendChild(mintVal);
+    mintGrid.appendChild(mintItem);
+    section.appendChild(mintGrid);
+  }
+
+  placeholder.replaceWith(section);
+}
+
+// ---------------------------------------------------------------------------
+// API helpers (private)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a Numista item by catalogId. Returns the normalized result or null.
+ * @param {string} catalogId
+ * @returns {Promise<Object|null>}
+ */
+async function _fetchNumistaResult(catalogId) {
+  if (!catalogId || typeof catalogAPI === 'undefined') return null;
+  try {
+    return await catalogAPI.lookupItem(catalogId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract metadata fields from a Numista API result.
+ * @param {Object} result
+ * @returns {Object}
+ */
+function _extractMetadata(result) {
+  return {
+    title: result.name || '',
+    country: result.country || '',
+    denomination: result.denomination || '',
+    diameter: result.diameter || result.size || 0,
+    thickness: result.thickness || 0,
+    weight: result.weight || 0,
+    shape: result.shape || '',
+    composition: result.composition || result.metal || '',
+    orientation: result.orientation || '',
+    commemorative: !!result.commemorative,
+    commemorativeDesc: result.commemorativeDesc || '',
+    rarityIndex: result.rarityIndex || 0,
+    kmReferences: result.kmReferences || [],
+    mintageByYear: result.mintageByYear || [],
+    technique: result.technique || '',
+    tags: result.tags || [],
+    obverseDesc: result.obverseDesc || '',
+    reverseDesc: result.reverseDesc || '',
+    edgeDesc: result.edgeDesc || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Iframe popup (private)
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a URL in a modal iframe popup overlay (1250px wide).
+ * Falls back to window.open() if the modal element isn't in the DOM.
+ * @param {string} url
+ * @param {string} [title='']
+ */
+function _openIframePopup(url, title) {
+  const modal = document.getElementById('iframePopupModal');
+  const frame = document.getElementById('iframePopupFrame');
+  const titleEl = document.getElementById('iframePopupTitle');
+  const closeBtn = document.getElementById('iframePopupCloseBtn');
+
+  if (!modal || !frame) {
+    // Fallback to window.open
+    window.open(url, '_blank', 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
+    return;
+  }
+
+  frame.src = url;
+  if (titleEl) titleEl.textContent = title || '';
+  modal.style.display = 'flex';
+
+  // Wire close (only once)
+  if (!modal._closeWired) {
+    modal._closeWired = true;
+
+    const close = () => {
+      modal.style.display = 'none';
+      frame.src = 'about:blank';
+    };
+
+    if (closeBtn) closeBtn.addEventListener('click', close);
+    modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && modal.style.display !== 'none') close();
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DOM helpers (private)
+// ---------------------------------------------------------------------------
+
+/** Create element with className */
+function _el(tag, className) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  return el;
+}
+
+/** Create a data section with title */
+function _section(title) {
+  const section = _el('div', 'view-detail-section');
+  const h = _el('div', 'view-section-title');
+  h.textContent = title;
+  section.appendChild(h);
+  return section;
+}
+
+/** Create a label/value detail item element */
+function _detailItem(label, value, extraClass) {
+  const item = _el('div', 'view-detail-item');
+  const lbl = _el('span', 'view-detail-label');
+  lbl.textContent = label;
+  const val = _el('span', 'view-detail-value' + (extraClass ? ' ' + extraClass : ''));
+  val.textContent = value;
+  item.appendChild(lbl);
+  item.appendChild(val);
+  return item;
+}
+
+/** Add a detail item to a grid */
+function _addDetail(grid, label, value, extraClass) {
+  grid.appendChild(_detailItem(label, value, extraClass));
+}
+
+/** Create an image slot with placeholder */
+function _imageSlot(side, label) {
+  const slot = _el('div', 'view-image-slot');
+  slot.dataset.side = side;
+
+  const ph = _el('div', 'view-image-placeholder');
+  ph.textContent = '\uD83E\uDE99'; // coin emoji
+  slot.appendChild(ph);
+
+  const lbl = _el('span', 'view-image-label');
+  lbl.textContent = label;
+  slot.appendChild(lbl);
+
+  return slot;
+}
+
+/** Replace placeholder with actual image in a slot */
+function _setSlotImage(slot, src) {
+  if (!slot || !src) return;
+  const ph = slot.querySelector('.view-image-placeholder');
+  if (!ph) return;
+
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = slot.dataset.side || 'Coin';
+  img.loading = 'lazy';
+  img.onerror = () => { img.style.display = 'none'; };
+  ph.replaceWith(img);
+}
+
+// ---------------------------------------------------------------------------
+// Global exposure
+// ---------------------------------------------------------------------------
+
+// ESC key handler
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    const modal = document.getElementById('viewItemModal');
+    if (modal && modal.style.display !== 'none') {
+      closeViewModal();
+    }
+  }
+});
+
+if (typeof window !== 'undefined') {
+  window.showViewModal = showViewModal;
+  window.closeViewModal = closeViewModal;
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.26.03",
+  "version": "3.27.00",
   "releaseDate": "2026-02-13",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **IndexedDB image cache** (`js/image-cache.js`) — fetches, resizes (400px), and JPEG-compresses Numista coin images with 50MB quota and graceful `file://` degradation
- **Item view modal** (`js/viewModal.js`) — card-style showcase with coin images (obverse/reverse), inventory data, valuation, grading, and enriched Numista metadata (15 configurable fields)
- **Settings toggles** for individual Numista fields in the API settings panel
- **View button** (eye icon) in table/card actions, card tap opens view modal on mobile
- **Reusable iframe popup** (1250px) for source URLs, N# Numista links, and external references
- **IndexedDB storage reporting** in settings footer and storage report modal
- **Search eBay** button in view modal footer
- **Mobile UX** — full-screen view modal, sticky footer with safe-area insets, primary-accent view button in card view
- **Popup width** standardized from 1200→1250px across all external link windows
- **COIN_IMAGES feature flag** (beta) gates entire system

## Files Updated

### New Files
- `js/image-cache.js` — IndexedDB storage layer (ImageCache class)
- `js/viewModal.js` — View modal controller + iframe popup helper

### Modified Files
- `js/constants.js` — APP_VERSION → 3.27.00, COIN_IMAGES flag, numistaViewFields config
- `js/state.js` — viewItemModal, viewModalCloseBtn element refs
- `js/events.js` — obverseImageUrl/reverseImageUrl on inventory items
- `js/catalog-api.js` — expanded Numista field extraction, fire-and-forget image caching
- `js/inventory.js` — view button in actions, card tap → view modal, popup widths
- `js/init.js` — ImageCache init, modal wiring, global exports
- `js/settings.js` — Numista field toggle wiring, IndexedDB in footer
- `js/utils.js` — IndexedDB in storage report, popup widths
- `js/numista-modal.js` — popup width 1200→1250
- `js/about.js` — embedded What's New fallback
- `index.html` — script tags, view modal HTML, iframe popup modal, settings checkboxes
- `css/styles.css` — view modal styles, mobile responsive, card view button, iframe popup
- `CHANGELOG.md` — v3.27.00 section
- `docs/announcements.md` — new What's New entry
- `version.json` — 3.27.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)