### PR TITLE
v3.29.01 — Codacy Duplication Reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.29.01] - 2026-02-15
+
+### Changed — Codacy Duplication Reduction
+
+- **Changed**: Extracted `wireFeatureFlagToggle` and `wireChipSortToggle` helpers to deduplicate 6 identical chip toggle handlers across settings.js and events.js
+- **Changed**: Merged `renderInlineChipConfigTable` into generic `_renderSectionConfigTable` with `emptyText` option
+- **Changed**: Extracted `buildItemFields` helper to deduplicate item field listings in add/edit paths
+- **Changed**: Extracted `closeItemModal` to deduplicate cancel/close button handlers
+- **Removed**: Unused Numista Query and N# form fields from pattern image rule form
+
+---
+
 ## [3.29.00] - 2026-02-15
 
 ### Added — Edit Modal Pattern Rule Toggle

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Codacy Duplication Reduction (v3.29.01)**: Extracted shared toggle helpers, merged config table renderers, deduplicated item field builders and modal close handlers. Removed unused Numista Query and N# fields from pattern image rules
 - **Edit Modal Pattern Rule Toggle (v3.29.00)**: "Apply to all matching items" checkbox in edit modal image upload — creates a pattern rule from keywords instead of per-item images. Extracted shared section config helpers to reduce code clones
 - **Price History Chart Overhaul & View Modal Customization (v3.28.00)**: Melt value chart derived from spot price history with range toggle pills (7d/14d/30d/60d/90d/180d/All). Retail value line anchored from purchase date to current market value. Layered chart fills for purchase, melt, and retail. Configurable view modal section order in Settings > Layout
 - **Timezone Selection & PWA Fixes (v3.27.06)**: Display timezone selector in Settings > System — all timestamps respect user-chosen zone while stored data stays UTC. Fixed bare UTC timestamp parsing for spot cards and history. PWA second-launch fix with absolute start_url and navigation-aware service worker. What's New splash stale cache fix (STACK-63, STACK-93)
-- **Numista Bulk Sync & IDB Cache Fix (v3.27.05)**: Bulk sync metadata + images from the Numista API card with inline progress and activity log. Fixed opaque blob IDB corruption that caused images to disappear after bulk cache on HTTPS. Table row thumbnail images with hover preloading (STACK-84, STACK-87, STACK-88)
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -2417,14 +2417,6 @@
                       <input type="text" id="patternRulePattern" class="form-control" placeholder="e.g. morgan, peace, walking liberty" />
                       <small id="patternRuleTip" class="pattern-rule-tip">Separate keywords with commas or semicolons. Matches item names containing any keyword.</small>
                     </div>
-                    <div class="pattern-rule-field">
-                      <label for="patternRuleReplacement">Numista Query (optional)</label>
-                      <input type="text" id="patternRuleReplacement" class="form-control" placeholder="e.g. 1 Dollar &quot;Morgan Dollar&quot;" />
-                    </div>
-                    <div class="pattern-rule-field pattern-rule-field-narrow">
-                      <label for="patternRuleNumistaId">N# (optional)</label>
-                      <input type="text" id="patternRuleNumistaId" class="form-control" placeholder="e.g. 1492" />
-                    </div>
                   </div>
                   <div class="pattern-rule-form-row">
                     <div class="pattern-rule-field">

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.29.01 &ndash; Codacy Duplication Reduction</strong>: Extracted shared toggle helpers, merged config table renderers, deduplicated item field builders and modal close handlers. Removed unused Numista Query and N# fields from pattern image rules</li>
     <li><strong>v3.29.00 &ndash; Edit Modal Pattern Rule Toggle</strong>: &ldquo;Apply to all matching items&rdquo; checkbox in edit modal image upload &mdash; creates a pattern rule from keywords instead of per-item images. Extracted shared section config helpers to reduce code clones</li>
     <li><strong>v3.28.00 &ndash; Price History Chart Overhaul &amp; View Modal Customization</strong>: Melt value chart derived from spot price history with range toggle pills (7d/14d/30d/60d/90d/180d/All). Retail value line anchored from purchase date to current market value. Layered chart fills for purchase, melt, and retail. Configurable view modal section order in Settings &gt; Layout</li>
     <li><strong>v3.27.06 &ndash; Timezone Selection &amp; PWA Fixes</strong>: Display timezone selector in Settings &gt; System &mdash; all timestamps respect user-chosen zone while stored data stays UTC. Fixed bare UTC timestamp parsing for spot cards and history. PWA second-launch fix with absolute start_url and navigation-aware service worker. What&rsquo;s New splash stale cache fix (STACK-63, STACK-93)</li>
-    <li><strong>v3.27.05 &ndash; Numista Bulk Sync &amp; IDB Cache Fix</strong>: Bulk sync metadata + images from the Numista API card with inline progress and activity log. Fixed opaque blob IDB corruption that caused images to disappear after bulk cache on HTTPS. Table row thumbnail images with hover preloading (STACK-84, STACK-87, STACK-88)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.29.00";
+const APP_VERSION = "3.29.01";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Enables offline support and installable PWA experience
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
-const CACHE_NAME = 'staktrakr-v3.29.00';
+const CACHE_NAME = 'staktrakr-v3.29.01';
 
 // Core shell assets to pre-cache on install
 const CORE_ASSETS = [

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.29.00",
+  "version": "3.29.01",
   "releaseDate": "2026-02-15",
   "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Extracted `wireFeatureFlagToggle` and `wireChipSortToggle` helpers to deduplicate 6 identical chip toggle handlers across settings.js and events.js
- Merged `renderInlineChipConfigTable` into generic `_renderSectionConfigTable` with `emptyText` option
- Extracted `buildItemFields` helper to deduplicate item field listings in add/edit paths
- Extracted `closeItemModal` to deduplicate cancel/close button handlers
- Removed unused Numista Query and N# form fields from pattern image rule form

## Files Updated

- `js/settings.js` — add `wireFeatureFlagToggle()`, `wireChipSortToggle()` helpers; replace 5 flag toggle handlers + 1 sort toggle; collapse `renderInlineChipConfigTable`
- `js/events.js` — extract `closeItemModal()`, `buildItemFields()`; use global toggle helpers
- `index.html` — remove unused pattern rule form fields
- `js/constants.js` — APP_VERSION → 3.29.01
- `sw.js` — CACHE_NAME → 3.29.01
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint

## Net Impact

-180 lines (325 removed, 145 added) — targets 5 of 8 Codacy duplication clusters from PR #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)