### PR TITLE
Convert loadInventory to async

### DIFF
--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -147,7 +147,7 @@ async function syncRestoreOverrideBackup() {
       }
     }
     if (typeof loadItemTags === 'function') loadItemTags();
-    if (typeof loadInventory === 'function') loadInventory();
+    if (typeof loadInventory === 'function') await loadInventory();
     if (typeof updateSummary === 'function') updateSummary();
     if (typeof renderTable === 'function') renderTable();
     if (typeof renderActiveFilters === 'function') renderActiveFilters();

--- a/js/events.js
+++ b/js/events.js
@@ -1977,7 +1977,7 @@ const setupDataManagementListeners = () => {
       localStorage.removeItem(LS_KEY);
       // STACK-62: Clear stale autocomplete cache so it rebuilds from fresh inventory
       if (typeof clearLookupCache === 'function') clearLookupCache();
-      loadInventory();
+      await loadInventory();
       renderTable();
       renderActiveFilters();
       if (typeof showAppAlert === "function") await showAppAlert("Inventory data cleared.", "Data Management");
@@ -2008,7 +2008,7 @@ const setupDataManagementListeners = () => {
       // Disconnect cloud providers (UI reset)
       if (typeof syncCloudUI === 'function') syncCloudUI();
 
-      loadInventory();
+      await loadInventory();
       renderTable();
       renderActiveFilters();
       loadSpotHistory();

--- a/js/init.js
+++ b/js/init.js
@@ -380,7 +380,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     // Load data
-    loadInventory();
+    await loadInventory();
 
     // Migrate: existing users keep header theme button visible
     if (inventory.length > 0 && localStorage.getItem('headerThemeBtnVisible') === null) {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -372,7 +372,7 @@ const restoreBackupZip = async (file) => {
       );
     }
 
-    loadInventory();
+    await loadInventory();
     renderTable();
     renderActiveFilters();
     loadSpotHistory();
@@ -654,11 +654,9 @@ const sanitizeTablesOnLoad = () => {
  * @returns {void} Updates the global inventory array with migrated data
  * @throws {Error} Logs errors to console if localStorage access fails
  */
-const loadInventory = () => {
+const loadInventory = async () => {
   try {
-    // For now, use synchronous loading to maintain compatibility
-    // TODO: Convert to async when updating all callers
-    const data = loadDataSync(LS_KEY, []);
+    const data = await loadData(LS_KEY, []);
     
     // Ensure data is an array
     if (!Array.isArray(data)) {

--- a/js/vault.js
+++ b/js/vault.js
@@ -358,7 +358,7 @@ function simpleHash(str) {
  * Restore vault data into localStorage and refresh UI.
  * @param {object} payload - Decrypted vault payload
  */
-function restoreVaultData(payload) {
+async function restoreVaultData(payload) {
   var data = payload.data;
   if (!data || typeof data !== "object") {
     throw new Error("Vault file appears corrupted.");
@@ -381,7 +381,7 @@ function restoreVaultData(payload) {
   // Refresh the full UI
   try {
     if (typeof loadItemTags === "function") loadItemTags();
-    if (typeof loadInventory === "function") loadInventory();
+    if (typeof loadInventory === "function") await loadInventory();
     if (typeof renderTable === "function") renderTable();
     if (typeof renderActiveFilters === "function") renderActiveFilters();
     if (typeof loadSpotHistory === "function") loadSpotHistory();
@@ -479,7 +479,7 @@ async function vaultDecryptAndRestore(fileBytes, password) {
   var plainBytes = await vaultDecrypt(parsed.ciphertext, key, parsed.iv);
   var payload = JSON.parse(new TextDecoder().decode(plainBytes));
   if (!payload || !payload.data) throw new Error("Vault file appears corrupted.");
-  restoreVaultData(payload);
+  await restoreVaultData(payload);
 }
 
 // =============================================================================


### PR DESCRIPTION
Refactored `loadInventory` in `js/inventory.js` to be an `async` function using `await loadData()` instead of the synchronous `loadDataSync`.

Updated all call sites to await the operation:
- `js/init.js`: Initialization logic (Phase 12).
- `js/events.js`: Data management actions (Remove Data, Boating Accident).
- `js/vault.js`: `restoreVaultData` is now `async` and awaits `loadInventory`.
- `js/cloud-sync.js`: `syncRestoreOverrideBackup` awaits `loadInventory`.
- `js/inventory.js`: `restoreBackupZip` awaits `loadInventory`.

---
*PR created automatically by Jules for task [2036257377833786704](https://jules.google.com/task/2036257377833786704) started by @lbruton*