### PR TITLE
feat(dialogs): add shared in-app dialog utility and migrate key native dialogs (STAK-161–175)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4332,6 +4332,7 @@
   <script defer src="./js/constants.js"></script>
   <script defer src="./js/state.js"></script>
   <script defer src="./js/utils.js"></script>
+  <script defer src="./js/dialogs.js"></script>
   <script defer src="./js/image-processor.js"></script>
   <script defer src="./js/image-cache.js"></script>
   <script defer src="./js/bulk-image-cache.js"></script>

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -1077,7 +1077,7 @@ const deleteSelectedItems = async () => {
 // NUMISTA INTEGRATION
 // =============================================================================
 
-const triggerBulkNumistaLookup = () => {
+const triggerBulkNumistaLookup = async () => {
   if (!catalogAPI || !catalogAPI.activeProvider) {
     if (typeof showCloudToast === 'function') showCloudToast('Configure Numista API key in Settings first.');
     return;
@@ -1087,7 +1087,9 @@ const triggerBulkNumistaLookup = () => {
   window._bulkEditNumistaCallback = receiveBulkNumistaResult;
 
   // Prompt user for search query
-  const query = prompt('Enter a coin name or Numista N# to search:');
+  const query = typeof showAppPrompt === 'function'
+    ? await showAppPrompt('Enter a coin name or Numista N# to search:', '', 'Numista Lookup')
+    : prompt('Enter a coin name or Numista N# to search:');
   if (!query || !query.trim()) {
     window._bulkEditNumistaCallback = null;
     return;

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -113,8 +113,11 @@ function renderCloudActivityTable() {
   });
 }
 
-function clearCloudActivityLog() {
-  if (!confirm('Clear all cloud activity log? This cannot be undone.')) return;
+async function clearCloudActivityLog() {
+  const confirmed = typeof showAppConfirm === 'function'
+    ? await showAppConfirm('Clear all cloud activity log? This cannot be undone.', 'Cloud Sync')
+    : confirm('Clear all cloud activity log? This cannot be undone.');
+  if (!confirmed) return;
   saveCloudActivityLog([]);
   var panel = document.getElementById('logPanel_cloud');
   if (panel) delete panel.dataset.rendered;
@@ -334,7 +337,11 @@ function cloudNotifyAuthFailure(provider, message, details) {
   if (typeof showCloudToast === 'function') {
     showCloudToast(fullMessage, 7000);
   } else {
-    alert(fullMessage);
+    if (typeof showAppAlert === 'function') {
+      showAppAlert(fullMessage, 'Cloud Sync');
+    } else {
+      alert(fullMessage);
+    }
   }
 }
 

--- a/js/dialogs.js
+++ b/js/dialogs.js
@@ -1,0 +1,106 @@
+/* global sanitizeHtml */
+(function () {
+  // Note: getElementById is used here intentionally. ensureDialogRoot() guarantees
+  // all dialog DOM elements exist before any lookup, making safeGetElement() unnecessary.
+  const escapeDialogText = (value) => {
+    if (typeof sanitizeHtml === 'function') {
+      return sanitizeHtml(String(value || '')).replace(/\n/g, '<br>');
+    }
+    return String(value || '').replace(/[&<>"']/g, (char) => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    }[char])).replace(/\n/g, '<br>');
+  };
+
+  const ensureDialogRoot = () => {
+    let root = document.getElementById('appDialogModal');
+    if (root) return root;
+
+    root = document.createElement('div');
+    root.id = 'appDialogModal';
+    root.className = 'modal';
+    root.style.display = 'none';
+    root.style.zIndex = '10060';
+    root.innerHTML = `
+      <div class="modal-content" style="max-width: 460px; width: calc(100% - 2rem)">
+        <div class="modal-header">
+          <h3 id="appDialogTitle">Notice</h3>
+          <button type="button" id="appDialogClose" class="modal-close" aria-label="Close dialog">&times;</button>
+        </div>
+        <div class="modal-body">
+          <p id="appDialogMessage" style="margin:0 0 1rem 0; line-height:1.5"></p>
+          <input id="appDialogInput" type="text" class="form-control" style="display:none; width:100%" />
+        </div>
+        <div class="modal-footer" style="display:flex; justify-content:flex-end; gap:.5rem">
+          <button type="button" id="appDialogCancel" class="btn btn-secondary" style="display:none">Cancel</button>
+          <button type="button" id="appDialogOk" class="btn btn-primary">OK</button>
+        </div>
+      </div>`;
+
+    document.body.appendChild(root);
+    return root;
+  };
+
+  const showDialog = ({ title, message, mode = 'alert', defaultValue = '' }) => new Promise((resolve) => {
+    const modal = ensureDialogRoot();
+    const titleEl = document.getElementById('appDialogTitle');
+    const messageEl = document.getElementById('appDialogMessage');
+    const inputEl = document.getElementById('appDialogInput');
+    const closeBtn = document.getElementById('appDialogClose');
+    const cancelBtn = document.getElementById('appDialogCancel');
+    const okBtn = document.getElementById('appDialogOk');
+
+    if (!titleEl || !messageEl || !inputEl || !closeBtn || !cancelBtn || !okBtn) {
+      resolve(mode === 'prompt' ? null : mode === 'confirm' ? false : undefined);
+      return;
+    }
+
+    titleEl.textContent = title || 'Notice';
+    messageEl.innerHTML = escapeDialogText(message);
+    cancelBtn.style.display = mode === 'alert' ? 'none' : '';
+    inputEl.style.display = mode === 'prompt' ? '' : 'none';
+    if (mode === 'prompt') {
+      inputEl.value = defaultValue || '';
+    }
+
+    const cleanup = () => {
+      modal.style.display = 'none';
+      closeBtn.onclick = null;
+      cancelBtn.onclick = null;
+      okBtn.onclick = null;
+      modal.onclick = null;
+      inputEl.onkeydown = null;
+      document.removeEventListener('keydown', onKeyDown);
+    };
+
+    const finish = (result) => {
+      cleanup();
+      resolve(result);
+    };
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape' && mode !== 'alert') finish(mode === 'prompt' ? null : false);
+      if (event.key === 'Enter' && mode === 'prompt') finish(inputEl.value);
+    };
+
+    closeBtn.onclick = () => finish(mode === 'alert' ? undefined : (mode === 'prompt' ? null : false));
+    cancelBtn.onclick = () => finish(mode === 'prompt' ? null : false);
+    okBtn.onclick = () => finish(mode === 'prompt' ? inputEl.value : mode === 'confirm' ? true : undefined);
+    modal.onclick = (event) => {
+      if (event.target === modal && mode !== 'alert') finish(mode === 'prompt' ? null : false);
+    };
+    inputEl.onkeydown = onKeyDown;
+    document.addEventListener('keydown', onKeyDown);
+
+    modal.style.display = 'flex';
+    if (mode === 'prompt') inputEl.focus();
+    else okBtn.focus();
+  });
+
+  window.showAppAlert = (message, title) => showDialog({ mode: 'alert', message, title });
+  window.showAppConfirm = (message, title) => showDialog({ mode: 'confirm', message, title });
+  window.showAppPrompt = (message, defaultValue, title) => showDialog({ mode: 'prompt', message, defaultValue, title });
+}());

--- a/js/events.js
+++ b/js/events.js
@@ -1797,20 +1797,27 @@ const setupVaultListeners = () => {
  * Sets up data-destructive action listeners (remove data, boating accident).
  */
 const setupDataManagementListeners = () => {
-  optionalListener(elements.removeInventoryDataBtn, "click", () => {
-    if (confirm("Remove all inventory items? This cannot be undone.")) {
+  optionalListener(elements.removeInventoryDataBtn, "click", async () => {
+    const confirmed = typeof showAppConfirm === "function"
+      ? await showAppConfirm("Remove all inventory items? This cannot be undone.", "Data Management")
+      : confirm("Remove all inventory items? This cannot be undone.");
+    if (confirmed) {
       localStorage.removeItem(LS_KEY);
       // STACK-62: Clear stale autocomplete cache so it rebuilds from fresh inventory
       if (typeof clearLookupCache === 'function') clearLookupCache();
       loadInventory();
       renderTable();
       renderActiveFilters();
-      alert("Inventory data cleared.");
+      if (typeof showAppAlert === "function") await showAppAlert("Inventory data cleared.", "Data Management");
+      else alert("Inventory data cleared.");
     }
   }, "Remove inventory data button");
 
-  optionalListener(elements.boatingAccidentBtn, "click", () => {
-    if (confirm("Did you really lose it all in a boating accident? This will wipe all local data.")) {
+  optionalListener(elements.boatingAccidentBtn, "click", async () => {
+    const confirmed = typeof showAppConfirm === "function"
+      ? await showAppConfirm("Did you really lose it all in a boating accident? This will wipe all local data.", "Data Management")
+      : confirm("Did you really lose it all in a boating accident? This will wipe all local data.");
+    if (confirmed) {
       // Nuclear wipe: clear every allowed localStorage key
       ALLOWED_STORAGE_KEYS.forEach((key) => {
         localStorage.removeItem(key);
@@ -1840,7 +1847,8 @@ const setupDataManagementListeners = () => {
       apiCache = null;
       updateSyncButtonStates();
 
-      alert("All data has been erased. Hope your scuba gear is ready!");
+      if (typeof showAppAlert === "function") await showAppAlert("All data has been erased. Hope your scuba gear is ready!", "Data Management");
+      else alert("All data has been erased. Hope your scuba gear is ready!");
     }
   }, "Boating accident button");
 };

--- a/js/search.js
+++ b/js/search.js
@@ -408,7 +408,7 @@ const deriveSearchLabel = (patterns) => {
   return pretty.join(' / ');
 };
 
-const handleSaveSearchPattern = () => {
+const handleSaveSearchPattern = async () => {
   const input = resolveElement('searchInput');
   if (!input || !input.id) return;
   const query = input.value || '';
@@ -420,7 +420,9 @@ const handleSaveSearchPattern = () => {
 
   const patterns = parseSearchPatterns(query);
   const defaultLabel = deriveSearchLabel(patterns);
-  const label = window.prompt('Label for saved filter chip:', defaultLabel);
+  const label = typeof showAppPrompt === 'function'
+    ? await showAppPrompt('Label for saved filter chip:', defaultLabel, 'Save Search Pattern')
+    : window.prompt('Label for saved filter chip:', defaultLabel);
   if (!label || !label.trim()) {
     updateSaveSearchButton(query, fuzzyUsed);
     return;

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.31.5-b1771474883';
+const CACHE_NAME = 'staktrakr-v3.31.5-b1771477450';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +
@@ -24,6 +24,7 @@ const CORE_ASSETS = [
   './js/constants.js',
   './js/state.js',
   './js/utils.js',
+  './js/dialogs.js',
   './js/image-cache.js',
   './js/fuzzy-search.js',
   './js/autocomplete.js',


### PR DESCRIPTION
## Summary

- **New module `js/dialogs.js`**: Promise-based `showAppAlert` / `showAppConfirm` / `showAppPrompt` helpers using an IIFE pattern. HTML escaping via `sanitizeHtml` (from `utils.js`) with a robust fallback entity-escaper. Newlines converted to `<br>` safely. Z-index `10060` (above `bulkConfirmModal` at `10050`). Full keyboard handling (Escape closes confirm/prompt; Enter submits prompt). Lifecycle cleanup on every resolve path.
- **`index.html`**: Script tag inserted after `utils.js`, before `image-processor.js` — correct per canonical load order in CLAUDE.md.
- **`sw.js` CORE_ASSETS**: `'./js/dialogs.js'` added after `'./js/utils.js'` — required by CLAUDE.md for all new `.js` files. Pre-commit hook auto-stamped `CACHE_NAME`.
- **Caller migrations** (all with native fallbacks):
  - `js/bulkEdit.js` — `triggerBulkNumistaLookup`: `async` + `showAppPrompt`
  - `js/cloud-storage.js` — `clearCloudActivityLog`: `async` + `showAppConfirm`; `cloudNotifyAuthFailure`: `showAppAlert`
  - `js/events.js` — `setupDataManagementListeners`: `async` + `showAppConfirm` / `showAppAlert`
  - `js/search.js` — `handleSaveSearchPattern`: `async` + `showAppPrompt`

## Source

Cherry-picked best elements from Codex PRs #268 and #269. PR #269's `dialogs.js` chosen as base (sanitized HTML escaping, explicit fallback escaper, no async correctness bugs). Missing `sw.js` CORE_ASSETS entry (shared omission in both PRs) fixed here.

## What's Deferred

- Broader 20-file migration from PR #268 (subsequent PR after foundation stabilizes)
- Consolidating `showBulkConfirm` and `showAppConfirm`
- Remaining native dialogs in `api.js`, `inventory.js`, `settings-listeners.js`, etc.

## Test Plan

- [ ] Open `index.html` via `file://` — trigger bulk edit Numista lookup → prompt modal appears
- [ ] Trigger cloud activity log clear → confirm modal appears
- [ ] Trigger save search pattern → prompt modal appears
- [ ] Verify Escape closes confirm/prompt but not alert
- [ ] Verify Enter submits prompts
- [ ] Load via `localhost` HTTP server → DevTools → Cache Storage → confirm `dialogs.js` cached
- [ ] ESLint: `npx eslint js/dialogs.js js/bulkEdit.js js/cloud-storage.js js/events.js js/search.js` → zero errors ✅ (pre-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)