### PR TITLE
v3.29.05 — Post-Release Hardening & Seed Cache Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.29.05] - 2026-02-15
+
+### Fixed — Post-Release Hardening & Seed Cache Fix
+
+- **Fixed**: Seed data cache staleness — service worker now uses stale-while-revalidate for spot-history files so Docker poller updates reach users between releases
+- **Fixed**: CoinFacts URL fallback for Raw/Authentic grades in View Modal cert badge (PR #161)
+- **Fixed**: Purchased chart range clamped to minimum 1 day to avoid All-range collision (PR #161)
+- **Fixed**: Verify promise unhandled rejection and window.open name sanitization (PR #161)
+- **Fixed**: Keyboard activation (Enter/Space) added to cert badge buttons for accessibility (PR #161)
+- **Fixed**: dailySpotEntries fallback on fetch failure, verify button visibility guard (PR #161)
+
+---
+
 ## [3.29.04] - 2026-02-15
 
 ### Added — STAK-110, STAK-111, STAK-113: View Modal Visual Sprint

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Post-Release Hardening & Seed Cache Fix (v3.29.05)**: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening
 - **View Modal Visual Sprint (v3.29.04)**: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)
 - **Price History Fixes & Chart Improvements (v3.29.03)**: Fixed Goldback items recording $0.00 retail in price history. Added per-item price history modal with inline delete and undo/redo. Fixed All-time chart on file:// protocol via seed bundle. Adaptive x-axis year labels. Custom date range picker on charts (STAK-108, STAK-109, STAK-103)
 - **PWA Crash Fix: Service Worker Error Handling (v3.29.02)**: Fixed installed PWA crash (ERR_FAILED) by adding error handling to all service worker fetch strategies. Navigation handler now falls back through cached index.html, cached root, and inline offline page
-- **Codacy Duplication Reduction (v3.29.01)**: Extracted shared toggle helpers, merged config table renderers, deduplicated item field builders and modal close handlers
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.29.05 &ndash; Post-Release Hardening &amp; Seed Cache Fix</strong>: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening</li>
     <li><strong>v3.29.04 &ndash; View Modal Visual Sprint</strong>: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)</li>
     <li><strong>v3.29.03 &ndash; Price History Fixes &amp; Chart Improvements</strong>: Fixed Goldback items recording $0.00 retail in price history. Added per-item price history modal with inline delete and undo/redo. Fixed All-time chart on file:// protocol via seed bundle. Adaptive x-axis year labels. Custom date range picker on charts (STAK-108, STAK-109, STAK-103)</li>
     <li><strong>v3.29.02 &ndash; PWA Crash Fix: Service Worker Error Handling</strong>: Fixed installed PWA crash (ERR_FAILED) by adding error handling to all service worker fetch strategies. Navigation handler now falls back through cached index.html, cached root, and inline offline page</li>
-    <li><strong>v3.29.01 &ndash; Codacy Duplication Reduction</strong>: Extracted shared toggle helpers, merged config table renderers, deduplicated item field builders and modal close handlers</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.29.04";
+const APP_VERSION = "3.29.05";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Enables offline support and installable PWA experience
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
-const CACHE_NAME = 'staktrakr-v3.29.04';
+const CACHE_NAME = 'staktrakr-v3.29.05';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +
@@ -149,6 +149,12 @@ self.addEventListener('fetch', (event) => {
           return offlineResponse();
         })
     );
+    return;
+  }
+
+  // Stale-while-revalidate for seed data (updated between releases by Docker poller)
+  if (url.origin === self.location.origin && url.pathname.startsWith('/data/spot-history')) {
+    event.respondWith(staleWhileRevalidate(event.request));
     return;
   }
 

--- a/sw.js
+++ b/sw.js
@@ -153,7 +153,7 @@ self.addEventListener('fetch', (event) => {
   }
 
   // Stale-while-revalidate for seed data (updated between releases by Docker poller)
-  if (url.origin === self.location.origin && url.pathname.startsWith('/data/spot-history')) {
+  if (url.origin === self.location.origin && url.pathname.includes('/data/spot-history')) {
     event.respondWith(staleWhileRevalidate(event.request));
     return;
   }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.29.04",
+  "version": "3.29.05",
   "releaseDate": "2026-02-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **SW seed cache fix**: Spot-history files now use stale-while-revalidate instead of cache-first, so Docker poller updates reach users between releases
- **PR #161 review fixes**: CoinFacts URL fallback for Raw/Authentic grades, Purchased range clamped to min 1 day, cert badge keyboard accessibility (Enter/Space), verify promise `.catch()`, window.open name sanitization, dailySpotEntries fetch failure fallback, verify button visibility guard
- **Codacy**: Blank lines before Markdown lists in skill files

## Files Updated

- `js/constants.js` — APP_VERSION → 3.29.05
- `sw.js` — CACHE_NAME → 3.29.05, added stale-while-revalidate route for seed data
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)