### PR TITLE
fix: enable tag filter chips and polish view modal tags section (STAK-98)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -9685,18 +9685,6 @@ body.force-card-view .table-footer-controls select {
 }
 
 /* --- View modal tag section ----------------------------------------------- */
-.view-tags-section {
-  margin-bottom: 1rem;
-}
-.view-tags-section .view-section-header {
-  font-weight: 600;
-  font-size: 0.85rem;
-  margin-bottom: 0.5rem;
-  color: var(--text-primary, #1f2937);
-}
-.view-tags-section .view-section-icon {
-  margin-right: 0.25rem;
-}
 .view-tags-container {
   display: flex;
   flex-wrap: wrap;

--- a/js/constants.js
+++ b/js/constants.js
@@ -744,7 +744,7 @@ const FILTER_CHIP_CATEGORY_DEFAULTS = [
   { id: 'grade',            label: 'Grades',            enabled: true, group: null },
   { id: 'numistaId',        label: 'Numista IDs',       enabled: true, group: null },
   { id: 'purity',           label: 'Purity',            enabled: true, group: null },
-  { id: 'tags',             label: 'Tags',              enabled: false, group: null },
+  { id: 'tags',             label: 'Tags',              enabled: true, group: null },
 ];
 
 /**
@@ -887,8 +887,8 @@ const VIEW_MODAL_SECTION_DEFAULTS = [
   { id: 'inventory',    label: 'Inventory details',  enabled: true },
   { id: 'grading',      label: 'Grading',            enabled: true },
   { id: 'numista',      label: 'Numista data',       enabled: true },
-  { id: 'tags',         label: 'Tags',               enabled: true },
   { id: 'notes',        label: 'Notes',              enabled: true },
+  { id: 'tags',         label: 'Tags',               enabled: true },
 ];
 
 /** Loads the view modal section config from localStorage, merged with defaults. */

--- a/js/filters.js
+++ b/js/filters.js
@@ -353,6 +353,7 @@ const renderActiveFilters = () => {
         { id: 'storageLocation', enabled: true }, { id: 'year', enabled: true },
         { id: 'grade', enabled: true }, { id: 'numistaId', enabled: true },
         { id: 'purity', enabled: true },
+        { id: 'tags', enabled: true },
       ];
 
   // Read sort preference from toggle active button or localStorage (default: alpha)

--- a/js/tags.js
+++ b/js/tags.js
@@ -204,12 +204,12 @@ const buildTagSection = (uuid, numistaTags, onChanged) => {
 
   // Always show section so user can add custom tags
   const section = document.createElement('div');
-  section.className = 'view-tags-section';
+  section.className = 'view-detail-section';
   section.id = 'viewTagsSection';
 
   const heading = document.createElement('div');
-  heading.className = 'view-section-header';
-  heading.innerHTML = '<span class="view-section-icon">&#9873;</span> Tags';
+  heading.className = 'view-section-title';
+  heading.textContent = 'Tags';
   section.appendChild(heading);
 
   const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- **Enable tag filter chips**: `FILTER_CHIP_CATEGORY_DEFAULTS` had tags `enabled: false` — chips never rendered even when items had matching tags above the min count threshold
- **Add tags to fallback config**: The hardcoded fallback in `renderActiveFilters()` was missing the `tags` entry entirely
- **Restyle view modal Tags section**: Replaced custom `view-tags-section`/`view-section-header` + hammer icon with the standard `view-detail-section`/`view-section-title` pattern used by all other modal sections (consistent uppercase header, primary color, no icon)
- **Move Tags below Notes**: Swapped order in `VIEW_MODAL_SECTION_DEFAULTS` so Notes renders before Tags

## Test plan
- [ ] Add the same tag to 2+ items, set chip minimum to 2 — tag filter chip should appear in the chip area
- [ ] Click tag chip to filter — only tagged items shown
- [ ] Open Settings > filter chip categories — Tags row present and enabled; toggle off/on works
- [ ] Open View Modal — Tags section uses same header style as Inventory/Notes (small uppercase, primary color, no icon)
- [ ] Tags section appears below Notes in View Modal
- [ ] Verify dark, sepia, light themes — tag chips and header consistent

Resolves STAK-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)