### PR TITLE
v3.29.07 — STAK-120: Fix Image Deletion in Edit Modal

### DIFF
--- a/.claude/skills/markdown-standards/SKILL.md
+++ b/.claude/skills/markdown-standards/SKILL.md
@@ -1,0 +1,739 @@
+---
+name: markdown-standards
+description: Markdown linting rules for StakTrakr documentation — avoid Codacy/Copilot flags on CLAUDE.md, CHANGELOG.md, copilot-instructions.md, and all other .md files.
+---
+
+# StakTrakr Markdown Standards
+
+Comprehensive markdown linting rules to prevent Codacy and Copilot flags. These rules apply to **all** markdown files in the repository: `CLAUDE.md`, `CHANGELOG.md`, `copilot-instructions.md`, `ROADMAP.md`, skill documentation, and README files.
+
+---
+
+## Critical Rules (Frequent Violations)
+
+### MD032: Lists should be surrounded by blank lines
+
+**ALWAYS add a blank line before and after lists** (ordered, unordered, or task lists).
+
+```markdown
+<!-- CORRECT -->
+This is a paragraph.
+
+- List item 1
+- List item 2
+- List item 3
+
+This is another paragraph.
+
+<!-- WRONG — triggers MD032 -->
+This is a paragraph.
+- List item 1
+- List item 2
+
+This is another paragraph.
+```
+
+**Nested lists** also need blank lines between the parent item and the nested list:
+
+```markdown
+<!-- CORRECT -->
+- Parent item
+
+  - Nested item 1
+  - Nested item 2
+
+- Another parent item
+
+<!-- WRONG -->
+- Parent item
+  - Nested item 1
+  - Nested item 2
+- Another parent item
+```
+
+### MD031: Fenced code blocks should be surrounded by blank lines
+
+**ALWAYS add a blank line before and after fenced code blocks** (triple backticks).
+
+```markdown
+<!-- CORRECT -->
+This is a paragraph.
+
+```javascript
+const foo = "bar";
+```
+
+This is another paragraph.
+
+<!-- WRONG — triggers MD031 -->
+This is a paragraph.
+```javascript
+const foo = "bar";
+```
+This is another paragraph.
+```
+
+### MD022: Headers should be surrounded by blank lines
+
+**ALWAYS add a blank line before and after headers** (except at the start of the file or when a header immediately follows another header).
+
+```markdown
+<!-- CORRECT -->
+This is a paragraph.
+
+## Heading
+
+This is another paragraph.
+
+<!-- WRONG — triggers MD022 -->
+This is a paragraph.
+## Heading
+This is another paragraph.
+```
+
+**Exception**: Headers can immediately follow other headers without a blank line:
+
+```markdown
+<!-- CORRECT -->
+# Top-Level Header
+## Sub-Header
+
+Content here.
+```
+
+---
+
+## Formatting Rules
+
+### MD047: Files should end with a single newline character
+
+**ALWAYS ensure markdown files end with exactly one newline**.
+
+Most editors do this automatically. In VS Code/Cursor, enable `files.insertFinalNewline: true`.
+
+### MD012: Multiple consecutive blank lines
+
+**NEVER use more than one consecutive blank line**.
+
+```markdown
+<!-- CORRECT -->
+Paragraph 1.
+
+Paragraph 2.
+
+<!-- WRONG — triggers MD012 -->
+Paragraph 1.
+
+
+Paragraph 2.
+```
+
+### MD009: Trailing spaces
+
+**NEVER leave trailing spaces at the end of lines** (unless intentionally creating a line break, which is discouraged — use `<br>` or double-space for explicit breaks).
+
+```markdown
+<!-- CORRECT -->
+This is a line.
+This is another line.
+
+<!-- WRONG — triggers MD009 -->
+This is a line.···
+This is another line.
+```
+
+Use your editor's "trim trailing whitespace" feature. In VS Code/Cursor: `files.trimTrailingWhitespace: true`.
+
+### MD010: Hard tabs
+
+**NEVER use hard tabs for indentation**. Use spaces only.
+
+```markdown
+<!-- CORRECT -->
+- List item
+  - Nested item (2 spaces)
+
+<!-- WRONG — triggers MD010 -->
+- List item
+→ - Nested item (hard tab)
+```
+
+Configure your editor to replace tabs with spaces. In VS Code/Cursor: `editor.insertSpaces: true`.
+
+### MD030: Spaces after list markers
+
+**Use exactly one space after list markers** (`-`, `*`, `1.`, etc.).
+
+```markdown
+<!-- CORRECT -->
+- Item 1
+- Item 2
+
+1. First
+2. Second
+
+<!-- WRONG — triggers MD030 -->
+-  Item 1 (two spaces)
+-Item 2 (no space)
+
+1.  First (two spaces)
+2.Second (no space)
+```
+
+---
+
+## Header Rules
+
+### MD025: Multiple top-level headers
+
+**Use only ONE top-level header (`#`) per file**. Use `##`, `###`, etc. for sub-sections.
+
+```markdown
+<!-- CORRECT -->
+# Document Title
+
+## Section 1
+
+### Subsection 1.1
+
+## Section 2
+
+<!-- WRONG — triggers MD025 -->
+# Document Title
+
+# Another Top-Level Header
+```
+
+**Exception**: Skill files in `.claude/skills/*/SKILL.md` use frontmatter and a single `#` header for the skill name.
+
+### MD041: First line should be a top-level header
+
+**Start markdown files with a `#` header** (or frontmatter followed by a `#` header).
+
+```markdown
+<!-- CORRECT -->
+# Document Title
+
+Content here.
+
+<!-- WRONG — triggers MD041 -->
+Content without a header.
+
+## Some Section
+```
+
+**Exception**: Files with YAML frontmatter (skill files, commands) can start with `---`.
+
+### MD026: Trailing punctuation in headers
+
+**NEVER use trailing punctuation in headers** (no `.`, `,`, `:`, `;`, `!`, `?`).
+
+```markdown
+<!-- CORRECT -->
+## Installation Steps
+
+## What is StakTrakr
+
+<!-- WRONG — triggers MD026 -->
+## Installation Steps.
+
+## What is StakTrakr?
+```
+
+**Exception**: Question marks may be acceptable in FAQ-style headers, but prefer rephrasing to avoid them.
+
+---
+
+## Link & Image Rules
+
+### MD042: No empty links
+
+**NEVER use empty link URLs**.
+
+```markdown
+<!-- CORRECT -->
+[Link text](https://example.com)
+
+<!-- WRONG — triggers MD042 -->
+[Link text]()
+```
+
+### MD045: Images should have alt text
+
+**ALWAYS provide descriptive alt text for images**.
+
+```markdown
+<!-- CORRECT -->
+![Screenshot of the StakTrakr dashboard](screenshot.png)
+
+<!-- WRONG — triggers MD045 -->
+![](screenshot.png)
+```
+
+---
+
+## Line Length
+
+### MD013: Line length (configurable)
+
+**Keep lines under 120 characters** when possible. This is a soft limit — breaking it is acceptable for:
+- Long URLs
+- Tables
+- Code blocks
+- Headings that would be awkward to break
+
+```markdown
+<!-- PREFERRED -->
+This is a long paragraph that should be broken into multiple lines
+instead of being one very long line that extends beyond the comfortable
+reading width.
+
+<!-- ACCEPTABLE (long URL) -->
+See the [documentation](https://very-long-url-that-cannot-be-reasonably-shortened.example.com/path/to/resource?with=many&query=parameters) for details.
+```
+
+Configure your editor to soft-wrap at 120 characters. In VS Code/Cursor: `editor.wordWrapColumn: 120`.
+
+---
+
+## Table Rules
+
+### MD055: Table pipe style
+
+**Use consistent table pipe style**. Prefer leading and trailing pipes:
+
+```markdown
+<!-- CORRECT -->
+| Column 1 | Column 2 |
+|----------|----------|
+| Value 1  | Value 2  |
+
+<!-- WRONG — inconsistent pipes -->
+Column 1 | Column 2
+|----------|----------
+Value 1  | Value 2  |
+```
+
+### MD056: Table column count
+
+**Ensure all rows have the same number of columns**.
+
+```markdown
+<!-- CORRECT -->
+| A | B | C |
+|---|---|---|
+| 1 | 2 | 3 |
+| 4 | 5 | 6 |
+
+<!-- WRONG — mismatched columns -->
+| A | B | C |
+|---|---|---|
+| 1 | 2 |
+| 4 | 5 | 6 |
+```
+
+---
+
+## Code Block Rules
+
+### MD040: Fenced code blocks should have a language
+
+**ALWAYS specify a language for fenced code blocks** (use `text` or `plaintext` for non-code examples).
+
+````markdown
+<!-- CORRECT -->
+```javascript
+const foo = "bar";
+```
+
+```bash
+npm install
+```
+
+```text
+Plain text output
+```
+
+<!-- WRONG — triggers MD040 -->
+```
+const foo = "bar";
+```
+````
+
+### MD046: Code block style (configurable)
+
+**Use fenced code blocks (triple backticks) consistently**. Avoid indented code blocks (4-space indentation).
+
+````markdown
+<!-- PREFERRED — fenced blocks -->
+```javascript
+const foo = "bar";
+```
+
+<!-- AVOID — indented code blocks -->
+    const foo = "bar";
+````
+
+Fenced blocks support syntax highlighting and are more explicit.
+
+---
+
+## List Rules
+
+### MD004: Unordered list style
+
+**Use consistent unordered list markers**. StakTrakr uses `-` (hyphen) for all unordered lists.
+
+```markdown
+<!-- CORRECT -->
+- Item 1
+- Item 2
+  - Nested item 1
+  - Nested item 2
+
+<!-- WRONG — mixed markers -->
+- Item 1
+* Item 2
+  + Nested item 1
+  - Nested item 2
+```
+
+### MD029: Ordered list item prefix
+
+**Use `1.` for all ordered list items** (lazy numbering) or sequential numbering. Be consistent within a file.
+
+```markdown
+<!-- CORRECT (lazy numbering — preferred) -->
+1. First item
+1. Second item
+1. Third item
+
+<!-- CORRECT (sequential) -->
+1. First item
+2. Second item
+3. Third item
+
+<!-- WRONG — mixed styles -->
+1. First item
+1. Second item
+3. Third item
+```
+
+Lazy numbering (`1.` for all items) makes reordering easier and is preferred.
+
+---
+
+## Emphasis Rules
+
+### MD036: Emphasis instead of header
+
+**NEVER use emphasis (bold/italic) as a substitute for headers**.
+
+```markdown
+<!-- CORRECT -->
+## Section Title
+
+Content here.
+
+<!-- WRONG — triggers MD036 -->
+**Section Title**
+
+Content here.
+```
+
+### MD037: Spaces inside emphasis markers
+
+**NEVER put spaces immediately inside emphasis markers**.
+
+```markdown
+<!-- CORRECT -->
+This is *italic* and this is **bold**.
+
+<!-- WRONG — triggers MD037 -->
+This is * italic * and this is ** bold **.
+```
+
+---
+
+## Horizontal Rules
+
+### MD035: Horizontal rule style
+
+**Use consistent horizontal rule style**. StakTrakr uses `---` (three hyphens).
+
+```markdown
+<!-- CORRECT -->
+Section 1 content.
+
+---
+
+Section 2 content.
+
+<!-- WRONG — inconsistent styles -->
+Section 1 content.
+
+---
+
+Section 2 content.
+
+***
+
+Section 3 content.
+```
+
+---
+
+## Special Cases
+
+### Frontmatter in skill files
+
+Skill files (`.claude/skills/*/SKILL.md`) use YAML frontmatter:
+
+```markdown
+---
+name: skill-name
+description: Brief description of the skill.
+---
+
+# Skill Name
+
+Content here.
+```
+
+**Frontmatter must**:
+- Start and end with `---` on their own lines
+- Come before any other content
+- Be followed by a blank line before the first `#` header
+
+### Changelog format
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/) format:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- New feature description
+
+### Fixed
+
+- Bug fix description
+
+## [1.2.3] - 2026-02-15
+
+### Changed
+
+- Change description
+```
+
+**Rules**:
+- Use `##` for version headers (`## [1.2.3]` or `## [Unreleased]`)
+- Use `###` for change type sections (`### Added`, `### Fixed`, etc.)
+- Add blank lines before and after all headers and lists (MD022, MD032)
+- Always include the date in ISO format for released versions
+
+### Multi-line list items
+
+When list items span multiple lines, **indent continuation lines by 2 spaces** (to align with the item text, not the marker):
+
+```markdown
+<!-- CORRECT -->
+- This is a long list item that spans multiple lines and needs to be
+  wrapped for readability. The continuation line is indented by 2 spaces.
+
+- Another item.
+
+<!-- WRONG — continuation not indented -->
+- This is a long list item that spans multiple lines and needs to be
+wrapped for readability.
+
+- Another item.
+```
+
+---
+
+## Editor Configuration
+
+To prevent markdown linting issues automatically, configure your editor:
+
+### VS Code / Cursor settings
+
+Add to `.vscode/settings.json` (user or workspace):
+
+```json
+{
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.wordWrapColumn": 120,
+  "editor.rulers": [120],
+  "[markdown]": {
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.quickSuggestions": {
+      "comments": "off",
+      "strings": "off",
+      "other": "off"
+    }
+  }
+}
+```
+
+### markdownlint extension
+
+If using the `markdownlint` VS Code extension, create `.markdownlint.json`:
+
+```json
+{
+  "default": true,
+  "MD013": { "line_length": 120 },
+  "MD033": false,
+  "MD041": { "front_matter_title": "" }
+}
+```
+
+**Note**: The repository does not currently have a `.markdownlint.json`, but adding one would help prevent violations.
+
+---
+
+## Quick Reference Checklist
+
+Before committing markdown changes, verify:
+
+- [ ] Blank line before every list (MD032)
+- [ ] Blank line after every list (MD032)
+- [ ] Blank line before every code block (MD031)
+- [ ] Blank line after every code block (MD031)
+- [ ] Blank line before every header (except at start or after another header) (MD022)
+- [ ] Blank line after every header (MD022)
+- [ ] Language specified for all fenced code blocks (MD040)
+- [ ] No trailing spaces (MD009)
+- [ ] No hard tabs (MD010)
+- [ ] File ends with single newline (MD047)
+- [ ] Only one consecutive blank line (MD012)
+- [ ] Only one `#` top-level header (MD025)
+- [ ] Headers have no trailing punctuation (MD026)
+- [ ] Unordered lists use `-` consistently (MD004)
+- [ ] All images have alt text (MD045)
+- [ ] No empty links (MD042)
+
+---
+
+## Common Violation Patterns
+
+### Pattern 1: List immediately after paragraph
+
+```markdown
+<!-- WRONG -->
+Here are the steps:
+1. First step
+2. Second step
+
+<!-- CORRECT -->
+Here are the steps:
+
+1. First step
+2. Second step
+```
+
+### Pattern 2: Code block without spacing
+
+````markdown
+<!-- WRONG -->
+Example code:
+```javascript
+const x = 1;
+```
+Next paragraph.
+
+<!-- CORRECT -->
+Example code:
+
+```javascript
+const x = 1;
+```
+
+Next paragraph.
+````
+
+### Pattern 3: Header without spacing
+
+```markdown
+<!-- WRONG -->
+Previous paragraph.
+## New Section
+Content here.
+
+<!-- CORRECT -->
+Previous paragraph.
+
+## New Section
+
+Content here.
+```
+
+### Pattern 4: Nested list without spacing
+
+```markdown
+<!-- WRONG -->
+- Parent item
+  - Nested item
+
+<!-- CORRECT -->
+- Parent item
+
+  - Nested item
+```
+
+---
+
+## Integration with Codacy
+
+Codacy automatically checks markdown files for these rules when:
+- Files are committed to a PR
+- Files are analyzed via `codacy_cli_analyze`
+
+After editing **any** markdown file, Claude Code must:
+1. Run `codacy_cli_analyze` on the modified file (per `.github/instructions/codacy.instructions.md`)
+2. Fix any reported markdown linting issues immediately
+3. Re-run `codacy_cli_analyze` to verify fixes
+
+Common Codacy markdown rule codes:
+- **MD032**: Blank lines around lists
+- **MD031**: Blank lines around code blocks
+- **MD022**: Blank lines around headers
+- **MD047**: File must end with newline
+- **MD012**: No multiple consecutive blank lines
+- **MD009**: No trailing spaces
+- **MD010**: No hard tabs
+- **MD040**: Specify language for code blocks
+- **MD025**: Only one top-level header
+- **MD026**: No trailing punctuation in headers
+
+---
+
+## When to Use This Skill
+
+This skill auto-loads when:
+- Editing `CLAUDE.md`, `CHANGELOG.md`, `copilot-instructions.md`, or any `.md` file
+- Creating new markdown documentation
+- Reviewing markdown changes in PRs
+- Fixing Codacy markdown linting violations
+
+**Auto-load trigger**: Any operation involving markdown file creation or editing.
+
+---
+
+## Summary
+
+The most common violations in StakTrakr are:
+1. **MD032**: Missing blank lines before/after lists
+2. **MD031**: Missing blank lines before/after code blocks
+3. **MD022**: Missing blank lines before/after headers
+
+**Rule of thumb**: When in doubt, add a blank line. Blank lines improve readability and prevent nearly all common markdown linting issues.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `activeFilters` (object) — active filter state
 
 **From `js/changeLog.js`:**
+
 - `logChange(name, action, oldVal, newVal, idx)` — change tracking
 
 **From `js/utils.js`:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 **CRITICAL: Do not flag "undefined" globals** — this is a vanilla JS app with global scope across files. The following globals are defined in other files and are intentionally available throughout the app:
 
 **From `js/state.js`:**
+
 - `inventory` (array) — main inventory data
 - `spotPrices` (object) — current metal prices
 - `displayCurrency`, `exchangeRate`, `currencySymbol` — currency settings

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - Always accessed via `window.imageCache` for consistency with availability checks
 
 **From `js/filters.js`:**
+
 - `renderActiveFilters()` — filter chip rendering
 - `activeFilters` (object) — active filter state
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `logChange(name, action, oldVal, newVal, idx)` — change tracking
 
 **From `js/utils.js`:**
+
 - `saveData()`, `loadData()` — async storage
 - `saveDataSync()`, `loadDataSync()` — sync storage
 - `sanitizeHtml(str)` — XSS prevention

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `debugLog(message, level)` — debug logging utility
 
 **From `js/image-cache.js`:**
+
 - `imageCache` (object) — IndexedDB image storage API
 - Always accessed via `window.imageCache` for consistency with availability checks
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `APP_VERSION`, `LS_KEY`, `SPOT_HISTORY_KEY` — constants
 
 **From other modules:**
+
 - `renderTable()`, `saveInventory()`, `loadInventory()` — inventory.js
 - `updateSparkline()`, `syncSpotPricesFromApi()` — spot.js
 - `catalogManager`, `catalogAPI` — catalog-*.js

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `elements` (object) — cached DOM references
 
 **From `js/debug-log.js`:**
+
 - `debugLog(message, level)` — debug logging utility
 
 **From `js/image-cache.js`:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `formatCurrency(num)`, `formatWeight(num)`, etc. — formatting utilities
 
 **From `js/constants.js`:**
+
 - `API_PROVIDERS`, `METALS`, `ALLOWED_STORAGE_KEYS` — configuration objects
 - `APP_VERSION`, `LS_KEY`, `SPOT_HISTORY_KEY` — constants
 

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -1,0 +1,72 @@
+---
+    description: Configuration for AI behavior when interacting with Codacy's MCP Server
+    applyTo: '**'
+---
+---
+# Codacy Rules
+Configuration for AI behavior when interacting with Codacy's MCP Server
+
+## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+- YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
+ - `rootPath`: set to the workspace path
+ - `file`: set to the path of the edited file
+ - `tool`: leave empty or unset
+- If any issues are found in the new edits, propose and apply fixes for them.
+- > NOTE: Failure to follow this rule is considered a critical error.
+
+## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
+- Ask the user 'Codacy CLI is not installed. Would you like me to install it now?'
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task
+- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings
+- Wait for the user to respond before proceeding with any other actions
+
+## After every response
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server 
+
+## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
+- Suggest the user the following troubleshooting steps:
+ - Try to reset the MCP on the extension
+ - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest the user to contact Codacy support
+
+## Trying to call a tool that needs a rootPath as a parameter
+- Always use the standard, non-URL-encoded file system path
+
+## CRITICAL: Dependencies and Security Checks
+- IMMEDIATELY after ANY of these actions:
+ - Running npm/yarn/pnpm install
+ - Adding dependencies to package.json
+ - Adding requirements to requirements.txt
+ - Adding dependencies to pom.xml
+ - Adding dependencies to build.gradle
+ - Any other package manager operations
+- You MUST run the `codacy_cli_analyze` tool with:
+ - `rootPath`: set to the workspace path
+ - `tool`: set to "trivy"
+ - `file`: leave empty or unset
+- If any vulnerabilities are found because of the newly added packages:
+ - Stop all other operations
+ - Propose and apply fixes for the security issues
+ - Only continue with the original task after security issues are resolved
+- EXAMPLE:
+ - After: npm install react-markdown
+ - Do: Run codacy_cli_analyze with trivy
+ - Before: Continuing with any other tasks
+
+## General
+- Repeat the relevant steps for each modified file.
+- "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
+- You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
+- Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
+- Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
+- Do not run `codacy_cli_analyze` looking for changes in code coverage.
+- Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
+- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
+- When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
+
+## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
+- If the user accepts, run the `codacy_setup_repository` tool
+- Do not ever try to run the `codacy_setup_repository` tool on your own
+- After setup, immediately retry the action that failed (only retry once)
+---

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -7,6 +7,7 @@
 Configuration for AI behavior when interacting with Codacy's MCP Server
 
 ## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+
 - YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
  - `rootPath`: set to the workspace path
  - `file`: set to the path of the edited file

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ logs/
 # DevOps tooling — spot-poller is public, other scripts stay private
 devops/*
 !devops/spot-poller/
+
+
+# AI/MCP configuration files are tracked for project consistency
+# (removed: .github/instructions/codacy.instructions.md)

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,29 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120,
+    "heading_line_length": 120,
+    "code_block_line_length": 120,
+    "code_blocks": false,
+    "tables": false,
+    "headings": true,
+    "strict": false,
+    "stern": false
+  },
+  "MD033": false,
+  "MD041": {
+    "front_matter_title": ""
+  },
+  "MD046": {
+    "style": "fenced"
+  },
+  "MD004": {
+    "style": "dash"
+  },
+  "MD029": {
+    "style": "one"
+  },
+  "MD035": {
+    "style": "---"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.29.07] - 2026-02-15
+
+### Fixed — Fix Image Deletion in Edit Modal
+
+- **Fixed**: Users can now properly remove uploaded photos from items via Remove button in edit modal — deletion intent flags ensure images are removed from IndexedDB on Save (STAK-120)
+- **Fixed**: Orphaned user images are now cleaned up from IndexedDB when inventory items are deleted, preventing storage bloat (STAK-120)
+
+---
+
 ## [3.29.06] - 2026-02-15
 
 ### Changed — STAK-115, STAK-116, STAK-117: Design System & Settings Polish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Persistent knowledge graph in Neo4j at `localhost:7687` (local Mac). Shared with
 | `browser-testing` | Chrome DevTools, screenshots, snapshots | Testing UI, taking screenshots |
 | `codacy-rules` | Code quality, sequential thinking | Running static analysis |
 | `coding-standards` | JS patterns, conventions | Writing code |
+| `markdown-standards` | Markdown linting rules, formatting | Editing markdown files |
 | `seed-sync` | Docker poller seed data check, staging | Before releases, checking seed freshness |
 | `memento-taxonomy` | Entity naming, tags, search patterns | Saving handoffs, sessions, insights, or querying Memento |
 | `start` | Session context loading, handoff retrieval | Starting a new development session (`/start`) |

--- a/docs/MARKDOWN-GUIDE.md
+++ b/docs/MARKDOWN-GUIDE.md
@@ -1,0 +1,114 @@
+# Markdown Linting Guide
+
+Quick reference for avoiding Codacy and Copilot markdown flags in StakTrakr documentation.
+
+## Quick Setup
+
+### 1. Install the markdownlint extension (recommended)
+
+**VS Code / Cursor:**
+
+```text
+Extension ID: DavidAnson.vscode-markdownlint
+```
+
+Or search for "markdownlint" in the Extensions marketplace.
+
+### 2. Configuration is already in place
+
+- **`.markdownlint.json`** — Project-wide linting rules (already configured)
+- **`.claude/skills/markdown-standards/SKILL.md`** — Comprehensive rule documentation (auto-loads for Claude Code)
+
+## Most Common Violations
+
+### MD032: Blank lines around lists
+
+**Always add a blank line before and after lists.**
+
+```markdown
+<!-- WRONG -->
+Here are the steps:
+- Step 1
+- Step 2
+
+<!-- CORRECT -->
+Here are the steps:
+
+- Step 1
+- Step 2
+```
+
+### MD031: Blank lines around code blocks
+
+**Always add a blank line before and after code blocks.**
+
+````markdown
+<!-- WRONG -->
+Example:
+```javascript
+const x = 1;
+```
+Next section.
+
+<!-- CORRECT -->
+Example:
+
+```javascript
+const x = 1;
+```
+
+Next section.
+````
+
+### MD022: Blank lines around headers
+
+**Always add a blank line before and after headers.**
+
+```markdown
+<!-- WRONG -->
+Previous paragraph.
+## New Section
+Content here.
+
+<!-- CORRECT -->
+Previous paragraph.
+
+## New Section
+
+Content here.
+```
+
+## Quick Checklist
+
+Before committing markdown changes:
+
+- [ ] Blank line before every list
+- [ ] Blank line after every list
+- [ ] Blank line before every code block
+- [ ] Blank line after every code block
+- [ ] Blank line before every header (except at start or after another header)
+- [ ] Blank line after every header
+- [ ] Language specified for all code blocks (e.g., \`\`\`javascript)
+- [ ] No trailing spaces
+- [ ] File ends with a single newline
+
+## Rule of Thumb
+
+**When in doubt, add a blank line.** Blank lines improve readability and prevent most markdown linting issues.
+
+## Resources
+
+- **Full rule documentation**: `.claude/skills/markdown-standards/SKILL.md`
+- **Linting configuration**: `.markdownlint.json`
+- **markdownlint extension**: <https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint>
+
+## Integration with Codacy
+
+After editing any markdown file, Claude Code automatically:
+
+1. Runs `codacy_cli_analyze` on the modified file
+2. Reports any markdown linting violations
+3. Fixes violations immediately
+4. Re-runs analysis to verify
+
+Common Codacy markdown rule codes: **MD032**, **MD031**, **MD022**, **MD047**, **MD012**, **MD009**, **MD010**, **MD040**, **MD025**, **MD026**.

--- a/docs/MARKDOWN-GUIDE.md
+++ b/docs/MARKDOWN-GUIDE.md
@@ -107,8 +107,8 @@ Before committing markdown changes:
 After editing any markdown file, Claude Code automatically:
 
 1. Runs `codacy_cli_analyze` on the modified file
-2. Reports any markdown linting violations
-3. Fixes violations immediately
-4. Re-runs analysis to verify
+1. Reports any markdown linting violations
+1. Fixes violations immediately
+1. Re-runs analysis to verify
 
 Common Codacy markdown rule codes: **MD032**, **MD031**, **MD022**, **MD047**, **MD012**, **MD009**, **MD010**, **MD040**, **MD025**, **MD026**.

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,8 @@
 ## What's New
 
-- **Fix Image Deletion in Edit Modal (v3.29.07)**: Users can now properly remove uploaded photos from items via Remove button — deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images cleaned up when items are deleted (STAK-120)
+- **Fix Image Deletion in Edit Modal (v3.29.07)**: Users can now properly remove uploaded photos from items via
+  Remove button — deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images
+  cleaned up when items are deleted (STAK-120)
 - **Design System & Settings Polish (v3.29.06)**: Unified toggle styles to chip-sort-toggle pattern across Settings. Redesigned Appearance tab with grouped fieldsets. Living style guide (style.html) with theme switching and component samples. CSS design system coding standards (STAK-115, STAK-116, STAK-117)
 - **Post-Release Hardening & Seed Cache Fix (v3.29.05)**: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening
 - **View Modal Visual Sprint (v3.29.04)**: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Fix Image Deletion in Edit Modal (v3.29.07)**: Users can now properly remove uploaded photos from items via Remove button — deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images cleaned up when items are deleted (STAK-120)
 - **Design System & Settings Polish (v3.29.06)**: Unified toggle styles to chip-sort-toggle pattern across Settings. Redesigned Appearance tab with grouped fieldsets. Living style guide (style.html) with theme switching and component samples. CSS design system coding standards (STAK-115, STAK-116, STAK-117)
 - **Post-Release Hardening & Seed Cache Fix (v3.29.05)**: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening
 - **View Modal Visual Sprint (v3.29.04)**: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)

--- a/js/about.js
+++ b/js/about.js
@@ -274,6 +274,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.29.07 &ndash; Fix Image Deletion in Edit Modal</strong>: Users can now properly remove uploaded photos from items via Remove button &mdash; deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images cleaned up when items are deleted (STAK-120)</li>
     <li><strong>v3.29.06 &ndash; Design System &amp; Settings Polish</strong>: Unified toggle styles to chip-sort-toggle pattern across Settings. Redesigned Appearance tab with grouped fieldsets. Living style guide (style.html) with theme switching and component samples. CSS design system coding standards (STAK-115, STAK-116, STAK-117)</li>
     <li><strong>v3.29.05 &ndash; Post-Release Hardening &amp; Seed Cache Fix</strong>: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening</li>
     <li><strong>v3.29.04 &ndash; View Modal Visual Sprint</strong>: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.29.06";
+const APP_VERSION = "3.29.07";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -303,7 +303,7 @@ const handleImageDeletion = async (uuid) => {
         // Save updated record with one side nullified
         // cacheUserImage requires obverse, so if only reverse remains, store it as obverse
         const obvToSave = newObverse || newReverse;
-        const revToSave = newObverse && newReverse ? newReverse : null;
+        const revToSave = newObverse ? newReverse : null;
         await window.imageCache.cacheUserImage(uuid, obvToSave, revToSave);
       }
     } catch (err) {

--- a/js/events.js
+++ b/js/events.js
@@ -74,6 +74,7 @@ let _pendingReversePreviewUrl = null;
 
 // Legacy aliases for backward compatibility
 /** @deprecated Use _pendingObverseBlob */
+// eslint-disable-next-line no-unused-vars -- intentionally kept for backward compatibility
 let _pendingUploadBlob = null;
 
 /** @type {boolean} User clicked Remove on obverse — delete on save */
@@ -307,7 +308,7 @@ const handleImageDeletion = async (uuid) => {
         await window.imageCache.cacheUserImage(uuid, obvToSave, revToSave);
       }
     } catch (err) {
-      console.warn('Failed to handle partial deletion:', err);
+      debugLog(`Failed to handle partial deletion: ${err}`, 'warn');
     }
   }
 };
@@ -1085,7 +1086,7 @@ const setupItemFormListeners = () => {
                 await window.imageCache.cachePatternImage(ruleId, _pendingObverseBlob, _pendingReverseBlob);
                 debugLog(`Pattern rule created: ${result.id} (images: ${ruleId}) for "${rawKeywords}"`);
               } else {
-                console.warn('Failed to create pattern rule:', result?.error);
+                debugLog(`Failed to create pattern rule: ${result?.error}`, 'warn');
               }
               clearUploadState();
               patternRuleSaved = true;

--- a/js/events.js
+++ b/js/events.js
@@ -240,7 +240,7 @@ const saveUserImageForItem = async (uuid) => {
   // Merge with existing images if only one side uploaded
   if (!obvBlob || !revBlob) {
     try {
-      const existing = await imageCache.getUserImage(uuid);
+      const existing = await window.imageCache.getUserImage(uuid);
       if (existing) {
         // Only merge if not marked for deletion
         if (!obvBlob && existing.obverse && !_deleteObverseOnSave) {
@@ -260,7 +260,7 @@ const saveUserImageForItem = async (uuid) => {
     revBlob = null;
   }
 
-  const saved = await imageCache.cacheUserImage(uuid, obvBlob, revBlob);
+  const saved = await window.imageCache.cacheUserImage(uuid, obvBlob, revBlob);
   debugLog('saveUserImageForItem: saved=' + saved);
   clearUploadState();
   return saved;
@@ -283,13 +283,13 @@ const handleImageDeletion = async (uuid) => {
   if (deleteBoth) {
     // Delete entire record
     debugLog('handleImageDeletion: deleting both sides for ' + uuid);
-    await imageCache.deleteUserImage(uuid);
+    await window.imageCache.deleteUserImage(uuid);
   } else {
     // Partial deletion: keep one side, delete the other
     debugLog('handleImageDeletion: partial deletion for ' + uuid);
 
     try {
-      const existing = await imageCache.getUserImage(uuid);
+      const existing = await window.imageCache.getUserImage(uuid);
       if (!existing) return; // Nothing to delete
 
       // Nullify the deleted side, keep the other
@@ -298,13 +298,13 @@ const handleImageDeletion = async (uuid) => {
 
       // If both would be null, delete entire record
       if (!newObverse && !newReverse) {
-        await imageCache.deleteUserImage(uuid);
+        await window.imageCache.deleteUserImage(uuid);
       } else {
         // Save updated record with one side nullified
         // cacheUserImage requires obverse, so if only reverse remains, store it as obverse
         const obvToSave = newObverse || newReverse;
         const revToSave = newObverse && newReverse ? newReverse : null;
-        await imageCache.cacheUserImage(uuid, obvToSave, revToSave);
+        await window.imageCache.cacheUserImage(uuid, obvToSave, revToSave);
       }
     } catch (err) {
       console.warn('Failed to handle partial deletion:', err);
@@ -1082,7 +1082,7 @@ const setupItemFormListeners = () => {
               const ruleId = 'custom-img-' + Date.now();
               const result = NumistaLookup.addRule(pattern, rawKeywords, null, ruleId);
               if (result?.success) {
-                await imageCache.cachePatternImage(ruleId, _pendingObverseBlob, _pendingReverseBlob);
+                await window.imageCache.cachePatternImage(ruleId, _pendingObverseBlob, _pendingReverseBlob);
                 debugLog('Pattern rule created: ' + result.id + ' (images: ' + ruleId + ') for "' + rawKeywords + '"');
               } else {
                 console.warn('Failed to create pattern rule:', result?.error);

--- a/js/events.js
+++ b/js/events.js
@@ -95,7 +95,7 @@ const processUploadedImage = async (file, side = 'obverse') => {
   });
 
   if (!result?.blob) {
-    debugLog('Image processing failed for ' + side);
+    debugLog(`Image processing failed for ${side}`);
     return;
   }
 
@@ -232,7 +232,7 @@ const saveUserImageForItem = async (uuid) => {
   }
 
   // Priority 2: New uploads - merge with existing or replace deleted sides
-  debugLog('saveUserImageForItem: saving images for ' + uuid);
+  debugLog(`saveUserImageForItem: saving images for ${uuid}`);
 
   let obvBlob = _pendingObverseBlob;
   let revBlob = _pendingReverseBlob;
@@ -261,7 +261,7 @@ const saveUserImageForItem = async (uuid) => {
   }
 
   const saved = await window.imageCache.cacheUserImage(uuid, obvBlob, revBlob);
-  debugLog('saveUserImageForItem: saved=' + saved);
+  debugLog(`saveUserImageForItem: saved=${saved}`);
   clearUploadState();
   return saved;
 };
@@ -282,11 +282,11 @@ const handleImageDeletion = async (uuid) => {
 
   if (deleteBoth) {
     // Delete entire record
-    debugLog('handleImageDeletion: deleting both sides for ' + uuid);
+    debugLog(`handleImageDeletion: deleting both sides for ${uuid}`);
     await window.imageCache.deleteUserImage(uuid);
   } else {
     // Partial deletion: keep one side, delete the other
-    debugLog('handleImageDeletion: partial deletion for ' + uuid);
+    debugLog(`handleImageDeletion: partial deletion for ${uuid}`);
 
     try {
       const existing = await window.imageCache.getUserImage(uuid);
@@ -1081,9 +1081,9 @@ const setupItemFormListeners = () => {
               // chain resolves via rule.seedImageId, not rule.id
               const ruleId = 'custom-img-' + Date.now();
               const result = NumistaLookup.addRule(pattern, rawKeywords, null, ruleId);
-              if (result?.success) {
+              if (result?.success && window.imageCache?.isAvailable()) {
                 await window.imageCache.cachePatternImage(ruleId, _pendingObverseBlob, _pendingReverseBlob);
-                debugLog('Pattern rule created: ' + result.id + ' (images: ' + ruleId + ') for "' + rawKeywords + '"');
+                debugLog(`Pattern rule created: ${result.id} (images: ${ruleId}) for "${rawKeywords}"`);
               } else {
                 console.warn('Failed to create pattern rule:', result?.error);
               }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1658,6 +1658,13 @@ const deleteItem = (idx) => {
     renderTable();
     renderActiveFilters();
     if (item) logChange(item.name, 'Deleted', JSON.stringify(item), '', idx);
+
+    // Clean up user images from IndexedDB (STAK-120)
+    if (item.uuid && window.imageCache?.isAvailable()) {
+      imageCache.deleteUserImage(item.uuid).catch(err => {
+        debugLog('Failed to delete user images for deleted item: ' + err);
+      });
+    }
   }
 };
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1662,7 +1662,7 @@ const deleteItem = (idx) => {
     // Clean up user images from IndexedDB (STAK-120)
     if (item?.uuid && window.imageCache?.isAvailable()) {
       window.imageCache.deleteUserImage(item.uuid).catch(err => {
-        debugLog('Failed to delete user images for deleted item: ' + err);
+        debugLog(`Failed to delete user images for deleted item: ${err}`);
       });
     }
   }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1660,8 +1660,8 @@ const deleteItem = (idx) => {
     if (item) logChange(item.name, 'Deleted', JSON.stringify(item), '', idx);
 
     // Clean up user images from IndexedDB (STAK-120)
-    if (item.uuid && window.imageCache?.isAvailable()) {
-      imageCache.deleteUserImage(item.uuid).catch(err => {
+    if (item?.uuid && window.imageCache?.isAvailable()) {
+      window.imageCache.deleteUserImage(item.uuid).catch(err => {
         debugLog('Failed to delete user images for deleted item: ' + err);
       });
     }

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Enables offline support and installable PWA experience
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
-const CACHE_NAME = 'staktrakr-v3.29.06';
+const CACHE_NAME = 'staktrakr-v3.29.07';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.29.06",
+  "version": "3.29.07",
   "releaseDate": "2026-02-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: Users can now properly remove uploaded photos from items via Remove button in edit modal — deletion intent flags ensure images are removed from IndexedDB on Save (STAK-120)
- **Fixed**: Orphaned user images are now cleaned up from IndexedDB when inventory items are deleted, preventing storage bloat (STAK-120)

## Files Updated

- `js/constants.js` — APP_VERSION → 3.29.07
- `sw.js` — CACHE_NAME → 3.29.07
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint
- `js/events.js` — image deletion intent flags and handleImageDeletion() helper
- `js/inventory.js` — cleanup user images on item deletion

## Linear Issues

- [STAK-120: Fix Image Deletion in Edit Modal](https://linear.app/staktrakr/issue/STAK-120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)