### PR TITLE
v3.28.00 — Price History Chart Overhaul & View Modal Customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.28.00] - 2026-02-14
+
+### Added — Price History Chart Overhaul & View Modal Customization
+
+- **Added**: Price history chart derives melt value from spot price history — every item gets a chart from day one
+- **Added**: Chart range toggle pills (7d / 14d / 30d / 60d / 90d / 180d / All) with 30d default
+- **Added**: Retail value line anchored from purchase date/price to current market value with sparse midpoint snapshots
+- **Added**: Layered chart fills — purchase (red), melt (green), retail (blue) with transparency blending
+- **Changed**: View modal section order: Images → Price History → Valuation → Inventory → Grading → Numista → Notes
+- **Added**: Configurable view modal section order in Settings > Layout with checkbox + arrow reorder table
+
+---
+
 ## [3.27.06] - 2026-02-14
 
 ### Added — Timezone Selection & PWA Fixes

--- a/css/styles.css
+++ b/css/styles.css
@@ -3156,11 +3156,19 @@ td input:checked + .slider:before {
 #viewItemModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
   color: #f8fafc;
-  padding: var(--spacing-lg) var(--spacing-xl);
-  padding-right: 2.5rem; /* room for close button */
+  padding: var(--spacing-sm) var(--spacing-xl);
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   box-shadow: var(--shadow);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.view-header-left {
+  flex: 1;
+  min-width: 0;
 }
 
 #viewItemModal .modal-header h2 {
@@ -3173,15 +3181,78 @@ td input:checked + .slider:before {
   white-space: nowrap;
 }
 
+.view-header-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+/* --- Header action buttons (eBay, Edit, Close) --- */
+.view-header-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.view-header-actions button {
+  padding: 5px 12px;
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: var(--transition);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  white-space: nowrap;
+}
+
+.view-header-actions button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.view-header-actions .view-edit-btn {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1e293b;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.view-header-actions .view-edit-btn:hover {
+  background: #fff;
+}
+
+.view-header-actions .view-ebay-btn {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.view-header-actions .view-ebay-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 #viewItemModal .view-modal-catalog-id {
   display: inline-block;
   font-size: 0.7rem;
   font-weight: 500;
   opacity: 0.85;
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(128, 128, 128, 0.2);
+  color: inherit;
   padding: 2px 8px;
   border-radius: 4px;
-  margin-top: 4px;
+}
+
+#viewItemModal .view-modal-count-chip {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  opacity: 0.85;
+  background: rgba(128, 128, 128, 0.2);
+  color: inherit;
+  padding: 2px 8px;
+  border-radius: 4px;
 }
 
 /* --- Scrollable body --- */
@@ -3292,6 +3363,8 @@ td input:checked + .slider:before {
   color: var(--primary);
   margin: 0 0 var(--spacing-sm) 0;
   padding-bottom: 2px;
+  padding-left: 8px;
+  border-left: 2px solid var(--primary);
 }
 
 .view-detail-grid {
@@ -3302,6 +3375,10 @@ td input:checked + .slider:before {
 
 .view-detail-grid.three-col {
   grid-template-columns: 1fr 1fr 1fr;
+}
+
+.view-detail-grid.four-col {
+  grid-template-columns: 1fr 1fr 1fr 1fr;
 }
 
 .view-detail-item {
@@ -3341,6 +3418,58 @@ td input:checked + .slider:before {
 
 .view-detail-value.muted {
   color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* --- Valuation section emphasis --- */
+.view-detail-section.view-valuation-section {
+  background: var(--bg-secondary);
+}
+
+/* --- Chart range pills --- */
+.view-chart-range-bar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: var(--spacing-sm);
+}
+
+.view-chart-range-pill {
+  padding: 2px 8px;
+  font-size: 0.6rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.view-chart-range-pill:hover {
+  background: var(--bg-tertiary);
+}
+
+.view-chart-range-pill.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+/* --- Price history chart --- */
+.view-chart-container {
+  position: relative;
+  width: 100%;
+  height: 200px;
+  margin-top: var(--spacing-sm);
+}
+
+.view-chart-no-data {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
   font-style: italic;
 }
 
@@ -3432,64 +3561,7 @@ td input:checked + .slider:before {
   word-break: break-word;
 }
 
-/* --- Footer actions --- */
-.view-modal-footer {
-  padding: var(--spacing) var(--spacing-xl);
-  border-top: 1px solid var(--border);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--spacing-sm);
-}
-
-.view-footer-left {
-  display: flex;
-  gap: var(--spacing-sm);
-}
-
-.view-footer-right {
-  display: flex;
-  gap: var(--spacing-sm);
-}
-
-.view-modal-footer button {
-  padding: 6px 16px;
-  border-radius: var(--radius);
-  font-size: 0.82rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: var(--transition);
-  border: 1px solid var(--border);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
-.view-modal-footer button:hover {
-  background: var(--bg-tertiary);
-}
-
-.view-modal-footer .view-edit-btn {
-  background: var(--primary);
-  color: #fff;
-  border-color: var(--primary);
-}
-
-.view-modal-footer .view-edit-btn:hover {
-  background: var(--primary-hover);
-  border-color: var(--primary-hover);
-}
-
-.view-ebay-btn {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  font-size: 0.78rem;
-}
-
-.view-ebay-btn:hover {
-  color: var(--text-primary);
-  border-color: var(--text-secondary);
-}
+/* (Footer removed — action buttons now live in .view-header-actions) */
 
 /* Clickable N# badge */
 .view-modal-catalog-id[style*="cursor: pointer"]:hover {
@@ -3511,11 +3583,21 @@ td input:checked + .slider:before {
   #viewItemModal .modal-header {
     border-radius: 0;
     padding: var(--spacing-sm) var(--spacing);
+    flex-wrap: wrap;
   }
 
   #viewItemModal .modal-header h2 {
     font-size: 0.95rem;
     line-height: 1.3;
+  }
+
+  .view-header-actions {
+    gap: 4px;
+  }
+
+  .view-header-actions button {
+    padding: 4px 8px;
+    font-size: 0.7rem;
   }
 
   /* Images: side-by-side but smaller — keep both visible */
@@ -3547,10 +3629,15 @@ td input:checked + .slider:before {
     height: 140px;
   }
 
-  /* 2-column data grid (down from 3) */
+  /* 2-column data grid (down from 3/4) */
   .view-detail-grid,
-  .view-detail-grid.three-col {
+  .view-detail-grid.three-col,
+  .view-detail-grid.four-col {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .view-chart-container {
+    height: 160px;
   }
 
   .view-detail-section {
@@ -3561,52 +3648,13 @@ td input:checked + .slider:before {
     padding: var(--spacing-sm) var(--spacing);
   }
 
-  /* Footer: sticky bottom bar with 44px touch targets + safe-area */
-  .view-modal-footer {
-    position: sticky;
-    bottom: 0;
-    background: var(--bg-primary);
-    border-top: 1px solid var(--border);
-    padding: var(--spacing-sm) var(--spacing);
-    padding-bottom: calc(var(--spacing-sm) + env(safe-area-inset-bottom, 0px));
-    z-index: 2;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm);
-  }
-
-  .view-modal-footer button {
-    min-height: 44px;
-    font-size: 0.85rem;
-    padding: 8px 16px;
-  }
-
-  .view-footer-left {
-    order: 2;
-    width: 100%;
-  }
-
-  .view-ebay-btn {
-    width: 100%;
-    min-height: 38px;
-  }
-
-  .view-footer-right {
-    order: 1;
-    width: 100%;
-    display: flex;
-    gap: var(--spacing-sm);
-  }
-
-  .view-footer-right button {
-    flex: 1;
-  }
-
 }
 
 /* --- Extra-small phones (≤480px) — single-column data, stacked images --- */
 @media (max-width: 480px) {
   .view-detail-grid,
-  .view-detail-grid.three-col {
+  .view-detail-grid.three-col,
+  .view-detail-grid.four-col {
     grid-template-columns: 1fr;
   }
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Price History Chart Overhaul & View Modal Customization (v3.28.00)**: Melt value chart derived from spot price history with range toggle pills (7d/14d/30d/60d/90d/180d/All). Retail value line anchored from purchase date to current market value. Layered chart fills for purchase, melt, and retail. Configurable view modal section order in Settings > Layout
 - **Timezone Selection & PWA Fixes (v3.27.06)**: Display timezone selector in Settings > System — all timestamps respect user-chosen zone while stored data stays UTC. Fixed bare UTC timestamp parsing for spot cards and history. PWA second-launch fix with absolute start_url and navigation-aware service worker. What's New splash stale cache fix (STACK-63, STACK-93)
 - **Numista Bulk Sync & IDB Cache Fix (v3.27.05)**: Bulk sync metadata + images from the Numista API card with inline progress and activity log. Fixed opaque blob IDB corruption that caused images to disappear after bulk cache on HTTPS. Table row thumbnail images with hover preloading (STACK-84, STACK-87, STACK-88)
 - **Spot Comparison Mode & Mobile API Settings (v3.27.04)**: 24h % comparison mode setting (Close/Close, Open/Open, Open/Close). Replaced drag-to-sort provider tabs with Sync Priority dropdowns. Mobile tab overflow fix. Consistent 24h % across all spot card views (STACK-89, STACK-90, STACK-92)
-- **PWA Support & Bug Fixes (v3.27.03)**: Installable app experience with offline caching via service worker. Fixed: edit-mode price preservation (STACK-81), stale spot-lookup on date change (STACK-82), Activity Log tabs showing stale data (STACK-83), Samsung S24+ Ultra layout (STACK-85). Removed redundant View icon (STACK-86). Spot history seed data from Docker poller infrastructure
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -1650,6 +1650,14 @@
                   <div class="chip-grouping-empty">Loading...</div>
                 </div>
               </div>
+
+              <div class="settings-group">
+                <div class="settings-group-label">Item detail modal</div>
+                <p class="settings-subtext">Reorder and toggle sections in the item view modal.</p>
+                <div class="chip-grouping-table-container" id="viewModalSectionConfigContainer">
+                  <div class="chip-grouping-empty">Loading...</div>
+                </div>
+              </div>
             </div>
 
             <!-- ===== TABLE SETTINGS ===== -->
@@ -2900,9 +2908,14 @@
     <div class="modal" id="viewItemModal" style="display: none">
       <div class="modal-content">
         <div class="modal-header">
-          <button aria-label="Close modal" class="modal-close" id="viewModalCloseBtn" style="position: absolute; top: var(--spacing-sm); right: var(--spacing-sm);">&times;</button>
-          <h2 id="viewModalTitle"></h2>
-          <span class="view-modal-catalog-id" id="viewModalCatalogId"></span>
+          <div class="view-header-left">
+            <h2 id="viewModalTitle"></h2>
+            <div class="view-header-badges">
+              <span class="view-modal-catalog-id" id="viewModalCatalogId"></span>
+              <span class="view-modal-count-chip" id="viewModalCountChip"></span>
+            </div>
+          </div>
+          <div class="view-header-actions" id="viewHeaderActions"></div>
         </div>
         <div class="modal-body" id="viewModalBody"></div>
       </div>

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.28.00 &ndash; Price History Chart Overhaul &amp; View Modal Customization</strong>: Melt value chart derived from spot price history with range toggle pills (7d/14d/30d/60d/90d/180d/All). Retail value line anchored from purchase date to current market value. Layered chart fills for purchase, melt, and retail. Configurable view modal section order in Settings &gt; Layout</li>
     <li><strong>v3.27.06 &ndash; Timezone Selection &amp; PWA Fixes</strong>: Display timezone selector in Settings &gt; System &mdash; all timestamps respect user-chosen zone while stored data stays UTC. Fixed bare UTC timestamp parsing for spot cards and history. PWA second-launch fix with absolute start_url and navigation-aware service worker. What&rsquo;s New splash stale cache fix (STACK-63, STACK-93)</li>
     <li><strong>v3.27.05 &ndash; Numista Bulk Sync &amp; IDB Cache Fix</strong>: Bulk sync metadata + images from the Numista API card with inline progress and activity log. Fixed opaque blob IDB corruption that caused images to disappear after bulk cache on HTTPS. Table row thumbnail images with hover preloading (STACK-84, STACK-87, STACK-88)</li>
     <li><strong>v3.27.04 &ndash; Spot Comparison Mode &amp; Mobile API Settings</strong>: 24h % comparison mode setting (Close/Close, Open/Open, Open/Close). Replaced drag-to-sort provider tabs with Sync Priority dropdowns. Mobile tab overflow fix. Consistent 24h % across all spot card views (STACK-89, STACK-90, STACK-92)</li>
-    <li><strong>v3.27.03 &ndash; PWA Support &amp; Bug Fixes</strong>: Installable app experience with offline caching via service worker. Fixed: edit-mode price preservation (STACK-81), stale spot-lookup on date change (STACK-82), Activity Log tabs showing stale data (STACK-83), Samsung S24+ Ultra layout (STACK-85). Removed redundant View icon (STACK-86). Spot history seed data from Docker poller infrastructure</li>
   `;
 };
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1456,14 +1456,21 @@ const syncLayoutVisibilityUI = () => {
 };
 
 /**
- * Renders the layout section config table in Settings > Layout.
- * Each row has a checkbox (enable/disable) and up/down arrows for reordering.
+ * Generic section-config table renderer.
+ * Builds a checkbox + arrow reorder table for any {id, label, enabled}[] config.
+ *
+ * @param {Object} opts
+ * @param {string} opts.containerId - DOM id of the container element
+ * @param {function} opts.getConfig - Returns the current config array
+ * @param {function} opts.saveConfig - Persists the updated config array
+ * @param {function} [opts.onApply] - Called after every change (e.g. applyLayoutOrder)
+ * @param {function} [opts.onRender] - Called to re-render after reorder (defaults to self)
  */
-const renderLayoutSectionConfigTable = () => {
-  const container = document.getElementById('layoutSectionConfigContainer');
-  if (!container || typeof getLayoutSectionConfig !== 'function') return;
+const _renderSectionConfigTable = (opts) => {
+  const container = document.getElementById(opts.containerId);
+  if (!container || typeof opts.getConfig !== 'function') return;
 
-  const config = getLayoutSectionConfig();
+  const config = opts.getConfig();
   container.textContent = '';
 
   if (!config.length) {
@@ -1491,12 +1498,12 @@ const renderLayoutSectionConfigTable = () => {
     cb.className = 'inline-chip-toggle';
     cb.title = 'Toggle ' + section.label;
     cb.addEventListener('change', () => {
-      const cfg = getLayoutSectionConfig();
+      const cfg = opts.getConfig();
       const item = cfg.at(idx);
       if (item) {
         item.enabled = cb.checked;
-        saveLayoutSectionConfig(cfg);
-        applyLayoutOrder();
+        opts.saveConfig(cfg);
+        if (opts.onApply) opts.onApply();
       }
     });
     tdCheck.appendChild(cb);
@@ -1517,14 +1524,14 @@ const renderLayoutSectionConfigTable = () => {
       btn.title = 'Move ' + dir;
       btn.disabled = disabled;
       btn.addEventListener('click', () => {
-        const cfg = getLayoutSectionConfig();
+        const cfg = opts.getConfig();
         const j = dir === 'up' ? idx - 1 : idx + 1;
         if (j < 0 || j >= cfg.length) return;
         const moved = cfg.splice(idx, 1).at(0);
         cfg.splice(j, 0, moved);
-        saveLayoutSectionConfig(cfg);
-        renderLayoutSectionConfigTable();
-        applyLayoutOrder();
+        opts.saveConfig(cfg);
+        (opts.onRender || (() => _renderSectionConfigTable(opts)))();
+        if (opts.onApply) opts.onApply();
       });
       return btn;
     };
@@ -1539,88 +1546,22 @@ const renderLayoutSectionConfigTable = () => {
   container.appendChild(table);
 };
 
-/**
- * Renders the view modal section config table in Settings > Layout.
- * Each row has a checkbox (enable/disable) and up/down arrows for reordering.
- * Mirrors renderLayoutSectionConfigTable() for consistency.
- */
-const renderViewModalSectionConfigTable = () => {
-  const container = document.getElementById('viewModalSectionConfigContainer');
-  if (!container || typeof getViewModalSectionConfig !== 'function') return;
+/** Renders the main page layout section config table in Settings > Layout. */
+const renderLayoutSectionConfigTable = () => _renderSectionConfigTable({
+  containerId: 'layoutSectionConfigContainer',
+  getConfig: getLayoutSectionConfig,
+  saveConfig: saveLayoutSectionConfig,
+  onApply: typeof applyLayoutOrder === 'function' ? applyLayoutOrder : null,
+  onRender: () => renderLayoutSectionConfigTable(),
+});
 
-  const config = getViewModalSectionConfig();
-  container.textContent = '';
-
-  if (!config.length) {
-    const empty = document.createElement('div');
-    empty.className = 'chip-grouping-empty';
-    empty.textContent = 'No sections available';
-    container.appendChild(empty);
-    return;
-  }
-
-  const table = document.createElement('table');
-  table.className = 'chip-grouping-table';
-  const tbody = document.createElement('tbody');
-
-  config.forEach((section, idx) => {
-    const tr = document.createElement('tr');
-    tr.dataset.sectionId = section.id;
-
-    // Checkbox cell
-    const tdCheck = document.createElement('td');
-    tdCheck.style.cssText = 'width:2rem;text-align:center';
-    const cb = document.createElement('input');
-    cb.type = 'checkbox';
-    cb.checked = section.enabled;
-    cb.className = 'inline-chip-toggle';
-    cb.title = 'Toggle ' + section.label;
-    cb.addEventListener('change', () => {
-      const cfg = getViewModalSectionConfig();
-      const item = cfg.at(idx);
-      if (item) {
-        item.enabled = cb.checked;
-        saveViewModalSectionConfig(cfg);
-      }
-    });
-    tdCheck.appendChild(cb);
-
-    // Label cell
-    const tdLabel = document.createElement('td');
-    tdLabel.textContent = section.label;
-
-    // Arrow buttons cell
-    const tdMove = document.createElement('td');
-    tdMove.style.cssText = 'width:3.5rem;text-align:right;white-space:nowrap';
-
-    const makeBtn = (dir, disabled) => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'inline-chip-move';
-      btn.textContent = dir === 'up' ? '\u2191' : '\u2193';
-      btn.title = 'Move ' + dir;
-      btn.disabled = disabled;
-      btn.addEventListener('click', () => {
-        const cfg = getViewModalSectionConfig();
-        const j = dir === 'up' ? idx - 1 : idx + 1;
-        if (j < 0 || j >= cfg.length) return;
-        const moved = cfg.splice(idx, 1).at(0);
-        cfg.splice(j, 0, moved);
-        saveViewModalSectionConfig(cfg);
-        renderViewModalSectionConfigTable();
-      });
-      return btn;
-    };
-    tdMove.appendChild(makeBtn('up', idx === 0));
-    tdMove.appendChild(makeBtn('down', idx === config.length - 1));
-
-    tr.append(tdCheck, tdLabel, tdMove);
-    tbody.appendChild(tr);
-  });
-
-  table.appendChild(tbody);
-  container.appendChild(table);
-};
+/** Renders the view modal section config table in Settings > Layout. */
+const renderViewModalSectionConfigTable = () => _renderSectionConfigTable({
+  containerId: 'viewModalSectionConfigContainer',
+  getConfig: getViewModalSectionConfig,
+  saveConfig: saveViewModalSectionConfig,
+  onRender: () => renderViewModalSectionConfigTable(),
+});
 
 /**
  * Shows/hides and reorders major page sections based on layout section config.

--- a/js/settings.js
+++ b/js/settings.js
@@ -1451,6 +1451,7 @@ window.applyHeaderToggleVisibility = applyHeaderToggleVisibility;
  */
 const syncLayoutVisibilityUI = () => {
   renderLayoutSectionConfigTable();
+  renderViewModalSectionConfigTable();
   applyLayoutOrder();
 };
 
@@ -1524,6 +1525,89 @@ const renderLayoutSectionConfigTable = () => {
         saveLayoutSectionConfig(cfg);
         renderLayoutSectionConfigTable();
         applyLayoutOrder();
+      });
+      return btn;
+    };
+    tdMove.appendChild(makeBtn('up', idx === 0));
+    tdMove.appendChild(makeBtn('down', idx === config.length - 1));
+
+    tr.append(tdCheck, tdLabel, tdMove);
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+};
+
+/**
+ * Renders the view modal section config table in Settings > Layout.
+ * Each row has a checkbox (enable/disable) and up/down arrows for reordering.
+ * Mirrors renderLayoutSectionConfigTable() for consistency.
+ */
+const renderViewModalSectionConfigTable = () => {
+  const container = document.getElementById('viewModalSectionConfigContainer');
+  if (!container || typeof getViewModalSectionConfig !== 'function') return;
+
+  const config = getViewModalSectionConfig();
+  container.textContent = '';
+
+  if (!config.length) {
+    const empty = document.createElement('div');
+    empty.className = 'chip-grouping-empty';
+    empty.textContent = 'No sections available';
+    container.appendChild(empty);
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'chip-grouping-table';
+  const tbody = document.createElement('tbody');
+
+  config.forEach((section, idx) => {
+    const tr = document.createElement('tr');
+    tr.dataset.sectionId = section.id;
+
+    // Checkbox cell
+    const tdCheck = document.createElement('td');
+    tdCheck.style.cssText = 'width:2rem;text-align:center';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = section.enabled;
+    cb.className = 'inline-chip-toggle';
+    cb.title = 'Toggle ' + section.label;
+    cb.addEventListener('change', () => {
+      const cfg = getViewModalSectionConfig();
+      const item = cfg.at(idx);
+      if (item) {
+        item.enabled = cb.checked;
+        saveViewModalSectionConfig(cfg);
+      }
+    });
+    tdCheck.appendChild(cb);
+
+    // Label cell
+    const tdLabel = document.createElement('td');
+    tdLabel.textContent = section.label;
+
+    // Arrow buttons cell
+    const tdMove = document.createElement('td');
+    tdMove.style.cssText = 'width:3.5rem;text-align:right;white-space:nowrap';
+
+    const makeBtn = (dir, disabled) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'inline-chip-move';
+      btn.textContent = dir === 'up' ? '\u2191' : '\u2193';
+      btn.title = 'Move ' + dir;
+      btn.disabled = disabled;
+      btn.addEventListener('click', () => {
+        const cfg = getViewModalSectionConfig();
+        const j = dir === 'up' ? idx - 1 : idx + 1;
+        if (j < 0 || j >= cfg.length) return;
+        const moved = cfg.splice(idx, 1).at(0);
+        cfg.splice(j, 0, moved);
+        saveViewModalSectionConfig(cfg);
+        renderViewModalSectionConfigTable();
       });
       return btn;
     };

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -838,13 +838,18 @@ function _createPriceHistoryChart(canvas, allSpotEntries, allRetailEntries, purc
     return best;
   };
 
-  // Anchor start: purchase price on the spot entry nearest to purchase date
-  // Only anchor if purchase date falls within the visible timeline range
-  if (purchaseDate > 0 && purchasePerUnit > 0 &&
-      purchaseDate >= spotEntries[0].ts &&
-      purchaseDate <= spotEntries[spotEntries.length - 1].ts) {
-    const idx = _nearestSpotIdx(purchaseDate);
-    retailData[idx] = purchasePerUnit;
+  // Anchor start: purchase price at the leftmost chart position.
+  // If purchase date is within the visible range, snap to that day.
+  // If purchase date is before the range, pin to index 0 so the
+  // retail line always starts with "what you paid" as a reference.
+  if (purchaseDate > 0 && purchasePerUnit > 0) {
+    if (purchaseDate >= spotEntries[0].ts &&
+        purchaseDate <= spotEntries[spotEntries.length - 1].ts) {
+      const idx = _nearestSpotIdx(purchaseDate);
+      retailData[idx] = purchasePerUnit;
+    } else if (purchaseDate < spotEntries[0].ts) {
+      retailData[0] = purchasePerUnit;
+    }
   }
 
   // Middle: sparse itemPriceHistory retail values snapped to nearest spot day

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Enables offline support and installable PWA experience
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
-const CACHE_NAME = 'staktrakr-v3.27.06';
+const CACHE_NAME = 'staktrakr-v3.28.00';
 
 // Core shell assets to pre-cache on install
 const CORE_ASSETS = [

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.27.06",
+  "version": "3.28.00",
   "releaseDate": "2026-02-14",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Price history chart overhaul**: Derives melt value from 60+ years of spot price history — every item gets a chart from day one, no longer dependent on sparse manual entries
- **Chart range toggle**: Compact pill buttons (7d / 14d / 30d / 60d / 90d / 180d / All) with 30d default for quick zoom into recent trends
- **Three-line chart**: Purchase price (red baseline), melt value (green), retail value (blue) with layered transparent fills
- **Retail value anchoring**: Purchase date/price as first plot point, current market value as endpoint, sparse manual entries as midpoints — handles weekend/holiday gaps with nearest-timestamp snapping
- **Configurable view modal sections**: Settings > Layout table with checkbox + arrow reorder for all 7 modal sections (images, price history, valuation, inventory, grading, numista, notes)
- **Section reorder default**: Price History and Valuation promoted above Inventory in the default view

## Files Updated

- `js/viewModal.js` — Chart overhaul, section builder refactor, range toggle
- `js/constants.js` — VIEW_MODAL_SECTION_DEFAULTS, get/save config, APP_VERSION → 3.28.00
- `js/settings.js` — renderViewModalSectionConfigTable()
- `css/styles.css` — Chart range pill styles, no-data fallback
- `index.html` — Settings group for view modal section order
- `sw.js` — CACHE_NAME → 3.28.00
- `CHANGELOG.md` — New v3.28.00 section
- `docs/announcements.md` — New What's New entry
- `js/about.js` — Embedded What's New fallback
- `version.json` — Remote version check endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)