### PR TITLE
🔒 Fix Stored XSS in API History Table

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -827,9 +827,9 @@ const renderApiHistoryTable = () => {
     "<tr><th data-column=\"timestamp\">Time</th><th data-column=\"metal\">Metal</th><th data-column=\"spot\">Price</th><th data-column=\"provider\">Source</th></tr>";
   data.forEach((e) => {
     const sourceLabel = e.source === "api-hourly"
-      ? `${e.provider || ""} (hourly)`
-      : (e.provider || "");
-    html += `<tr><td>${e.timestamp}</td><td>${e.metal}</td><td>${formatCurrency(
+      ? `${escapeHtml(e.provider || "")} (hourly)`
+      : (escapeHtml(e.provider || ""));
+    html += `<tr><td>${escapeHtml(e.timestamp)}</td><td>${escapeHtml(e.metal)}</td><td>${formatCurrency(
       e.spot,
     )}</td><td>${sourceLabel}</td></tr>`;
   });

--- a/js/utils.js
+++ b/js/utils.js
@@ -3098,6 +3098,7 @@ if (typeof window !== 'undefined') {
   window.loadExchangeRates = loadExchangeRates;
   window.saveExchangeRates = saveExchangeRates;
   window.fetchExchangeRates = fetchExchangeRates;
+  window.escapeHtml = escapeHtml;
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -3111,5 +3112,6 @@ if (typeof module !== 'undefined' && module.exports) {
     getContrastColor,
     debounce,
     generateUUID,
+    escapeHtml,
   };
 }


### PR DESCRIPTION
Fixed a stored XSS vulnerability in `js/api.js` where API history data (timestamp, metal, provider) was interpolated directly into `innerHTML` without escaping.

**Changes:**
- **`js/api.js`**: Updated `renderApiHistoryTable` to use `escapeHtml()` for `e.timestamp`, `e.metal`, and `e.provider` before constructing the HTML string.
- **`js/utils.js`**: Exported `escapeHtml` to `module.exports` and `window.escapeHtml` to ensure availability for testing and consistent usage across the codebase.

**Verification:**
- Created a reproduction script `reproduce_issue.js` that successfully demonstrated the vulnerability with unescaped input.
- Updated the reproduction script with the fixed logic and confirmed that malicious scripts are now properly escaped.
- Ran `npm run lint` to ensure code style compliance.
- Manually verified the changes in `js/api.js` and `js/utils.js`.

**Risk Assessment:**
- **Risk:** High (Stored XSS).
- **Fix Impact:** Low (UI display only).

---
*PR created automatically by Jules for task [2719096294393537881](https://jules.google.com/task/2719096294393537881) started by @lbruton*