### PR TITLE
v3.27.05 — Numista Bulk Sync & IDB Cache Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.27.05] - 2026-02-14
+
+### Added — Numista Bulk Sync & IDB Cache Fix
+
+- **Added**: Numista Bulk Sync — metadata + image syncing from API card with inline stats, progress, and activity log (STACK-87, STACK-88)
+- **Changed**: Moved image cache controls from Settings > System into the Numista API card as "Bulk Sync"
+- **Fixed**: Opaque blob IDB corruption — images disappeared after bulk cache on HTTPS (STACK-87)
+- **Fixed**: Empty blob safety guard in getImageUrl() prevents blocking CDN fallback
+- **Added**: Table row thumbnail images with hover preloading (STACK-84)
+
+---
+
 ## [3.27.04] - 2026-02-14
 
 ### Added — Spot Comparison Mode & Mobile API Settings

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Numista Bulk Sync & IDB Cache Fix (v3.27.05)**: Bulk sync metadata + images from the Numista API card with inline progress and activity log. Fixed opaque blob IDB corruption that caused images to disappear after bulk cache on HTTPS. Table row thumbnail images with hover preloading (STACK-84, STACK-87, STACK-88)
 - **Spot Comparison Mode & Mobile API Settings (v3.27.04)**: 24h % comparison mode setting (Close/Close, Open/Open, Open/Close). Replaced drag-to-sort provider tabs with Sync Priority dropdowns. Mobile tab overflow fix. Consistent 24h % across all spot card views (STACK-89, STACK-90, STACK-92)
 - **PWA Support & Bug Fixes (v3.27.03)**: Installable app experience with offline caching via service worker. Fixed: edit-mode price preservation (STACK-81), stale spot-lookup on date change (STACK-82), Activity Log tabs showing stale data (STACK-83), Samsung S24+ Ultra layout (STACK-85). Removed redundant View icon (STACK-86). Spot history seed data from Docker poller infrastructure
 - **Coin Image Cache & Item View Modal (v3.27.00)**: IndexedDB image cache for Numista coin photos with 50MB quota. Card-style view modal with images, inventory data, valuation, grading, and enriched Numista metadata. Settings toggles for 15 fields. View button in table/card actions. Clickable source URLs and N# badges open in popup windows. eBay search from view modal. Full-screen mobile layout with sticky footer
-- **XSS & HTML Injection Hardening (v3.26.03)**: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -1880,6 +1880,40 @@
                       <label class="settings-checkbox-label"><input type="checkbox" data-nf="imageTooltips" checked> Image tooltips</label>
                     </div>
                   </div>
+
+                  <!-- Numista Bulk Sync (STACK-87/88) -->
+                  <div class="settings-group" id="numistaBulkSyncGroup" style="margin-top: 1rem; border-top: 1px solid var(--border); padding-top: 0.75rem; display: none;">
+                    <div class="settings-group-label">Bulk Sync</div>
+                    <p class="settings-subtext">
+                      Sync metadata and images for all inventory items with Numista catalog IDs.
+                      Uses your API key (counts toward monthly quota).
+                    </p>
+
+                    <!-- Stats bar -->
+                    <div id="numistaSyncStats" class="settings-subtext" style="margin-bottom:0.5rem;"></div>
+
+                    <!-- Eligible items table (collapsible) -->
+                    <details style="margin-bottom:0.5rem;">
+                      <summary style="font-size:0.8rem;cursor:pointer;opacity:0.7;">Show eligible items</summary>
+                      <div id="numistaSyncTableContainer" class="chip-grouping-table-container" style="max-height:180px;overflow-y:auto;margin-top:0.35rem;"></div>
+                    </details>
+
+                    <!-- Activity log (collapsible) -->
+                    <details style="margin-bottom:0.5rem;">
+                      <summary style="font-size:0.8rem;cursor:pointer;opacity:0.7;">Activity log</summary>
+                      <div id="numistaSyncLog" style="max-height:120px;overflow-y:auto;border:1px solid var(--border-color, #ddd);border-radius:4px;padding:0.4rem;margin-top:0.25rem;background:var(--bg-secondary, #f9f9f9);"></div>
+                    </details>
+
+                    <!-- Progress -->
+                    <progress id="numistaSyncProgress" value="0" max="0" style="display:none;width:100%;margin-bottom:0.5rem;"></progress>
+
+                    <!-- Action buttons -->
+                    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+                      <button type="button" class="btn info" id="numistaSyncStartBtn">Sync All</button>
+                      <button type="button" class="btn warning" id="numistaSyncCancelBtn" style="display:none;">Cancel</button>
+                      <button type="button" class="btn danger" id="numistaSyncClearBtn" style="font-size:0.8rem;">Clear Cache</button>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -2291,17 +2325,6 @@
                 </button>
               </div>
 
-              <!-- Coin Image Cache (STACK-87) — gated by COIN_IMAGES flag + IDB availability -->
-              <div class="settings-group" id="bulkImageCacheGroup" style="display:none;">
-                <label>Coin Image Cache</label>
-                <p class="settings-subtext">
-                  Download and cache coin images for offline viewing.
-                  Manage cached images, bulk download, or clear the cache.
-                </p>
-                <button class="btn settings-action-btn" id="openImageCacheBtn" type="button">
-                  Manage Image Cache
-                </button>
-              </div>
             </div>
 
             <!-- ===== GOLDBACK PRICING (STACK-45) ===== -->
@@ -2712,49 +2735,6 @@
         </div>
         <div class="modal-footer api-history-footer">
           <button type="button" class="btn" id="exportGoldbackHistoryBtn">Export History</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- =============================================================================
-       IMAGE CACHE MANAGER MODAL
-
-       Sub-modal opened from Settings > System > Manage Image Cache.
-       Shows cache stats, per-entry table with actions, real-time activity log,
-       and bulk cache controls.
-       ============================================================================= -->
-    <div class="modal" id="imageCacheModal" style="display: none">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2>Image Cache Manager</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="imageCacheCloseBtn"
-          >
-            &times;
-          </button>
-        </div>
-        <div class="modal-body">
-          <!-- Stats bar -->
-          <div id="imageCacheStats" class="settings-subtext" style="margin-bottom:0.75rem;"></div>
-
-          <!-- Cached images table -->
-          <div id="cachedImagesTableContainer" class="chip-grouping-table-container" style="max-height:220px;overflow-y:auto;margin-bottom:0.75rem;"></div>
-
-          <!-- Activity log -->
-          <label style="font-size:0.8rem;opacity:0.7;">Activity Log</label>
-          <div id="imageCacheLog" style="max-height:150px;overflow-y:auto;border:1px solid var(--border-color, #ddd);border-radius:4px;padding:0.4rem;margin-top:0.25rem;background:var(--bg-secondary, #f9f9f9);"></div>
-
-          <!-- Progress bar (hidden until bulk cache starts) -->
-          <progress id="imageCacheProgress" value="0" max="0" style="display:none;width:100%;margin-top:0.5rem;"></progress>
-        </div>
-        <div class="modal-footer" style="display:flex;gap:0.5rem;justify-content:space-between;">
-          <div style="display:flex;gap:0.5rem;">
-            <button type="button" class="btn" id="imageCacheStartBtn">Cache All Images</button>
-            <button type="button" class="btn warning" id="imageCacheCancelBtn" style="display:none;">Cancel</button>
-          </div>
-          <button type="button" class="btn danger" id="imageCacheClearAllBtn">Clear All</button>
         </div>
       </div>
     </div>

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.27.05 &ndash; Numista Bulk Sync &amp; IDB Cache Fix</strong>: Bulk sync metadata + images from the Numista API card with inline progress and activity log. Fixed opaque blob IDB corruption that caused images to disappear after bulk cache on HTTPS. Table row thumbnail images with hover preloading (STACK-84, STACK-87, STACK-88)</li>
     <li><strong>v3.27.04 &ndash; Spot Comparison Mode &amp; Mobile API Settings</strong>: 24h % comparison mode setting (Close/Close, Open/Open, Open/Close). Replaced drag-to-sort provider tabs with Sync Priority dropdowns. Mobile tab overflow fix. Consistent 24h % across all spot card views (STACK-89, STACK-90, STACK-92)</li>
     <li><strong>v3.27.03 &ndash; PWA Support &amp; Bug Fixes</strong>: Installable app experience with offline caching via service worker. Fixed: edit-mode price preservation (STACK-81), stale spot-lookup on date change (STACK-82), Activity Log tabs showing stale data (STACK-83), Samsung S24+ Ultra layout (STACK-85). Removed redundant View icon (STACK-86). Spot history seed data from Docker poller infrastructure</li>
     <li><strong>v3.27.00 &ndash; Coin Image Cache &amp; Item View Modal</strong>: IndexedDB image cache for Numista coin photos with 50MB quota. Card-style view modal with images, inventory data, valuation, grading, and enriched Numista metadata. Settings toggles for 15 fields. View button in table/card actions. Clickable source URLs and N# badges open in popup windows. eBay search from view modal. Full-screen mobile layout with sticky footer</li>
-    <li><strong>v3.26.03 &ndash; XSS &amp; HTML Injection Hardening</strong>: Escaped item names in Price History, metal/source/provider in Spot History, and source/data-attrs in Spot Lookup. Added shared escapeHtml() utility</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.27.04";
+const APP_VERSION = "3.27.05";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/init.js
+++ b/js/init.js
@@ -210,10 +210,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.bulkEditBtn = safeGetElement("bulkEditBtn");
     elements.bulkEditCloseBtn = safeGetElement("bulkEditCloseBtn");
 
-    // Image cache elements (STACK-87)
-    elements.bulkImageCacheGroup = safeGetElement("bulkImageCacheGroup");
-    elements.openImageCacheBtn = safeGetElement("openImageCacheBtn");
-    elements.imageCacheModal = safeGetElement("imageCacheModal");
 
     // Settings change log panel
     elements.settingsChangeLogClearBtn = safeGetElement("settingsChangeLogClearBtn");

--- a/js/settings.js
+++ b/js/settings.js
@@ -83,6 +83,14 @@ const switchProviderTab = (key) => {
   document.querySelectorAll('.settings-provider-tab').forEach(tab => {
     tab.classList.toggle('active', tab.dataset.provider === key);
   });
+
+  // Render Numista bulk sync UI when switching to Numista tab (STACK-87/88)
+  if (key === 'NUMISTA' && typeof renderNumistaSyncUI === 'function') {
+    const syncGroup = document.getElementById('numistaBulkSyncGroup');
+    if (syncGroup && syncGroup.style.display !== 'none') {
+      renderNumistaSyncUI();
+    }
+  }
 };
 
 /**
@@ -248,11 +256,12 @@ const syncSettingsUI = () => {
     syncGoldbackSettingsUI();
   }
 
-  // Bulk image cache visibility (STACK-87)
-  if (elements.bulkImageCacheGroup) {
-    const showBulkCache = window.featureFlags?.isEnabled('COIN_IMAGES') &&
-                          window.imageCache?.isAvailable();
-    elements.bulkImageCacheGroup.style.display = showBulkCache ? '' : 'none';
+  // Numista bulk sync visibility (STACK-87/88)
+  const numistaSyncGroup = document.getElementById('numistaBulkSyncGroup');
+  if (numistaSyncGroup) {
+    const showBulkSync = window.featureFlags?.isEnabled('COIN_IMAGES') &&
+                         window.imageCache?.isAvailable();
+    numistaSyncGroup.style.display = showBulkSync ? '' : 'none';
   }
 
   // Spot compare mode (STACK-92)
@@ -620,10 +629,24 @@ const setupSettingsEventListeners = () => {
     window.setupChipGroupingEvents();
   }
 
-  // Image Cache Manager modal opener (STACK-87)
-  if (elements.openImageCacheBtn) {
-    elements.openImageCacheBtn.addEventListener('click', () => {
-      if (typeof showImageCacheModal === 'function') showImageCacheModal();
+  // Numista Bulk Sync inline controls (STACK-87/88)
+  const nsStartBtn = document.getElementById('numistaSyncStartBtn');
+  if (nsStartBtn) {
+    nsStartBtn.addEventListener('click', () => {
+      if (typeof startBulkSync === 'function') startBulkSync();
+    });
+  }
+  const nsCancelBtn = document.getElementById('numistaSyncCancelBtn');
+  if (nsCancelBtn) {
+    nsCancelBtn.addEventListener('click', () => {
+      if (window.BulkImageCache) BulkImageCache.abort();
+      nsCancelBtn.style.display = 'none';
+    });
+  }
+  const nsClearBtn = document.getElementById('numistaSyncClearBtn');
+  if (nsClearBtn) {
+    nsClearBtn.addEventListener('click', () => {
+      if (typeof clearAllCachedData === 'function') clearAllCachedData();
     });
   }
 
@@ -782,32 +805,6 @@ const setupSettingsEventListeners = () => {
     });
   }
 
-  // Image Cache Manager modal events (STACK-87)
-  const icCloseBtn = document.getElementById('imageCacheCloseBtn');
-  if (icCloseBtn) {
-    icCloseBtn.addEventListener('click', () => {
-      if (typeof hideImageCacheModal === 'function') hideImageCacheModal();
-    });
-  }
-  const icStartBtn = document.getElementById('imageCacheStartBtn');
-  if (icStartBtn) {
-    icStartBtn.addEventListener('click', () => {
-      if (typeof startBulkCacheFromModal === 'function') startBulkCacheFromModal();
-    });
-  }
-  const icCancelBtn = document.getElementById('imageCacheCancelBtn');
-  if (icCancelBtn) {
-    icCancelBtn.addEventListener('click', () => {
-      if (window.BulkImageCache) BulkImageCache.abort();
-      icCancelBtn.style.display = 'none';
-    });
-  }
-  const icClearAllBtn = document.getElementById('imageCacheClearAllBtn');
-  if (icClearAllBtn) {
-    icClearAllBtn.addEventListener('click', () => {
-      if (typeof clearAllCachedImages === 'function') clearAllCachedImages();
-    });
-  }
 
   // Settings modal backdrop click
   const modal = document.getElementById('settingsModal');

--- a/js/state.js
+++ b/js/state.js
@@ -189,9 +189,6 @@ const elements = {
   viewItemModal: null,
   viewModalCloseBtn: null,
 
-  // Image cache elements (STACK-87)
-  bulkImageCacheGroup: null,
-  openImageCacheBtn: null,
 
   // Settings modal elements
   settingsBtn: null,
@@ -201,7 +198,6 @@ const elements = {
   apiInfoModal: null,
   apiHistoryModal: null,
   goldbackHistoryModal: null,
-  imageCacheModal: null,
   cloudSyncModal: null,
   apiQuotaModal: null,
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.27.04",
+  "version": "3.27.05",
   "releaseDate": "2026-02-14",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Numista Bulk Sync**: Metadata + image syncing from the API card with inline stats, progress, and activity log (STACK-87, STACK-88)
- **IDB Cache Fix**: Opaque blob corruption — images disappeared after bulk cache on HTTPS. Added empty-blob safety guard in `getImageUrl()`
- **UI Reorganization**: Moved image cache controls from Settings > System into the Numista API card as "Bulk Sync"
- **Table Thumbnails**: Row thumbnail images with hover preloading (STACK-84)

## Files Updated

- `js/constants.js` — APP_VERSION → 3.27.05
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint
- `js/image-cache.js` — opaque blob fix + getImageUrl safety guard
- `js/bulk-image-cache.js` — metadata sync + restructured skip logic
- `js/image-cache-modal.js` — refactored from modal to inline Numista card UI
- `js/settings.js` — new event wiring for bulk sync controls
- `index.html` — removed System tab cache section, added Numista card sync UI, removed modal
- `js/state.js` / `js/init.js` — cleaned up removed element references

## Linear Issues

- STACK-87: Bulk cache all inventory coin images
- STACK-88: Include image cache in ZIP backup and restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)