### PR TITLE
v3.32.11 — PR #395 Review Fixes — Code Quality & Correctness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ number collisions; worktrees prevent filesystem conflicts.
 7. Cleanup: `git worktree remove .claude/worktrees/patch-VERSION --force && git branch -d patch/VERSION && rm devops/version.lock`
 
 Lock format (JSON):
+
 ```json
 {
   "locked": "3.32.09",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.11] - 2026-02-22
+
+### Fixed — PR #395 Review Fixes — Code Quality & Correctness
+
+- **Fixed**: `logItemChanges` null-dereference on item-add/delete — guarded `forEach` loop for null `oldItem`/`newItem`; now records single Added/Deleted entry
+- **Fixed**: `changeLog` raw `localStorage.setItem` calls replaced with `saveDataSync()` across all callsites
+- **Fixed**: `getManifestEntries`/`markSynced` exposed as `window.*` globals — array property approach lost on `changeLog = []` reassignment
+- **Fixed**: Sync toast showed wrong provider — status string was `"success"` but `syncProviderChain` returns `"ok"`
+- **Fixed**: Swallowed post-reset backfill error now logs to `console.warn` for debuggability
+- **Fixed**: `api-health.js` modal calls use `window.` prefix; `readyState` guard added for late-loading scripts
+- **Fixed**: `safeGetElement` used in `initSpotHistoryButtons` (was raw `document.getElementById`)
+
+---
+
 ## [3.32.10] - 2026-02-22
 
 ### Added — Worktree Protocol & Branch Protection Infrastructure

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **PR #395 Review Fixes (v3.32.11)**: logItemChanges null-guard for add/delete; changeLog writes use saveDataSync(); getManifestEntries/markSynced exposed as window globals; sync toast provider fixed ("ok" not "success"); backfill catch logs warn; api-health readyState guard; safeGetElement in initSpotHistoryButtons
 - **Worktree Protocol & Branch Protection (v3.32.10)**: Agents now use isolated git worktrees (patch/VERSION) for concurrent work; main branch protected with Codacy required check; release skill creates/cleans up worktrees automatically
 - **WeakMap Search Cache Correctness (v3.32.09)**: Cache miss guard uses strict undefined check; notes edits invalidate search cache immediately; undo/redo now reflects reverted field values in search
 - **OAuth State Security Hardening (v3.32.08)**: Provider now parsed from trusted savedState after CSRF check; PKCE challenge adds .catch() to clean sessionStorage on failure; stale oauth state removed on exchange failure
 - **Backend Data Integrity & Sparkline Fix (v3.32.07)**: Sync restore clears scoped keys before writing; DiffEngine module added for inventory merge; vault manifest AES-256-GCM crypto; sparkline spikes fixed via intraday dedup and ±1% Y-axis normalization (STAK-183, STAK-186, STAK-187, STAK-188)
-- **API Health Badge (v3.32.06)**: Footer and About modal now show live API data freshness status — click the badge for details on last update time and coin coverage
-
 ## Development Roadmap
 
 ### Next Up

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.11 &ndash; PR #395 Review Fixes</strong>: logItemChanges null-guard for add/delete; changeLog writes use saveDataSync(); getManifestEntries/markSynced exposed as window globals; sync toast provider fixed (&ldquo;ok&rdquo; not &ldquo;success&rdquo;); backfill catch logs warn; api-health readyState guard; safeGetElement in initSpotHistoryButtons</li>
     <li><strong>v3.32.10 &ndash; Worktree Protocol &amp; Branch Protection</strong>: Agents now use isolated git worktrees (patch/VERSION) for concurrent work; main branch protected with Codacy required check; release skill creates/cleans up worktrees automatically</li>
     <li><strong>v3.32.09 &ndash; WeakMap Search Cache Correctness</strong>: Cache miss guard uses strict undefined check; notes edits invalidate search cache immediately; undo/redo now reflects reverted field values in search</li>
     <li><strong>v3.32.08 &ndash; OAuth State Security Hardening</strong>: Provider now parsed from trusted savedState after CSRF check; PKCE challenge adds .catch() to clean sessionStorage on failure; stale oauth state removed on exchange failure</li>
     <li><strong>v3.32.07 &ndash; Backend Data Integrity &amp; Sparkline Fix</strong>: Sync restore clears scoped keys before writing; DiffEngine module added for inventory merge; vault manifest AES-256-GCM crypto; sparkline spikes fixed via intraday dedup and &plusmn;1% Y-axis normalization (STAK-183, STAK-186, STAK-187, STAK-188)</li>
-    <li><strong>v3.32.06 &ndash; API Health Badge</strong>: Footer and About modal now show live API data freshness status &mdash; click the badge for details on last update time and coin coverage</li>
   `;
 };
 

--- a/js/api-health.js
+++ b/js/api-health.js
@@ -107,14 +107,14 @@ const showApiHealthModal = () => {
   } else {
     _setModalLoading();
   }
-  if (window.openModalById) openModalById("apiHealthModal");
+  if (window.openModalById) window.openModalById("apiHealthModal");
 };
 
 /**
  * Hides the API health modal.
  */
 const hideApiHealthModal = () => {
-  if (window.closeModalById) closeModalById("apiHealthModal");
+  if (window.closeModalById) window.closeModalById("apiHealthModal");
 };
 
 // Guard to ensure the keydown listener is registered only once
@@ -162,4 +162,8 @@ if (typeof window !== "undefined") {
   window.initApiHealth = initApiHealth;
 }
 
-document.addEventListener("DOMContentLoaded", initApiHealth);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initApiHealth);
+} else {
+  initApiHealth();
+}

--- a/js/api.js
+++ b/js/api.js
@@ -2969,7 +2969,7 @@ const initSpotHistoryButtons = () => {
   const exportBtn = document.getElementById("exportSpotHistoryBtn");
   if (exportBtn) exportBtn.addEventListener("click", exportSpotHistory);
 
-  const restoreBtn = document.getElementById("restoreHistoricalDataBtn");
+  const restoreBtn = safeGetElement("restoreHistoricalDataBtn");
   if (restoreBtn) restoreBtn.addEventListener("click", restoreHistoricalSpotData);
 
   const importBtn = document.getElementById("importSpotHistoryBtn");

--- a/js/constants.js
+++ b/js/constants.js
@@ -286,7 +286,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.10";
+const APP_VERSION = "3.32.11";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -2050,7 +2050,7 @@ const setupDataManagementListeners = () => {
       if (typeof backfillStaktrakrHourly === 'function') {
         backfillStaktrakrHourly()
           .then(() => { if (typeof updateAllSparklines === 'function') updateAllSparklines(); })
-          .catch(() => {});
+          .catch((err) => { console.warn('[StakTrakr] Post-reset backfill failed:', err); });
       }
 
       apiConfig = { provider: "", keys: {} };
@@ -2644,7 +2644,7 @@ const setupApiEvents = () => {
             const { updatedCount, anySucceeded, results } = await syncProviderChain({ showProgress: true, forceSync: true });
             if (typeof showToast === "function") {
               if (updatedCount > 0) {
-                const providerName = Object.entries(results).find(([_, s]) => s === "success")?.[0];
+                const providerName = Object.entries(results).find(([_, s]) => s === "ok")?.[0];
                 const label = providerName ? (API_PROVIDERS[providerName]?.name || providerName) : "API";
                 showToast(`\u2713 Synced ${updatedCount} prices from ${label}`);
               } else if (!anySucceeded) {

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.10-b1771788232';
+const CACHE_NAME = 'staktrakr-v3.32.10-b1771788236';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.10-b1771788226';
+const CACHE_NAME = 'staktrakr-v3.32.10-b1771788232';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.10-b1771786641';
+const CACHE_NAME = 'staktrakr-v3.32.10-b1771788220';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.10-b1771788236';
+const CACHE_NAME = 'staktrakr-v3.32.11-b1771788377';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.10-b1771788220';
+const CACHE_NAME = 'staktrakr-v3.32.10-b1771788226';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.10",
+  "version": "3.32.11",
   "releaseDate": "2026-02-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — do not merge until QA'd via Cloudflare preview.**

## Summary

- **A2**: `logItemChanges` null-dereference on item-add/delete — guarded forEach loop; now records single Added/Deleted entry
- **A3**: `changeLog` raw `localStorage.setItem` calls replaced with `saveDataSync()` across all callsites
- **A6**: `getManifestEntries`/`markSynced` exposed as `window.*` globals — array properties lost on `changeLog = []` reassignment
- **A1**: Sync toast showed wrong provider — status string was `"success"`, `syncProviderChain` returns `"ok"`
- **A8**: Swallowed post-reset backfill error now logs to `console.warn`
- **A4/A5**: `api-health.js` modal calls use `window.` prefix; `readyState` guard added
- **A7**: `safeGetElement` in `initSpotHistoryButtons` (was `document.getElementById`)
- **A9**: Verified false positive — `cloud_pkce_verifier` already cleaned up before exchange

## Files Changed

- `js/changeLog.js` — null guard, saveDataSync, window globals
- `js/events.js` — status string fix, backfill catch
- `js/api-health.js` — window. prefix, readyState guard
- `js/api.js` — safeGetElement

## QA Notes

- Trigger a spot sync (Settings → API → Sync All) — toast should now show the provider name correctly
- Add/delete an inventory item — change log should record a single Added/Deleted entry without crashing
- Open About modal on `file://` — What's New should show v3.32.11 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)