### PR TITLE
v3.30.04 — Pagination Dropdown Fix & Settings Reorganization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.30.04] - 2026-02-16
+
+### Fixed — Pagination Dropdown Fix & Settings Reorganization
+
+- **Fixed**: Settings modal "Visible rows" dropdown now includes value 6 — prevents silent fallback to 12 when switching between card and table views
+- **Changed**: Items-per-page default changed from 12 to 6 across all code paths
+- **Added**: 128 and 512 options to both footer and settings dropdowns
+- **Changed**: "Table" settings tab renamed to "Inventory" with card settings consolidated under it
+
+---
+
 ## [3.30.03] - 2026-02-17
 
 ### Fixed — STAK-130: PumpkinCrouton Patch — Purity Input & Save Fix

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Pagination Dropdown Fix & Settings Reorganization (v3.30.04)**: Settings "Visible rows" dropdown now includes value 6, preventing silent fallback when switching views. Default items-per-page changed from 12 to 6. Added 128 and 512 options. "Table" tab renamed to "Inventory" with card settings consolidated
 - **PumpkinCrouton Patch — Purity Input & Save Fix (v3.30.03)**: Added .9995 (pure platinum) to purity dropdown. Custom purity accepts 4 decimal places. Fixed save corruption where hidden custom purity input blocked all form submissions. Duplicate items now preserve original purchase date. Thanks to u/PumpkinCrouton for the report (STAK-130)
 - **Keyless Provider Fixes & Hourly History Pull (v3.30.02)**: Fixed keyless providers (STAKTRAKR) enabling sync buttons, connected status, and auto-select. STAKTRAKR usage counter with 5000 default quota. Hourly history pull for STAKTRAKR (1–30 days) and MetalPriceAPI (up to 7 days). History log distinguishes hourly entries. One-time migration for existing users
 - **StakTrakr Free API Provider & UTC Poller Fix (v3.30.01)**: Free, keyless StakTrakr API provider at rank 1 fetching hourly spot prices. Provider panel with "Free" badge and best-effort disclaimer. 1st–5th priority labels across all providers. Poller switched to UTC for timezone-neutral paths. Auto-sync works without any API keys
-- **Card View Engine, Mobile Overhaul & UI Polish (v3.30.00)**: Three card view styles (Sparkline Header, Full-Bleed, Split Card) with header button cycling. CDN image URLs with dedicated table image column and card thumbnails. Mobile viewport overhaul with responsive breakpoints. Rows-per-page options with floating back-to-top button. Theme-aware sparkline colors. CSV/JSON/ZIP export includes image URLs (STAK-118, STAK-106, STAK-124, STAK-125, STAK-126)
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -817,11 +817,13 @@
             <div class="table-item-count"><strong id="itemCount"></strong></div>
             <select id="itemsPerPage" class="control-select" title="Visible rows">
               <option value="3">3</option>
-              <option value="6">6</option>
-              <option value="12" selected>12</option>
+              <option value="6" selected>6</option>
+              <option value="12">12</option>
               <option value="24">24</option>
               <option value="48">48</option>
               <option value="96">96</option>
+              <option value="128">128</option>
+              <option value="512">512</option>
               <option value="all">All</option>
             </select>
           </div>
@@ -1643,7 +1645,7 @@
             </button>
             <button class="settings-nav-item" data-section="table">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
-              Table
+              Inventory
             </button>
             <button class="settings-nav-item" data-section="grouping">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
@@ -1737,35 +1739,6 @@
                 </div>
               </div>
 
-              <!-- ── Card View (STAK-118) ── -->
-              <div class="settings-fieldset">
-                <div class="settings-fieldset-title">Card View</div>
-                <div class="settings-group">
-                  <div class="settings-group-label">Card style</div>
-                  <p class="settings-subtext">Choose the card layout used in mobile and optional desktop card view.</p>
-                  <select id="settingsCardStyle">
-                    <option value="A">A: Sparkline Header</option>
-                    <option value="B">B: Full-Bleed Overlay</option>
-                    <option value="C">C: Split Card</option>
-                  </select>
-                </div>
-                <div class="settings-group">
-                  <div class="settings-group-label">Desktop card view</div>
-                  <p class="settings-subtext">Show cards instead of the table on wide screens. Cards are always used on mobile.</p>
-                  <div class="chip-sort-toggle" id="settingsDesktopCardView">
-                    <button type="button" class="chip-sort-btn" data-val="yes">On</button>
-                    <button type="button" class="chip-sort-btn" data-val="no">Off</button>
-                  </div>
-                </div>
-                <div class="settings-group">
-                  <div class="settings-group-label">Header card view button</div>
-                  <p class="settings-subtext">Show a quick card/table toggle button in the app header.</p>
-                  <div class="chip-sort-toggle" id="settingsHeaderCardViewBtn">
-                    <button type="button" class="chip-sort-btn" data-val="yes">On</button>
-                    <button type="button" class="chip-sort-btn" data-val="no">Off</button>
-                  </div>
-                </div>
-              </div>
             </div>
 
             <!-- ===== TABLE SETTINGS ===== -->
@@ -1776,10 +1749,13 @@
                 <div class="settings-group-label">Visible rows</div>
                 <select id="settingsItemsPerPage">
                   <option value="3">3</option>
+                  <option value="6">6</option>
                   <option value="12">12</option>
                   <option value="24">24</option>
                   <option value="48">48</option>
                   <option value="96">96</option>
+                  <option value="128">128</option>
+                  <option value="512">512</option>
                   <option value="all">All</option>
                 </select>
               </div>
@@ -1789,6 +1765,34 @@
                 <p class="settings-subtext">Choose which badges appear next to item names in the table.</p>
                 <div class="chip-grouping-table-container" id="inlineChipConfigContainer">
                   <div class="chip-grouping-empty">Loading...</div>
+                </div>
+              </div>
+
+              <!-- ── Card View (STAK-118) ── -->
+              <h3>Card View</h3>
+              <div class="settings-group">
+                <div class="settings-group-label">Card style</div>
+                <p class="settings-subtext">Choose the card layout used in mobile and optional desktop card view.</p>
+                <select id="settingsCardStyle">
+                  <option value="A">A: Sparkline Header</option>
+                  <option value="B">B: Full-Bleed Overlay</option>
+                  <option value="C">C: Split Card</option>
+                </select>
+              </div>
+              <div class="settings-group">
+                <div class="settings-group-label">Desktop card view</div>
+                <p class="settings-subtext">Show cards instead of the table on wide screens. Cards are always used on mobile.</p>
+                <div class="chip-sort-toggle" id="settingsDesktopCardView">
+                  <button type="button" class="chip-sort-btn" data-val="yes">On</button>
+                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
+                </div>
+              </div>
+              <div class="settings-group">
+                <div class="settings-group-label">Header card view button</div>
+                <p class="settings-subtext">Show a quick card/table toggle button in the app header.</p>
+                <div class="chip-sort-toggle" id="settingsHeaderCardViewBtn">
+                  <button type="button" class="chip-sort-btn" data-val="yes">On</button>
+                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
                 </div>
               </div>
             </div>

--- a/js/about.js
+++ b/js/about.js
@@ -274,10 +274,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.30.04 &ndash; Pagination Dropdown Fix &amp; Settings Reorganization</strong>: Settings &ldquo;Visible rows&rdquo; dropdown now includes value 6, preventing silent fallback when switching views. Default items-per-page changed from 12 to 6. Added 128 and 512 options. &ldquo;Table&rdquo; tab renamed to &ldquo;Inventory&rdquo; with card settings consolidated</li>
     <li><strong>v3.30.03 &ndash; PumpkinCrouton Patch &mdash; Purity Input &amp; Save Fix</strong>: Added .9995 (pure platinum) to purity dropdown. Custom purity accepts 4 decimal places. Fixed save corruption where hidden custom purity input blocked all form submissions. Duplicate items now preserve original purchase date. Thanks to u/PumpkinCrouton for the report (STAK-130)</li>
     <li><strong>v3.30.02 &ndash; Keyless Provider Fixes &amp; Hourly History Pull</strong>: Fixed keyless providers (STAKTRAKR) enabling sync buttons, connected status, and auto-select. STAKTRAKR usage counter with 5000 default quota. Hourly history pull for STAKTRAKR (1&ndash;30 days) and MetalPriceAPI (up to 7 days). History log distinguishes hourly entries. One-time migration for existing users</li>
     <li><strong>v3.30.01 &ndash; StakTrakr Free API Provider &amp; UTC Poller Fix</strong>: Free, keyless StakTrakr API provider at rank 1 fetching hourly spot prices. Provider panel with &ldquo;Free&rdquo; badge and best-effort disclaimer. 1st&ndash;5th priority labels across all providers. Poller switched to UTC for timezone-neutral paths. Auto-sync works without any API keys</li>
-    <li><strong>v3.30.00 &ndash; Card View Engine, Mobile Overhaul &amp; UI Polish</strong>: Three card view styles (Sparkline Header, Full-Bleed, Split Card) with header button cycling. CDN image URLs with dedicated table image column and card thumbnails. Mobile viewport overhaul with responsive breakpoints. Rows-per-page options with floating back-to-top button. Theme-aware sparkline colors. CSV/JSON/ZIP export includes image URLs (STAK-118, STAK-106, STAK-124, STAK-125, STAK-126)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -282,7 +282,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.30.03";
+const APP_VERSION = "3.30.04";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/init.js
+++ b/js/init.js
@@ -419,15 +419,15 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (elements.itemsPerPage) elements.itemsPerPage.value = 'all';
         } else {
           const parsed = parseInt(savedIpp, 10);
-          if ([3, 12, 24, 48, 96].includes(parsed)) {
+          if ([3, 6, 12, 24, 48, 96, 128, 512].includes(parsed)) {
             itemsPerPage = parsed;
             if (elements.itemsPerPage) elements.itemsPerPage.value = String(parsed);
           }
         }
       } else {
-        // No saved preference — default to 12
-        itemsPerPage = 12;
-        if (elements.itemsPerPage) elements.itemsPerPage.value = '12';
+        // No saved preference — default to 6
+        itemsPerPage = 6;
+        if (elements.itemsPerPage) elements.itemsPerPage.value = '6';
       }
     } catch (e) { /* ignore */ }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -544,7 +544,7 @@ const setupSettingsEventListeners = () => {
 
   // Apply view-appropriate items-per-page default when switching views.
   // Card view always uses "all" (Infinity). Table view restores the user's
-  // previous preference (saved before switching to card) or falls back to 12.
+  // previous preference (saved before switching to card) or falls back to 6.
   let _savedTableIpp = null;
   const applyViewIpp = () => {
     const enteringCard = localStorage.getItem(DESKTOP_CARD_VIEW_KEY) === 'true';
@@ -558,7 +558,7 @@ const setupSettingsEventListeners = () => {
       ippStr = 'all';
     } else {
       // Restore table IPP
-      const restored = _savedTableIpp || '12';
+      const restored = _savedTableIpp || '6';
       _savedTableIpp = null;
       itemsPerPage = restored === 'all' ? Infinity : Number(restored);
       ippStr = restored;

--- a/js/state.js
+++ b/js/state.js
@@ -13,7 +13,7 @@ let notesIndex = null;
 let editingChangeLogIndex = null;
 
 /** @type {number} Number of visible rows in the portal (scrollable table) view */
-let itemsPerPage = 12;
+let itemsPerPage = 6;
 
 /** @type {string} Current search query */
 let searchQuery = "";

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.30.03';
+const CACHE_NAME = 'staktrakr-v3.30.04';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.30.03",
-  "releaseDate": "2026-02-17",
+  "version": "3.30.04",
+  "releaseDate": "2026-02-16",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: Settings modal "Visible rows" dropdown now includes value `6` — prevents silent fallback to `12` when switching between card and table views
- **Changed**: Items-per-page default changed from `12` to `6` across all code paths
- **Added**: `128` and `512` options to both footer and settings dropdowns
- **Changed**: "Table" settings tab renamed to "Inventory" with card settings consolidated under it

## Files Updated

- `index.html` — Fix both dropdowns, move `selected`, rename tab, relocate card settings
- `js/constants.js` — APP_VERSION → 3.30.04
- `js/init.js` — Validation array + default fallback → 6
- `js/settings.js` — `applyViewIpp` restore fallback → 6
- `js/state.js` — Default `itemsPerPage = 6`
- `js/about.js` — Embedded What's New fallback
- `sw.js` — CACHE_NAME → 3.30.04
- `version.json` — Remote version check endpoint
- `CHANGELOG.md` — New section
- `docs/announcements.md` — New What's New entry

## Test Plan

- [ ] Open app → confirm footer dropdown defaults to 6 and shows all 9 options
- [ ] Open Settings → Inventory tab → confirm dropdown shows same 9 options with 6 selected
- [ ] Confirm card settings (Card style, Desktop card view, Header card view button) appear under "Card View" subheading in Inventory tab
- [ ] Confirm Layout tab no longer has card settings
- [ ] Toggle desktop card view on → confirm IPP goes to All → toggle off → confirm restores to 6
- [ ] Select value like 48, switch to cards and back → confirm 48 is restored (not 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)