### PR TITLE
feat: add settings modal redesign mockups (Tabler-inspired + journey accordion)

### DIFF
--- a/mockups/settings-modal-redesign/framework-research.md
+++ b/mockups/settings-modal-redesign/framework-research.md
@@ -1,0 +1,52 @@
+# Settings Modal Redesign: Lightweight Framework Research (file:// Compatible)
+
+## Constraints from StakTrakr
+
+- Must run directly from `file://` with no build step.
+- Must be lightweight and easy to drop into vanilla JavaScript globals.
+- Must support custom theming via existing CSS variables (`--bg-*`, `--text-*`, `--border`, etc.).
+- Should not require Node runtime or bundling.
+
+## Candidates
+
+### 1) Tabler (recommended visual direction)
+- **Type:** Bootstrap-based UI kit.
+- **Why it fits:** Excellent admin/settings IA patterns (sidebar + content cards), mobile-ready, clear information density.
+- **file:// viability:** Works if assets are vendored locally (`tabler.min.css`, optional JS bundle).
+- **Weight:** Moderate (larger than utility-only libs).
+- **Integration approach:** Use Tabler-inspired layout patterns while keeping existing IDs and JS behavior.
+
+### 2) Pico.css
+- **Type:** Class-light CSS framework.
+- **Why it fits:** Very small, semantic HTML first, easy to theme with CSS vars.
+- **file:// viability:** Excellent when local CSS file is included.
+- **Weight:** Lightweight.
+- **Integration approach:** Good for rapid modal/card/accordion structures without extra JS.
+
+### 3) Shoelace (Web Components)
+- **Type:** Component library (`<sl-dialog>`, `<sl-tab-group>`, etc.).
+- **Why it fits:** Accessible components out of the box.
+- **file:// viability:** Works only when JS/CSS component assets are local and correctly referenced.
+- **Weight:** Moderate.
+- **Integration approach:** Potentially powerful, but migration effort is higher because existing modal logic is not component-based.
+
+### 4) Spectre.css
+- **Type:** Minimal CSS framework.
+- **Why it fits:** Small and simple; easy to adopt selectively.
+- **file:// viability:** Excellent when vendored.
+- **Weight:** Lightweight.
+- **Integration approach:** Can provide baseline visual polish with minimal rewiring.
+
+## Recommendation
+
+1. **Primary direction:** Keep vanilla JS and implement a **Tabler-inspired shell** for settings (sidebar + grouped cards + sticky action footer).
+2. **Secondary direction:** Provide an **accordion/journey layout** for mobile-first discoverability.
+3. **Adoption strategy:** Vendor any third-party CSS locally if chosen later, but first validate IA and UX with framework-inspired mockups that preserve existing control IDs and section mapping.
+
+## What was implemented in this mockup package
+
+- Two modal prototypes in `test.html`:
+  - **Design A:** Tabler-inspired workspace modal.
+  - **Design B:** Progressive accordion/journey modal.
+- Prototypes are themed with StakTrakr variables for light/dark/sepia compatibility.
+- Settings sections are sourced from live `index.html` markup via `fetch` + `DOMParser`, preserving current section labels and panel content structure.

--- a/mockups/settings-modal-redesign/styles.css
+++ b/mockups/settings-modal-redesign/styles.css
@@ -1,0 +1,213 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background: var(--bg-primary, #eef2f7);
+  color: var(--text-primary, #1b232c);
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+button {
+  border: 1px solid var(--border, #cbd5e1);
+  background: var(--bg-card, #fff);
+  color: var(--text-primary, #1b232c);
+  border-radius: 8px;
+  padding: 0.55rem 0.8rem;
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--border-hover, #94a3b8);
+}
+
+.pill.active {
+  background: var(--primary, #3b82f6);
+  color: #fff;
+  border-color: transparent;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 0.45);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem;
+  z-index: 20;
+}
+
+.overlay.open {
+  display: flex;
+}
+
+.mock-modal {
+  width: min(1200px, 100%);
+  max-height: min(92vh, 950px);
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border, #cbd5e1);
+  background: var(--bg-secondary, #e2e8f0);
+}
+
+.modal-body {
+  min-height: 0;
+  overflow: auto;
+}
+
+/* Design A: Tabler-inspired */
+.design-a .modal-body {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+}
+
+.settings-nav-grid {
+  border-right: 1px solid var(--border, #cbd5e1);
+  background: linear-gradient(180deg, var(--bg-secondary, #e2e8f0), var(--bg-primary, #eef2f7));
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+  align-content: start;
+}
+
+.settings-nav-grid .settings-nav-item {
+  text-align: left;
+  width: 100%;
+}
+
+.settings-nav-grid .settings-nav-item.active {
+  background: var(--primary, #3b82f6);
+  color: #fff;
+  border-color: transparent;
+}
+
+.settings-content-cards {
+  padding: 1rem;
+  display: grid;
+  gap: 0.9rem;
+  align-content: start;
+}
+
+.settings-section-panel {
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 12px;
+  padding: 0.9rem;
+  background: var(--bg-card, #fff);
+}
+
+.settings-group {
+  padding: 0.65rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-secondary, #e2e8f0) 45%, transparent);
+  margin-bottom: 0.65rem;
+}
+
+.settings-group-label {
+  font-weight: 600;
+}
+
+.settings-subtext {
+  margin-top: 0.2rem;
+  color: var(--text-muted, #344351);
+  font-size: 0.88rem;
+}
+
+/* Design B: Journey */
+.design-b .modal-body {
+  padding: 0.8rem;
+}
+
+.journey-search {
+  margin-bottom: 0.8rem;
+}
+
+.journey-search input {
+  width: 100%;
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 10px;
+  padding: 0.6rem 0.7rem;
+  background: var(--bg-card, #fff);
+  color: var(--text-primary, #1b232c);
+}
+
+.journey-accordion {
+  display: grid;
+  gap: 0.55rem;
+}
+
+details.section {
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--bg-card, #fff);
+}
+
+details.section > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 0.7rem 0.8rem;
+  background: var(--bg-secondary, #e2e8f0);
+  font-weight: 600;
+}
+
+details.section[open] > summary {
+  border-bottom: 1px solid var(--border, #cbd5e1);
+}
+
+.section-panel-wrap {
+  padding: 0.75rem;
+}
+
+.modal-footer {
+  border-top: 1px solid var(--border, #cbd5e1);
+  padding: 0.65rem 1rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  background: var(--bg-secondary, #e2e8f0);
+  position: sticky;
+  bottom: 0;
+}
+
+@media (max-width: 960px) {
+  .design-a .modal-body {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-nav-grid {
+    border-right: 0;
+    border-bottom: 1px solid var(--border, #cbd5e1);
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  }
+}

--- a/mockups/settings-modal-redesign/test.html
+++ b/mockups/settings-modal-redesign/test.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings Modal Redesign Mockups</title>
+    <link rel="stylesheet" href="../../css/styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <h1>Settings Modal Redesign Mockups</h1>
+      <p>
+        These prototypes load the current settings sections from <code>index.html</code> so content and IDs stay aligned
+        with the existing modal while testing new IA/layout patterns.
+      </p>
+
+      <section class="toolbar">
+        <strong>Theme:</strong>
+        <button type="button" class="pill active" data-theme-choice="light">Light</button>
+        <button type="button" class="pill" data-theme-choice="dark">Dark</button>
+        <button type="button" class="pill" data-theme-choice="sepia">Sepia</button>
+      </section>
+
+      <section class="toolbar">
+        <button type="button" id="openDesignA">Open Design A (Tabler-inspired)</button>
+        <button type="button" id="openDesignB">Open Design B (Journey accordion)</button>
+      </section>
+
+      <p><a href="./framework-research.md">Framework research notes</a></p>
+    </main>
+
+    <div class="overlay" id="overlayA">
+      <div class="mock-modal design-a">
+        <header class="modal-header">
+          <h2>Settings — Design A</h2>
+          <button type="button" data-close="overlayA">Close</button>
+        </header>
+        <div class="modal-body" id="designABody"></div>
+        <footer class="modal-footer">
+          <button type="button">Reset to defaults</button>
+          <button type="button" class="pill active">Save settings</button>
+        </footer>
+      </div>
+    </div>
+
+    <div class="overlay" id="overlayB">
+      <div class="mock-modal design-b">
+        <header class="modal-header">
+          <h2>Settings — Design B</h2>
+          <button type="button" data-close="overlayB">Close</button>
+        </header>
+        <div class="modal-body" id="designBBody"></div>
+        <footer class="modal-footer">
+          <button type="button">Reset to defaults</button>
+          <button type="button" class="pill active">Save settings</button>
+        </footer>
+      </div>
+    </div>
+
+    <script src="./test.js" defer></script>
+  </body>
+</html>

--- a/mockups/settings-modal-redesign/test.js
+++ b/mockups/settings-modal-redesign/test.js
@@ -1,0 +1,183 @@
+const state = {
+  sourceLoaded: false,
+  navButtons: [],
+  panels: [],
+};
+
+const loadSourceSettings = async () => {
+  if (state.sourceLoaded) {
+    return;
+  }
+
+  const response = await fetch('../../index.html');
+  const html = await response.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  const navSource = doc.querySelector('#settingsModal .settings-sidebar');
+  const panelSource = doc.querySelector('#settingsModal .settings-content-area');
+
+  if (!navSource || !panelSource) {
+    throw new Error('Could not load settings modal source from index.html');
+  }
+
+  state.navButtons = [...navSource.querySelectorAll('.settings-nav-item')].map((el) => ({
+    label: el.textContent.trim(),
+    section: el.dataset.section,
+  }));
+
+  state.panels = [...panelSource.querySelectorAll('.settings-section-panel')].map((panel) => ({
+    id: panel.id,
+    section: panel.id.replace('settingsPanel_', ''),
+    html: panel.innerHTML,
+  }));
+
+  state.sourceLoaded = true;
+};
+
+const renderDesignA = () => {
+  const root = document.getElementById('designABody');
+  root.innerHTML = '';
+
+  const nav = document.createElement('nav');
+  nav.className = 'settings-nav-grid';
+
+  const content = document.createElement('section');
+  content.className = 'settings-content-cards';
+
+  state.navButtons.forEach((item, index) => {
+    const btn = document.createElement('button');
+    btn.className = `settings-nav-item${index === 0 ? ' active' : ''}`;
+    btn.textContent = item.label;
+    btn.type = 'button';
+    btn.dataset.section = item.section;
+    nav.appendChild(btn);
+  });
+
+  state.panels.forEach((panel, index) => {
+    const section = document.createElement('section');
+    section.className = 'settings-section-panel';
+    section.dataset.section = panel.section;
+    section.style.display = index === 0 ? 'block' : 'none';
+    section.innerHTML = panel.html;
+    content.appendChild(section);
+  });
+
+  nav.addEventListener('click', (event) => {
+    const btn = event.target.closest('.settings-nav-item');
+    if (!btn) {
+      return;
+    }
+    const target = btn.dataset.section;
+    [...nav.querySelectorAll('.settings-nav-item')].forEach((el) => {
+      el.classList.toggle('active', el.dataset.section === target);
+    });
+    [...content.querySelectorAll('.settings-section-panel')].forEach((el) => {
+      el.style.display = el.dataset.section === target ? 'block' : 'none';
+    });
+  });
+
+  root.append(nav, content);
+};
+
+const renderDesignB = () => {
+  const root = document.getElementById('designBBody');
+  root.innerHTML = '';
+
+  const searchWrap = document.createElement('div');
+  searchWrap.className = 'journey-search';
+  searchWrap.innerHTML = '<input id="journeySearchInput" type="search" placeholder="Search settings sections..." />';
+
+  const accordion = document.createElement('div');
+  accordion.className = 'journey-accordion';
+
+  state.panels.forEach((panel, index) => {
+    const details = document.createElement('details');
+    details.className = 'section';
+    details.open = index < 2;
+    details.dataset.section = panel.section;
+
+    const summary = document.createElement('summary');
+    const label = state.navButtons.find((item) => item.section === panel.section)?.label || panel.section;
+    summary.textContent = label;
+
+    const panelWrap = document.createElement('div');
+    panelWrap.className = 'section-panel-wrap';
+    panelWrap.innerHTML = panel.html;
+
+    details.append(summary, panelWrap);
+    accordion.appendChild(details);
+  });
+
+  root.append(searchWrap, accordion);
+
+  const input = root.querySelector('#journeySearchInput');
+  input.addEventListener('input', () => {
+    const term = input.value.trim().toLowerCase();
+    [...accordion.querySelectorAll('details.section')].forEach((section) => {
+      const visible = section.textContent.toLowerCase().includes(term);
+      section.style.display = visible ? 'block' : 'none';
+      if (term && visible) {
+        section.open = true;
+      }
+    });
+  });
+};
+
+const setTheme = (theme) => {
+  const html = document.documentElement;
+  const body = document.body;
+  body.classList.remove('dark-mode');
+  html.removeAttribute('data-theme');
+
+  if (theme === 'dark') {
+    body.classList.add('dark-mode');
+  } else if (theme === 'sepia') {
+    html.setAttribute('data-theme', 'sepia');
+  }
+
+  [...document.querySelectorAll('[data-theme-choice]')].forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.themeChoice === theme);
+  });
+};
+
+const openOverlay = (id) => {
+  document.getElementById(id).classList.add('open');
+};
+
+const closeOverlay = (id) => {
+  document.getElementById(id).classList.remove('open');
+};
+
+const init = async () => {
+  await loadSourceSettings();
+  renderDesignA();
+  renderDesignB();
+  setTheme('light');
+
+  document.getElementById('openDesignA').addEventListener('click', () => openOverlay('overlayA'));
+  document.getElementById('openDesignB').addEventListener('click', () => openOverlay('overlayB'));
+
+  document.body.addEventListener('click', (event) => {
+    const closeBtn = event.target.closest('[data-close]');
+    if (closeBtn) {
+      closeOverlay(closeBtn.dataset.close);
+      return;
+    }
+
+    const overlay = event.target.closest('.overlay.open');
+    if (overlay && event.target === overlay) {
+      closeOverlay(overlay.id);
+    }
+
+    const themeBtn = event.target.closest('[data-theme-choice]');
+    if (themeBtn) {
+      setTheme(themeBtn.dataset.themeChoice);
+    }
+  });
+};
+
+init().catch((error) => {
+  console.error(error);
+  alert('Failed to load mockup source data. Open this file from a local web server for best compatibility.');
+});


### PR DESCRIPTION
### Motivation

- The existing settings modal has grown large and difficult to navigate across device sizes and needs improved IA while retaining all current functionality.  
- Provide lightweight, file://-compatible options for a drop-in redesign without introducing a build step or heavy framework dependency.  
- Produce concrete, theme-aware prototypes that preserve current IDs and controls so the team can validate migration approach before touching production code.

### Description

- Added a new mockup package at `mockups/settings-modal-redesign/` containing `test.html`, `test.js`, `styles.css`, and a `framework-research.md` notes file.  
- Implemented two responsive modal prototypes: **Design A** (Tabler-inspired sidebar + card workspace) and **Design B** (mobile-first journey/accordion with section search), both themed to use existing CSS variables.  
- The prototypes dynamically load the live settings sidebar and section panels from `index.html` using `fetch` + `DOMParser` so markup, IDs, and control wiring remain aligned for a drop-in migration plan.  
- Included a short research doc comparing lightweight, file://-compatible frameworks (`Tabler`, `Pico.css`, `Shoelace`, `Spectre.css`) and a recommended visual direction.

### Testing

- Ran linting on the mockup script with `npx eslint mockups/settings-modal-redesign/test.js`, which completed successfully.  
- Attempted automated browser verification and screenshot capture using a Playwright script against a local `http.server`, but the Playwright run timed out / could not resolve the served route in this environment, so screenshots were not produced.  
- Performed manual static verification of generated files and the `fetch`/`DOMParser` logic (mockup loads content when served via HTTP as designed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d6d344a4832ead3277d23d872a7d)