### PR TITLE
🛡️ Sentinel: [CRITICAL] Strengthen vault encryption parameters

### DIFF
--- a/js/vault.js
+++ b/js/vault.js
@@ -20,8 +20,8 @@
 const VAULT_MAGIC = new Uint8Array([0x53, 0x54, 0x56, 0x41, 0x55, 0x4C, 0x54]); // "STVAULT"
 const VAULT_VERSION = 0x01;
 const VAULT_HEADER_SIZE = 56;
-const VAULT_PBKDF2_ITERATIONS = 100000;
-const VAULT_MIN_PASSWORD_LENGTH = 8;
+const VAULT_PBKDF2_ITERATIONS = 600000;
+const VAULT_MIN_PASSWORD_LENGTH = 12;
 const VAULT_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
 
 // =============================================================================
@@ -686,8 +686,13 @@ async function handleVaultAction() {
 
   var password = passwordEl ? passwordEl.value : "";
 
-  // Validate password length
-  if (password.length < VAULT_MIN_PASSWORD_LENGTH) {
+  // Determine effective mode
+  var isCloudExport = mode === "cloud-export";
+  var isCloudImport = mode === "cloud-import";
+  var effectiveMode = (isCloudExport) ? "export" : (isCloudImport) ? "import" : mode;
+
+  // Validate password length (only for new exports)
+  if (effectiveMode === "export" && password.length < VAULT_MIN_PASSWORD_LENGTH) {
     showVaultStatus(
       "error",
       "Password must be at least " + VAULT_MIN_PASSWORD_LENGTH + " characters.",
@@ -695,10 +700,6 @@ async function handleVaultAction() {
     return;
   }
 
-  // Determine effective mode
-  var isCloudExport = mode === "cloud-export";
-  var isCloudImport = mode === "cloud-import";
-  var effectiveMode = (isCloudExport) ? "export" : (isCloudImport) ? "import" : mode;
 
   if (effectiveMode === "export") {
     var confirm = confirmEl ? confirmEl.value : "";


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Weak default security parameters for vault encryption (PBKDF2 iterations = 100,000, password length = 8).
🎯 Impact: Increases susceptibility to brute-force attacks on exported vault files.
🔧 Fix:
- Increased `VAULT_PBKDF2_ITERATIONS` to 600,000 (OWASP recommended minimum for PBKDF2-HMAC-SHA256).
- Increased `VAULT_MIN_PASSWORD_LENGTH` to 12.
- Refactored `handleVaultAction` to enforce the new password length only for new exports, ensuring backward compatibility for imports.
✅ Verification:
- Verified code logic ensures imports use the iteration count from the file header.
- Verified frontend behavior with Playwright script (password length validation correctly blocks short passwords for export).
- Passed `npm run lint`.

---
*PR created automatically by Jules for task [12859863336530224717](https://jules.google.com/task/12859863336530224717) started by @lbruton*