### PR TITLE
Repo rename: StackTrackr → StakTrakr

### DIFF
--- a/.claude/commands/loop.md
+++ b/.claude/commands/loop.md
@@ -3,7 +3,7 @@ description: Sprint loop — daisy-chain context across chat rewinds for multi-t
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, mcp__linear-server__*, mcp__memento__*, mcp__claude-context__*
 ---
 
-# Sprint Loop — StackTrackr
+# Sprint Loop — StakTrakr
 
 This command manages a **rewind-based sprint workflow** for sessions with multiple tasks. The user will rewind the chat back to this message after each task, preserving the base context while carrying forward progress via handoff files.
 
@@ -28,7 +28,7 @@ Look for the most recent sprint handoff:
 
 1. Check `logs/sprint/` directory for files matching `handoff_*.md` (newest first)
 2. If found, read it — it contains what was completed, what's next, and any state to carry forward
-3. If no file found, also search Memento: `semantic_search("stacktrackr sprint handoff", limit: 3)`
+3. If no file found, also search Memento: `semantic_search("staktrakr sprint handoff", limit: 3)`
 4. If nothing found anywhere, this is a fresh loop — ask the user what we're working on
 
 ### Step 2: Quick git check
@@ -84,9 +84,9 @@ Write to `logs/sprint/handoff_[TIMESTAMP].md`:
 ### Step 3: Save to Memento
 
 Save a lightweight handoff entity to Memento with:
-- Entity type: `STACKTRACKR:DEVELOPMENT:HANDOFF`
+- Entity type: `STAKTRAKR:DEVELOPMENT:HANDOFF`
 - Observations: TIMESTAMP, ABSTRACT (1 line), SUMMARY (full handoff content)
-- Tags: `project:stacktrackr`, `type:sprint-handoff`
+- Tags: `project:staktrakr`, `type:sprint-handoff`
 
 ### Step 4: Confirm ready for rewind
 

--- a/.claude/commands/patch-review.md
+++ b/.claude/commands/patch-review.md
@@ -1,4 +1,4 @@
-# StackTrackr Patch Review
+# StakTrakr Patch Review
 
 Comprehensive security and quality review of uncommitted or staged changes.
 

--- a/.claude/commands/recall-handoff.md
+++ b/.claude/commands/recall-handoff.md
@@ -4,7 +4,7 @@ Recall a specific development handoff by ID: $ARGUMENTS
 
 **Usage Patterns:**
 ```bash
-/recall-handoff id:STACKTRACKR-HANDOFF-20251001-143045    # Full handoff ID with timestamp
+/recall-handoff id:STAKTRAKR-HANDOFF-20251001-143045    # Full handoff ID with timestamp
 /recall-handoff id:12                                   # Shorthand ID lookup
 /recall-handoff recent                                  # Most recent handoff
 /recall-handoff date:2025-09-07                         # Handoffs from specific date
@@ -44,7 +44,7 @@ mcp__memento__open_nodes({
 **Tag-Based Search Examples (optimal search method):**
 - `"handoff spec:001"` - All handoffs for specification 001 (search_nodes - exact tag)
 - `"handoff blocked"` - Handoffs with blocking issues (search_nodes - exact tag)
-- `"handoff project:stacktrackr in-progress"` - Active StackTrackr handoffs (search_nodes - tags)
+- `"handoff project:staktrakr in-progress"` - Active StakTrakr handoffs (search_nodes - tags)
 - `"handoff week-38-2025"` - This week's handoffs (search_nodes - temporal tag)
 - `"backend architecture decisions"` - Backend design handoffs (semantic_search - concepts)
 

--- a/.claude/commands/save-conversation.md
+++ b/.claude/commands/save-conversation.md
@@ -10,7 +10,7 @@ Save current conversation highlights to Memento with auto-generated session ID: 
 - Project-specific insights with proper classification
 
 **Entity Details:**
-- **Classification**: Use PROJECT:DOMAIN:TYPE pattern (e.g., STACKTRACKR:DEVELOPMENT:SESSION)
+- **Classification**: Use PROJECT:DOMAIN:TYPE pattern (e.g., STAKTRAKR:DEVELOPMENT:SESSION)
 - **Name**: Descriptive title based on main topic and context
 - **Observations**: Actionable outcomes and key learnings (not full transcripts)
 - **Relations**: Link to current project and related technical concepts
@@ -18,7 +18,7 @@ Save current conversation highlights to Memento with auto-generated session ID: 
 **Session ID Generation:**
 ```javascript
 // Auto-generate session ID: PROJECT-KEYWORD-YYYYMMDD-HHMMSS
-const generateSessionID = (keyword, project = "STACKTRACKR") => {
+const generateSessionID = (keyword, project = "STAKTRAKR") => {
   const now = new Date();
 
   // DATE VERIFICATION: Ensure we're using correct current date
@@ -44,7 +44,7 @@ const generateSessionID = (keyword, project = "STACKTRACKR") => {
   return `${project}-${keyword.toUpperCase()}-${date}-${time}`;
 };
 
-// Example: "STACKTRACKR-PRICING-20251001-143045"
+// Example: "STAKTRAKR-PRICING-20251001-143045"
 ```
 
 **Memory Tools:**
@@ -69,7 +69,7 @@ mcp__memento__add_observations({
   observations: [{
     entityName: "Session: [GENERATED_SESSION_ID]",
     contents: [
-      "TAG: project:[PROJECT_NAME]",        // Required: project:stacktrackr, project:zen, etc.
+      "TAG: project:[PROJECT_NAME]",        // Required: project:staktrakr, project:zen, etc.
       "TAG: spec:[SPEC_NUMBER]",            // If working on a spec: spec:001, spec:002, etc.
       "TAG: [CATEGORY]",                    // Required: frontend, backend, database, etc.
       "TAG: [IMPACT]",                      // Optional: feature, enhancement, critical-bug, etc.

--- a/.claude/commands/save-handoff.md
+++ b/.claude/commands/save-handoff.md
@@ -5,7 +5,7 @@ Create comprehensive handoff package with unique handoff ID: $ARGUMENTS
 **Step 1: Generate Handoff ID**
 ```javascript
 // Auto-generate handoff ID: PROJECT-HANDOFF-YYYYMMDD-HHMMSS
-const generateHandoffID = (project = "STACKTRACKR") => {
+const generateHandoffID = (project = "STAKTRAKR") => {
   const now = new Date();
 
   // DATE VERIFICATION: Ensure we're using correct current date
@@ -30,7 +30,7 @@ const generateHandoffID = (project = "STACKTRACKR") => {
 
   return `${project}-HANDOFF-${date}-${time}`;
 };
-// Example: "STACKTRACKR-HANDOFF-20251001-143045"
+// Example: "STAKTRAKR-HANDOFF-20251001-143045"
 ```
 
 **Step 2: Save to Memento with ID**
@@ -56,7 +56,7 @@ mcp__memento__add_observations({
   observations: [{
     entityName: "Handoff: [GENERATED_HANDOFF_ID]",
     contents: [
-      "TAG: project:[PROJECT_NAME]",        // Required: project:stacktrackr, project:zen, etc.
+      "TAG: project:[PROJECT_NAME]",        // Required: project:staktrakr, project:zen, etc.
       "TAG: handoff",                       // Always include for handoffs
       "TAG: spec:[ACTIVE_SPEC]",           // Current spec being worked on
       "TAG: [CATEGORY]",                    // Work area: frontend, backend, database, etc.
@@ -105,9 +105,9 @@ const getWeekNumber = () => {
 **JSON Structure:**
 ```json
 {
-  "handoff_id": "STACKTRACKR-HANDOFF-20251001-143045",
+  "handoff_id": "STAKTRAKR-HANDOFF-20251001-143045",
   "timestamp": "2025-10-01T14:30:45Z",
-  "project": "StackTrackr", 
+  "project": "StakTrakr", 
   "session_context": "Brief description",
   "active_files": ["path:line", "path:line"],
   "key_decisions": ["decision 1", "decision 2"],

--- a/.claude/commands/save-insights.md
+++ b/.claude/commands/save-insights.md
@@ -11,7 +11,7 @@ Extract and save high-value insights to Memento with PROJECT:DOMAIN:TYPE classif
 - Security considerations and implementation approaches
 
 **Entity Details:**
-- **Classification**: Use PROJECT:DOMAIN:TYPE (e.g., SYSTEM:WORKFLOW:PATTERN, STACKTRACKR:PRICING:INSIGHT)
+- **Classification**: Use PROJECT:DOMAIN:TYPE (e.g., SYSTEM:WORKFLOW:PATTERN, STAKTRAKR:PRICING:INSIGHT)
 - **Name**: Specific, searchable title describing the core insight
 - **Observations**: Concrete, actionable knowledge applicable to future projects
 - **Relations**: Connect to relevant technologies, frameworks, or project patterns
@@ -19,7 +19,7 @@ Extract and save high-value insights to Memento with PROJECT:DOMAIN:TYPE classif
 **Insight ID Generation:**
 ```javascript
 // Auto-generate insight ID: PROJECT-INSIGHT-YYYYMMDD-HHMMSS
-const generateInsightID = (project = "STACKTRACKR") => {
+const generateInsightID = (project = "STAKTRAKR") => {
   const now = new Date();
 
   // DATE VERIFICATION: Ensure we're using correct current date
@@ -45,7 +45,7 @@ const generateInsightID = (project = "STACKTRACKR") => {
   return `${project}-INSIGHT-${date}-${time}`;
 };
 
-// Example: "STACKTRACKR-INSIGHT-20251001-143045"
+// Example: "STAKTRAKR-INSIGHT-20251001-143045"
 ```
 
 **Memory Tools:**

--- a/.claude/commands/save-rewind.md
+++ b/.claude/commands/save-rewind.md
@@ -12,7 +12,7 @@
 
 ```javascript
 // Auto-generate rewind ID: PROJECT-REWIND-YYYYMMDD-HHMMSS
-const generateRewindID = (project = "STACKTRACKR") => {
+const generateRewindID = (project = "STAKTRAKR") => {
   const now = new Date();
 
   // Use UTC for consistency
@@ -33,7 +33,7 @@ const generateRewindID = (project = "STACKTRACKR") => {
 // Lightweight structure - only 5 core observations
 mcp__memento__create_entities([{
   name: "Rewind: [GENERATED_REWIND_ID]",
-  entityType: "STACKTRACKR:SESSION:REWIND",
+  entityType: "STAKTRAKR:SESSION:REWIND",
   observations: [
     `TIMESTAMP: ${new Date().toISOString()}`,
     `ABSTRACT: [One sentence - what was just accomplished]`,
@@ -55,7 +55,7 @@ mcp__memento__add_observations({
   observations: [{
     entityName: "Rewind: [GENERATED_REWIND_ID]",
     contents: [
-      "TAG: project:stacktrackr",
+      "TAG: project:staktrakr",
       "TAG: rewind",
       "TAG: spec:[LINEAR_ISSUE]",
       `TAG: week-${getWeekNumber()}-${new Date().getFullYear()}`

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -3,7 +3,7 @@ description: Quick session start — load recent context without a full prime.
 allowed-tools: Bash, Read, Grep, Glob, mcp__linear-server__*, mcp__memento__*, mcp__claude-context__*
 ---
 
-# Session Start — StackTrackr
+# Session Start — StakTrakr
 
 Lightweight context loader for the start of a development session. Gets you up to speed in 30 seconds, not 5 minutes.
 
@@ -36,7 +36,7 @@ Run these commands (parallel where possible):
 
 ## Phase 2: Linear Quick Check
 
-Query the **StackTrackr** team (ID: `f876864d-ff80-4231-ae6c-a8e5cb69aca4`) for active work:
+Query the **StakTrakr** team (ID: `f876864d-ff80-4231-ae6c-a8e5cb69aca4`) for active work:
 
 1. List **In Progress** issues (these are what we're likely continuing)
 2. List **Todo** issues (these are queued next)
@@ -48,7 +48,7 @@ If no In Progress issues, skip to Phase 3.
 
 Search Memento for the most recent handoff or session save:
 
-1. `mcp__memento__semantic_search` with query: `"stacktrackr handoff session"`, limit: 3, min_similarity: 0.5
+1. `mcp__memento__semantic_search` with query: `"staktrakr handoff session"`, limit: 3, min_similarity: 0.5
 2. If a handoff entity is found, read it with `mcp__memento__open_nodes` for full context
 3. If no handoff found, that's fine — Phase 1 and 2 provide sufficient context
 
@@ -57,7 +57,7 @@ Search Memento for the most recent handoff or session save:
 Produce a concise summary (not a formal report — just conversational):
 
 ```
-Session Start — StackTrackr v[VERSION] on [BRANCH]
+Session Start — StakTrakr v[VERSION] on [BRANCH]
 
 Recent: [1-2 sentence summary of last few commits]
 In Progress: [STACK-XX: title, STACK-YY: title] or "None"

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,4 +1,4 @@
-# StackTrackr Verification
+# StakTrakr Verification
 
 Run comprehensive verification on the current codebase state before committing.
 

--- a/.claude/skills/browser-testing/SKILL.md
+++ b/.claude/skills/browser-testing/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: browser-testing
-description: Browser automation patterns for StackTrackr UI testing — screenshots, accessibility snapshots, interaction recording, theme/scaling verification. Use when testing UI, taking screenshots, running Chrome DevTools, or verifying themes/layouts.
+description: Browser automation patterns for StakTrakr UI testing — screenshots, accessibility snapshots, interaction recording, theme/scaling verification. Use when testing UI, taking screenshots, running Chrome DevTools, or verifying themes/layouts.
 user-invocable: false
 ---
 
-# StackTrackr Browser Testing
+# StakTrakr Browser Testing
 
-Patterns and workflows for testing the StackTrackr UI using Chrome MCP tools. Use this skill when working on themes, layout scaling, responsive design, visual regression, or any task that requires viewing or interacting with the live UI.
+Patterns and workflows for testing the StakTrakr UI using Chrome MCP tools. Use this skill when working on themes, layout scaling, responsive design, visual regression, or any task that requires viewing or interacting with the live UI.
 
 ---
 
@@ -14,7 +14,7 @@ Patterns and workflows for testing the StackTrackr UI using Chrome MCP tools. Us
 
 ### 1. Start the local server
 
-StackTrackr must be served over HTTP for full browser tool access:
+StakTrakr must be served over HTTP for full browser tool access:
 
 ```bash
 python3 -m http.server 8888
@@ -54,7 +54,7 @@ Keep the server running in the background for the duration of the testing sessio
 
 **Navigation** — use `navigate_page`. Works with both protocols:
 - HTTP: `http://localhost:8888/index.html`
-- File: `file:///Volumes/DATA/GitHub/StackTrackr/index.html`
+- File: `file:///Volumes/DATA/GitHub/StakTrakr/index.html`
 
 **Accessibility snapshots** — use `take_snapshot`. Returns a structured tree:
 ```
@@ -96,7 +96,7 @@ JSON.stringify(window.featureFlags)
 3. Capture extra frames before/after each action for smooth playback
 4. Name files meaningfully: `theme_switch_dark.gif`, `add_item_flow.gif`
 
-**Page reading** — `read_page` works on localhost but StackTrackr's single-page HTML is very dense. Tips:
+**Page reading** — `read_page` works on localhost but StakTrakr's single-page HTML is very dense. Tips:
 - Use CSS selectors to target specific sections: `read_page` with a selector like `#inventoryTable`
 - For full-page analysis, prefer `chrome-devtools` `take_snapshot` instead
 - If output is truncated, use `evaluate_script` to extract specific data
@@ -119,7 +119,7 @@ JSON.stringify(window.featureFlags)
 
 ### Output size limits
 
-StackTrackr is a single HTML page with dense DOM. Some tools hit character limits:
+StakTrakr is a single HTML page with dense DOM. Some tools hit character limits:
 - `read_page` at depth > 1 can exceed output limits
 - `take_snapshot` returns ~400 lines for the full app — manageable but large
 - Use `evaluate_script` with targeted DOM queries for specific element inspection

--- a/.claude/skills/claude-context-rules/SKILL.md
+++ b/.claude/skills/claude-context-rules/SKILL.md
@@ -8,14 +8,14 @@ user-invocable: false
 
 Semantic code search via AST-based indexing, Milvus vector database, and OpenAI embeddings.
 
-**Index path**: `/Volumes/DATA/GitHub/StackTrackr` (40 files, ~885 chunks as of Feb 2026).
+**Index path**: `/Volumes/DATA/GitHub/StakTrakr` (40 files, ~885 chunks as of Feb 2026).
 
 ## Rules
 
 - **Always use `search_code` as the first step** for any codebase lookup — it's the fastest way to orient yourself (~2s, zero subprocess tokens). For single-function or architectural questions, it's often all you need.
 - **For cross-cutting or scattered concerns**, Claude-Context may return incomplete results (e.g., finding 3 of 7 escape functions). When results seem partial, pass the initial findings as seed context to an Explore agent for comprehensive coverage.
 - **For literal string matches**, use Grep directly — Claude-Context uses semantic embeddings and can confuse similar concepts (e.g., ranking `importCsv` above `exportCsv` for an "export" query).
-- **Always pass the absolute path** `/Volumes/DATA/GitHub/StackTrackr` — relative paths will fail.
+- **Always pass the absolute path** `/Volumes/DATA/GitHub/StakTrakr` — relative paths will fail.
 - **Use natural language queries**, not code patterns. Good: `"how are spot prices fetched from the API"`. Bad: `"fetchSpotPrice function"` (use Grep for literal matches).
 - **Use `extensionFilter`** to narrow results when you know the file type (e.g., `[".js"]` for JS-only results).
 - **Raise `limit`** (default 10, max 50) for broad exploratory searches; keep it low for targeted lookups.

--- a/.claude/skills/codacy-rules/SKILL.md
+++ b/.claude/skills/codacy-rules/SKILL.md
@@ -13,7 +13,7 @@ Code quality analysis and static analysis.
 - **Use for code quality checks** when available.
 - **Configured via `CODACY_ACCOUNT_TOKEN`** from macOS Keychain — no manual token setup required.
 - **Check tool availability** via ToolSearch before use — tools may not always be loaded.
-- **StackTrackr maintains an A+ rating** — all commits and PRs must pass Codacy quality gates.
+- **StakTrakr maintains an A+ rating** — all commits and PRs must pass Codacy quality gates.
 
 ---
 

--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: coding-standards
-description: StackTrackr coding standards — vanilla JavaScript, single-page app, no build step, localStorage persistence.
+description: StakTrakr coding standards — vanilla JavaScript, single-page app, no build step, localStorage persistence.
 ---
 
-# StackTrackr Coding Standards
+# StakTrakr Coding Standards
 
 Coding standards for a **pure client-side precious metals inventory tracker**. Single HTML page (`index.html`), vanilla JavaScript, localStorage persistence, no backend, no build step. Must work on both `file://` protocol and HTTP servers.
 

--- a/.claude/skills/linear-workspace/SKILL.md
+++ b/.claude/skills/linear-workspace/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: linear-workspace
-description: Linear workspace structure, team IDs, issue routing rules, and label conventions for StackTrackr. Use when creating, updating, or querying Linear issues.
+description: Linear workspace structure, team IDs, issue routing rules, and label conventions for StakTrakr. Use when creating, updating, or querying Linear issues.
 user-invocable: false
 ---
 
-# Linear Workspace — StackTrackr
+# Linear Workspace — StakTrakr
 
 Reference guide for routing issues to the correct team, using the right labels, and avoiding unnecessary API calls.
 
@@ -12,14 +12,14 @@ Reference guide for routing issues to the correct team, using the right labels, 
 
 | Team | ID | Prefix | Visibility | Purpose |
 |------|----|--------|------------|---------|
-| **StackTrackr** | `f876864d-ff80-4231-ae6c-a8e5cb69aca4` | STACK- | Public | All user-facing features, bugs, and improvements |
+| **StakTrakr** | `f876864d-ff80-4231-ae6c-a8e5cb69aca4` | STACK- | Public | All user-facing features, bugs, and improvements |
 | **Developers** | `38d57c9f-388c-41ec-9cd2-259a21a5df1c` | DEVS- | Private | Internal strategy, research, architecture notes, sensitive roadmap items |
 
 **Always use the team ID directly** — never call `list_teams` to look it up. This avoids the "too much data" error and saves an API round-trip.
 
 ## Issue Routing Rules
 
-### Goes on StackTrackr (public)
+### Goes on StakTrakr (public)
 
 - User-facing features and enhancements
 - Bug fixes
@@ -39,7 +39,7 @@ Reference guide for routing issues to the correct team, using the right labels, 
 - Anything the user explicitly asks to keep private
 - Research spikes and prototyping notes
 
-**When in doubt, ask the user** which team an issue should go on. Default to StackTrackr unless the content is sensitive or strategic.
+**When in doubt, ask the user** which team an issue should go on. Default to StakTrakr unless the content is sensitive or strategic.
 
 ## Labels
 
@@ -87,7 +87,7 @@ Always filter by team ID to avoid loading the entire workspace:
 
 ```
 mcp__linear-server__list_issues
-  team: "f876864d-ff80-4231-ae6c-a8e5cb69aca4"  # StackTrackr
+  team: "f876864d-ff80-4231-ae6c-a8e5cb69aca4"  # StakTrakr
   state: "In Progress"                            # Filter by state
   limit: 10                                       # Keep results small
 ```
@@ -119,4 +119,4 @@ mcp__linear-server__get_issue
 
 ## Assignee
 
-Default assignee for StackTrackr issues: **Lonnie B.** (ID: `ba9478fe-2f7b-4d51-9460-a2e2031e2ea8`). Only set assignee when explicitly asked.
+Default assignee for StakTrakr issues: **Lonnie B.** (ID: `ba9478fe-2f7b-4d51-9460-a2e2031e2ea8`). Only set assignee when explicitly asked.

--- a/.claude/skills/pr-resolve/skill.md
+++ b/.claude/skills/pr-resolve/skill.md
@@ -1,4 +1,4 @@
-# PR Resolve — StackTrackr
+# PR Resolve — StakTrakr
 
 Review, reply to, and resolve all PR review comments and CI check failures. Handles Copilot review threads, Codacy quality gate findings, and human reviewer comments in a single pass.
 
@@ -24,7 +24,7 @@ Use GraphQL to get threads with full context:
 ```bash
 gh api graphql -f query='
 {
-  repository(owner: "lbruton", name: "StackTrackr") {
+  repository(owner: "lbruton", name: "StakTrakr") {
     pullRequest(number: PR_NUMBER) {
       reviewThreads(first: 50) {
         nodes {
@@ -59,17 +59,17 @@ If Codacy failed or reported issues:
 
 1. **Check Codacy PR comments** — Codacy sometimes leaves inline comments:
    ```bash
-   gh api repos/lbruton/StackTrackr/pulls/PR_NUMBER/comments --jq '.[] | select(.user.login | test("codacy"; "i")) | "\(.id) | \(.path):\(.line) | \(.body)"'
+   gh api repos/lbruton/StakTrakr/pulls/PR_NUMBER/comments --jq '.[] | select(.user.login | test("codacy"; "i")) | "\(.id) | \(.path):\(.line) | \(.body)"'
    ```
 
 2. **Fetch Codacy PR findings via MCP** — use the Codacy MCP tools for detailed analysis:
    ```
-   mcp__codacy__codacy_list_pull_request_issues  (provider: "gh", owner: "lbruton", repo: "StackTrackr", pullRequestNumber: PR_NUMBER)
+   mcp__codacy__codacy_list_pull_request_issues  (provider: "gh", owner: "lbruton", repo: "StakTrakr", pullRequestNumber: PR_NUMBER)
    ```
 
 3. **Cross-reference with Codacy dashboard** — for pattern-level details:
    ```
-   mcp__codacy__codacy_get_repository_with_analysis  (provider: "gh", owner: "lbruton", repo: "StackTrackr")
+   mcp__codacy__codacy_get_repository_with_analysis  (provider: "gh", owner: "lbruton", repo: "StakTrakr")
    ```
 
 ### Step 4: Summarize all findings
@@ -215,7 +215,7 @@ Valid concern. <Brief acknowledgment>. Tracked as [STACK-XX](link) for a future 
 
 Reply using the GitHub API:
 ```bash
-gh api repos/lbruton/StackTrackr/pulls/PR_NUMBER/comments/COMMENT_ID/replies \
+gh api repos/lbruton/StakTrakr/pulls/PR_NUMBER/comments/COMMENT_ID/replies \
   -f body="REPLY_TEXT"
 ```
 
@@ -256,7 +256,7 @@ After all fixes are pushed, wait for CI to re-run, then verify:
 ```bash
 gh api graphql -f query='
 {
-  repository(owner: "lbruton", name: "StackTrackr") {
+  repository(owner: "lbruton", name: "StakTrakr") {
     pullRequest(number: PR_NUMBER) {
       reviewThreads(first: 50) {
         nodes {

--- a/.claude/skills/release/skill.md
+++ b/.claude/skills/release/skill.md
@@ -4,7 +4,7 @@ description: Release workflow — version bump, changelog, announcements, commit
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, mcp__linear-server__*
 ---
 
-# Release — StackTrackr
+# Release — StakTrakr
 
 End-to-end release workflow: bump version across all 7 files, commit to dev, and create a PR to main.
 
@@ -27,7 +27,7 @@ Before gathering release context, run the `/seed-sync` workflow to check for uns
 
 1. `git log --oneline main..dev` — list all commits on dev that aren't on main yet
 2. `git diff --stat main..dev` — summary of files changed
-3. Check Linear for any **In Progress** or recently **Done** issues on the StackTrackr team (ID: `f876864d-ff80-4231-ae6c-a8e5cb69aca4`) that relate to commits on dev
+3. Check Linear for any **In Progress** or recently **Done** issues on the StakTrakr team (ID: `f876864d-ff80-4231-ae6c-a8e5cb69aca4`) that relate to commits on dev
 
 ### Step 2: Read current state
 
@@ -154,7 +154,7 @@ Update the version and release date at the project root:
 {
   "version": "NEW_VERSION",
   "releaseDate": "YYYY-MM-DD",
-  "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
+  "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }
 ```
 
@@ -292,7 +292,7 @@ Release complete!
 Version:  vNEW_VERSION
 Commit:   [hash] [message]
 PR:       #XX — [url]
-Release:  https://github.com/lbruton/StackTrackr/releases/tag/vNEW_VERSION
+Release:  https://github.com/lbruton/StakTrakr/releases/tag/vNEW_VERSION
 Linear:   STACK-XX → Done (if applicable)
 
 Next: merge the PR on GitHub when ready (release tag already created).

--- a/.claude/skills/seed-sync/SKILL.md
+++ b/.claude/skills/seed-sync/SKILL.md
@@ -1,4 +1,4 @@
-# Seed Data Sync — StackTrackr
+# Seed Data Sync — StakTrakr
 
 Check the Docker spot-price poller output and stage any new seed data for commit. Can also fetch today's prices directly without Docker.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Most MCP tool rules are in auto-loading skills (`.claude/skills/`). Only safety-
 Persistent knowledge graph in Neo4j at `localhost:7687` (local Mac). Shared with HexTrackr.
 
 - **NEVER use `read_graph`** — graph exceeds 200K tokens, will fail. Use `search_nodes` or `semantic_search` instead.
-- **Always tag** entities with `TAG: project:stacktrackr` for project isolation.
+- **Always tag** entities with `TAG: project:staktrakr` for project isolation.
 - See `TAXONOMY.md` for the complete tagging taxonomy.
 
 ### Tool Rules (auto-loaded via skills)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 
 # StakTrakr
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8)](https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![MIT License](https://img.shields.io/github/license/lbruton/StakTrakr?style=flat-square)](https://github.com/lbruton/StakTrakr/blob/main/LICENSE)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8)](https://app.codacy.com/gh/lbruton/StakTrakr/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![GitHub Issues](https://img.shields.io/github/issues/lbruton/StakTrakr?style=flat-square)](https://github.com/lbruton/StakTrakr/issues)
+[![Reddit Community](https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&label=community)](https://www.reddit.com/r/staktrakr/)
+[![Sponsor](https://img.shields.io/badge/sponsor-%E2%99%A1-ea4aaa?style=flat-square)](https://github.com/sponsors/lbruton)
 [![Maintained by Claude Code](https://img.shields.io/badge/Maintained%20by-Claude%20Code-blueviolet)](https://claude.ai/code)
 
 **Track your precious metals stack. Your Way!**
@@ -192,4 +196,4 @@ docs/                   Architecture documentation
 
 MIT License. See [LICENSE](LICENSE) for details.
 
-Contributions via fork and pull request are welcome. Report issues at [GitHub Issues](https://github.com/lbruton/StackTrackr/issues).
+Contributions via fork and pull request are welcome. Report issues at [GitHub Issues](https://github.com/lbruton/StakTrakr/issues).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Issues](https://img.shields.io/github/issues/lbruton/StakTrakr?style=flat-square)](https://github.com/lbruton/StakTrakr/issues)
 [![Reddit Community](https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&label=community)](https://www.reddit.com/r/staktrakr/)
 [![Sponsor](https://img.shields.io/badge/sponsor-%E2%99%A1-ea4aaa?style=flat-square)](https://github.com/sponsors/lbruton)
-[![Maintained by Claude Code](https://img.shields.io/badge/Maintained%20by-Claude%20Code-blueviolet)](https://claude.ai/code)
+[![Maintained by Claude Code](https://img.shields.io/badge/Maintained%20by-Claude%20Code-blueviolet)](https://claude.com/claude-code)
 
 **Track your precious metals stack. Your Way!**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-
-
-
 # StakTrakr
-
+ 
 [![MIT License](https://img.shields.io/github/license/lbruton/StakTrakr?style=flat-square)](https://github.com/lbruton/StakTrakr/blob/main/LICENSE)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8)](https://app.codacy.com/gh/lbruton/StakTrakr/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![GitHub Issues](https://img.shields.io/github/issues/lbruton/StakTrakr?style=flat-square)](https://github.com/lbruton/StakTrakr/issues)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
+
+
+
 # StakTrakr
 
-**Track Your Stack. Your Way.**
-
-A powerful, privacy-first precious metals portfolio tracker for Silver, Gold, Platinum, Palladium, and Goldbacks. Runs entirely in your browser — no accounts, no cloud, no data collection. Your stack, your data, your rules.
-
-**Live site:** [www.staktrakr.com](https://www.staktrakr.com)
-
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8)](https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Maintained by Claude Code](https://img.shields.io/badge/Maintained%20by-Claude%20Code-blueviolet)](https://claude.ai/code)
+
+**Track your precious metals stack. Your Way!**
+
+A powerful, privacy-first precious metals portfolio tracker for Silver, Gold, Platinum, Palladium, and Goldbacks. Runs entirely in your browser — Your stack, your data, your rules.
+
+
+**Give it a try today at:** [www.staktrakr.com](https://www.staktrakr.com)
+
 
 ![StakTrakr Screenshot](ScreenshotStakTrakr.png)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Project direction and planned work. Each item links to its full Linear issue for details, discussion, and status tracking.
 
-**Linear board**: [StackTrackr](https://linear.app/hextrackr/team/STACK/backlog)
+**Linear board**: [StakTrakr](https://linear.app/hextrackr/team/STACK/backlog)
 
 ---
 

--- a/devops/spot-poller/poller.py
+++ b/devops/spot-poller/poller.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-StackTrackr Seed Data Poller
+StakTrakr Seed Data Poller
 =============================
 Long-running script (designed for Docker) that:
   1. On startup: backfills any gap since the last seed data entry
@@ -130,7 +130,7 @@ def log(msg):
 
 
 def main():
-    log("StackTrackr Seed Data Poller starting...")
+    log("StakTrakr Seed Data Poller starting...")
 
     api_key = seed.load_config()
     data_dir = seed.resolve_data_dir()

--- a/devops/spot-poller/update-seed-data.py
+++ b/devops/spot-poller/update-seed-data.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-StackTrackr Seed Data Updater
+StakTrakr Seed Data Updater
 =============================
 Backfills gaps in data/spot-history-{YEAR}.json using MetalPriceAPI's /timeframe endpoint.
 One-shot script — run manually, then commit when ready.
@@ -264,7 +264,7 @@ def merge_into_year_files(data_dir, new_entries, dry_run=False):
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Backfill StackTrackr seed price data from MetalPriceAPI."
+        description="Backfill StakTrakr seed price data from MetalPriceAPI."
     )
     parser.add_argument(
         "--dry-run",

--- a/index.html
+++ b/index.html
@@ -1316,9 +1316,9 @@
       <div class="footer-meta">
         <span>Thank you for using <span id="footerBrand">StakTrakr</span> <a id="versionBadge" class="version-badge" style="display: none"></a>. &copy; 2025-2026 <a id="footerDomain" href="https://staktrakr.com" target="_blank" rel="noopener">staktrakr.com</a>. Created with love on Apple Silicon.</span>
         <div class="footer-badges">
-          <a href="https://github.com/lbruton/StackTrackr" target="_blank" rel="noopener"><img src="https://img.shields.io/github/license/lbruton/StackTrackr?style=flat-square" alt="MIT License" height="20"></a>
-          <a href="https://app.codacy.com/gh/lbruton/StackTrackr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
-          <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StackTrackr?style=flat-square" alt="GitHub Issues" height="20"></a>
+          <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener"><img src="https://img.shields.io/github/license/lbruton/StakTrakr?style=flat-square" alt="MIT License" height="20"></a>
+          <a href="https://app.codacy.com/gh/lbruton/StakTrakr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
+          <a href="https://github.com/lbruton/StakTrakr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StakTrakr?style=flat-square" alt="GitHub Issues" height="20"></a>
           <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
           <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/sponsor-%E2%99%A1-ea4aaa?style=flat-square" alt="Sponsor" height="20"></a>
         </div>
@@ -1427,7 +1427,7 @@
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
                 <span id="aboutSiteDomain">staktrakr.com</span>
               </a>
-              <a href="https://github.com/lbruton/StackTrackr" target="_blank" rel="noopener" class="about-badge">
+              <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener" class="about-badge">
                 <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
                 Source
               </a>
@@ -1435,7 +1435,7 @@
                 <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
                 Community
               </a>
-              <a href="https://github.com/lbruton/StackTrackr/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="about-badge">
+              <a href="https://github.com/lbruton/StakTrakr/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="about-badge">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
                 MIT License
               </a>
@@ -1505,7 +1505,7 @@
               </a>
               <a
                 class="resource-btn"
-                href="https://github.com/lbruton/StackTrackr"
+                href="https://github.com/lbruton/StakTrakr"
                 target="_blank"
                 rel="noopener"
               >
@@ -1546,7 +1546,7 @@
               </a>
               <a
                 class="resource-btn"
-                href="https://github.com/lbruton/StackTrackr"
+                href="https://github.com/lbruton/StakTrakr"
                 target="_blank"
                 rel="noopener"
               >

--- a/js/about.js
+++ b/js/about.js
@@ -183,7 +183,7 @@ const loadAnnouncements = async () => {
 const showFullChangelog = () => {
   // Try to open changelog documentation
   window.open(
-    "https://github.com/lbruton/StackTrackr/blob/main/CHANGELOG.md",
+    "https://github.com/lbruton/StakTrakr/blob/main/CHANGELOG.md",
     "_blank",
     "noopener,noreferrer",
   );

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -124,7 +124,7 @@ const renderVersionBadge = (badge, remoteVersion, releaseUrl) => {
 };
 
 /** @constant {string} GITHUB_RELEASES_URL - Fallback link for static version badge */
-const GITHUB_RELEASES_URL = "https://github.com/lbruton/StackTrackr/releases/latest";
+const GITHUB_RELEASES_URL = "https://github.com/lbruton/StakTrakr/releases/latest";
 
 /**
  * Shows a static version badge linking to GitHub releases.

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<ruleset name="StackTrackr"
+<ruleset name="StakTrakr"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
-    <description>StackTrackr PMD ruleset — excludes false-positive rules for client-side JS</description>
+    <description>StakTrakr PMD ruleset — excludes false-positive rules for client-side JS</description>
 
     <!-- Include all ECMAScript error-prone rules with exclusions for false positives. -->
     <rule ref="category/ecmascript/errorprone.xml">

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "version": "3.29.02",
   "releaseDate": "2026-02-15",
-  "releaseUrl": "https://github.com/lbruton/StackTrackr/releases/latest"
+  "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- **Repo rename**: Updated all `lbruton/StackTrackr` GitHub URLs to `lbruton/StakTrakr` across 27 files — user-facing code, internal skills/commands, devops scripts, and project config
- **README badges**: Added MIT License, GitHub Issues, Reddit Community, and Sponsor badges to match the app footer
- **README content**: Revised README copy and added Codacy + Claude Code badges (from PR #141)
- CHANGELOG.md historical references intentionally preserved

## Test plan
- [ ] Verify Cloudflare Pages triggers a build from the new repo name
- [ ] Confirm all footer badge images render correctly on the live site
- [ ] Spot-check GitHub URLs in the About modal and What's New modal
- [ ] Verify README badges render on the GitHub repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)