### PR TITLE
feat: add responsive settings modal UX mockups (Tabler-inspired + adaptive)

### DIFF
--- a/mockups/settings-modal/README.md
+++ b/mockups/settings-modal/README.md
@@ -1,0 +1,44 @@
+# Settings Modal Mockups (Research + Prototype)
+
+## Lightweight framework research (file:// compatible)
+
+These options are intentionally CSS-first (or progressive enhancement) so they can run without a build step and remain compatible with `file://` launch.
+
+1. **Tabler CSS (inspired target)**
+   - Why fit: design language already matches dashboard/admin UI patterns and gives clean cards, nav, forms, and modal primitives.
+   - File protocol fit: can be vendored as static CSS/JS assets in repo and linked via relative `<link>` and `<script>` tags.
+   - Integration approach: use Tabler utility/card classes only, keep existing JS modal logic and IDs.
+
+2. **Picocss (class-light semantic CSS)**
+   - Why fit: very small footprint, minimal class churn, and works well for readable forms/sections.
+   - File protocol fit: single CSS file can be vendored locally, no runtime dependency.
+   - Integration approach: keep current DOM IDs/events, only adjust layout wrappers.
+
+3. **Shoelace Web Components (optional progressive enhancement)**
+   - Why fit: accessible tabs, drawers, dialogs, and segmented controls out of the box.
+   - File protocol fit: works when component files are served locally from repo; no bundler required.
+   - Integration approach: migrate modal shell widgets first (tabs/accordion), preserve existing data/control wiring.
+
+4. **Spectre.css / Milligram / Water.css (tiny fallback options)**
+   - Why fit: lightweight utility/form styling with minimal JS assumptions.
+   - File protocol fit: pure CSS files can be shipped locally and loaded via relative paths.
+
+## Mockups created
+
+- `test.html` includes two settings modal concepts:
+  1. **Design A: Tabler-inspired navigation shell** (left nav + carded settings overview + sticky footer actions).
+  2. **Design B: Adaptive workspace shell** (search-first pane + workflow accordions).
+
+Both mockups:
+- are responsive for mobile/tablet/desktop breakpoints,
+- support light/dark/sepia theme toggling,
+- preserve all current settings domains in the IA mapping.
+
+## How to run
+
+Open directly:
+- `file:///.../mockups/settings-modal/test.html`
+
+Or via local server:
+- `python -m http.server 8000`
+- navigate to `http://localhost:8000/mockups/settings-modal/test.html`

--- a/mockups/settings-modal/test.html
+++ b/mockups/settings-modal/test.html
@@ -1,0 +1,391 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Settings Modal Mockups</title>
+  <style>
+    :root {
+      --bg: #f5f7fb;
+      --surface: #ffffff;
+      --surface-muted: #f1f4fa;
+      --text: #1f2937;
+      --text-muted: #64748b;
+      --accent: #206bc4;
+      --accent-soft: #dbeafe;
+      --border: #dbe2ef;
+      --success: #0f766e;
+      --radius-lg: 16px;
+      --radius-md: 10px;
+      --shadow: 0 20px 50px rgba(15, 23, 42, 0.2);
+    }
+
+    html[data-theme='dark'] {
+      --bg: #0f172a;
+      --surface: #111827;
+      --surface-muted: #1f2937;
+      --text: #e5e7eb;
+      --text-muted: #94a3b8;
+      --accent: #60a5fa;
+      --accent-soft: #1e3a8a;
+      --border: #334155;
+      --success: #34d399;
+      --shadow: 0 30px 65px rgba(0, 0, 0, 0.55);
+    }
+
+    html[data-theme='sepia'] {
+      --bg: #f8f1e5;
+      --surface: #fff8ed;
+      --surface-muted: #f6ebd9;
+      --text: #5b4632;
+      --text-muted: #927860;
+      --accent: #8b5e34;
+      --accent-soft: #ead9bf;
+      --border: #dec6a6;
+      --success: #4d7c0f;
+      --shadow: 0 20px 50px rgba(93, 64, 34, 0.22);
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    .page {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      gap: 16px;
+    }
+
+    .toolbar {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      padding: 14px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .btn-group, .theme-group { display: flex; gap: 10px; flex-wrap: wrap; }
+
+    button {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      color: var(--text);
+      padding: 9px 12px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    button.primary {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent);
+    }
+
+    .note {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 14px;
+      color: var(--text-muted);
+      font-size: 0.93rem;
+      line-height: 1.45;
+    }
+
+    .modal-shell {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.62);
+      padding: 16px;
+      z-index: 40;
+      overflow: auto;
+    }
+
+    .modal-shell.open { display: flex; align-items: center; justify-content: center; }
+
+    .modal {
+      width: min(1120px, 100%);
+      max-height: min(92vh, 950px);
+      background: var(--surface);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+    }
+
+    .modal-head, .modal-foot {
+      border-bottom: 1px solid var(--border);
+      padding: 14px 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    .modal-foot {
+      border-bottom: 0;
+      border-top: 1px solid var(--border);
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    .layout-a {
+      display: grid;
+      grid-template-columns: 260px 1fr;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .nav-a {
+      background: var(--surface-muted);
+      padding: 10px;
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+    }
+
+    .nav-a button {
+      width: 100%;
+      text-align: left;
+      margin-bottom: 8px;
+    }
+
+    .nav-a button.active {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent);
+    }
+
+    .content { overflow-y: auto; padding: 16px; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px;
+      background: var(--surface);
+    }
+
+    .label { font-size: 0.8rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: .03em; }
+    .value { font-weight: 650; margin-top: 4px; }
+
+    .pill { padding: 2px 8px; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-size: 0.76rem; font-weight: 700; }
+
+    .layout-b {
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .left-pane {
+      border-right: 1px solid var(--border);
+      padding: 14px;
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+      gap: 12px;
+      background: var(--surface-muted);
+    }
+
+    input[type='search'] {
+      width: 100%;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      padding: 9px 10px;
+      background: var(--surface);
+      color: var(--text);
+    }
+
+    .list button { width: 100%; text-align: left; margin-bottom: 7px; }
+
+    .accordion { display: grid; gap: 10px; }
+    .accordion details {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface);
+      padding: 8px 10px;
+    }
+
+    .accordion summary { cursor: pointer; font-weight: 650; }
+    .mini { color: var(--text-muted); font-size: 0.85rem; margin-top: 7px; }
+
+    @media (max-width: 900px) {
+      .layout-a, .layout-b { grid-template-columns: 1fr; }
+      .nav-a, .left-pane { border-right: 0; border-bottom: 1px solid var(--border); max-height: 240px; }
+      .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <div class="toolbar">
+      <div class="btn-group">
+        <button class="primary" data-open="tabler">Open Design A · Tabler-Inspired</button>
+        <button class="primary" data-open="adaptive">Open Design B · Adaptive Workspace</button>
+      </div>
+      <div class="theme-group">
+        <button data-theme="light">Light</button>
+        <button data-theme="dark">Dark</button>
+        <button data-theme="sepia">Sepia</button>
+      </div>
+    </div>
+
+    <section class="note">
+      <strong>Mockup objectives:</strong> both prototypes keep every existing settings domain visible (Site, Layout, Table,
+      Grouping, Search, API, Files, Cloud, Images, System, Currency, Goldback, Activity Log), reduce navigation friction,
+      and are designed to drop into light/dark/sepia themes.
+    </section>
+  </main>
+
+  <div class="modal-shell" id="modal-tabler">
+    <section class="modal" role="dialog" aria-modal="true" aria-label="Tabler-inspired settings modal">
+      <header class="modal-head">
+        <div>
+          <strong>Settings · Design A (Tabler-inspired)</strong>
+          <div class="mini">Sidebar + section cards + quick metrics for scanability.</div>
+        </div>
+        <button data-close>Close</button>
+      </header>
+      <div class="layout-a">
+        <nav class="nav-a">
+          <button class="active">Site</button>
+          <button>Layout</button>
+          <button>Table</button>
+          <button>Grouping</button>
+          <button>Search</button>
+          <button>API</button>
+          <button>Files</button>
+          <button>Cloud</button>
+          <button>Images</button>
+          <button>System</button>
+          <button>Currency</button>
+          <button>Goldback</button>
+          <button>Activity Log</button>
+        </nav>
+        <section class="content">
+          <div class="grid">
+            <article class="card"><div class="label">Theme mode</div><div class="value">Light · Dark · Sepia · System</div></article>
+            <article class="card"><div class="label">Items per page</div><div class="value">10 / 25 / 50 / 100 / All</div></article>
+            <article class="card"><div class="label">Search enhancements</div><div class="value">Fuzzy autocomplete · Numista lookup</div></article>
+            <article class="card"><div class="label">Grouping tools</div><div class="value">Smart chips · dynamic chips · badges</div></article>
+            <article class="card"><div class="label">API providers</div><div class="value">Metals API chain + Numista + PCGS</div></article>
+            <article class="card"><div class="label">Storage & backup</div><div class="value">CSV/PDF/ZIP + encrypted vault <span class="pill">safe</span></div></article>
+            <article class="card"><div class="label">Image cache controls</div><div class="value">Table images, side toggle, cache management</div></article>
+            <article class="card"><div class="label">Activity history</div><div class="value">Change log · spot history · catalog history</div></article>
+          </div>
+        </section>
+      </div>
+      <footer class="modal-foot">
+        <span>Sticky action bar keeps Save / Export / Reset always accessible.</span>
+        <div class="btn-group"><button>Reset</button><button class="primary">Save Settings</button></div>
+      </footer>
+    </section>
+  </div>
+
+  <div class="modal-shell" id="modal-adaptive">
+    <section class="modal" role="dialog" aria-modal="true" aria-label="Adaptive workspace settings modal">
+      <header class="modal-head">
+        <div>
+          <strong>Settings · Design B (Adaptive workspace)</strong>
+          <div class="mini">Search-first + grouped workflows for mobile/tablet/desktop.</div>
+        </div>
+        <button data-close>Close</button>
+      </header>
+      <div class="layout-b">
+        <aside class="left-pane">
+          <input type="search" placeholder="Find settings: theme, API, cache, currency..." />
+          <div class="card">
+            <div class="label">Pinned workflows</div>
+            <div class="list">
+              <button>New device setup</button>
+              <button>Performance tuning</button>
+              <button>Import / export</button>
+              <button>API diagnostics</button>
+            </div>
+          </div>
+          <div class="card">
+            <div class="label">Coverage</div>
+            <div class="mini">All 13 existing sections mapped into workflow groups.</div>
+            <div class="mini">No controls removed; organization only.</div>
+          </div>
+        </aside>
+        <section class="content">
+          <div class="accordion">
+            <details open>
+              <summary>Appearance & navigation</summary>
+              <div class="mini">Site · Layout · Table settings grouped together for immediate visual behavior tuning.</div>
+            </details>
+            <details>
+              <summary>Data intelligence & grouping</summary>
+              <div class="mini">Grouping · Search · Goldback in one place for pricing and findability workflows.</div>
+            </details>
+            <details>
+              <summary>Connectivity & providers</summary>
+              <div class="mini">API, Numista/PCGS, sync status, key diagnostics, quota feedback.</div>
+            </details>
+            <details>
+              <summary>Backups, storage & security</summary>
+              <div class="mini">Files · Cloud · System · Images with exports, vault restore, cache stats, and cleanup tools.</div>
+            </details>
+            <details>
+              <summary>Regional preferences & auditing</summary>
+              <div class="mini">Currency + Activity Log with persistent history tables and quick filters.</div>
+            </details>
+          </div>
+        </section>
+      </div>
+      <footer class="modal-foot">
+        <span>Mobile: collapses into stacked search + accordions. Desktop: dual pane with command palette feel.</span>
+        <div class="btn-group"><button>Cancel</button><button class="primary">Apply</button></div>
+      </footer>
+    </section>
+  </div>
+
+  <script>
+    document.querySelectorAll('[data-open]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const target = btn.getAttribute('data-open');
+        const modal = document.getElementById(`modal-${target}`);
+        if (modal) modal.classList.add('open');
+      });
+    });
+
+    document.querySelectorAll('[data-close]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const shell = btn.closest('.modal-shell');
+        if (shell) shell.classList.remove('open');
+      });
+    });
+
+    document.querySelectorAll('.modal-shell').forEach((shell) => {
+      shell.addEventListener('click', (event) => {
+        if (event.target === shell) shell.classList.remove('open');
+      });
+    });
+
+    document.querySelectorAll('[data-theme]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        document.documentElement.setAttribute('data-theme', btn.getAttribute('data-theme'));
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- The existing Settings modal has grown large and hard to scan, so a lightweight, IA-focused redesign is needed to make related controls easier to find and use across screen sizes. 
- Prototypes must be `file://`-compatible, drop-in theme-compatible with the three app themes, and preserve 100% of the current settings sections for a non-destructive evaluation.

### Description
- Added a mockup workspace at `mockups/settings-modal/` with research notes on lightweight, `file://`-compatible frameworks such as Tabler CSS, Pico.css, Shoelace, and tiny CSS fallbacks in `mockups/settings-modal/README.md`.
- Added an interactive prototype page `mockups/settings-modal/test.html` that contains two full mockups: Design A (Tabler-inspired sidebar + carded overview + sticky action bar) and Design B (search-first adaptive workspace with grouped workflow accordions).
- The prototypes are responsive for mobile/tablet/desktop, include light/dark/sepia theme toggles, and include small in-page JS to open/close modals so the designs can be tested without any build step.
- The mockups intentionally preserve all existing settings domains (Site, Layout, Table, Grouping, Search, API, Files, Cloud, Images, System, Currency, Goldback, Activity Log) so they can be evaluated as drop-in replacements for all three themes.

### Testing
- Served the mockup page using `python3 -m http.server` and validated that the page loads successfully under HTTP and is also usable via `file://` by design.
- Ran an automated Playwright script that opened the page and captured screenshots of both modal concepts, producing `settings-modal-tabler.png` and `settings-modal-adaptive.png`, which confirmed interactive behavior and responsive layout.
- Verified the added files are present in the repository and that the mockup page responds to theme toggles and open/close interactions (all automated checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d6d344a4832ead3277d23d872a7d)