### PR TITLE
v3.29.08 — Fix What's New Modal Showing Stale Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.29.08] - 2026-02-15
+
+### Fixed — Fix What's New Modal Showing Stale Version
+
+- **Fixed**: What's New modal no longer shows stale version content after deployments — version check now uses `APP_VERSION` directly instead of potentially stale localStorage value
+- **Fixed**: Service worker local asset strategy changed from cache-first to stale-while-revalidate so deployment updates propagate on next page load
+
+---
+
 ## [3.29.07] - 2026-02-15
 
 ### Fixed — Fix Image Deletion in Edit Modal

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,12 +1,10 @@
 ## What's New
 
-- **Fix Image Deletion in Edit Modal (v3.29.07)**: Users can now properly remove uploaded photos from items via
-  Remove button — deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images
-  cleaned up when items are deleted (STAK-120)
+- **Fix What's New Modal Showing Stale Version (v3.29.08)**: Version check uses APP_VERSION directly instead of potentially stale localStorage value. Service worker local assets switched to stale-while-revalidate so deployment updates propagate on next load
+- **Fix Image Deletion in Edit Modal (v3.29.07)**: Users can now properly remove uploaded photos from items via Remove button — deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images cleaned up when items are deleted (STAK-120)
 - **Design System & Settings Polish (v3.29.06)**: Unified toggle styles to chip-sort-toggle pattern across Settings. Redesigned Appearance tab with grouped fieldsets. Living style guide (style.html) with theme switching and component samples. CSS design system coding standards (STAK-115, STAK-116, STAK-117)
 - **Post-Release Hardening & Seed Cache Fix (v3.29.05)**: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening
 - **View Modal Visual Sprint (v3.29.04)**: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)
-- **Price History Fixes & Chart Improvements (v3.29.03)**: Fixed Goldback items recording $0.00 retail in price history. Added per-item price history modal with inline delete and undo/redo. Fixed All-time chart on file:// protocol via seed bundle. Adaptive x-axis year labels. Custom date range picker on charts (STAK-108, STAK-109, STAK-103)
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -274,11 +274,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.29.08 &ndash; Fix What&apos;s New Modal Showing Stale Version</strong>: Version check uses APP_VERSION directly instead of potentially stale localStorage value. Service worker local assets switched to stale-while-revalidate so deployment updates propagate on next load</li>
     <li><strong>v3.29.07 &ndash; Fix Image Deletion in Edit Modal</strong>: Users can now properly remove uploaded photos from items via Remove button &mdash; deletion intent flags ensure images are removed from IndexedDB on Save. Orphaned images cleaned up when items are deleted (STAK-120)</li>
     <li><strong>v3.29.06 &ndash; Design System &amp; Settings Polish</strong>: Unified toggle styles to chip-sort-toggle pattern across Settings. Redesigned Appearance tab with grouped fieldsets. Living style guide (style.html) with theme switching and component samples. CSS design system coding standards (STAK-115, STAK-116, STAK-117)</li>
     <li><strong>v3.29.05 &ndash; Post-Release Hardening &amp; Seed Cache Fix</strong>: Service worker uses stale-while-revalidate for seed data so Docker poller updates reach users between releases. CoinFacts URL fallback for Raw/Authentic grades. Purchased chart range clamped to min 1 day. Cert badge keyboard accessibility. Verify promise and window.open hardening</li>
     <li><strong>v3.29.04 &ndash; View Modal Visual Sprint</strong>: Certification badge overlay on images with authority-specific colors and clickable grade/verify. Chart range pills (1Y, 5Y, 10Y, Purchased). Valuation-first default section order. Purchase date in valuation section (STAK-110, STAK-111, STAK-113)</li>
-    <li><strong>v3.29.03 &ndash; Price History Fixes &amp; Chart Improvements</strong>: Fixed Goldback items recording $0.00 retail in price history. Added per-item price history modal with inline delete and undo/redo. Fixed All-time chart on file:// protocol via seed bundle. Adaptive x-axis year labels. Custom date range picker on charts (STAK-108, STAK-109, STAK-103)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -254,7 +254,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.29.07";
+const APP_VERSION = "3.29.08";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -16,7 +16,7 @@ const checkVersionChange = () => {
   }
 
   const acknowledged = localStorage.getItem(VERSION_ACK_KEY);
-  const current = localStorage.getItem(APP_VERSION_KEY) || APP_VERSION;
+  const current = APP_VERSION;
   if (typeof window !== 'undefined' && typeof window.debugLog === "function") {
     window.debugLog(`versionCheck: ack=${acknowledged}, current=${current}, APP_VERSION=${APP_VERSION}`);
   }

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Enables offline support and installable PWA experience
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
-const CACHE_NAME = 'staktrakr-v3.29.07';
+const CACHE_NAME = 'staktrakr-v3.29.08';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +
@@ -158,9 +158,9 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Cache-first for local assets
+  // Stale-while-revalidate for local assets (ensures updates propagate)
   if (url.origin === self.location.origin) {
-    event.respondWith(cacheFirst(event.request));
+    event.respondWith(staleWhileRevalidate(event.request));
     return;
   }
 });

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.29.07",
+  "version": "3.29.08",
   "releaseDate": "2026-02-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: What's New modal no longer shows stale version content after deployments — version check now uses `APP_VERSION` directly instead of potentially stale localStorage value
- **Fixed**: Service worker local asset strategy changed from cache-first to stale-while-revalidate so deployment updates propagate on next page load

## Files Updated

- `js/versionCheck.js` — use `APP_VERSION` directly instead of localStorage read
- `sw.js` — local assets: cache-first → stale-while-revalidate; CACHE_NAME → 3.29.08
- `js/constants.js` — APP_VERSION → 3.29.08
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)