### PR TITLE
feat: GitHub Actions spot poller + hourly price collection

### DIFF
--- a/.github/workflows/merge-seed-data.yml
+++ b/.github/workflows/merge-seed-data.yml
@@ -1,0 +1,41 @@
+# Nightly merge of seed/hourly data from `data` branch into `dev`
+name: Merge Seed Data
+
+on:
+  schedule:
+    # 5:00 AM UTC = midnight EST — merge after the day's data is complete
+    - cron: '0 5 * * *'
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0 # Full history needed for merge
+
+      - name: Merge data branch into dev
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin data
+          if git merge origin/data --no-edit; then
+            git push
+            echo "Merged data → dev successfully."
+          else
+            echo "::error::Merge conflict merging data → dev. Resolve manually."
+            git merge --abort
+            exit 1
+          fi
+
+      - name: Sync dev scripts back to data branch
+        run: |
+          git checkout data
+          git merge origin/dev --no-edit -m "sync: dev scripts → data" || true
+          git push || true

--- a/.github/workflows/spot-poller.yml
+++ b/.github/workflows/spot-poller.yml
@@ -1,0 +1,53 @@
+# Hourly spot price poller — writes to the `data` branch
+# Requires repository secret: METAL_PRICE_API_KEY
+name: Spot Price Poller
+
+on:
+  schedule:
+    # Every hour at :05 (avoid the :00 rush on GitHub Actions)
+    - cron: '5 * * * *'
+  workflow_dispatch: # Manual trigger for testing
+
+env:
+  TZ: America/New_York
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout data branch
+        uses: actions/checkout@v4
+        with:
+          ref: data
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r devops/spot-poller/requirements.txt
+
+      - name: Run poller (single shot)
+        env:
+          METAL_PRICE_API_KEY: ${{ secrets.METAL_PRICE_API_KEY }}
+          DATA_DIR: ${{ github.workspace }}/data
+        run: python devops/spot-poller/poller.py --once
+
+      - name: Commit and push data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/
+          if git diff --cached --quiet; then
+            echo "No new data to commit."
+          else
+            HOUR=$(date +%H)
+            DATE=$(date +%Y-%m-%d)
+            git commit -m "spot: ${DATE} hour ${HOUR} price data"
+            git push
+          fi

--- a/data/hourly/2026/02/16/18.json
+++ b/data/hourly/2026/02/16/18.json
@@ -1,0 +1,30 @@
+[
+  {
+    "spot": 4993.49,
+    "metal": "Gold",
+    "source": "hourly",
+    "provider": "MetalPriceAPI",
+    "timestamp": "2026-02-16 12:00:00"
+  },
+  {
+    "spot": 76.6,
+    "metal": "Silver",
+    "source": "hourly",
+    "provider": "MetalPriceAPI",
+    "timestamp": "2026-02-16 12:00:00"
+  },
+  {
+    "spot": 2028.58,
+    "metal": "Platinum",
+    "source": "hourly",
+    "provider": "MetalPriceAPI",
+    "timestamp": "2026-02-16 12:00:00"
+  },
+  {
+    "spot": 1725.35,
+    "metal": "Palladium",
+    "source": "hourly",
+    "provider": "MetalPriceAPI",
+    "timestamp": "2026-02-16 12:00:00"
+  }
+]


### PR DESCRIPTION
## Summary

- **Hourly price collection**: poller now writes every poll to `data/hourly/YYYY/MM/DD/HH.json` sharded folder tree for future REST API
- **Noon seed logic**: daily seed file (`spot-history-YYYY.json`) now captures the 12:00 PM EST price instead of the first available price
- **GitHub Actions workflows**: replaces Docker-based polling with two Actions:
  - `spot-poller.yml` — hourly cron fetches prices, commits to `data` branch
  - `merge-seed-data.yml` — nightly merge from `data` → `dev`
- **`--once` flag** on `poller.py` for single-shot execution in CI

## Files changed (this feature)

| File | Change |
|------|--------|
| `devops/spot-poller/poller.py` | `write_hourly()`, noon seed logic, `--once` flag |
| `devops/spot-poller/update-seed-data.py` | `save_hourly_file()`, `overwrite` param on merge |
| `.github/workflows/spot-poller.yml` | Hourly cron → poll → commit to `data` branch |
| `.github/workflows/merge-seed-data.yml` | Nightly merge `data` → `dev` + script sync |
| `data/hourly/2026/02/16/18.json` | First hourly data file |

## Test plan

- [ ] Verify Actions appear under repo Actions tab after merge
- [ ] Manual trigger "Spot Price Poller" workflow — confirm hourly file created on `data` branch
- [ ] Confirm daily seed only writes at noon+ (check logs for "noon+ window" message)
- [ ] Confirm nightly merge workflow merges `data` → `dev` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)