### PR TITLE
v3.30.06 — STAK-131: Card View Sort Controls & UX Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.30.06] - 2026-02-17
+
+### Added — Card View Sort Controls & UX Polish
+
+- **Added**: Card sort bar with sort-by dropdown, direction toggle, and A/B/C card style toggle — visible only in card view (STAK-131)
+- **Changed**: Pagination dropdown hidden in card view — cards always show all items
+- **Changed**: Default table rows changed from 6 to 12
+- **Changed**: Header card view button now simply toggles card/table view
+- **Changed**: Numista name matching (NUMISTA_SEARCH_LOOKUP) disabled by default
+
+---
+
 ## [3.30.05] - 2026-02-16
 
 ### Fixed — Sort Column Index Realignment

--- a/css/styles.css
+++ b/css/styles.css
@@ -9030,6 +9030,78 @@ th {
    CARD VIEW STYLES — Selectable card designs A/B/C/D (STAK-118)
    ============================================================================= */
 
+/* Card sort bar — sort dropdown + direction toggle + card style toggle (STAK-131) */
+.card-sort-bar {
+  display: none;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: 0.4rem 0.75rem;
+  margin: 0 auto 0.5rem;
+  max-width: 1400px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.card-sort-left,
+.card-sort-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.card-sort-bar .control-label {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.card-sort-bar .control-select {
+  min-width: 7rem;
+  font-size: 0.8rem;
+  padding: 0.2rem 1.4rem 0.2rem 0.4rem;
+}
+
+.card-sort-dir-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.card-sort-dir-btn:hover {
+  background: var(--bg-secondary);
+}
+
+/* Arrow visibility based on data attribute */
+.card-sort-dir-btn .sort-arrow-down { display: none; }
+.card-sort-dir-btn .sort-arrow-up { display: block; }
+.card-sort-dir-btn[data-dir="desc"] .sort-arrow-up { display: none; }
+.card-sort-dir-btn[data-dir="desc"] .sort-arrow-down { display: block; }
+
+/* Mobile: stack sort bar controls */
+@media (max-width: 480px) {
+  .card-sort-bar {
+    justify-content: center;
+    gap: var(--spacing-xs);
+    padding: 0.35rem 0.5rem;
+  }
+  .card-sort-left,
+  .card-sort-right {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}
+
 /* Container — hidden by default, JS toggles display */
 .card-view-grid {
   display: none;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Card View Sort Controls & UX Polish (v3.30.06)**: Card sort bar with sort dropdown, direction toggle, and A/B/C style toggle visible only in card view. Pagination hidden in card view. Default table rows changed to 12. Header button simplified to toggle card/table view. Numista name matching disabled by default (STAK-131)
 - **Sort Column Index Realignment (v3.30.05)**: All table sorts after Type were off by one since v3.30.00 — the Image column was missing from the sort index map, causing every column from Name onward to sort by the wrong field. Retail and Gain/Loss sorting now also uses correct Goldback denomination pricing
 - **Pagination Dropdown Fix & Settings Reorganization (v3.30.04)**: Settings "Visible rows" dropdown now includes value 6, preventing silent fallback when switching views. Default items-per-page changed from 12 to 6. Added 128 and 512 options. "Table" tab renamed to "Inventory" with card settings consolidated
 - **PumpkinCrouton Patch — Purity Input & Save Fix (v3.30.03)**: Added .9995 (pure platinum) to purity dropdown. Custom purity accepts 4 decimal places. Fixed save corruption where hidden custom purity input blocked all form submissions. Duplicate items now preserve original purchase date. Thanks to u/PumpkinCrouton for the report (STAK-130)
 - **Keyless Provider Fixes & Hourly History Pull (v3.30.02)**: Fixed keyless providers (STAKTRAKR) enabling sync buttons, connected status, and auto-select. STAKTRAKR usage counter with 5000 default quota. Hourly history pull for STAKTRAKR (1–30 days) and MetalPriceAPI (up to 7 days). History log distinguishes hourly entries. One-time migration for existing users
-- **StakTrakr Free API Provider & UTC Poller Fix (v3.30.01)**: Free, keyless StakTrakr API provider at rank 1 fetching hourly spot prices. Provider panel with "Free" badge and best-effort disclaimer. 1st–5th priority labels across all providers. Poller switched to UTC for timezone-neutral paths. Auto-sync works without any API keys
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -705,6 +705,38 @@
          Portal view shows all items in a scrollable table with sticky headers
          ============================================================================= -->
         <section class="table-section" id="tableSectionEl">
+          <div class="card-sort-bar" id="cardSortBar" style="display:none">
+            <div class="card-sort-left">
+              <span class="control-label">Sort:</span>
+              <select id="cardSortColumn" class="control-select" title="Sort cards by column">
+                <option value="0">Date</option>
+                <option value="1">Metal</option>
+                <option value="2">Type</option>
+                <option value="4">Name</option>
+                <option value="5">Qty</option>
+                <option value="6">Weight</option>
+                <option value="7">Purchase</option>
+                <option value="8">Melt Value</option>
+                <option value="9">Retail</option>
+                <option value="10">Gain/Loss</option>
+                <option value="11">Source</option>
+              </select>
+              <button type="button" class="card-sort-dir-btn" id="cardSortDirBtn" title="Toggle sort direction">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline class="sort-arrow-up" points="18 15 12 9 6 15"/>
+                  <polyline class="sort-arrow-down" points="6 9 12 15 18 9"/>
+                </svg>
+              </button>
+            </div>
+            <div class="card-sort-right">
+              <span class="control-label">Style:</span>
+              <div class="chip-sort-toggle" id="cardStyleToggle">
+                <button type="button" class="chip-sort-btn active" data-style="A" title="Chart cards">A</button>
+                <button type="button" class="chip-sort-btn" data-style="B" title="Hero cards">B</button>
+                <button type="button" class="chip-sort-btn" data-style="C" title="Split cards">C</button>
+              </div>
+            </div>
+          </div>
           <div class="card-view-grid" id="cardViewGrid"></div>
           <div class="portal-scroll">
           <table id="inventoryTable">
@@ -817,8 +849,8 @@
             <div class="table-item-count"><strong id="itemCount"></strong></div>
             <select id="itemsPerPage" class="control-select" title="Visible rows">
               <option value="3">3</option>
-              <option value="6" selected>6</option>
-              <option value="12">12</option>
+              <option value="6">6</option>
+              <option value="12" selected>12</option>
               <option value="24">24</option>
               <option value="48">48</option>
               <option value="96">96</option>

--- a/js/about.js
+++ b/js/about.js
@@ -274,11 +274,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.30.06 &ndash; Card View Sort Controls &amp; UX Polish</strong>: Card sort bar with sort dropdown, direction toggle, and A/B/C style toggle visible only in card view. Pagination hidden in card view. Default table rows changed to 12. Header button simplified to toggle card/table view. Numista name matching disabled by default (STAK-131)</li>
     <li><strong>v3.30.05 &ndash; Sort Column Index Realignment</strong>: All table sorts after Type were off by one since v3.30.00 &mdash; the Image column was missing from the sort index map, causing every column from Name onward to sort by the wrong field. Retail and Gain/Loss sorting now also uses correct Goldback denomination pricing</li>
     <li><strong>v3.30.04 &ndash; Pagination Dropdown Fix &amp; Settings Reorganization</strong>: Settings &ldquo;Visible rows&rdquo; dropdown now includes value 6, preventing silent fallback when switching views. Default items-per-page changed from 12 to 6. Added 128 and 512 options. &ldquo;Table&rdquo; tab renamed to &ldquo;Inventory&rdquo; with card settings consolidated</li>
     <li><strong>v3.30.03 &ndash; PumpkinCrouton Patch &mdash; Purity Input &amp; Save Fix</strong>: Added .9995 (pure platinum) to purity dropdown. Custom purity accepts 4 decimal places. Fixed save corruption where hidden custom purity input blocked all form submissions. Duplicate items now preserve original purchase date. Thanks to u/PumpkinCrouton for the report (STAK-130)</li>
     <li><strong>v3.30.02 &ndash; Keyless Provider Fixes &amp; Hourly History Pull</strong>: Fixed keyless providers (STAKTRAKR) enabling sync buttons, connected status, and auto-select. STAKTRAKR usage counter with 5000 default quota. Hourly history pull for STAKTRAKR (1&ndash;30 days) and MetalPriceAPI (up to 7 days). History log distinguishes hourly entries. One-time migration for existing users</li>
-    <li><strong>v3.30.01 &ndash; StakTrakr Free API Provider &amp; UTC Poller Fix</strong>: Free, keyless StakTrakr API provider at rank 1 fetching hourly spot prices. Provider panel with &ldquo;Free&rdquo; badge and best-effort disclaimer. 1st&ndash;5th priority labels across all providers. Poller switched to UTC for timezone-neutral paths. Auto-sync works without any API keys</li>
   `;
 };
 

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -783,3 +783,81 @@ const bindCardClickHandler = (container) => {
   });
 };
 
+// ---------------------------------------------------------------------------
+// Card Sort Bar — sort controls + style toggle (STAK-131)
+// ---------------------------------------------------------------------------
+
+/** @type {boolean} Whether card sort bar event listeners have been bound */
+let _cardSortBarBound = false;
+
+/**
+ * Updates the card sort bar UI to reflect current sort state and card style.
+ * Called from renderTable() whenever card view is active.
+ */
+const updateCardSortBar = () => {
+  const bar = document.getElementById('cardSortBar');
+  if (!bar) return;
+
+  // Sync sort dropdown with current sortColumn
+  const colSelect = document.getElementById('cardSortColumn');
+  if (colSelect && colSelect.value !== String(sortColumn)) {
+    colSelect.value = String(sortColumn);
+  }
+
+  // Sync direction button
+  const dirBtn = document.getElementById('cardSortDirBtn');
+  if (dirBtn) {
+    dirBtn.setAttribute('data-dir', sortDirection);
+    dirBtn.title = sortDirection === 'asc' ? 'Ascending — click to reverse' : 'Descending — click to reverse';
+  }
+
+  // Sync card style toggle
+  const style = getCardStyle();
+  const styleToggle = document.getElementById('cardStyleToggle');
+  if (styleToggle) {
+    styleToggle.querySelectorAll('.chip-sort-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.style === style);
+    });
+  }
+};
+
+/**
+ * Binds event listeners on the card sort bar (once).
+ */
+const initCardSortBar = () => {
+  if (_cardSortBarBound) return;
+  _cardSortBarBound = true;
+
+  // Sort column dropdown
+  const colSelect = document.getElementById('cardSortColumn');
+  if (colSelect) {
+    colSelect.addEventListener('change', () => {
+      sortColumn = parseInt(colSelect.value, 10);
+      if (typeof renderTable === 'function') renderTable();
+    });
+  }
+
+  // Sort direction toggle
+  const dirBtn = document.getElementById('cardSortDirBtn');
+  if (dirBtn) {
+    dirBtn.addEventListener('click', () => {
+      sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+      if (typeof renderTable === 'function') renderTable();
+    });
+  }
+
+  // Card style A/B/C toggle
+  const styleToggle = document.getElementById('cardStyleToggle');
+  if (styleToggle) {
+    styleToggle.addEventListener('click', (e) => {
+      const btn = e.target.closest('.chip-sort-btn');
+      if (!btn || !btn.dataset.style) return;
+      localStorage.setItem(CARD_STYLE_KEY, btn.dataset.style);
+      // Sync settings select if open
+      const styleSelect = document.getElementById('settingsCardStyle');
+      if (styleSelect) styleSelect.value = btn.dataset.style;
+      if (typeof renderTable === 'function') renderTable();
+    });
+  }
+};
+

--- a/js/constants.js
+++ b/js/constants.js
@@ -282,7 +282,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.30.05";
+const APP_VERSION = "3.30.06";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -1025,7 +1025,7 @@ const FEATURE_FLAGS = {
     phase: "stable"
   },
   NUMISTA_SEARCH_LOOKUP: {
-    enabled: true,
+    enabled: false,
     urlOverride: true,
     userToggle: true,
     description: "Pattern-based Numista search improvement",

--- a/js/init.js
+++ b/js/init.js
@@ -425,9 +425,9 @@ document.addEventListener("DOMContentLoaded", async () => {
           }
         }
       } else {
-        // No saved preference — default to 6
-        itemsPerPage = 6;
-        if (elements.itemsPerPage) elements.itemsPerPage.value = '6';
+        // No saved preference — default to 12
+        itemsPerPage = 12;
+        if (elements.itemsPerPage) elements.itemsPerPage.value = '12';
       }
     } catch (e) { /* ignore */ }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1305,13 +1305,20 @@ const renderTable = () => {
     const sortedInventory = sortInventory(filteredInventory);
     debugLog('renderTable start', sortedInventory.length, 'items');
 
-    // STAK-118: Card view rendering branch
+    // STAK-131: Card sort bar + card view rendering branch
+    const cardSortBar = document.getElementById('cardSortBar');
+    const footerSelect = document.querySelector('.table-footer-controls select');
     if (typeof isCardViewActive === 'function' && isCardViewActive()) {
       const cardGrid = safeGetElement('cardViewGrid');
       const portalScroll = document.querySelector('.portal-scroll');
       if (cardGrid) {
         cardGrid.style.display = 'flex';
         if (portalScroll) portalScroll.style.display = 'none';
+        // Show card sort bar and hide pagination dropdown
+        if (cardSortBar) cardSortBar.style.display = 'flex';
+        if (footerSelect) footerSelect.style.display = 'none';
+        if (typeof initCardSortBar === 'function') initCardSortBar();
+        if (typeof updateCardSortBar === 'function') updateCardSortBar();
 
         renderCardView(sortedInventory, cardGrid);
         bindCardClickHandler(cardGrid);
@@ -1332,6 +1339,9 @@ const renderTable = () => {
       cardGridEl.style.overflowY = '';
     }
     if (portalScrollEl) portalScrollEl.style.display = '';
+    // Hide card sort bar and show pagination dropdown
+    if (cardSortBar) cardSortBar.style.display = 'none';
+    if (footerSelect) footerSelect.style.display = '';
 
     const rows = [];
     const chipConfig = typeof getInlineChipConfig === 'function' ? getInlineChipConfig() : [];

--- a/js/settings.js
+++ b/js/settings.js
@@ -544,7 +544,7 @@ const setupSettingsEventListeners = () => {
 
   // Apply view-appropriate items-per-page default when switching views.
   // Card view always uses "all" (Infinity). Table view restores the user's
-  // previous preference (saved before switching to card) or falls back to 6.
+  // previous preference (saved before switching to card) or falls back to 12.
   let _savedTableIpp = null;
   const applyViewIpp = () => {
     const enteringCard = localStorage.getItem(DESKTOP_CARD_VIEW_KEY) === 'true';
@@ -558,7 +558,7 @@ const setupSettingsEventListeners = () => {
       ippStr = 'all';
     } else {
       // Restore table IPP
-      const restored = _savedTableIpp || '6';
+      const restored = _savedTableIpp || '12';
       _savedTableIpp = null;
       itemsPerPage = restored === 'all' ? Infinity : Number(restored);
       ippStr = restored;
@@ -569,31 +569,16 @@ const setupSettingsEventListeners = () => {
     if (settingsIpp) settingsIpp.value = ippStr;
   };
 
-  // Card view header button (STAK-118)
-  // Click: cycle card style A → B → C → A
-  // Shift+click: toggle table/card view
-  const CARD_STYLES = ['A', 'B', 'C'];
+  // Card view header button (STAK-131) — simple toggle between table and card view
   const headerCardViewBtn = document.getElementById('headerCardViewBtn');
   if (headerCardViewBtn) {
-    headerCardViewBtn.addEventListener('click', (e) => {
-      if (e.shiftKey) {
-        // Shift+click: toggle table ↔ card view
-        const isCard = localStorage.getItem(DESKTOP_CARD_VIEW_KEY) === 'true';
-        const newVal = !isCard;
-        localStorage.setItem(DESKTOP_CARD_VIEW_KEY, String(newVal));
-        document.body.classList.toggle('force-card-view', newVal);
-        applyViewIpp();
-        syncChipToggle('settingsDesktopCardView', newVal ? 'yes' : 'no');
-      } else {
-        // Click: cycle card style
-        const cur = localStorage.getItem(CARD_STYLE_KEY) || 'A';
-        const nextIdx = (CARD_STYLES.indexOf(cur) + 1) % CARD_STYLES.length;
-        const next = CARD_STYLES[nextIdx];
-        localStorage.setItem(CARD_STYLE_KEY, next);
-        // Sync settings select if open
-        const styleSelect = document.getElementById('settingsCardStyle');
-        if (styleSelect) styleSelect.value = next;
-      }
+    headerCardViewBtn.addEventListener('click', () => {
+      const isCard = localStorage.getItem(DESKTOP_CARD_VIEW_KEY) === 'true';
+      const newVal = !isCard;
+      localStorage.setItem(DESKTOP_CARD_VIEW_KEY, String(newVal));
+      document.body.classList.toggle('force-card-view', newVal);
+      applyViewIpp();
+      syncChipToggle('settingsDesktopCardView', newVal ? 'yes' : 'no');
       if (typeof renderTable === 'function') renderTable();
     });
   }

--- a/js/state.js
+++ b/js/state.js
@@ -13,7 +13,7 @@ let notesIndex = null;
 let editingChangeLogIndex = null;
 
 /** @type {number} Number of visible rows in the portal (scrollable table) view */
-let itemsPerPage = 6;
+let itemsPerPage = 12;
 
 /** @type {string} Current search query */
 let searchQuery = "";

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version is tied to APP_VERSION — old caches are purged on activate
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.30.05';
+const CACHE_NAME = 'staktrakr-v3.30.06';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.30.05",
-  "releaseDate": "2026-02-16",
+  "version": "3.30.06",
+  "releaseDate": "2026-02-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Added**: Card sort bar with sort-by dropdown, direction toggle, and A/B/C card style toggle — visible only in card view (STAK-131)
- **Changed**: Pagination dropdown hidden in card view — cards always show all items
- **Changed**: Default table rows changed from 6 to 12
- **Changed**: Header card view button simplified to just toggle card/table view
- **Changed**: Numista name matching (NUMISTA_SEARCH_LOOKUP) disabled by default

## Files Updated

- `js/constants.js` — APP_VERSION → 3.30.06, NUMISTA_SEARCH_LOOKUP default false
- `sw.js` — CACHE_NAME → 3.30.06
- `CHANGELOG.md` — new section
- `docs/announcements.md` — new What's New entry
- `js/about.js` — embedded What's New fallback
- `version.json` — remote version check endpoint
- `css/styles.css` — card sort bar styles
- `index.html` — card sort bar markup, default IPP 12
- `js/card-view.js` — initCardSortBar/updateCardSortBar functions
- `js/inventory.js` — card sort bar visibility toggle in renderTable()
- `js/settings.js` — simplified header button, IPP default 12
- `js/state.js` — IPP default 12
- `js/init.js` — IPP default 12

## Linear Issues

- STAK-131: Card View Sort Controls & View Style Toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)