### PR TITLE
feat(STAK-202): Retail Price Poller via Firecrawl

### DIFF
--- a/.github/workflows/retail-price-poller.yml
+++ b/.github/workflows/retail-price-poller.yml
@@ -1,0 +1,50 @@
+# Daily retail price poller — scrapes 4 dealer sites via Firecrawl
+# Writes to data/retail/{coin-slug}/{YYYY-MM-DD}.json on the `data` branch
+# Requires repository secret: FIRECRAWL_API_KEY
+name: Retail Price Poller
+
+on:
+  schedule:
+    # 11:00 AM EST = 16:00 UTC (shift to 15:00 UTC cron during EDT)
+    - cron: '0 16 * * *'
+  workflow_dispatch: # Manual trigger for testing
+
+env:
+  TZ: UTC
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout data branch
+        uses: actions/checkout@v4
+        with:
+          ref: data
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run price extractor
+        env:
+          FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+          DATA_DIR: ${{ github.workspace }}/data
+        run: node devops/retail-poller/price-extract.js
+
+      - name: Commit and push data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/retail/
+          if git diff --cached --quiet; then
+            echo "No new data to commit."
+          else
+            DATE=$(date -u +%Y-%m-%d)
+            git commit -m "retail: ${DATE} daily price data"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,10 @@ __pycache__/
 # DevOps tooling — spot-poller and hooks are public, other scripts stay private
 devops/*
 !devops/spot-poller/
+!devops/retail-poller/
 !devops/hooks/
 
 
 # AI/MCP configuration files are tracked for project consistency
 # (removed: .github/instructions/codacy.instructions.md)
+.firecrawl/

--- a/devops/retail-poller/.env.example
+++ b/devops/retail-poller/.env.example
@@ -1,0 +1,15 @@
+# Browserbase credentials (https://www.browserbase.com/settings)
+BROWSERBASE_API_KEY=
+BROWSERBASE_PROJECT_ID=
+
+# Browser mode: "browserbase" (cloud) or "local" (local Chromium)
+BROWSER_MODE=browserbase
+
+# Data directory (absolute path to repo data/ folder, on the data branch)
+DATA_DIR=../../data
+
+# Optional: override which coins/providers to capture
+# Comma-separated coin slugs (default: ase,age,generic-silver-round,buffalo)
+# COINS=ase,age,generic-silver-round,buffalo
+# Comma-separated provider IDs (default: sdbullion,apmex)
+# PROVIDERS=sdbullion,apmex

--- a/devops/retail-poller/.gitignore
+++ b/devops/retail-poller/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/devops/retail-poller/capture.js
+++ b/devops/retail-poller/capture.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * StakTrakr Retail Price Capture
+ * ================================
+ * Visits dealer product pages via Browserbase (cloud) or local Chromium,
+ * takes a screenshot of each, and writes a manifest for downstream
+ * extraction (Gemini vision, Jules, etc.).
+ *
+ * Starter set: 4 coins × 2 providers = 8 screenshots.
+ * Expand via COINS / PROVIDERS env vars or by editing providers.json.
+ *
+ * Usage:
+ *   npm run capture            # Browserbase cloud
+ *   npm run capture:local      # Local Chromium (needs `npx playwright install chromium`)
+ */
+
+import { chromium } from "playwright-core";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { config } from "dotenv";
+
+config(); // load .env
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const BROWSER_MODE = process.env.BROWSER_MODE || "browserbase";
+const BROWSERBASE_API_KEY = process.env.BROWSERBASE_API_KEY;
+const BROWSERBASE_PROJECT_ID = process.env.BROWSERBASE_PROJECT_ID;
+const DATA_DIR = resolve(process.env.DATA_DIR || "../../data");
+
+// Starter set — override with COINS=ase,age,... and PROVIDERS=sdbullion,apmex,...
+const DEFAULT_COINS = ["ase", "age", "generic-silver-round", "buffalo"];
+const DEFAULT_PROVIDERS = ["sdbullion", "apmex"];
+
+const COINS = (process.env.COINS || DEFAULT_COINS.join(",")).split(",").map(s => s.trim());
+const PROVIDERS = (process.env.PROVIDERS || DEFAULT_PROVIDERS.join(",")).split(",").map(s => s.trim());
+
+// Per-page delays (ms) — be polite, avoid rate limits
+const PAGE_LOAD_WAIT = 4000;    // wait after domcontentloaded for JS rendering
+const INTER_PAGE_DELAY = 1500;  // pause between pages
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function today() {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function log(msg) {
+  const ts = new Date().toISOString().slice(11, 19);
+  console.log(`[${ts}] ${msg}`);
+}
+
+function loadProviders() {
+  const providerPath = join(DATA_DIR, "retail", "providers.json");
+  try {
+    return JSON.parse(readFileSync(providerPath, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to read providers.json at ${providerPath}`);
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+function buildTargetList(providersJson) {
+  const targets = [];
+  for (const coinSlug of COINS) {
+    const coin = providersJson.coins[coinSlug];
+    if (!coin) {
+      log(`WARN: coin "${coinSlug}" not found in providers.json, skipping`);
+      continue;
+    }
+    for (const provider of coin.providers) {
+      if (!PROVIDERS.includes(provider.id)) continue;
+      if (!provider.enabled || !provider.url) {
+        log(`WARN: ${coinSlug}/${provider.id} disabled or no URL, skipping`);
+        continue;
+      }
+      targets.push({
+        coin: coinSlug,
+        metal: coin.metal,
+        provider: provider.id,
+        url: provider.url,
+      });
+    }
+  }
+  return targets;
+}
+
+// ---------------------------------------------------------------------------
+// Browser connection
+// ---------------------------------------------------------------------------
+
+async function connectBrowser() {
+  if (BROWSER_MODE === "local") {
+    log("Launching local Chromium...");
+    // Requires: npx playwright install chromium
+    const { chromium: localChromium } = await import("playwright");
+    return localChromium.launch({ headless: true });
+  }
+
+  // Browserbase cloud via CDP
+  if (!BROWSERBASE_API_KEY || !BROWSERBASE_PROJECT_ID) {
+    console.error("BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID required for cloud mode.");
+    console.error("Set BROWSER_MODE=local to use local Chromium instead.");
+    process.exit(1);
+  }
+
+  log("Creating Browserbase session...");
+  const response = await fetch("https://www.browserbase.com/v1/sessions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-bb-api-key": BROWSERBASE_API_KEY,
+    },
+    body: JSON.stringify({ projectId: BROWSERBASE_PROJECT_ID }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    console.error(`Browserbase session creation failed (${response.status}): ${text}`);
+    process.exit(1);
+  }
+
+  const session = await response.json();
+  log(`Browserbase session: ${session.id}`);
+
+  const wsUrl = `wss://connect.browserbase.com?apiKey=${BROWSERBASE_API_KEY}&sessionId=${session.id}`;
+  log("Connecting via CDP...");
+  return chromium.connectOverCDP(wsUrl);
+}
+
+// ---------------------------------------------------------------------------
+// Main capture loop
+// ---------------------------------------------------------------------------
+
+async function captureAll() {
+  const providersJson = loadProviders();
+  const targets = buildTargetList(providersJson);
+
+  if (targets.length === 0) {
+    console.error("No targets to capture. Check COINS/PROVIDERS env vars.");
+    process.exit(1);
+  }
+
+  log(`Capturing ${targets.length} pages (${COINS.length} coins × ${PROVIDERS.length} providers)`);
+
+  // Create output directory: data/retail/_artifacts/YYYY-MM-DD/
+  const dateStr = today();
+  const outDir = join(DATA_DIR, "retail", "_artifacts", dateStr);
+  mkdirSync(outDir, { recursive: true });
+
+  const browser = await connectBrowser();
+  const context = browser.contexts()[0] || await browser.newContext({
+    viewport: { width: 1280, height: 900 },
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  });
+  const page = await context.newPage();
+
+  const manifest = {
+    captured_at: new Date().toISOString(),
+    date: dateStr,
+    coins: COINS,
+    providers: PROVIDERS,
+    results: [],
+  };
+
+  for (const target of targets) {
+    const filename = `${target.coin}_${target.provider}.png`;
+    const filepath = join(outDir, filename);
+
+    log(`${target.coin}/${target.provider} → ${target.url}`);
+
+    try {
+      const response = await page.goto(target.url, {
+        waitUntil: "domcontentloaded",
+        timeout: 30000,
+      });
+      const status = response ? response.status() : 0;
+
+      // Wait for JS to render prices
+      await page.waitForTimeout(PAGE_LOAD_WAIT);
+
+      // Take full-page screenshot
+      await page.screenshot({ path: filepath, fullPage: false });
+
+      const title = await page.title();
+
+      manifest.results.push({
+        coin: target.coin,
+        provider: target.provider,
+        metal: target.metal,
+        url: target.url,
+        status,
+        title,
+        screenshot: filename,
+        ok: status === 200 && !title.toLowerCase().includes("not found"),
+      });
+
+      log(`  ✓ ${status} "${title.slice(0, 60)}" → ${filename}`);
+    } catch (err) {
+      manifest.results.push({
+        coin: target.coin,
+        provider: target.provider,
+        metal: target.metal,
+        url: target.url,
+        status: 0,
+        title: "",
+        screenshot: null,
+        ok: false,
+        error: err.message.slice(0, 200),
+      });
+      log(`  ✗ ERROR: ${err.message.slice(0, 100)}`);
+    }
+
+    // Polite delay between requests
+    await page.waitForTimeout(INTER_PAGE_DELAY);
+  }
+
+  // Write manifest
+  const manifestPath = join(outDir, "manifest.json");
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  log(`Manifest written: ${manifestPath}`);
+
+  // Summary
+  const ok = manifest.results.filter(r => r.ok).length;
+  const fail = manifest.results.filter(r => !r.ok).length;
+  log(`Done: ${ok} captured, ${fail} failed out of ${targets.length} targets`);
+
+  await browser.close();
+  return manifest;
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+captureAll().catch(err => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/devops/retail-poller/package.json
+++ b/devops/retail-poller/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "staktrakr-retail-poller",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Screenshot capture for retail precious metals price extraction",
+  "type": "module",
+  "scripts": {
+    "capture": "node capture.js",
+    "capture:local": "BROWSER_MODE=local node capture.js"
+  },
+  "dependencies": {
+    "playwright-core": "^1.49.0",
+    "dotenv": "^16.4.0"
+  },
+  "devDependencies": {
+    "playwright": "^1.49.0"
+  }
+}

--- a/devops/retail-poller/price-extract.js
+++ b/devops/retail-poller/price-extract.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ * StakTrakr Retail Price Extractor
+ * ==================================
+ * Reads providers.json, scrapes each dealer URL via Firecrawl,
+ * extracts the lowest in-stock price, and writes daily JSON files
+ * to data/retail/{coin-slug}/{YYYY-MM-DD}.json
+ *
+ * Usage:
+ *   FIRECRAWL_API_KEY=fc-... node price-extract.js
+ *
+ * Environment:
+ *   FIRECRAWL_API_KEY  Required. Firecrawl API key.
+ *   DATA_DIR           Path to repo data/ folder (default: ../../data)
+ *   COINS              Comma-separated coin slugs to run (default: all)
+ *   DRY_RUN            Set to "1" to skip writing files
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY;
+const DATA_DIR = resolve(process.env.DATA_DIR || join(__dirname, "../../data"));
+const DRY_RUN = process.env.DRY_RUN === "1";
+const COIN_FILTER = process.env.COINS ? process.env.COINS.split(",").map(s => s.trim()) : null;
+
+// Firecrawl free/pay-as-you-go tier = 2 concurrent scrapes
+const CONCURRENCY = 2;
+const SCRAPE_TIMEOUT_MS = 30_000;
+const RETRY_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 3_000;
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+function log(msg) {
+  console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+}
+
+function warn(msg) {
+  console.warn(`[${new Date().toISOString().slice(11, 19)}] WARN: ${msg}`);
+}
+
+// ---------------------------------------------------------------------------
+// Price extraction from Firecrawl markdown
+// ---------------------------------------------------------------------------
+
+// Plausible per-coin price ranges by metal type.
+// Used to filter out accessories, roll totals, and spot ticker values.
+const METAL_PRICE_RANGE = {
+  silver:   { min: 50,   max: 500   },
+  gold:     { min: 1500, max: 20000 },
+  platinum: { min: 500,  max: 8000  },
+  palladium: { min: 300, max: 8000  },
+};
+
+/**
+ * Extract the lowest plausible per-coin price from scraped markdown.
+ *
+ * All candidate prices are filtered against the metal's expected range to
+ * exclude accessories (capsules, tubes), bulk roll totals, and spot tickers.
+ *
+ * Strategy order:
+ *  1. "As Low As $XX.XX" — JM Bullion, Monument Metals, SD Bullion
+ *  2. First standalone dollar amount on its own line — APMEX
+ *  3. Lowest plausible price in a markdown table column
+ */
+function extractPrice(markdown, metal) {
+  if (!markdown) return null;
+
+  const range = METAL_PRICE_RANGE[metal] || { min: 5, max: 200_000 };
+
+  function inRange(p) {
+    return p >= range.min && p <= range.max;
+  }
+
+  // Strategy 1: All "As Low As $XX.XX" occurrences filtered to coin range.
+  // Taking the minimum of in-range matches handles pages that show both
+  // per-coin ("As Low As $93.81") and roll totals ("As Low As $1,902").
+  const asLowAsPattern = /[Aa]s\s+[Ll]ow\s+[Aa]s[\s\\]*\$?([\d,]+\.\d{2})/g;
+  const asLowAsPrices = [];
+  let m;
+  while ((m = asLowAsPattern.exec(markdown)) !== null) {
+    const p = parseFloat(m[1].replace(/,/g, ""));
+    if (inRange(p)) asLowAsPrices.push(p);
+  }
+  if (asLowAsPrices.length > 0) return Math.min(...asLowAsPrices);
+
+  // Strategy 2: Standalone dollar amount on its own line (APMEX top-of-page price)
+  const lines = markdown.split("\n");
+  for (const line of lines) {
+    const standalone = line.trim().match(/^\$?([\d,]+\.\d{2})\$?\\?$/);
+    if (standalone) {
+      const p = parseFloat(standalone[1].replace(/,/g, ""));
+      if (inRange(p)) return p;
+    }
+  }
+
+  // Strategy 3: Plausible prices in markdown table cells
+  const tablePrices = [];
+  const tableCellPattern = /\|\s*\*{0,2}\$?([\d,]+\.\d{2})\*{0,2}\s*\|/g;
+  while ((m = tableCellPattern.exec(markdown)) !== null) {
+    const p = parseFloat(m[1].replace(/,/g, ""));
+    if (inRange(p)) tablePrices.push(p);
+  }
+  if (tablePrices.length > 0) return Math.min(...tablePrices);
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Firecrawl API
+// ---------------------------------------------------------------------------
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+async function scrapeUrl(url, attempt = 1) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SCRAPE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch("https://api.firecrawl.dev/v1/scrape", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${FIRECRAWL_API_KEY}`,
+      },
+      body: JSON.stringify({
+        url,
+        formats: ["markdown"],
+        onlyMainContent: true,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${text.slice(0, 200)}`);
+    }
+
+    const json = await response.json();
+    return json?.data?.markdown ?? null;
+
+  } catch (err) {
+    if (attempt < RETRY_ATTEMPTS) {
+      warn(`Retry ${attempt}/${RETRY_ATTEMPTS} for ${url}: ${err.message}`);
+      await sleep(RETRY_DELAY_MS * attempt);
+      return scrapeUrl(url, attempt + 1);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency pool
+// ---------------------------------------------------------------------------
+
+async function runConcurrent(tasks, concurrency) {
+  const results = new Array(tasks.length);
+  let idx = 0;
+  async function worker() {
+    while (idx < tasks.length) {
+      const i = idx++;
+      results[i] = await tasks[i]();
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// File writers
+// ---------------------------------------------------------------------------
+
+function writeDailyJson(coinSlug, dateStr, data) {
+  const dir = join(DATA_DIR, "retail", coinSlug);
+  const filePath = join(dir, `${dateStr}.json`);
+  if (DRY_RUN) {
+    log(`[DRY RUN] ${filePath}`);
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+  log(`Wrote ${filePath}`);
+}
+
+function updateProviderCandidates(failures, dateStr) {
+  if (failures.length === 0) return;
+  const candidatesPath = join(DATA_DIR, "retail", "provider_candidates.json");
+  let doc = { schema_version: 1, last_updated: dateStr, candidates: [] };
+
+  if (existsSync(candidatesPath)) {
+    try {
+      doc = JSON.parse(readFileSync(candidatesPath, "utf-8"));
+    } catch {
+      warn("Could not parse provider_candidates.json, starting fresh");
+    }
+  }
+
+  doc.last_updated = dateStr;
+  for (const { coinSlug, providerId, url, error } of failures) {
+    const key = `${coinSlug}/${providerId}`;
+    const existing = doc.candidates.find(c => c.key === key);
+    if (existing) {
+      existing.consecutive_failures = (existing.consecutive_failures || 0) + 1;
+      existing.last_error = error;
+      existing.last_attempted = dateStr;
+    } else {
+      doc.candidates.push({
+        key,
+        coin: coinSlug,
+        provider: providerId,
+        url,
+        consecutive_failures: 1,
+        last_error: error,
+        last_attempted: dateStr,
+        last_working_date: null,
+      });
+    }
+  }
+
+  if (DRY_RUN) { log("[DRY RUN] Would update provider_candidates.json"); return; }
+  writeFileSync(candidatesPath, JSON.stringify(doc, null, 2) + "\n");
+  log(`Updated provider_candidates.json (${failures.length} failures logged)`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!FIRECRAWL_API_KEY) {
+    console.error("Error: FIRECRAWL_API_KEY is required.");
+    process.exit(1);
+  }
+
+  const providersPath = join(DATA_DIR, "retail", "providers.json");
+  if (!existsSync(providersPath)) {
+    console.error(`Error: providers.json not found at ${providersPath}`);
+    process.exit(1);
+  }
+
+  const providersJson = JSON.parse(readFileSync(providersPath, "utf-8"));
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const generatedAt = new Date().toISOString();
+
+  // Build scrape targets
+  const targets = [];
+  for (const [coinSlug, coin] of Object.entries(providersJson.coins)) {
+    if (COIN_FILTER && !COIN_FILTER.includes(coinSlug)) continue;
+    for (const provider of coin.providers) {
+      if (!provider.enabled || !provider.url) continue;
+      targets.push({ coinSlug, coin, provider });
+    }
+  }
+
+  log(`Retail price extraction: ${targets.length} targets, ${CONCURRENCY} concurrent`);
+  if (DRY_RUN) log("DRY RUN — no files written");
+
+  // Scrape all targets
+  const scrapeResults = [];
+  const tasks = targets.map(({ coinSlug, coin, provider }) => async () => {
+    log(`Scraping ${coinSlug}/${provider.id}`);
+    try {
+      const markdown = await scrapeUrl(provider.url);
+      const price = extractPrice(markdown, coin.metal);
+      if (price !== null) {
+        log(`  ✓ ${coinSlug}/${provider.id}: $${price.toFixed(2)}`);
+      } else {
+        warn(`  ? ${coinSlug}/${provider.id}: page loaded but no price found`);
+      }
+      scrapeResults.push({ coinSlug, coin, providerId: provider.id, url: provider.url, price, ok: price !== null, error: price === null ? "price_not_found" : null });
+    } catch (err) {
+      warn(`  ✗ ${coinSlug}/${provider.id}: ${err.message.slice(0, 120)}`);
+      scrapeResults.push({ coinSlug, coin, providerId: provider.id, url: provider.url, price: null, ok: false, error: err.message.slice(0, 200) });
+    }
+  });
+
+  await runConcurrent(tasks, CONCURRENCY);
+
+  // Aggregate per coin and write output
+  const coinSlugs = [...new Set(scrapeResults.map(r => r.coinSlug))];
+  const allFailures = [];
+
+  for (const coinSlug of coinSlugs) {
+    const coinResults = scrapeResults.filter(r => r.coinSlug === coinSlug);
+    const successful = coinResults.filter(r => r.ok);
+    const failed = coinResults.filter(r => !r.ok);
+
+    const pricesBySite = {};
+    const extractionMethods = {};
+    const urlsUsed = [];
+    for (const r of successful) {
+      pricesBySite[r.providerId] = r.price;
+      extractionMethods[r.providerId] = "firecrawl";
+      urlsUsed.push(r.url);
+    }
+
+    const prices = Object.values(pricesBySite);
+    const sorted = [...prices].sort((a, b) => a - b);
+
+    writeDailyJson(coinSlug, dateStr, {
+      date: dateStr,
+      generated_at_utc: generatedAt,
+      currency: "USD",
+      prices_by_site: pricesBySite,
+      extraction_methods: extractionMethods,
+      source_count: prices.length,
+      average_price: prices.length ? Math.round(prices.reduce((a, b) => a + b, 0) / prices.length * 100) / 100 : null,
+      median_price: sorted.length ? sorted[Math.floor(sorted.length / 2)] : null,
+      failed_sites: failed.map(r => r.providerId),
+      urls_used: urlsUsed,
+    });
+
+    for (const r of failed) {
+      allFailures.push({ coinSlug, providerId: r.providerId, url: r.url, error: r.error });
+    }
+  }
+
+  updateProviderCandidates(allFailures, dateStr);
+
+  const ok = scrapeResults.filter(r => r.ok).length;
+  const fail = scrapeResults.length - ok;
+  log(`Done: ${ok}/${scrapeResults.length} prices captured, ${fail} failures`);
+
+  if (ok === 0) {
+    console.error("All scrapes failed.");
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `devops/retail-poller/price-extract.js` — Node.js script that scrapes JM Bullion, APMEX, SD Bullion, and Monument Metals via Firecrawl API and writes daily JSON to `data/retail/{coin-slug}/{YYYY-MM-DD}.json` on the `data` branch
- Adds `.github/workflows/retail-price-poller.yml` — GitHub Actions workflow scheduled at **11am EST (16:00 UTC)** daily
- `FIRECRAWL_API_KEY` already added to repo secrets

## How it works

1. Workflow checks out `data` branch
2. Runs `node devops/retail-poller/price-extract.js`
3. For each of 44 coin×provider targets: calls Firecrawl API, extracts lowest per-coin price using metal-range-filtered regex (filters out accessories and bulk roll prices)
4. Writes `data/retail/{coin-slug}/{YYYY-MM-DD}.json` per the schema in the design doc
5. Commits and pushes to `data` branch → served at `api.staktrakr.com`

## Test plan

- [x] Tested locally against all 4 providers — 8/8 prices captured
- [x] ASE prices validated: $90.93–$95.17 (correct range for silver spot ~$75)
- [ ] Trigger workflow manually after merge to verify CI run
- [ ] Check `data` branch for written JSON after first run

Resolves STAK-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)