### PR TITLE
Fix tag restoration and import timing issues (STAK-126)

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -405,7 +405,7 @@ const restoreBackupZip = async (file) => {
           restoredTags = itemTagsObj.tags;
         }
       } catch (e) {
-        debugLog('restoreBackupZip: item_tags.json parse error', e);
+        debugWarn('restoreBackupZip: item_tags.json parse error', e);
       }
     }
     itemTags = restoredTags || {};

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -399,9 +399,13 @@ const restoreBackupZip = async (file) => {
     const itemTagsStr = await zip.file("item_tags.json")?.async("string");
     let restoredTags = null;
     if (itemTagsStr) {
-      const itemTagsObj = JSON.parse(itemTagsStr);
-      if (itemTagsObj.tags && typeof itemTagsObj.tags === 'object') {
-        restoredTags = itemTagsObj.tags;
+      try {
+        const itemTagsObj = JSON.parse(itemTagsStr);
+        if (itemTagsObj.tags && typeof itemTagsObj.tags === 'object') {
+          restoredTags = itemTagsObj.tags;
+        }
+      } catch (e) {
+        debugLog('restoreBackupZip: item_tags.json parse error', e);
       }
     }
     itemTags = restoredTags || {};

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -397,13 +397,15 @@ const restoreBackupZip = async (file) => {
 
     // Restore item tags (STAK-126)
     const itemTagsStr = await zip.file("item_tags.json")?.async("string");
+    let restoredTags = null;
     if (itemTagsStr) {
       const itemTagsObj = JSON.parse(itemTagsStr);
       if (itemTagsObj.tags && typeof itemTagsObj.tags === 'object') {
-        itemTags = itemTagsObj.tags;
-        if (typeof saveItemTags === 'function') saveItemTags();
+        restoredTags = itemTagsObj.tags;
       }
     }
+    itemTags = restoredTags || {};
+    if (typeof saveItemTags === 'function') saveItemTags();
 
     // Restore cached coin images (STACK-88)
     if (window.imageCache?.isAvailable()) {


### PR DESCRIPTION
## Summary
This PR fixes issues with item tag restoration during backup recovery and tag import timing during JSON imports. The changes ensure tags are properly restored even when parsing fails, and defer tag application until after item deduplication to avoid duplicate tag assignments.

## Key Changes
- **Backup restoration**: Wrapped `item_tags.json` parsing in try-catch to gracefully handle malformed JSON, defaulting to empty tags object if parsing fails
- **Tag restoration timing**: Moved `itemTags` assignment and `saveItemTags()` call outside the conditional block to ensure they always execute after attempting restoration
- **Import tag batching**: Changed tag application during JSON import to collect pending tags in a Map keyed by item UUID instead of immediately calling `addItemTag()`
- **Deduplication safety**: Moved tag application to after item deduplication logic to prevent duplicate tags from being added to the same item
- **Persistence optimization**: Consolidated `saveItemTags()` call to execute once after all tags are applied, rather than during the import loop

## Implementation Details
- Tags are now collected in `pendingTagsByUuid` Map during the import loop and applied in a separate pass after deduplication
- Error handling for corrupted backup files is more robust with explicit try-catch around JSON parsing
- The tag restoration flow is now more predictable: attempt parse → set to restored value or empty object → always save

https://claude.ai/code/session_01Nq18Gxyeh714GnKs3uE4Ct