### PR TITLE
fix(STAK-173): remove stale eslint-disable directives

### DIFF
--- a/js/bulk-image-cache.js
+++ b/js/bulk-image-cache.js
@@ -7,7 +7,6 @@
 // Image caching is handled on-demand by the view modal (viewModal.js).
 // =============================================================================
 
-// eslint-disable-next-line no-unused-vars
 const BulkImageCache = (() => {
   let _aborted = false;
   let _running = false;

--- a/js/image-cache-modal.js
+++ b/js/image-cache-modal.js
@@ -336,7 +336,6 @@ const clearAllCachedData = async () => {
     return;
   }
 
-  // eslint-disable-next-line no-restricted-globals
   if (!confirm(`Delete all ${usage.count} cached entries (images + metadata)? This cannot be undone.`)) return;
 
   const ok = await imageCache.clearAll();


### PR DESCRIPTION
### Motivation
- Reduce lint noise and remove unused/incorrect `eslint-disable` directives so CI/Codacy linting reflects real issues and the codebase stays maintainable.

### Description
- Removed two unnecessary `eslint-disable` comments: the `no-unused-vars` directive before the `BulkImageCache` IIFE in `js/bulk-image-cache.js` and the `no-restricted-globals` directive before the confirmation in `js/image-cache-modal.js`.

### Testing
- Ran `npx eslint js/*.js` and the lint pass now completes with no file-level warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699699a89ed0832e860db2bf4a86eac6)