### PR TITLE
v3.30.03 — STAK-130: PumpkinCrouton Patch — Purity Input & Save Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.30.03] - 2026-02-17
+
+### Fixed — STAK-130: PumpkinCrouton Patch — Purity Input & Save Fix
+
+- **Fixed**: Purity dropdown now includes .9995 (standard pure platinum) as a preset option (STAK-130)
+- **Fixed**: Custom purity input accepts 4 decimal places instead of 3 (STAK-130)
+- **Fixed**: Hidden custom purity input no longer blocks form submission — resolves save corruption where no items could be edited after entering an invalid custom purity value (STAK-130)
+- **Fixed**: Duplicate item preserves original purchase date instead of defaulting to today (STAK-130)
+
+Thanks to u/PumpkinCrouton for finding and reporting this bug.
+
+---
+
 ## [3.30.02] - 2026-02-16
 
 ### Fixed — Keyless Provider Fixes & Hourly History Pull

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **PumpkinCrouton Patch — Purity Input & Save Fix (v3.30.03)**: Added .9995 (pure platinum) to purity dropdown. Custom purity accepts 4 decimal places. Fixed save corruption where hidden custom purity input blocked all form submissions. Duplicate items now preserve original purchase date. Thanks to u/PumpkinCrouton for the report (STAK-130)
 - **Keyless Provider Fixes & Hourly History Pull (v3.30.02)**: Fixed keyless providers (STAKTRAKR) enabling sync buttons, connected status, and auto-select. STAKTRAKR usage counter with 5000 default quota. Hourly history pull for STAKTRAKR (1–30 days) and MetalPriceAPI (up to 7 days). History log distinguishes hourly entries. One-time migration for existing users
 - **StakTrakr Free API Provider & UTC Poller Fix (v3.30.01)**: Free, keyless StakTrakr API provider at rank 1 fetching hourly spot prices. Provider panel with "Free" badge and best-effort disclaimer. 1st–5th priority labels across all providers. Poller switched to UTC for timezone-neutral paths. Auto-sync works without any API keys
 - **Card View Engine, Mobile Overhaul & UI Polish (v3.30.00)**: Three card view styles (Sparkline Header, Full-Bleed, Split Card) with header button cycling. CDN image URLs with dedicated table image column and card thumbnails. Mobile viewport overhaul with responsive breakpoints. Rows-per-page options with floating back-to-top button. Theme-aware sparkline colors. CSV/JSON/ZIP export includes image URLs (STAK-118, STAK-106, STAK-124, STAK-125, STAK-126)
-- **Fix What's New Modal Showing Stale Version (v3.29.08)**: Version check uses APP_VERSION directly instead of potentially stale localStorage value. Service worker local assets switched to stale-while-revalidate so deployment updates propagate on next load
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -910,6 +910,7 @@
                 <select id="itemPuritySelect">
                   <option value="1.0">100% — Pure</option>
                   <option value="0.9999">.9999 — Four Nines</option>
+                  <option value="0.9995">.9995 — Pure Platinum</option>
                   <option value="0.999">.999 — Fine</option>
                   <option value="0.925">.925 — Sterling</option>
                   <option value="0.900">.900 — 90% Silver</option>
@@ -950,7 +951,7 @@
             <div id="purityCustomWrapper" class="grid grid-2" style="display:none;">
               <div>
                 <label for="itemPurity">Custom Purity</label>
-                <input id="itemPurity" type="number" min="0.001" max="1" step="0.001" placeholder="e.g. 0.925" />
+                <input id="itemPurity" type="number" min="0.001" max="1" step="0.0001" placeholder="e.g. 0.9995" />
               </div>
             </div>
             <!-- Row: Name & Year (Name wider) -->

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.30.03 &ndash; PumpkinCrouton Patch &mdash; Purity Input &amp; Save Fix</strong>: Added .9995 (pure platinum) to purity dropdown. Custom purity accepts 4 decimal places. Fixed save corruption where hidden custom purity input blocked all form submissions. Duplicate items now preserve original purchase date. Thanks to u/PumpkinCrouton for the report (STAK-130)</li>
     <li><strong>v3.30.02 &ndash; Keyless Provider Fixes &amp; Hourly History Pull</strong>: Fixed keyless providers (STAKTRAKR) enabling sync buttons, connected status, and auto-select. STAKTRAKR usage counter with 5000 default quota. Hourly history pull for STAKTRAKR (1&ndash;30 days) and MetalPriceAPI (up to 7 days). History log distinguishes hourly entries. One-time migration for existing users</li>
     <li><strong>v3.30.01 &ndash; StakTrakr Free API Provider &amp; UTC Poller Fix</strong>: Free, keyless StakTrakr API provider at rank 1 fetching hourly spot prices. Provider panel with &ldquo;Free&rdquo; badge and best-effort disclaimer. 1st&ndash;5th priority labels across all providers. Poller switched to UTC for timezone-neutral paths. Auto-sync works without any API keys</li>
     <li><strong>v3.30.00 &ndash; Card View Engine, Mobile Overhaul &amp; UI Polish</strong>: Three card view styles (Sparkline Header, Full-Bleed, Split Card) with header button cycling. CDN image URLs with dedicated table image column and card thumbnails. Mobile viewport overhaul with responsive breakpoints. Rows-per-page options with floating back-to-top button. Theme-aware sparkline colors. CSV/JSON/ZIP export includes image URLs (STAK-118, STAK-106, STAK-124, STAK-125, STAK-126)</li>
-    <li><strong>v3.29.08 &ndash; Fix What&apos;s New Modal Showing Stale Version</strong>: Version check uses APP_VERSION directly instead of potentially stale localStorage value. Service worker local assets switched to stale-while-revalidate so deployment updates propagate on next load</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -282,7 +282,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.30.02";
+const APP_VERSION = "3.30.03";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -2049,6 +2049,7 @@ const setupSearch = () => {
           // Reset purity to default (form.reset already sets select to first option)
           const purityCustom = elements.purityCustomWrapper;
           if (purityCustom) purityCustom.style.display = 'none';
+          if (elements.itemPurity) elements.itemPurity.value = '';
           // Reset gb denomination picker (STACK-45)
           if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
           // Hide PCGS verified icon in add mode

--- a/js/init.js
+++ b/js/init.js
@@ -564,9 +564,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (elements.itemPuritySelect) {
           elements.itemPuritySelect.addEventListener('change', () => {
             const wrapper = elements.purityCustomWrapper || document.getElementById('purityCustomWrapper');
-            if (wrapper) {
-              wrapper.style.display = elements.itemPuritySelect.value === 'custom' ? '' : 'none';
-            }
+            const input = elements.itemPurity || document.getElementById('itemPurity');
+            const isCustom = elements.itemPuritySelect.value === 'custom';
+            if (wrapper) wrapper.style.display = isCustom ? '' : 'none';
+            if (input && !isCustom) input.value = '';
           });
         }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1922,7 +1922,7 @@ const editItem = (idx, logIdx = null) => {
 
 /**
  * Duplicates an inventory item by opening the add modal pre-filled with
- * the source item's fields. Date defaults to today, qty resets to 1.
+ * the source item's fields. Date preserves the original purchase date, qty resets to 1.
  *
  * @param {number} idx - Index of item to duplicate
  */

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1856,6 +1856,7 @@ const editItem = (idx, logIdx = null) => {
     if (presetOption) {
       puritySelect.value = presetOption.value;
       if (purityCustom) purityCustom.style.display = 'none';
+      if (purityInput) purityInput.value = '';
     } else {
       puritySelect.value = 'custom';
       if (purityCustom) purityCustom.style.display = '';
@@ -1971,7 +1972,7 @@ const duplicateItem = (idx) => {
   elements.storageLocation.value = item.storageLocation && item.storageLocation !== 'Unknown' ? item.storageLocation : '';
   if (elements.itemSerialNumber) elements.itemSerialNumber.value = item.serialNumber || '';
   if (elements.itemNotes) elements.itemNotes.value = item.notes || '';
-  elements.itemDate.value = todayStr(); // Default to today
+  elements.itemDate.value = item.date || todayStr();
   if (elements.itemCatalog) elements.itemCatalog.value = item.numistaId || '';
   if (elements.itemYear) elements.itemYear.value = item.year || item.issuedYear || '';
   if (elements.itemGrade) elements.itemGrade.value = item.grade || '';
@@ -1990,6 +1991,7 @@ const duplicateItem = (idx) => {
     if (presetOpt) {
       dupPuritySelect.value = presetOpt.value;
       if (dupPurityCustom) dupPurityCustom.style.display = 'none';
+      if (dupPurityInput) dupPurityInput.value = '';
     } else {
       dupPuritySelect.value = 'custom';
       if (dupPurityCustom) dupPurityCustom.style.display = '';

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.30.02';
+const CACHE_NAME = 'staktrakr-v3.30.03';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.30.02",
-  "releaseDate": "2026-02-16",
+  "version": "3.30.03",
+  "releaseDate": "2026-02-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: Purity dropdown now includes .9995 (standard pure platinum) as a preset option
- **Fixed**: Custom purity input accepts 4 decimal places instead of 3
- **Fixed**: Hidden custom purity input no longer blocks form submission — resolves save corruption where no items could be edited after entering an invalid custom purity value
- **Fixed**: Duplicate item preserves original purchase date instead of defaulting to today

Thanks to u/PumpkinCrouton for finding and reporting this bug.

## Files Updated

- `index.html` — .9995 dropdown option, step 0.001→0.0001
- `js/events.js` — clear custom purity input on modal reset
- `js/init.js` — clear custom purity input when dropdown changes from Custom
- `js/inventory.js` — clear custom purity on preset select, duplicate preserves date
- `js/constants.js` — APP_VERSION → 3.30.03
- `sw.js` — CACHE_NAME → 3.30.03
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint

## Linear Issues

- [STAK-130: Purity input rejects .9995, triggers save corruption state](https://linear.app/hextrackr/issue/STAK-130)

🤖 Generated with [Claude Code](https://claude.com/claude-code)