### PR TITLE
feat: table thumbnails + browser-cache preload fallback

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2607,6 +2607,21 @@ td[data-column="name"] {
   white-space: nowrap;
 }
 
+/* Table thumbnail — coin obverse preview */
+.table-thumb {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg-tertiary, #2a2a2a);
+  vertical-align: middle;
+}
+/* Hide thumbnail when no image URL available (src omitted until IDB enhancement) */
+.table-thumb:not([src]) {
+  display: none;
+}
+
 /* Tags never shrink — always visible */
 .name-cell-content > .year-tag,
 .name-cell-content > .numista-tag,
@@ -8048,6 +8063,12 @@ th {
     white-space: normal;
     text-overflow: clip;
     font-size: 1.05rem;
+  }
+
+  /* Table thumb in card view — slightly larger */
+  #inventoryTable tbody td[data-column="name"] .table-thumb {
+    width: 36px;
+    height: 36px;
   }
 
   /* Chips: horizontal row, touch-friendly size */

--- a/index.html
+++ b/index.html
@@ -2290,6 +2290,18 @@
                   Open Bulk Editor
                 </button>
               </div>
+
+              <!-- Coin Image Cache (STACK-87) — gated by COIN_IMAGES flag + IDB availability -->
+              <div class="settings-group" id="bulkImageCacheGroup" style="display:none;">
+                <label>Coin Image Cache</label>
+                <p class="settings-subtext">
+                  Download and cache coin images for offline viewing.
+                  Manage cached images, bulk download, or clear the cache.
+                </p>
+                <button class="btn settings-action-btn" id="openImageCacheBtn" type="button">
+                  Manage Image Cache
+                </button>
+              </div>
             </div>
 
             <!-- ===== GOLDBACK PRICING (STACK-45) ===== -->
@@ -2705,6 +2717,49 @@
     </div>
 
     <!-- =============================================================================
+       IMAGE CACHE MANAGER MODAL
+
+       Sub-modal opened from Settings > System > Manage Image Cache.
+       Shows cache stats, per-entry table with actions, real-time activity log,
+       and bulk cache controls.
+       ============================================================================= -->
+    <div class="modal" id="imageCacheModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Image Cache Manager</h2>
+          <button
+            aria-label="Close modal"
+            class="modal-close"
+            id="imageCacheCloseBtn"
+          >
+            &times;
+          </button>
+        </div>
+        <div class="modal-body">
+          <!-- Stats bar -->
+          <div id="imageCacheStats" class="settings-subtext" style="margin-bottom:0.75rem;"></div>
+
+          <!-- Cached images table -->
+          <div id="cachedImagesTableContainer" class="chip-grouping-table-container" style="max-height:220px;overflow-y:auto;margin-bottom:0.75rem;"></div>
+
+          <!-- Activity log -->
+          <label style="font-size:0.8rem;opacity:0.7;">Activity Log</label>
+          <div id="imageCacheLog" style="max-height:150px;overflow-y:auto;border:1px solid var(--border-color, #ddd);border-radius:4px;padding:0.4rem;margin-top:0.25rem;background:var(--bg-secondary, #f9f9f9);"></div>
+
+          <!-- Progress bar (hidden until bulk cache starts) -->
+          <progress id="imageCacheProgress" value="0" max="0" style="display:none;width:100%;margin-top:0.5rem;"></progress>
+        </div>
+        <div class="modal-footer" style="display:flex;gap:0.5rem;justify-content:space-between;">
+          <div style="display:flex;gap:0.5rem;">
+            <button type="button" class="btn" id="imageCacheStartBtn">Cache All Images</button>
+            <button type="button" class="btn warning" id="imageCacheCancelBtn" style="display:none;">Cancel</button>
+          </div>
+          <button type="button" class="btn danger" id="imageCacheClearAllBtn">Clear All</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- =============================================================================
        CATALOG HISTORY MODAL
 
        Modal for viewing catalog API call history (Numista lookups, searches).
@@ -2904,6 +2959,8 @@
   <script defer src="./js/state.js"></script>
   <script defer src="./js/utils.js"></script>
   <script defer src="./js/image-cache.js"></script>
+  <script defer src="./js/bulk-image-cache.js"></script>
+  <script defer src="./js/image-cache-modal.js"></script>
   <script defer src="./js/fuzzy-search.js"></script>
   <script defer src="./js/autocomplete.js"></script>
   <script defer src="./js/numista-lookup.js"></script>

--- a/js/bulk-image-cache.js
+++ b/js/bulk-image-cache.js
@@ -1,0 +1,253 @@
+// BULK IMAGE CACHE (STACK-87)
+// =============================================================================
+// Downloads and caches all coin images for inventory items that have Numista IDs.
+// Sequential with configurable delay to avoid CDN rate-limiting.
+// Resolves catalog IDs from catalogManager when not directly on items.
+// Fetches image URLs from Numista API when not stored on the item.
+// Reuses imageCache.cacheImages() pipeline (fetch → resize → compress → store).
+// =============================================================================
+
+// eslint-disable-next-line no-unused-vars
+const BulkImageCache = (() => {
+  let _aborted = false;
+  let _running = false;
+
+  /**
+   * Preloads image URLs into the browser cache via hidden <img> elements.
+   * Works on file:// protocol where fetch/canvas are blocked by CORS.
+   * @param {string} obverseUrl
+   * @param {string} reverseUrl
+   * @returns {Promise<boolean>} true if at least one image loaded
+   */
+  function _preloadViaBrowserCache(obverseUrl, reverseUrl) {
+    const urls = [obverseUrl, reverseUrl].filter(Boolean);
+    if (!urls.length) return Promise.resolve(false);
+
+    return new Promise((resolve) => {
+      let loaded = 0;
+      let succeeded = false;
+      const total = urls.length;
+
+      for (const url of urls) {
+        const img = new Image();
+        img.onload = () => {
+          succeeded = true;
+          if (++loaded >= total) resolve(succeeded);
+        };
+        img.onerror = () => {
+          if (++loaded >= total) resolve(succeeded);
+        };
+        img.src = url;
+      }
+
+      // Safety timeout — don't hang forever
+      setTimeout(() => resolve(succeeded), 15000);
+    });
+  }
+
+  /**
+   * Resolves catalog ID for an inventory item.
+   * Checks item.numistaId first, then catalogManager mappings.
+   * @param {Object} item
+   * @returns {string} Catalog ID or empty string
+   */
+  function resolveCatalogId(item) {
+    if (item.numistaId && String(item.numistaId).trim()) {
+      return String(item.numistaId).trim();
+    }
+    // Fall back to catalogManager mapping by serial
+    if (item.serial && window.catalogManager) {
+      const mapped = catalogManager.getCatalogId(String(item.serial));
+      if (mapped && String(mapped).trim()) return String(mapped).trim();
+    }
+    return '';
+  }
+
+  /**
+   * Build the list of unique {item, catalogId} entries eligible for caching.
+   * @returns {Array<{item: Object, catalogId: string}>}
+   */
+  function buildEligibleList() {
+    const seen = new Set();
+    const list = [];
+    for (const item of (typeof inventory !== 'undefined' ? inventory : [])) {
+      const catId = resolveCatalogId(item);
+      if (!catId) continue;
+      if (seen.has(catId)) continue;
+      seen.add(catId);
+      list.push({ item, catalogId: catId });
+    }
+    return list;
+  }
+
+  /**
+   * Cache images for all inventory items that have Numista catalog IDs.
+   * Resolves IDs from catalogManager and fetches image URLs from Numista API
+   * when they are not stored on the inventory item.
+   * @param {Object} opts
+   * @param {function({current:number, total:number, catalogId:string}):void} [opts.onProgress]
+   * @param {function({cached:number, skipped:number, failed:number, apiLookups:number, quotaExceeded:boolean, elapsed:number}):void} [opts.onComplete]
+   * @param {function({catalogId:string, status:string, message:string}):void} [opts.onLog]
+   * @param {number} [opts.delay=200] - Delay (ms) between network requests
+   * @returns {Promise<void>}
+   */
+  async function cacheAll({ onProgress, onComplete, onLog, delay = 200 } = {}) {
+    if (_running) return;
+    if (!window.imageCache?.isAvailable()) return;
+
+    _running = true;
+    _aborted = false;
+
+    const startTime = Date.now();
+    let cached = 0;
+    let skipped = 0;
+    let failed = 0;
+    let apiLookups = 0;
+    let quotaExceeded = false;
+
+    const entries = buildEligibleList();
+    const total = entries.length;
+
+    for (let i = 0; i < entries.length; i++) {
+      if (_aborted) break;
+
+      const { item, catalogId } = entries[i];
+
+      if (onProgress) {
+        onProgress({ current: i + 1, total, catalogId });
+      }
+
+      // Skip if already cached
+      if (await imageCache.hasImages(catalogId)) {
+        skipped++;
+        if (onLog) onLog({ catalogId, status: 'skip-cached', message: 'Already cached' });
+        continue;
+      }
+
+      // Check quota before fetching
+      const usage = await imageCache.getStorageUsage();
+      if (usage.totalBytes >= usage.limitBytes) {
+        quotaExceeded = true;
+        if (onLog) onLog({ catalogId, status: 'quota', message: 'Storage quota exceeded — stopping' });
+        break;
+      }
+
+      // Resolve image URLs: item props → IDB record → Numista API lookup
+      // Validate URLs — corrupted strings (missing ://) must be treated as empty
+      const _valid = (u) => ImageCache.isValidImageUrl(u);
+      let obverseUrl = _valid(item.obverseImageUrl) ? item.obverseImageUrl : '';
+      let reverseUrl = _valid(item.reverseImageUrl) ? item.reverseImageUrl : '';
+
+      // Check existing IDB record for stored URLs
+      if (!obverseUrl && !reverseUrl) {
+        const imgRecord = await imageCache.getImages(catalogId);
+        obverseUrl = _valid(imgRecord?.obverseUrl) ? imgRecord.obverseUrl : '';
+        reverseUrl = _valid(imgRecord?.reverseUrl) ? imgRecord.reverseUrl : '';
+      }
+
+      // Last resort: call Numista API to fetch image URLs
+      if (!obverseUrl && !reverseUrl && window.catalogAPI) {
+        if (onLog) onLog({ catalogId, status: 'api-lookup', message: 'Looking up image URLs from Numista...' });
+        try {
+          const result = await catalogAPI.lookupItem(catalogId);
+          apiLookups++;
+          obverseUrl = result?.imageUrl || '';
+          reverseUrl = result?.reverseImageUrl || '';
+          // Persist URLs back to item for future use
+          if (obverseUrl) item.obverseImageUrl = obverseUrl;
+          if (reverseUrl) item.reverseImageUrl = reverseUrl;
+          // Also sync numistaId back to item if it was only in catalogManager
+          if (!item.numistaId) item.numistaId = catalogId;
+        } catch (err) {
+          failed++;
+          if (onLog) onLog({ catalogId, status: 'failed', message: `API lookup failed: ${err.message}` });
+          if (i < entries.length - 1 && !_aborted) {
+            await new Promise(r => setTimeout(r, delay));
+          }
+          continue;
+        }
+      }
+
+      if (!obverseUrl && !reverseUrl) {
+        skipped++;
+        if (onLog) onLog({ catalogId, status: 'skip-no-url', message: 'No image URLs available' });
+        continue;
+      }
+
+      if (onLog) {
+        const urlInfo = [obverseUrl ? 'obverse' : '', reverseUrl ? 'reverse' : ''].filter(Boolean).join(' + ');
+        onLog({ catalogId, status: 'caching', message: `Downloading: ${urlInfo} ...` });
+      }
+
+      try {
+        const result = await imageCache.cacheImages(catalogId, obverseUrl, reverseUrl);
+        if (result) {
+          cached++;
+          if (onLog) onLog({ catalogId, status: 'cached', message: 'Cached successfully' });
+        } else {
+          // IDB caching failed — try browser-cache preload via <img> elements
+          const preloaded = await _preloadViaBrowserCache(obverseUrl, reverseUrl);
+          if (preloaded) {
+            cached++;
+            if (onLog) onLog({ catalogId, status: 'browser-cached',
+              message: 'Preloaded to browser cache (file:// mode)' });
+          } else {
+            failed++;
+            const urls = [obverseUrl, reverseUrl].filter(Boolean).join(', ');
+            if (onLog) onLog({ catalogId, status: 'failed',
+              message: `All cache strategies failed — URLs: ${urls}` });
+          }
+        }
+      } catch (err) {
+        // IDB threw — try browser-cache preload as last resort
+        const preloaded = await _preloadViaBrowserCache(obverseUrl, reverseUrl);
+        if (preloaded) {
+          cached++;
+          if (onLog) onLog({ catalogId, status: 'browser-cached',
+            message: 'Preloaded to browser cache (file:// mode)' });
+        } else {
+          failed++;
+          if (onLog) onLog({ catalogId, status: 'failed', message: err.message || 'Unknown error' });
+        }
+      }
+
+      // Delay between requests to avoid rate-limiting
+      if (i < entries.length - 1 && !_aborted) {
+        await new Promise(r => setTimeout(r, delay));
+      }
+    }
+
+    _running = false;
+
+    // Persist any URL updates back to localStorage
+    if ((cached > 0 || apiLookups > 0) && typeof saveInventory === 'function') {
+      saveInventory();
+    }
+
+    const elapsed = Date.now() - startTime;
+    if (onComplete) {
+      onComplete({ cached, skipped, failed, apiLookups, quotaExceeded, elapsed });
+    }
+  }
+
+  /**
+   * Abort a running bulk cache operation.
+   */
+  function abort() {
+    _aborted = true;
+  }
+
+  /**
+   * Whether a bulk cache operation is currently running.
+   * @returns {boolean}
+   */
+  function isRunning() {
+    return _running;
+  }
+
+  return { cacheAll, abort, isRunning, buildEligibleList, resolveCatalogId };
+})();
+
+if (typeof window !== 'undefined') {
+  window.BulkImageCache = BulkImageCache;
+}

--- a/js/image-cache-modal.js
+++ b/js/image-cache-modal.js
@@ -1,0 +1,392 @@
+// IMAGE CACHE MANAGER MODAL
+// =============================================================================
+// Sub-modal opened from Settings > System to manage cached coin images.
+// Shows stats, eligible item table with per-row status, real-time activity log,
+// and bulk cache controls. Resolves catalog IDs from catalogManager.
+// =============================================================================
+
+/** @type {Map<string, HTMLElement>} Status cells keyed by catalogId for live updates */
+let _statusCells = new Map();
+
+/**
+ * Opens the Image Cache Manager modal, rendering stats and item table.
+ */
+const showImageCacheModal = async () => {
+  _statusCells.clear();
+  if (typeof openModalById === 'function') {
+    openModalById('imageCacheModal');
+  }
+  await renderCacheStats();
+  await renderEligibleItemsTable();
+};
+
+/**
+ * Closes the Image Cache Manager modal.
+ */
+const hideImageCacheModal = () => {
+  if (typeof closeModalById === 'function') {
+    closeModalById('imageCacheModal');
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Stats bar
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the cache statistics bar: count, total size, quota percentage.
+ */
+const renderCacheStats = async () => {
+  const container = document.getElementById('imageCacheStats');
+  if (!container) return;
+
+  if (!window.imageCache?.isAvailable()) {
+    container.textContent = 'Image cache not available';
+    return;
+  }
+
+  const usage = await imageCache.getStorageUsage();
+  const sizeMb = (usage.totalBytes / (1024 * 1024)).toFixed(2);
+  const limitMb = (usage.limitBytes / (1024 * 1024)).toFixed(0);
+  const pct = usage.limitBytes > 0 ? ((usage.totalBytes / usage.limitBytes) * 100).toFixed(1) : '0.0';
+
+  // Count eligible items for the summary line
+  const eligible = window.BulkImageCache ? BulkImageCache.buildEligibleList() : [];
+
+  container.textContent = '';
+
+  const statsText = document.createElement('span');
+  statsText.textContent = `${usage.count} cached \u00b7 ${eligible.length} eligible \u00b7 ${sizeMb} MB / ${limitMb} MB (${pct}%)`;
+  container.appendChild(statsText);
+
+  const bar = document.createElement('progress');
+  bar.value = usage.totalBytes;
+  bar.max = usage.limitBytes;
+  bar.style.cssText = 'width:100%;margin-top:0.35rem;';
+  container.appendChild(bar);
+};
+
+// ---------------------------------------------------------------------------
+// Eligible items table (shows all N# items with cache status)
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the table of all inventory items that have Numista catalog IDs.
+ * Each row shows: N#, item name, cache status, and action buttons.
+ * Status cells are tracked in _statusCells for live updates during bulk cache.
+ */
+const renderEligibleItemsTable = async () => {
+  const container = document.getElementById('cachedImagesTableContainer');
+  if (!container) return;
+
+  container.textContent = '';
+  _statusCells.clear();
+
+  if (!window.imageCache?.isAvailable()) {
+    const empty = document.createElement('div');
+    empty.className = 'chip-grouping-empty';
+    empty.textContent = 'Image cache not available';
+    container.appendChild(empty);
+    return;
+  }
+
+  // Get eligible items from BulkImageCache (resolves catalogManager mappings)
+  const entries = window.BulkImageCache ? BulkImageCache.buildEligibleList() : [];
+
+  if (!entries.length) {
+    const empty = document.createElement('div');
+    empty.className = 'chip-grouping-empty';
+    empty.textContent = 'No items with Numista catalog IDs found';
+    container.appendChild(empty);
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'chip-grouping-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  ['N#', 'Item Name', 'Status', ''].forEach(text => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    th.style.cssText = 'font-size:0.75rem;font-weight:normal;opacity:0.6;padding:0.2rem 0.4rem';
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+
+  for (const { item, catalogId } of entries) {
+    const isCached = await imageCache.hasImages(catalogId);
+    const hasUrls = !!(item.obverseImageUrl || item.reverseImageUrl);
+
+    const tr = document.createElement('tr');
+
+    // Catalog ID cell
+    const tdId = document.createElement('td');
+    tdId.style.cssText = 'font-family:monospace;font-size:0.85rem;white-space:nowrap';
+    tdId.textContent = catalogId;
+
+    // Item name cell
+    const tdName = document.createElement('td');
+    tdName.textContent = item.name || '\u2014';
+    tdName.style.cssText = 'max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+
+    // Status cell (updated live during bulk cache)
+    const tdStatus = document.createElement('td');
+    tdStatus.style.cssText = 'font-size:0.8rem;white-space:nowrap';
+    if (isCached) {
+      tdStatus.textContent = '\u2713 Cached';
+      tdStatus.style.color = 'var(--success-color, green)';
+    } else if (hasUrls) {
+      tdStatus.textContent = 'Ready';
+      tdStatus.style.color = 'var(--text-secondary, #888)';
+    } else {
+      tdStatus.textContent = 'Needs API lookup';
+      tdStatus.style.color = 'var(--warning-color, orange)';
+    }
+    _statusCells.set(catalogId, tdStatus);
+
+    // Actions cell
+    const tdActions = document.createElement('td');
+    tdActions.style.cssText = 'white-space:nowrap;text-align:right';
+
+    if (isCached) {
+      // Re-sync button
+      const syncBtn = document.createElement('button');
+      syncBtn.type = 'button';
+      syncBtn.className = 'inline-chip-move';
+      syncBtn.textContent = '\u21BB';
+      syncBtn.title = 'Re-sync images';
+      syncBtn.addEventListener('click', async () => {
+        syncBtn.disabled = true;
+        await resyncCachedEntry(catalogId);
+        syncBtn.disabled = false;
+        await renderEligibleItemsTable();
+        await renderCacheStats();
+      });
+
+      // Delete button
+      const delBtn = document.createElement('button');
+      delBtn.type = 'button';
+      delBtn.className = 'inline-chip-move';
+      delBtn.textContent = '\u2715';
+      delBtn.title = 'Delete cached images';
+      delBtn.addEventListener('click', async () => {
+        await imageCache.deleteImages(catalogId);
+        logCacheActivity(`Deleted cache for ${catalogId}`, 'warn');
+        await renderEligibleItemsTable();
+        await renderCacheStats();
+      });
+
+      tdActions.append(syncBtn, delBtn);
+    }
+
+    tr.append(tdId, tdName, tdStatus, tdActions);
+    tbody.appendChild(tr);
+  }
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+};
+
+/**
+ * Re-syncs a single cached entry: deletes then re-fetches from inventory/API URLs.
+ * @param {string} catalogId
+ */
+const resyncCachedEntry = async (catalogId) => {
+  const item = (typeof inventory !== 'undefined' ? inventory : []).find(i => {
+    const resolved = window.BulkImageCache ? BulkImageCache.resolveCatalogId(i) : '';
+    return resolved === catalogId;
+  });
+
+  await imageCache.deleteImages(catalogId);
+
+  let obverseUrl = item?.obverseImageUrl || '';
+  let reverseUrl = item?.reverseImageUrl || '';
+
+  // If no URLs on item, try Numista API
+  if (!obverseUrl && !reverseUrl && window.catalogAPI) {
+    logCacheActivity(`${catalogId}: Looking up URLs from Numista...`, 'info');
+    try {
+      const result = await catalogAPI.lookupItem(catalogId);
+      obverseUrl = result?.imageUrl || '';
+      reverseUrl = result?.reverseImageUrl || '';
+      if (item) {
+        if (obverseUrl) item.obverseImageUrl = obverseUrl;
+        if (reverseUrl) item.reverseImageUrl = reverseUrl;
+        if (typeof saveInventory === 'function') saveInventory();
+      }
+    } catch (err) {
+      logCacheActivity(`${catalogId}: API lookup failed: ${err.message}`, 'error');
+      return;
+    }
+  }
+
+  if (!obverseUrl && !reverseUrl) {
+    logCacheActivity(`${catalogId}: No image URLs available`, 'warn');
+    return;
+  }
+
+  logCacheActivity(`${catalogId}: Re-fetching images...`, 'info');
+  const ok = await imageCache.cacheImages(catalogId, obverseUrl, reverseUrl);
+  if (ok) {
+    logCacheActivity(`${catalogId}: Re-synced successfully`, 'success');
+  } else {
+    logCacheActivity(`${catalogId}: Re-sync failed`, 'error');
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Activity log
+// ---------------------------------------------------------------------------
+
+/**
+ * Appends a timestamped line to the activity log and auto-scrolls.
+ * @param {string} message
+ * @param {'info'|'success'|'warn'|'error'} [type='info']
+ */
+const logCacheActivity = (message, type = 'info') => {
+  const logEl = document.getElementById('imageCacheLog');
+  if (!logEl) return;
+
+  const line = document.createElement('div');
+  line.style.cssText = 'font-size:0.8rem;font-family:monospace;padding:0.1rem 0;';
+
+  const colorMap = { info: 'inherit', success: 'var(--success-color, green)', warn: 'var(--warning-color, orange)', error: 'var(--danger-color, red)' };
+  line.style.color = colorMap[type] || 'inherit';
+
+  const now = new Date();
+  const ts = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  line.textContent = `[${ts}] ${message}`;
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+};
+
+/**
+ * Updates a status cell in the eligible items table for live feedback.
+ * @param {string} catalogId
+ * @param {string} text
+ * @param {string} color - CSS color value
+ */
+const updateStatusCell = (catalogId, text, color) => {
+  const cell = _statusCells.get(catalogId);
+  if (!cell) return;
+  cell.textContent = text;
+  cell.style.color = color;
+};
+
+// ---------------------------------------------------------------------------
+// Bulk cache from modal
+// ---------------------------------------------------------------------------
+
+/**
+ * Starts the bulk cache operation from within the modal.
+ * Updates per-row status cells in real time as items are processed.
+ */
+const startBulkCacheFromModal = () => {
+  if (!window.BulkImageCache || BulkImageCache.isRunning()) return;
+
+  const startBtn = document.getElementById('imageCacheStartBtn');
+  const cancelBtn = document.getElementById('imageCacheCancelBtn');
+  const progressBar = document.getElementById('imageCacheProgress');
+
+  if (startBtn) startBtn.disabled = true;
+  if (cancelBtn) cancelBtn.style.display = '';
+  if (progressBar) {
+    progressBar.style.display = '';
+    progressBar.value = 0;
+    progressBar.max = 0;
+  }
+
+  logCacheActivity('Starting bulk image cache...', 'info');
+
+  const statusColorMap = {
+    'skip-cached': ['var(--success-color, green)', '\u2713 Cached'],
+    'skip-no-url': ['var(--warning-color, orange)', 'No URLs'],
+    'api-lookup': ['var(--text-secondary, #888)', 'API lookup...'],
+    'caching': ['var(--text-secondary, #888)', 'Downloading...'],
+    'cached': ['var(--success-color, green)', '\u2713 Cached'],
+    'browser-cached': ['var(--color-info, #5b9bd5)', '\u2295 Browser'],
+    'failed': ['var(--danger-color, red)', '\u2717 Failed'],
+    'quota': ['var(--danger-color, red)', 'Quota exceeded'],
+  };
+
+  BulkImageCache.cacheAll({
+    onProgress: ({ current, total }) => {
+      if (progressBar) {
+        progressBar.max = total;
+        progressBar.value = current;
+      }
+    },
+    onLog: ({ catalogId, status, message }) => {
+      // Update the table row status cell
+      const [color, label] = statusColorMap[status] || ['inherit', status];
+      updateStatusCell(catalogId, label, color);
+
+      // Log to activity log
+      const logTypeMap = {
+        'skip-cached': 'info', 'skip-no-url': 'warn', 'api-lookup': 'info',
+        'caching': 'info', 'cached': 'success', 'failed': 'error', 'quota': 'error'
+      };
+      logCacheActivity(`${catalogId}: ${message}`, logTypeMap[status] || 'info');
+    },
+    onComplete: async ({ cached, skipped, failed, apiLookups, quotaExceeded, elapsed }) => {
+      if (startBtn) startBtn.disabled = false;
+      if (cancelBtn) cancelBtn.style.display = 'none';
+      if (progressBar) progressBar.style.display = 'none';
+
+      const secs = (elapsed / 1000).toFixed(1);
+      let msg = `Complete in ${secs}s: ${cached} cached, ${skipped} skipped, ${failed} failed`;
+      if (apiLookups > 0) msg += `, ${apiLookups} API lookups`;
+      msg += '.';
+      if (quotaExceeded) msg += ' Quota limit reached.';
+      logCacheActivity(msg, failed > 0 || quotaExceeded ? 'warn' : 'success');
+
+      // Refresh table and stats
+      await renderEligibleItemsTable();
+      await renderCacheStats();
+
+      // Refresh settings footer storage display
+      if (typeof updateSettingsFooter === 'function') updateSettingsFooter();
+    }
+  });
+};
+
+/**
+ * Clears all cached images after confirmation.
+ */
+const clearAllCachedImages = async () => {
+  if (!window.imageCache?.isAvailable()) return;
+
+  const usage = await imageCache.getStorageUsage();
+  if (usage.count === 0) {
+    logCacheActivity('No cached images to clear', 'info');
+    return;
+  }
+
+  // eslint-disable-next-line no-restricted-globals
+  if (!confirm(`Delete all ${usage.count} cached images? This cannot be undone.`)) return;
+
+  const ok = await imageCache.clearAll();
+  if (ok) {
+    logCacheActivity(`Cleared all ${usage.count} cached images`, 'warn');
+  } else {
+    logCacheActivity('Failed to clear cache', 'error');
+  }
+
+  await renderEligibleItemsTable();
+  await renderCacheStats();
+  if (typeof updateSettingsFooter === 'function') updateSettingsFooter();
+};
+
+// ---------------------------------------------------------------------------
+// Global exports
+// ---------------------------------------------------------------------------
+if (typeof window !== 'undefined') {
+  window.showImageCacheModal = showImageCacheModal;
+  window.hideImageCacheModal = hideImageCacheModal;
+  window.startBulkCacheFromModal = startBulkCacheFromModal;
+  window.clearAllCachedImages = clearAllCachedImages;
+}

--- a/js/init.js
+++ b/js/init.js
@@ -210,6 +210,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.bulkEditBtn = safeGetElement("bulkEditBtn");
     elements.bulkEditCloseBtn = safeGetElement("bulkEditCloseBtn");
 
+    // Image cache elements (STACK-87)
+    elements.bulkImageCacheGroup = safeGetElement("bulkImageCacheGroup");
+    elements.openImageCacheBtn = safeGetElement("openImageCacheBtn");
+    elements.imageCacheModal = safeGetElement("imageCacheModal");
+
     // Settings change log panel
     elements.settingsChangeLogClearBtn = safeGetElement("settingsChangeLogClearBtn");
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -248,6 +248,13 @@ const syncSettingsUI = () => {
     syncGoldbackSettingsUI();
   }
 
+  // Bulk image cache visibility (STACK-87)
+  if (elements.bulkImageCacheGroup) {
+    const showBulkCache = window.featureFlags?.isEnabled('COIN_IMAGES') &&
+                          window.imageCache?.isAvailable();
+    elements.bulkImageCacheGroup.style.display = showBulkCache ? '' : 'none';
+  }
+
   // Spot compare mode (STACK-92)
   const spotCompareSelect = document.getElementById('settingsSpotCompareMode');
   if (spotCompareSelect) {
@@ -613,6 +620,13 @@ const setupSettingsEventListeners = () => {
     window.setupChipGroupingEvents();
   }
 
+  // Image Cache Manager modal opener (STACK-87)
+  if (elements.openImageCacheBtn) {
+    elements.openImageCacheBtn.addEventListener('click', () => {
+      if (typeof showImageCacheModal === 'function') showImageCacheModal();
+    });
+  }
+
   // Settings modal close button
   const closeBtn = document.getElementById('settingsCloseBtn');
   if (closeBtn) {
@@ -765,6 +779,33 @@ const setupSettingsEventListeners = () => {
   if (gbExportBtn) {
     gbExportBtn.addEventListener('click', () => {
       if (typeof exportGoldbackHistory === 'function') exportGoldbackHistory();
+    });
+  }
+
+  // Image Cache Manager modal events (STACK-87)
+  const icCloseBtn = document.getElementById('imageCacheCloseBtn');
+  if (icCloseBtn) {
+    icCloseBtn.addEventListener('click', () => {
+      if (typeof hideImageCacheModal === 'function') hideImageCacheModal();
+    });
+  }
+  const icStartBtn = document.getElementById('imageCacheStartBtn');
+  if (icStartBtn) {
+    icStartBtn.addEventListener('click', () => {
+      if (typeof startBulkCacheFromModal === 'function') startBulkCacheFromModal();
+    });
+  }
+  const icCancelBtn = document.getElementById('imageCacheCancelBtn');
+  if (icCancelBtn) {
+    icCancelBtn.addEventListener('click', () => {
+      if (window.BulkImageCache) BulkImageCache.abort();
+      icCancelBtn.style.display = 'none';
+    });
+  }
+  const icClearAllBtn = document.getElementById('imageCacheClearAllBtn');
+  if (icClearAllBtn) {
+    icClearAllBtn.addEventListener('click', () => {
+      if (typeof clearAllCachedImages === 'function') clearAllCachedImages();
     });
   }
 

--- a/js/state.js
+++ b/js/state.js
@@ -189,6 +189,10 @@ const elements = {
   viewItemModal: null,
   viewModalCloseBtn: null,
 
+  // Image cache elements (STACK-87)
+  bulkImageCacheGroup: null,
+  openImageCacheBtn: null,
+
   // Settings modal elements
   settingsBtn: null,
   settingsModal: null,
@@ -197,6 +201,7 @@ const elements = {
   apiInfoModal: null,
   apiHistoryModal: null,
   goldbackHistoryModal: null,
+  imageCacheModal: null,
   cloudSyncModal: null,
   apiQuotaModal: null,
 

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -345,10 +345,12 @@ async function loadViewImages(item, container) {
     if (obvUrl || revUrl) return true;
   }
 
-  // Fallback: CDN URLs stored on the item
-  if (item.obverseImageUrl) _setSlotImage(obvSlot, item.obverseImageUrl);
-  if (item.reverseImageUrl) _setSlotImage(revSlot, item.reverseImageUrl);
-  if (item.obverseImageUrl || item.reverseImageUrl) return true;
+  // Fallback: CDN URLs stored on the item (validate to skip corrupted URLs)
+  const validObv = ImageCache.isValidImageUrl(item.obverseImageUrl);
+  const validRev = ImageCache.isValidImageUrl(item.reverseImageUrl);
+  if (validObv) _setSlotImage(obvSlot, item.obverseImageUrl);
+  if (validRev) _setSlotImage(revSlot, item.reverseImageUrl);
+  if (validObv || validRev) return true;
 
   return false;
 }


### PR DESCRIPTION
## Summary
- **Table thumbnails**: Coin obverse preview images in the inventory Name column with progressive IDB blob URL enhancement
- **Browser-cache preload fallback**: When IndexedDB caching fails on `file://` protocol (CORS), falls back to hidden `<img>` preloading into the browser's native HTTP cache
- **Image cache modal**: New `browser-cached` status indicator (⊕ Browser) for items cached via browser preload strategy
- **Memory management**: Blob URL tracking with revocation on re-render and page unload to prevent leaks

## Key changes
| File | Change |
|------|--------|
| `js/inventory.js` | Thumbnail `<img>` in name cell, `_enhanceTableThumbnails()` for IDB→blob upgrade, blob URL lifecycle |
| `css/styles.css` | `.table-thumb` styles — 28px round (desktop), 36px (mobile card view) |
| `js/bulk-image-cache.js` | `_preloadViaBrowserCache()` helper + dual-strategy fallback in `cacheAll()` |
| `js/image-cache-modal.js` | `browser-cached` status in `statusColorMap` |

## Test plan
- [ ] Open on `file://` — items with valid Numista URLs show round thumbnails in Name column
- [ ] Items with corrupted/missing URLs show no thumbnail (gracefully hidden)
- [ ] Settings → Image Cache Manager → "Cache All Images" — items get "⊕ Browser" status on `file://`
- [ ] On HTTP server — IndexedDB caching works, thumbnails show from IDB blob URLs
- [ ] View modal still shows full images via API Tier 3 fallback
- [ ] Page reload — thumbnails load from browser cache
- [ ] Mobile card view — thumbnails render at 36px

🤖 Generated with [Claude Code](https://claude.com/claude-code)