### PR TITLE
v3.27.04 — Spot Comparison Mode & Mobile API Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.27.04] - 2026-02-14
+
+### Added — Spot Comparison Mode & Mobile API Settings
+
+- **Added**: User setting for 24h % comparison mode — Close/Close, Open/Open, Open/Close (STACK-92)
+- **Changed**: Replaced drag-to-sort provider tabs with explicit Sync Priority dropdowns that work on all devices (STACK-90)
+- **Changed**: Provider tabs now scroll horizontally on mobile instead of overflowing (STACK-90)
+- **Removed**: Sync Mode toggle (Always/Backup) — replaced by priority numbers (STACK-90)
+- **Fixed**: Cache-bust favicon and add root-level copies for PWA
+- **Fixed**: Consistent 24h % across all spot card views (STACK-89)
+- **Changed**: Extract fetchAndCache helper in service worker
+
+---
+
 ## [3.27.03] - 2026-02-14
 
 ### Added — PWA Support & Bug Fixes

--- a/css/styles.css
+++ b/css/styles.css
@@ -1316,27 +1316,20 @@ input[type="submit"] {
   margin-left: 0.5rem;
 }
 
-/* Pinned provider tab (Numista — not draggable) */
+/* Pinned provider tab (Numista) */
 .settings-provider-tab.pinned {
   cursor: default;
 }
 
-/* Drag-in-progress visual feedback */
-.settings-provider-tabs.dragging .settings-provider-tab:not(.pinned) {
-  opacity: 0.7;
-  transition: opacity 0.15s;
-}
-
-.settings-provider-tab.drag-over {
-  border-bottom: 2px solid var(--primary);
-}
-
-.settings-provider-tab[draggable="true"] {
-  cursor: grab;
-}
-
-.settings-provider-tab[draggable="true"]:active {
-  cursor: grabbing;
+/* Provider priority dropdown (STACK-90) */
+.provider-priority-select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.85rem;
+  min-width: 140px;
 }
 
 .settings-subtext {
@@ -1955,6 +1948,9 @@ input[type="submit"] {
   gap: 0;
   border-bottom: 2px solid var(--border);
   margin: 1rem 0 0 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
 }
 
 .settings-provider-tab {
@@ -2076,6 +2072,10 @@ input[type="submit"] {
   }
 
   .settings-content-area { padding: var(--spacing); }
+
+  /* Provider tabs: horizontal scroll on mobile (STACK-90) */
+  .settings-provider-tabs { flex-wrap: nowrap; }
+  .settings-provider-tab { white-space: nowrap; flex-shrink: 0; padding: 0.5rem 0.75rem; font-size: 0.75rem; }
 }
 
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,9 @@
 ## What's New
 
+- **Spot Comparison Mode & Mobile API Settings (v3.27.04)**: 24h % comparison mode setting (Close/Close, Open/Open, Open/Close). Replaced drag-to-sort provider tabs with Sync Priority dropdowns. Mobile tab overflow fix. Consistent 24h % across all spot card views (STACK-89, STACK-90, STACK-92)
 - **PWA Support & Bug Fixes (v3.27.03)**: Installable app experience with offline caching via service worker. Fixed: edit-mode price preservation (STACK-81), stale spot-lookup on date change (STACK-82), Activity Log tabs showing stale data (STACK-83), Samsung S24+ Ultra layout (STACK-85). Removed redundant View icon (STACK-86). Spot history seed data from Docker poller infrastructure
 - **Coin Image Cache & Item View Modal (v3.27.00)**: IndexedDB image cache for Numista coin photos with 50MB quota. Card-style view modal with images, inventory data, valuation, grading, and enriched Numista metadata. Settings toggles for 15 fields. View button in table/card actions. Clickable source URLs and N# badges open in popup windows. eBay search from view modal. Full-screen mobile layout with sticky footer
-- **STACK-79, STACK-80: XSS & HTML Injection Hardening (v3.26.03)**: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility
-- **Autocomplete Migration & Version Check CORS (v3.26.02)**: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect
-- **STACK-62: Autocomplete & Fuzzy Search Pipeline (v3.26.00)**: Autocomplete dropdowns on form inputs (name, purchase/storage location), abbreviation expansion in search (ASE, kook, krug, etc.), fuzzy fallback with indicator banner, registerName() for dynamic suggestions, Firefox compatibility fix
+- **XSS & HTML Injection Hardening (v3.26.03)**: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -1621,6 +1621,17 @@
                 </label>
               </div>
 
+              <!-- Spot price comparison mode (STACK-92) -->
+              <div class="settings-group">
+                <div class="settings-group-label">24h price comparison</div>
+                <p class="settings-subtext">Choose how the 24h percentage change on spot cards is calculated.</p>
+                <select id="settingsSpotCompareMode">
+                  <option value="close-close">Close / Close (default)</option>
+                  <option value="open-open">Open / Open</option>
+                  <option value="open-close">Open / Close</option>
+                </select>
+              </div>
+
               <div class="settings-placeholder" style="margin-top: 1.5rem;">
                 <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="19" cy="13" r="2.5"/><circle cx="16" cy="20" r="2.5"/><circle cx="7" cy="20" r="2.5"/><circle cx="4" cy="13" r="2.5"/><circle cx="12" cy="13" r="3"/></svg>
                 <p>Custom themes coming soon.</p>
@@ -1815,10 +1826,10 @@
               <div class="settings-provider-tabs">
                 <button class="settings-provider-tab pinned active" data-provider="NUMISTA">Numista</button>
                 <button class="settings-provider-tab pinned" data-provider="PCGS">PCGS</button>
-                <button class="settings-provider-tab" data-provider="METALS_DEV" draggable="true">Metals.dev</button>
-                <button class="settings-provider-tab" data-provider="METALS_API" draggable="true">Metals-API</button>
-                <button class="settings-provider-tab" data-provider="METAL_PRICE_API" draggable="true">MetalPriceAPI</button>
-                <button class="settings-provider-tab" data-provider="CUSTOM" draggable="true">Custom Spot API</button>
+                <button class="settings-provider-tab" data-provider="METALS_DEV">Metals.dev</button>
+                <button class="settings-provider-tab" data-provider="METALS_API">Metals-API</button>
+                <button class="settings-provider-tab" data-provider="METAL_PRICE_API">MetalPriceAPI</button>
+                <button class="settings-provider-tab" data-provider="CUSTOM">Custom Spot API</button>
               </div>
 
               <!-- Numista Provider Panel -->
@@ -1927,11 +1938,13 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label>Sync Mode:</label>
-                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_METALS_DEV" data-provider="METALS_DEV">
-                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
-                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
-                      </div>
+                      <label for="providerPriority_METALS_DEV">Sync Priority:</label>
+                      <select class="provider-priority-select" id="providerPriority_METALS_DEV" data-provider="METALS_DEV">
+                        <option value="1">1 — Primary</option>
+                        <option value="2">2 — Backup</option>
+                        <option value="3">3 — Tertiary</option>
+                        <option value="0">Disabled</option>
+                      </select>
                     </div>
                     <div class="provider-history-pull">
                       <label for="historyPullDays_METALS_DEV">Pull History:</label>
@@ -1994,11 +2007,13 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label>Sync Mode:</label>
-                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_METALS_API" data-provider="METALS_API">
-                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
-                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
-                      </div>
+                      <label for="providerPriority_METALS_API">Sync Priority:</label>
+                      <select class="provider-priority-select" id="providerPriority_METALS_API" data-provider="METALS_API">
+                        <option value="1">1 — Primary</option>
+                        <option value="2">2 — Backup</option>
+                        <option value="3">3 — Tertiary</option>
+                        <option value="0">Disabled</option>
+                      </select>
                     </div>
                     <div class="provider-history-pull">
                       <label for="historyPullDays_METALS_API">Pull History:</label>
@@ -2065,11 +2080,13 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label>Sync Mode:</label>
-                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_METAL_PRICE_API" data-provider="METAL_PRICE_API">
-                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
-                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
-                      </div>
+                      <label for="providerPriority_METAL_PRICE_API">Sync Priority:</label>
+                      <select class="provider-priority-select" id="providerPriority_METAL_PRICE_API" data-provider="METAL_PRICE_API">
+                        <option value="1">1 — Primary</option>
+                        <option value="2">2 — Backup</option>
+                        <option value="3">3 — Tertiary</option>
+                        <option value="0">Disabled</option>
+                      </select>
                     </div>
                     <div class="provider-history-pull">
                       <label for="historyPullDays_METAL_PRICE_API">Pull History:</label>
@@ -2150,11 +2167,13 @@
                       </select>
                     </div>
                     <div class="provider-setting-row">
-                      <label>Sync Mode:</label>
-                      <div class="chip-sort-toggle sync-mode-toggle" id="syncMode_CUSTOM" data-provider="CUSTOM">
-                        <button type="button" class="chip-sort-btn" data-mode="always">Always</button>
-                        <button type="button" class="chip-sort-btn" data-mode="backup">Backup</button>
-                      </div>
+                      <label for="providerPriority_CUSTOM">Sync Priority:</label>
+                      <select class="provider-priority-select" id="providerPriority_CUSTOM" data-provider="CUSTOM">
+                        <option value="1">1 — Primary</option>
+                        <option value="2">2 — Backup</option>
+                        <option value="3">3 — Tertiary</option>
+                        <option value="0">Disabled</option>
+                      </select>
                     </div>
                     <!-- Custom providers: no history pull (batch not supported) -->
                     <div class="metal-selection">

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.27.04 &ndash; Spot Comparison Mode &amp; Mobile API Settings</strong>: 24h % comparison mode setting (Close/Close, Open/Open, Open/Close). Replaced drag-to-sort provider tabs with Sync Priority dropdowns. Mobile tab overflow fix. Consistent 24h % across all spot card views (STACK-89, STACK-90, STACK-92)</li>
     <li><strong>v3.27.03 &ndash; PWA Support &amp; Bug Fixes</strong>: Installable app experience with offline caching via service worker. Fixed: edit-mode price preservation (STACK-81), stale spot-lookup on date change (STACK-82), Activity Log tabs showing stale data (STACK-83), Samsung S24+ Ultra layout (STACK-85). Removed redundant View icon (STACK-86). Spot history seed data from Docker poller infrastructure</li>
     <li><strong>v3.27.00 &ndash; Coin Image Cache &amp; Item View Modal</strong>: IndexedDB image cache for Numista coin photos with 50MB quota. Card-style view modal with images, inventory data, valuation, grading, and enriched Numista metadata. Settings toggles for 15 fields. View button in table/card actions. Clickable source URLs and N# badges open in popup windows. eBay search from view modal. Full-screen mobile layout with sticky footer</li>
-    <li><strong>v3.26.03 &ndash; STACK-79, STACK-80: XSS &amp; HTML Injection Hardening</strong>: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility</li>
-    <li><strong>v3.26.02 &ndash; Autocomplete Migration &amp; Version Check CORS</strong>: One-time migration auto-enables fuzzy autocomplete for users with silently disabled flag. Fixed version check CORS failure from staktrakr.com 301 redirect</li>
+    <li><strong>v3.26.03 &ndash; XSS &amp; HTML Injection Hardening</strong>: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.27.03";
+const APP_VERSION = "3.27.04";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -525,6 +525,9 @@ const FEATURE_FLAGS_KEY = "featureFlags";
 /** @constant {string} SPOT_TREND_RANGE_KEY - LocalStorage key for sparkline trend range preferences */
 const SPOT_TREND_RANGE_KEY = "spotTrendRange";
 
+/** @constant {string} SPOT_COMPARE_MODE_KEY - LocalStorage key for 24h % comparison mode (STACK-92) */
+const SPOT_COMPARE_MODE_KEY = "spotCompareMode";
+
 /** @constant {string} ITEMS_PER_PAGE_KEY - LocalStorage key for items per page setting */
 const ITEMS_PER_PAGE_KEY = "settingsItemsPerPage";
 
@@ -564,11 +567,13 @@ const ALLOWED_STORAGE_KEYS = [
   "staktrakr.catalog.settings",
   CATALOG_HISTORY_KEY,
   SPOT_TREND_RANGE_KEY,
+  SPOT_COMPARE_MODE_KEY,
   ITEMS_PER_PAGE_KEY,
   "chipCustomGroups",
   "chipBlacklist",
   "inlineChipConfig",
   "apiProviderOrder",
+  "providerPriority",
   "filterChipCategoryConfig",
   "chipSortOrder",
   GOLDBACK_PRICES_KEY,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.27.02",
-  "releaseDate": "2026-02-13",
+  "version": "3.27.04",
+  "releaseDate": "2026-02-14",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Added**: 24h % comparison mode setting — Close/Close, Open/Open, Open/Close (STACK-92)
- **Changed**: Replaced drag-to-sort provider tabs with Sync Priority dropdowns for all devices (STACK-90)
- **Changed**: Provider tabs scroll horizontally on mobile instead of overflowing (STACK-90)
- **Removed**: Sync Mode toggle — replaced by priority numbers with auto-shift (STACK-90)
- **Fixed**: Cache-bust favicon and root-level copies for PWA
- **Fixed**: Consistent 24h % across all spot card views (STACK-89)
- **Changed**: Extract fetchAndCache helper in service worker

## Files Updated

- `js/constants.js` — APP_VERSION → 3.27.04, new storage keys
- `CHANGELOG.md` — new v3.27.04 section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint (corrected from 3.27.02)
- `css/styles.css` — tab overflow fix, priority dropdown styles, removed drag CSS
- `index.html` — comparison mode select, priority dropdowns replacing sync mode toggles
- `js/settings.js` — priority system replacing drag-to-sort, comparison mode listener
- `js/spot.js` — open/close sparkline data, get24hChange() helper
- `js/api.js` — priority-based sync engine, updated getProviderOrder()

## Linear Issues

- STACK-89: Consistent 24h % across all spot card views
- STACK-90: Mobile API settings — priority dropdowns + tab overflow
- STACK-92: 24h % comparison mode setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)