### PR TITLE
📝 Scribe: Remove unused `openEbaySearch` from `js/utils.js`

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3018,14 +3018,6 @@ function generateStorageReport(){
 }
 
 /**
- * Opens eBay sold listings search for the given item name and metal
- * @param {string} searchTerm - The item name and metal to search for
- */
-function openEbaySearch(searchTerm) {
-  openEbaySoldSearch(searchTerm);
-}
-
-/**
  * Strips search-operator characters from a search term for use in external URLs.
  * Removes quotes, parentheses, and backslashes that act as search operators on eBay.
  * @param {string} term - Raw search term (may contain user-entered punctuation)
@@ -3116,7 +3108,6 @@ if (typeof window !== 'undefined') {
   window.downloadStorageReport = downloadStorageReport;
   window.openStorageReportPopup = openStorageReportPopup;
   window.debounce = debounce;
-  window.openEbaySearch = openEbaySearch;
   window.openEbayBuySearch = openEbayBuySearch;
   window.openEbaySoldSearch = openEbaySoldSearch;
   window.cleanSearchTerm = cleanSearchTerm;


### PR DESCRIPTION
- 💡 **What**: Removed `openEbaySearch` function and its `window` export from `js/utils.js`.
- 🔍 **Evidence**:
    - `grep -rn "openEbaySearch" js/ index.html functions/` returned 0 results outside of the definition/export.
    - `CHANGELOG.md` confirms: "Split `openEbaySearch()` into `openEbayBuySearch()` ... and `openEbaySoldSearch()`", indicating this function is a deprecated wrapper.
- 📁 **Files changed**: `js/utils.js`
- ✅ **Verified**:
    - Confirmed `openEbaySearch` was **not** present in `module.exports`, avoiding `ReferenceError`.
    - `npm run lint` passed.
    - Script load order in `index.html` is unaffected.

---
*PR created automatically by Jules for task [9251306475212063718](https://jules.google.com/task/9251306475212063718) started by @lbruton*