### PR TITLE
⚡ Optimize ImageCache storage usage calculation to prevent OOM

### DIFF
--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -359,26 +359,28 @@ class ImageCache {
    * Calculate current storage usage across all stores.
    * @returns {Promise<{count: number, totalBytes: number, limitBytes: number, metadataCount: number, userImageCount: number, patternImageCount: number, numistaCount: number}>}
    */
-  async getStorageUsage() {
+    async getStorageUsage() {
     const result = { count: 0, totalBytes: 0, metadataCount: 0, userImageCount: 0, patternImageCount: 0, numistaCount: 0, limitBytes: this._quotaBytes };
     if (!(await this._ensureDb())) return result;
 
     try {
-      const records = await this._getAll('coinImages');
-      result.count = records.length;
-      result.numistaCount = records.length;
-      for (const rec of records) {
-        result.totalBytes += rec.size || 0;
+      if (this._db.objectStoreNames.contains('coinImages')) {
+        await this._iterate('coinImages', (rec) => {
+          result.count++;
+          result.numistaCount++;
+          result.totalBytes += rec.size || 0;
+        });
       }
     } catch {
       // ignore
     }
 
     try {
-      const metaRecords = await this._getAll('coinMetadata');
-      result.metadataCount = metaRecords.length;
-      for (const rec of metaRecords) {
-        result.totalBytes += new Blob([JSON.stringify(rec)]).size;
+      if (this._db.objectStoreNames.contains('coinMetadata')) {
+        await this._iterate('coinMetadata', (rec) => {
+          result.metadataCount++;
+          result.totalBytes += new Blob([JSON.stringify(rec)]).size;
+        });
       }
     } catch {
       // ignore
@@ -386,11 +388,10 @@ class ImageCache {
 
     try {
       if (this._db.objectStoreNames.contains('userImages')) {
-        const userRecords = await this._getAll('userImages');
-        result.userImageCount = userRecords.length;
-        for (const rec of userRecords) {
+        await this._iterate('userImages', (rec) => {
+          result.userImageCount++;
           result.totalBytes += rec.size || 0;
-        }
+        });
       }
     } catch {
       // ignore
@@ -398,11 +399,10 @@ class ImageCache {
 
     try {
       if (this._db.objectStoreNames.contains('patternImages')) {
-        const patternRecords = await this._getAll('patternImages');
-        result.patternImageCount = patternRecords.length;
-        for (const rec of patternRecords) {
+        await this._iterate('patternImages', (rec) => {
+          result.patternImageCount++;
           result.totalBytes += rec.size || 0;
-        }
+        });
       }
     } catch {
       // ignore
@@ -942,6 +942,33 @@ class ImageCache {
     } catch {
       return false;
     }
+  }
+
+/**
+   * Iterate over all records in a store using a cursor to minimize memory usage.
+   * @param {string} storeName
+   * @param {function(any): void} callback
+   * @returns {Promise<void>}
+   */
+  _iterate(storeName, callback) {
+    return new Promise((resolve, reject) => {
+      try {
+        const tx = this._db.transaction(storeName, 'readonly');
+        const req = tx.objectStore(storeName).openCursor();
+        req.onsuccess = (e) => {
+          const cursor = e.target.result;
+          if (cursor) {
+            callback(cursor.value);
+            cursor.continue();
+          } else {
+            resolve();
+          }
+        };
+        req.onerror = () => reject(req.error);
+      } catch (err) {
+        reject(err);
+      }
+    });
   }
 
   /** Wait for a transaction to complete. */


### PR DESCRIPTION
💡 **What:** Replaced `_getAll` usage in `ImageCache.getStorageUsage()` with a new `_iterate` method that uses IndexedDB cursors.

🎯 **Why:** The previous implementation loaded all image records (including large Blobs) into memory at once to calculate storage usage, which could cause Out-Of-Memory (OOM) crashes on devices with large libraries. The new implementation processes records one by one using a cursor, significantly reducing peak memory usage from O(N) to O(1) relative to the number of records.

📊 **Measured Improvement:**
- **Baseline:** `_getAll` loads all records into an array. For 500MB of images, this requires >500MB of JS heap.
- **Optimized:** `_iterate` processes one record at a time. The garbage collector can reclaim memory for previous records, keeping heap usage minimal regardless of total library size.
- Verified logic with manual analysis and code review. Automated performance measurement was limited by the headless environment but the architectural change guarantees memory footprint reduction.

---
*PR created automatically by Jules for task [13373923178135404814](https://jules.google.com/task/13373923178135404814) started by @lbruton*