### PR TITLE
fix: move Save Filter button to filter chip controls bar (STAK-104)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4850,51 +4850,31 @@ a.about-badge:hover {
   align-items: center;
 }
 
-.search-input-wrapper {
-  position: relative;
+#searchInput {
   flex: 1;
 }
 
-.search-input-wrapper #searchInput {
-  width: 100%;
-  padding-right: 3.25rem;
-}
-
-.search-save-btn {
-  display: inline-flex;
-  position: absolute;
-  right: 0.45rem;
-  top: 50%;
-  transform: translateY(-50%);
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.5rem 0.75rem;
+/* Save Filter button in filter-controls bar — matches chip-sort-btn style */
+.save-filter-btn {
+  padding: 0.2rem 0.6rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  transition: all 0.15s ease;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.search-save-btn:hover {
-  color: var(--primary);
+.save-filter-btn:hover {
+  background: var(--primary);
+  color: #fff;
   border-color: var(--primary);
 }
 
-.search-save-btn.is-disabled,
-.search-save-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.search-save-btn:focus-visible {
+.save-filter-btn:focus-visible {
   outline: 2px solid var(--primary);
   outline-offset: 2px;
-}
-
-.search-save-btn svg {
-  width: 1.25rem;
-  height: 1.25rem;
 }
 
 .modern-icon-btn {
@@ -5776,8 +5756,9 @@ input:disabled + .slider {
     gap: var(--spacing-xs);
   }
 
-  .search-input-wrapper {
+  .search-container #searchInput {
     flex: 1;
+    min-width: 0;
   }
 
   .search-action-btn span {
@@ -5900,7 +5881,7 @@ input:disabled + .slider {
     min-width: 180px;
   }
 
-  .search-input-wrapper #searchInput {
+  .search-container #searchInput {
     min-width: 160px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -627,24 +627,11 @@
               </svg>
               <span>Add Item</span>
             </button>
-            <div class="search-input-wrapper">
-              <input
-                id="searchInput"
-                placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
-                type="text"
-              />
-              <button
-                type="button"
-                class="btn search-save-btn"
-                id="saveSearchPatternBtn"
-                title="Save as filter chip"
-                aria-label="Save search as filter chip"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
-                </svg>
-              </button>
-            </div>
+            <input
+              id="searchInput"
+              placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
+              type="text"
+            />
             <button
               class="btn search-action-btn clear-btn"
               id="clearBtn"
@@ -696,6 +683,9 @@
                   <button type="button" class="chip-sort-btn active" data-sort="alpha">A-Z</button>
                   <button type="button" class="chip-sort-btn" data-sort="count">Qty</button>
                 </div>
+              </div>
+              <div class="control-group" id="saveSearchPatternGroup" style="display:none">
+                <button type="button" class="chip-sort-btn save-filter-btn" id="saveSearchPatternBtn" title="Save current search as a custom filter chip">Save Filter</button>
               </div>
             </div>
             <div class="filter-row">

--- a/js/search.js
+++ b/js/search.js
@@ -392,13 +392,10 @@ const shouldShowSearchSaveButton = (query, fuzzyUsed) => {
 };
 
 const updateSaveSearchButton = (query, fuzzyUsed = false) => {
-  const btn = resolveElement('saveSearchPatternBtn');
-  if (!btn || !btn.id) return;
+  const group = resolveElement('saveSearchPatternGroup');
+  if (!group || !group.id) return;
   const canSave = shouldShowSearchSaveButton(query, fuzzyUsed);
-  btn.style.display = '';
-  btn.disabled = !canSave;
-  btn.classList.toggle('is-disabled', !canSave);
-  btn.setAttribute('aria-disabled', (!canSave).toString());
+  group.style.display = canSave ? '' : 'none';
 };
 
 const deriveSearchLabel = (patterns) => {
@@ -408,8 +405,6 @@ const deriveSearchLabel = (patterns) => {
 };
 
 const handleSaveSearchPattern = () => {
-  const btn = resolveElement('saveSearchPatternBtn');
-  if (btn && btn.disabled) return;
   const input = resolveElement('searchInput');
   if (!input || !input.id) return;
   const query = input.value || '';


### PR DESCRIPTION
The bookmark icon inside the search input had hover/positioning bugs (bouncing out of the box, dark mode background mismatch). Replaced it with a "Save Filter" text button in the filter-controls bar alongside the existing Chip Sort and Smart Grouping toggles. Uses chip-sort-btn styling for full theme awareness. Button shows/hides based on whether the search query qualifies for saving.

https://claude.ai/code/session_01DKswq3bXCsAYTTfGukMprH