### PR TITLE
Palette UX Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Loading State Patterns
+**Learning:** Replaces button text with 'Searching...' causing loss of context (icons) and potential layout shifts.
+**Action:** Use `setButtonLoading` utility to preserve dimensions and show a spinner while maintaining button shape.

--- a/js/events.js
+++ b/js/events.js
@@ -1482,9 +1482,14 @@ const setupItemFormListeners = () => {
         }
 
         const btn = elements.searchNumistaBtn;
-        const originalHTML = btn.innerHTML;
-        btn.textContent = 'Searching...';
-        btn.disabled = true;
+        if (typeof setButtonLoading === 'function') {
+          setButtonLoading(btn, true, 'Searching...');
+        } else {
+          // Fallback if util not loaded
+          btn.dataset.originalHtml = btn.innerHTML;
+          btn.textContent = 'Searching...';
+          btn.disabled = true;
+        }
 
         // Type → Numista category mapping for smarter search results
         const TYPE_TO_NUMISTA_CATEGORY = {
@@ -1546,9 +1551,12 @@ const setupItemFormListeners = () => {
           console.error('Numista search error:', error);
           appAlert('Search failed: ' + error.message);
         } finally {
-          // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
-          btn.innerHTML = originalHTML;
-          btn.disabled = false;
+          if (typeof setButtonLoading === 'function') {
+            setButtonLoading(btn, false);
+          } else {
+            btn.innerHTML = btn.dataset.originalHtml || btn.innerHTML;
+            btn.disabled = false;
+          }
         }
       },
       "Search Numista button",
@@ -1567,9 +1575,13 @@ const setupItemFormListeners = () => {
         }
 
         const btn = elements.lookupPcgsBtn;
-        const originalHTML = btn.innerHTML;
-        btn.textContent = 'Looking up...';
-        btn.disabled = true;
+        if (typeof setButtonLoading === 'function') {
+          setButtonLoading(btn, true, 'Looking up...');
+        } else {
+          btn.dataset.originalHtml = btn.innerHTML;
+          btn.textContent = 'Looking up...';
+          btn.disabled = true;
+        }
 
         try {
           const result = await lookupPcgsFromForm();
@@ -1589,8 +1601,12 @@ const setupItemFormListeners = () => {
           console.error('PCGS lookup error:', error);
           appAlert('PCGS lookup failed: ' + error.message);
         } finally {
-          btn.innerHTML = originalHTML;
-          btn.disabled = false;
+          if (typeof setButtonLoading === 'function') {
+            setButtonLoading(btn, false);
+          } else {
+            btn.innerHTML = btn.dataset.originalHtml || btn.innerHTML;
+            btn.disabled = false;
+          }
         }
       },
       "Lookup PCGS button",

--- a/js/utils.js
+++ b/js/utils.js
@@ -3053,6 +3053,36 @@ function openEbaySoldSearch(searchTerm) {
   window.open(ebayUrl, `ebay_sold_${Date.now()}`, 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
 }
 
+
+/**
+ * Sets a button's loading state, preserving its width and original content.
+ * @param {HTMLButtonElement} btn - The button element
+ * @param {boolean} isLoading - Whether to set loading state
+ * @param {string} [loadingText] - Optional text to show next to spinner
+ */
+const setButtonLoading = (btn, isLoading, loadingText = '') => {
+  if (!btn) return;
+  if (isLoading) {
+    if (!btn.dataset.originalHtml) {
+      btn.dataset.originalHtml = btn.innerHTML;
+      // Lock width to prevent layout jump
+      const rect = btn.getBoundingClientRect();
+      if (rect.width > 0) btn.style.width = rect.width + 'px';
+    }
+    btn.disabled = true;
+    // Spinner SVG (reusing existing spin animation)
+    const spinner = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 0.8s linear infinite; margin-right:0.4em; vertical-align: middle;"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>';
+    btn.innerHTML = spinner + (loadingText || 'Loading...');
+  } else {
+    if (btn.dataset.originalHtml) {
+      btn.innerHTML = btn.dataset.originalHtml;
+      delete btn.dataset.originalHtml;
+    }
+    btn.style.width = '';
+    btn.disabled = false;
+  }
+};
+
 if (typeof window !== 'undefined') {
   window.getContrastColor = getContrastColor;
   window.generateStorageReport = generateStorageReport;
@@ -3099,6 +3129,7 @@ if (typeof window !== 'undefined') {
   window.loadExchangeRates = loadExchangeRates;
   window.saveExchangeRates = saveExchangeRates;
   window.fetchExchangeRates = fetchExchangeRates;
+  window.setButtonLoading = setButtonLoading;
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -3112,5 +3143,6 @@ if (typeof module !== 'undefined' && module.exports) {
     getContrastColor,
     debounce,
     generateUUID,
+    setButtonLoading,
   };
 }

--- a/modify_events.py
+++ b/modify_events.py
@@ -1,0 +1,105 @@
+import sys
+
+def modify_events():
+    with open('js/events.js', 'r') as f:
+        content = f.read()
+
+    # Replacements for Numista search
+    numista_search_start = """        const btn = elements.searchNumistaBtn;
+        const originalHTML = btn.innerHTML;
+        btn.textContent = 'Searching...';
+        btn.disabled = true;"""
+
+    numista_search_start_new = """        const btn = elements.searchNumistaBtn;
+        if (typeof setButtonLoading === 'function') {
+          setButtonLoading(btn, true, 'Searching...');
+        } else {
+          // Fallback if util not loaded
+          btn.dataset.originalHtml = btn.innerHTML;
+          btn.textContent = 'Searching...';
+          btn.disabled = true;
+        }"""
+
+    if numista_search_start in content:
+        content = content.replace(numista_search_start, numista_search_start_new)
+    else:
+        print("Warning: Could not find Numista search start block")
+
+    # The finally block for Numista search is a bit generic, so we need to match carefully.
+    # It looks like:
+    #         } finally {
+    #           btn.innerHTML = originalHTML;
+    #           btn.disabled = false;
+    #         }
+    # But since 'originalHTML' variable is local, we should be careful.
+
+    # Actually, I can replace the logic inside the block.
+    # Let's target the exact string including the finally block context.
+
+    # For Numista search:
+    numista_finally = """        } finally {
+          // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
+          btn.innerHTML = originalHTML;
+          btn.disabled = false;
+        }"""
+
+    numista_finally_new = """        } finally {
+          if (typeof setButtonLoading === 'function') {
+            setButtonLoading(btn, false);
+          } else {
+            btn.innerHTML = btn.dataset.originalHtml || originalHTML;
+            btn.disabled = false;
+          }
+        }"""
+
+    if numista_finally in content:
+        content = content.replace(numista_finally, numista_finally_new)
+    else:
+        print("Warning: Could not find Numista search finally block")
+
+
+    # Replacements for PCGS lookup
+    pcgs_lookup_start = """        const btn = elements.lookupPcgsBtn;
+        const originalHTML = btn.innerHTML;
+        btn.textContent = 'Looking up...';
+        btn.disabled = true;"""
+
+    pcgs_lookup_start_new = """        const btn = elements.lookupPcgsBtn;
+        if (typeof setButtonLoading === 'function') {
+          setButtonLoading(btn, true, 'Looking up...');
+        } else {
+          btn.dataset.originalHtml = btn.innerHTML;
+          btn.textContent = 'Looking up...';
+          btn.disabled = true;
+        }"""
+
+    if pcgs_lookup_start in content:
+        content = content.replace(pcgs_lookup_start, pcgs_lookup_start_new)
+    else:
+        print("Warning: Could not find PCGS lookup start block")
+
+    pcgs_finally = """        } finally {
+          btn.innerHTML = originalHTML;
+          btn.disabled = false;
+        }"""
+
+    pcgs_finally_new = """        } finally {
+          if (typeof setButtonLoading === 'function') {
+            setButtonLoading(btn, false);
+          } else {
+            btn.innerHTML = btn.dataset.originalHtml || originalHTML;
+            btn.disabled = false;
+          }
+        }"""
+
+    if pcgs_finally in content:
+        content = content.replace(pcgs_finally, pcgs_finally_new)
+    else:
+        print("Warning: Could not find PCGS lookup finally block")
+
+    with open('js/events.js', 'w') as f:
+        f.write(content)
+    print("Successfully modified js/events.js")
+
+if __name__ == "__main__":
+    modify_events()

--- a/modify_utils.py
+++ b/modify_utils.py
@@ -1,0 +1,66 @@
+import sys
+
+def modify_utils():
+    with open('js/utils.js', 'r') as f:
+        content = f.read()
+
+    new_function = """
+/**
+ * Sets a button's loading state, preserving its width and original content.
+ * @param {HTMLButtonElement} btn - The button element
+ * @param {boolean} isLoading - Whether to set loading state
+ * @param {string} [loadingText] - Optional text to show next to spinner
+ */
+const setButtonLoading = (btn, isLoading, loadingText = '') => {
+  if (!btn) return;
+  if (isLoading) {
+    if (!btn.dataset.originalHtml) {
+      btn.dataset.originalHtml = btn.innerHTML;
+      // Lock width to prevent layout jump
+      const rect = btn.getBoundingClientRect();
+      if (rect.width > 0) btn.style.width = rect.width + 'px';
+    }
+    btn.disabled = true;
+    // Spinner SVG (reusing existing spin animation)
+    const spinner = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 0.8s linear infinite; margin-right:0.4em; vertical-align: middle;"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>';
+    btn.innerHTML = spinner + (loadingText || 'Loading...');
+  } else {
+    if (btn.dataset.originalHtml) {
+      btn.innerHTML = btn.dataset.originalHtml;
+      delete btn.dataset.originalHtml;
+    }
+    btn.style.width = '';
+    btn.disabled = false;
+  }
+};
+
+"""
+
+    # Insert function definition
+    insert_marker = "if (typeof window !== 'undefined') {"
+    if insert_marker in content:
+        content = content.replace(insert_marker, new_function + insert_marker)
+    else:
+        print("Error: Could not find insert marker")
+        return
+
+    # Export to window
+    window_marker = 'window.fetchExchangeRates = fetchExchangeRates;'
+    if window_marker in content:
+        content = content.replace(window_marker, window_marker + '\n  window.setButtonLoading = setButtonLoading;')
+    else:
+        print("Error: Could not find window export marker")
+
+    # Export to module
+    module_marker = '    generateUUID,'
+    if module_marker in content:
+        content = content.replace(module_marker, module_marker + '\n    setButtonLoading,')
+    else:
+        print("Error: Could not find module export marker")
+
+    with open('js/utils.js', 'w') as f:
+        f.write(content)
+    print("Successfully modified js/utils.js")
+
+if __name__ == "__main__":
+    modify_utils()


### PR DESCRIPTION
💡 What: Replaced text-based loading state with a spinner animation for Numista search and PCGS lookup buttons. Added a reusable `setButtonLoading` utility.
🎯 Why: Text replacement causes layout shifts and removes context (icons). A spinner provides better feedback without disrupting the UI.
♿ Accessibility: Maintained button disabled state during loading to prevent double-submission.

---
*PR created automatically by Jules for task [8207144074069593257](https://jules.google.com/task/8207144074069593257) started by @lbruton*