### PR TITLE
STAK-137: Migrate inline onclick handlers to events.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -1262,7 +1262,7 @@
       <div class="modal-content" style="max-width: 32rem;">
         <div class="modal-header">
           <h2 id="notesViewTitle">Notes</h2>
-          <button aria-label="Close modal" class="modal-close" onclick="closeModalById('notesViewModal')">×</button>
+          <button aria-label="Close modal" class="modal-close" id="notesViewCloseBtn">×</button>
         </div>
         <div class="modal-body">
           <div id="notesViewContent" style="white-space: pre-wrap; line-height: 1.5; min-height: 3rem; max-height: 20rem; overflow-y: auto;"></div>
@@ -2742,7 +2742,7 @@
               <p class="settings-subtext">
                 Set market prices for Goldback denominations manually or auto-estimate from gold spot.
                 Check current rates at
-                <a href="#" id="goldbackExchangeRateLink" onclick="window.open('https://www.goldback.com/exchange-rates/', 'goldback_rates', 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'); return false;">goldback.com/exchange-rates</a>.
+                <a href="#" id="goldbackExchangeRateLink">goldback.com/exchange-rates</a>.
               </p>
 
               <div class="settings-group">
@@ -2951,7 +2951,6 @@
             aria-label="Close modal"
             class="modal-close"
             id="vaultCloseBtn"
-            onclick="closeVaultModal()"
           >
             &times;
           </button>
@@ -2980,7 +2979,6 @@
                 class="password-toggle"
                 id="vaultPasswordToggle"
                 title="Show/hide password"
-                onclick="toggleVaultPasswordVisibility('vaultPassword', this)"
               >&#9678;</button>
             </div>
           </div>
@@ -3006,7 +3004,6 @@
                 class="password-toggle"
                 id="vaultConfirmToggle"
                 title="Show/hide password"
-                onclick="toggleVaultPasswordVisibility('vaultConfirmPassword', this)"
               >&#9678;</button>
             </div>
             <div class="password-match" id="vaultMatchIndicator"></div>
@@ -3019,8 +3016,8 @@
           </div>
 
           <div class="encryption-actions">
-            <button class="btn" id="vaultActionBtn" onclick="handleVaultAction()">Export</button>
-            <button class="btn warning" onclick="closeVaultModal()">Cancel</button>
+            <button class="btn" id="vaultActionBtn">Export</button>
+            <button class="btn warning" id="vaultCancelBtn">Cancel</button>
           </div>
         </div>
       </div>
@@ -3318,7 +3315,7 @@
       <div class="modal-content numista-results-modal-content">
         <div class="modal-header">
           <h2 id="spotLookupTitle">Spot Price Lookup</h2>
-          <button aria-label="Close modal" class="modal-close" onclick="closeSpotLookupModal()">&times;</button>
+          <button aria-label="Close modal" class="modal-close" id="spotLookupCloseBtn">&times;</button>
         </div>
         <div class="modal-body" id="spotLookupBody">
         </div>

--- a/js/events.js
+++ b/js/events.js
@@ -1571,6 +1571,22 @@ const setupNoteAndModalListeners = () => {
 
   optionalListener(elements.cancelNotesBtn, "click", dismissNotesModal, "Cancel notes button");
   optionalListener(elements.notesCloseBtn, "click", dismissNotesModal, "Notes modal close button");
+  optionalListener(document.getElementById('notesViewCloseBtn'), "click", () => {
+    if (typeof closeModalById === 'function') closeModalById('notesViewModal');
+  }, "Notes view modal close button");
+
+  optionalListener(document.getElementById('goldbackExchangeRateLink'), "click", (e) => {
+    e.preventDefault();
+    window.open(
+      'https://www.goldback.com/exchange-rates/',
+      'goldback_rates',
+      'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no',
+    );
+  }, "Goldback exchange rates link");
+
+  optionalListener(document.getElementById('spotLookupCloseBtn'), "click", () => {
+    if (typeof closeSpotLookupModal === 'function') closeSpotLookupModal();
+  }, "Spot lookup modal close button");
 
   optionalListener(elements.debugCloseBtn, "click",
     () => { if (typeof hideDebugModal === "function") hideDebugModal(); },
@@ -1711,6 +1727,12 @@ const setupSpotPriceListeners = () => {
  * Sets up vault backup/restore listeners and password strength UI.
  */
 const setupVaultListeners = () => {
+  const vaultCloseBtn = document.getElementById('vaultCloseBtn');
+  const vaultActionBtn = document.getElementById('vaultActionBtn');
+  const vaultCancelBtn = document.getElementById('vaultCancelBtn');
+  const vaultPasswordToggle = document.getElementById('vaultPasswordToggle');
+  const vaultConfirmToggle = document.getElementById('vaultConfirmToggle');
+
   optionalListener(elements.vaultExportBtn, "click",
     () => { openVaultModal("export"); },
     "Vault export button");
@@ -1726,6 +1748,30 @@ const setupVaultListeners = () => {
       e.target.value = "";
     }
   }, "Vault import file input");
+
+  optionalListener(vaultCloseBtn, "click", () => {
+    if (typeof closeVaultModal === 'function') closeVaultModal();
+  }, "Vault modal close button");
+
+  optionalListener(vaultActionBtn, "click", () => {
+    if (typeof handleVaultAction === 'function') handleVaultAction();
+  }, "Vault modal action button");
+
+  optionalListener(vaultCancelBtn, "click", () => {
+    if (typeof closeVaultModal === 'function') closeVaultModal();
+  }, "Vault modal cancel button");
+
+  optionalListener(vaultPasswordToggle, "click", () => {
+    if (typeof toggleVaultPasswordVisibility === 'function') {
+      toggleVaultPasswordVisibility('vaultPassword', vaultPasswordToggle);
+    }
+  }, "Vault password toggle");
+
+  optionalListener(vaultConfirmToggle, "click", () => {
+    if (typeof toggleVaultPasswordVisibility === 'function') {
+      toggleVaultPasswordVisibility('vaultConfirmPassword', vaultConfirmToggle);
+    }
+  }, "Vault confirm password toggle");
 
   // Vault modal live password events
   const pw = document.getElementById("vaultPassword");


### PR DESCRIPTION
## Summary
- migrate all inline onclick handlers from index.html to listener wiring in js/events.js
- add stable IDs for modal controls that previously relied on inline handlers
- preserve existing behavior for notes view close, Goldback external link popup, vault modal actions/toggles, and spot lookup close

## Validation
- verified there are zero inline onclick attributes in index.html
- manual code review confirms handlers are now bound with addEventListener in js/events.js
- lint run was attempted but npm registry was unavailable in the current environment (network resolution failure)
