### PR TITLE
v3.32.12 — Configurable Vault Password Idle Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.12] - 2026-02-22
+
+### Added — Configurable Vault Password Idle Timeout (STAK-183)
+
+- **Added**: "Auto-lock after idle" dropdown in Settings → Cloud Sync → Session Password Cache — choose 15 min, 30 min, 1 hour, 2 hours, or Never
+- **Changed**: Vault password idle lock reads the user's setting at arm time instead of a hardcoded 15-minute constant; "Never" disables auto-clear entirely
+
+---
+
 ## [3.32.11] - 2026-02-22
 
 ### Fixed — PR #395 Review Fixes — Code Quality & Correctness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Works on `file://` and HTTP. Runtime artifact: zero build step, zero install. Se
 
 **Multi-agent patch workflow (when concurrent work is in flight):**
 
+> **Prerequisite:** `git fetch origin && git pull origin dev` — local dev must be in sync with remote before starting any patch. Hard gate — do not skip.
+
 1. `/release patch` → claims version lock → creates worktree `patch/VERSION` at `.claude/worktrees/patch-VERSION/`
 2. All work happens in the worktree (file edits, version bump, commit)
 3. Push `patch/VERSION` → open draft PR `patch/VERSION → dev` → Cloudflare generates preview URL

--- a/devops/version-lock-protocol.md
+++ b/devops/version-lock-protocol.md
@@ -16,7 +16,28 @@ The actual lock state lives in `devops/version.lock` (gitignored). Worktrees liv
 
 ---
 
-## Full Protocol (9 steps)
+## Full Protocol (10 steps)
+
+### Step 0 — SYNC with remote before starting
+
+Before claiming the version lock or creating a worktree, confirm local `dev` is in sync
+with `origin/dev`. A worktree created from a stale HEAD produces PRs that conflict with
+or silently drop remote commits that landed while you were offline.
+
+```bash
+git fetch origin
+git rev-list HEAD..origin/dev --count
+```
+
+- **Count is 0:** Proceed to Step 1. ✅
+- **Count > 0:** HARD STOP. Show the incoming commits and require a pull:
+
+```bash
+git log --oneline HEAD..origin/dev   # show what you'd be missing
+git pull origin dev                   # pull, then restart from Step 0
+```
+
+Do not proceed until `git rev-list HEAD..origin/dev --count` returns `0`.
 
 ### Step 1 — SYNC local dev with origin/dev
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Configurable Vault Idle Timeout (v3.32.12)**: New "Auto-lock after idle" dropdown in Settings → Cloud Sync — choose 15 min, 30 min, 1 hour, 2 hours, or Never before the vault password cache clears automatically
 - **PR #395 Review Fixes (v3.32.11)**: logItemChanges null-guard for add/delete; changeLog writes use saveDataSync(); getManifestEntries/markSynced exposed as window globals; sync toast provider fixed ("ok" not "success"); backfill catch logs warn; api-health readyState guard; safeGetElement in initSpotHistoryButtons
 - **Worktree Protocol & Branch Protection (v3.32.10)**: Agents now use isolated git worktrees (patch/VERSION) for concurrent work; main branch protected with Codacy required check; release skill creates/cleans up worktrees automatically
 - **WeakMap Search Cache Correctness (v3.32.09)**: Cache miss guard uses strict undefined check; notes edits invalidate search cache immediately; undo/redo now reflects reverted field values in search
 - **OAuth State Security Hardening (v3.32.08)**: Provider now parsed from trusted savedState after CSRF check; PKCE challenge adds .catch() to clean sessionStorage on failure; stale oauth state removed on exchange failure
-- **Backend Data Integrity & Sparkline Fix (v3.32.07)**: Sync restore clears scoped keys before writing; DiffEngine module added for inventory merge; vault manifest AES-256-GCM crypto; sparkline spikes fixed via intraday dedup and ±1% Y-axis normalization (STAK-183, STAK-186, STAK-187, STAK-188)
 ## Development Roadmap
 
 ### Next Up

--- a/docs/tests/known-failures.md
+++ b/docs/tests/known-failures.md
@@ -1,0 +1,68 @@
+# Known Test Failures & Flaky Tests
+
+Living registry of Playwright smoke tests that are broken, flaky, or deprecated.
+Updated whenever a test failure is triaged during a smoke test run.
+
+**Source of truth for the `smoke-test` skill Phase 3 registry.**
+After editing this file, copy the active/resolved tables into `.claude/skills/smoke-test/SKILL.md`.
+
+---
+
+## Status Key
+
+| Icon | Meaning |
+|------|---------|
+| ⚠️ Flaky | Passes sometimes — timing, environment, or external dependency |
+| 🔴 Broken | Consistently fails — stale selector, wrong assertion, deprecated feature |
+| ⏭️ Skipped | `test.skip()` in code — requires API keys or unavailable infrastructure |
+| ✅ Resolved | Fixed — kept here to prevent re-filing |
+
+---
+
+## Currently Known Active Issues
+
+| ID | Spec | Test Name | Status | Root Cause | First Seen |
+|----|------|-----------|--------|------------|------------|
+| KF-001 | `api-integrations.spec.js` | `STAK-255: hourlyBaseUrls and RETAIL_API_ENDPOINTS use correct paths` | ⚠️ Flaky | Asserts exact URL structure (`api1.staktrakr.com/data/hourly`) in `window.API_PROVIDERS.STAKTRAKR.hourlyBaseUrls`; breaks when API constants are reorganised | 2026-02-22 |
+| KF-002 | `api-integrations.spec.js` | `STAK-215: syncStatus shows save-failure message when localStorage quota is exceeded` | ⚠️ Flaky | Forces `localStorage.setItem` to throw a quota error via mock; not reproducible against Cloudflare Pages (different storage policy) | 2026-02-22 |
+| KF-003 | `live-demo.spec.js` | `live demo — load, hover spot cards, open About` | ⚠️ Flaky | No hard assertions — pure timing test; ack modal dismiss timing differs on HTTPS vs local HTTP; fails intermittently against preview URLs | 2026-02-22 |
+| KF-004 | `market-toggle.spec.js` | `Test 1: New user sees all 5 header buttons by default` | 🔴 Broken | `#headerMarketBtn` not visible on fresh load — selector may have changed or button render order changed since test was written | 2026-02-22 |
+| KF-005 | `market-toggle.spec.js` | `Test 4: Responsive grid layout (3-col → 2-col → 1-col)` | 🔴 Broken | Asserts `mobileCols.split(' ').length === 1` (single column) but receives `2`; browserless viewport sizing doesn't match expected mobile breakpoint | 2026-02-22 |
+| KF-006 | `import-export.spec.js` | `JSON round-trip preserves serialNumber` | ⚠️ Flaky | `page.waitForEvent('download')` unreliable against HTTPS Cloudflare Pages URLs; passes consistently on local HTTP server | 2026-02-22 |
+| KF-007 | `backup-restore.spec.js` | `Vault encrypted backup flow` | ⚠️ Flaky | Timeout — vault AES-256-GCM crypto + seed inventory size pushes past browserless Docker timeout; intermittent | 2026-02-22 |
+
+---
+
+## Resolved (do not re-file)
+
+| ID | Spec | Test Name | Status | Resolved In | Notes |
+|----|------|-----------|--------|-------------|-------|
+| BUG-001 | `ui-checks.spec.js` | Search returns 0 results intermittently | ✅ Resolved | dev | Confirmed not triggered across multiple runs |
+| BUG-002 | `crud.spec.js` | Autocomplete ghost text persists after modal close | ✅ Resolved | dev | Confirmed not triggered across multiple runs |
+| BUG-006 | `crud.spec.js` | Delete executed immediately with no confirmation dialog | ✅ Resolved | v3.31.5 | Replaced with `showBulkConfirm` DOM modal |
+| STAK-229 | `backup-restore.spec.js` | Vault backup test timeout (seed inventory too large) | ✅ Resolved | v3.32.x | Wipe inventory before vault export; `test.setTimeout(120_000)` |
+| STAK-206 | `ui-checks.spec.js` | Card view items-per-page constraint never applied | ✅ Resolved | dev | `pagination.js` row vs item unit mismatch corrected |
+
+---
+
+## Skipped (require API keys / infrastructure)
+
+| Spec | Test Name | Reason |
+|------|-----------|--------|
+| `api-integrations.spec.js` | Dropbox: Login and sync | Needs OAuth token |
+| `api-integrations.spec.js` | Numista: Search and fill item | Needs Numista API key |
+| `api-integrations.spec.js` | PCGS: Verify cert number | Needs PCGS API key |
+| `api-integrations.spec.js` | Metal price providers: Sync current prices | Needs metals API key |
+
+---
+
+## How to triage a new failure
+
+1. Run the smoke test and identify the failing test name + spec
+2. Check this file — if it matches a Known Active issue, no Linear issue needed
+3. If new: file a Linear bug, add a row to **Currently Known Active Issues** with today's date
+4. If it seems fixed in a subsequent run: move to **Resolved**, note the version
+
+---
+
+*Last updated: 2026-02-22 — v3.32.12 smoke run against `patch-3-32-12.staktrakr.pages.dev`*

--- a/index.html
+++ b/index.html
@@ -3171,7 +3171,7 @@
                 </div>
                 <div class="cloud-status-row" style="margin-top:0.5rem">
                   <label class="cloud-status-label" for="cloudVaultIdleTimeout">Auto-lock after idle</label>
-                  <select id="cloudVaultIdleTimeout" class="control-select" title="Clear cached vault password after this period of inactivity" onchange="localStorage.setItem('cloud_vault_idle_timeout',this.value);if(typeof _resetIdleLockTimer==='function')_resetIdleLockTimer();">
+                  <select id="cloudVaultIdleTimeout" class="control-select" title="Clear cached vault password after this period of inactivity">
                     <option value="15">15 minutes</option>
                     <option value="30">30 minutes</option>
                     <option value="60">1 hour</option>

--- a/index.html
+++ b/index.html
@@ -3169,6 +3169,16 @@
                   <span class="cloud-status-label">Cache status</span>
                   <span class="cloud-status-value" id="cloudPwCacheStatus">Not cached</span>
                 </div>
+                <div class="cloud-status-row" style="margin-top:0.5rem">
+                  <label class="cloud-status-label" for="cloudVaultIdleTimeout">Auto-lock after idle</label>
+                  <select id="cloudVaultIdleTimeout" class="control-select" title="Clear cached vault password after this period of inactivity" onchange="localStorage.setItem('cloud_vault_idle_timeout',this.value);if(typeof _resetIdleLockTimer==='function')_resetIdleLockTimer();">
+                    <option value="15">15 minutes</option>
+                    <option value="30">30 minutes</option>
+                    <option value="60">1 hour</option>
+                    <option value="120">2 hours</option>
+                    <option value="0">Never</option>
+                  </select>
+                </div>
               </div>
 
             </div>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.12 &ndash; Configurable Vault Idle Timeout</strong>: New &ldquo;Auto-lock after idle&rdquo; dropdown in Settings &rarr; Cloud Sync &mdash; choose 15 min, 30 min, 1 hour, 2 hours, or Never before the vault password cache clears automatically</li>
     <li><strong>v3.32.11 &ndash; PR #395 Review Fixes</strong>: logItemChanges null-guard for add/delete; changeLog writes use saveDataSync(); getManifestEntries/markSynced exposed as window globals; sync toast provider fixed (&ldquo;ok&rdquo; not &ldquo;success&rdquo;); backfill catch logs warn; api-health readyState guard; safeGetElement in initSpotHistoryButtons</li>
     <li><strong>v3.32.10 &ndash; Worktree Protocol &amp; Branch Protection</strong>: Agents now use isolated git worktrees (patch/VERSION) for concurrent work; main branch protected with Codacy required check; release skill creates/cleans up worktrees automatically</li>
     <li><strong>v3.32.09 &ndash; WeakMap Search Cache Correctness</strong>: Cache miss guard uses strict undefined check; notes edits invalidate search cache immediately; undo/redo now reflects reverted field values in search</li>
     <li><strong>v3.32.08 &ndash; OAuth State Security Hardening</strong>: Provider now parsed from trusted savedState after CSRF check; PKCE challenge adds .catch() to clean sessionStorage on failure; stale oauth state removed on exchange failure</li>
-    <li><strong>v3.32.07 &ndash; Backend Data Integrity &amp; Sparkline Fix</strong>: Sync restore clears scoped keys before writing; DiffEngine module added for inventory merge; vault manifest AES-256-GCM crypto; sparkline spikes fixed via intraday dedup and &plusmn;1% Y-axis normalization (STAK-183, STAK-186, STAK-187, STAK-188)</li>
   `;
 };
 

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -1067,10 +1067,13 @@ function _getIdleLockTimeoutMs() {
 function _resetIdleLockTimer() {
   if (!sessionStorage.getItem('cloud_vault_pw_cache')) return;
   clearTimeout(_idleLockTimer);
-  clearTimeout(_idleThrottleTimer);
-  _idleThrottleTimer = null;
   var timeoutMs = _getIdleLockTimeoutMs();
-  if (timeoutMs === 0) return; // "Never" — no auto-lock
+  if (timeoutMs === 0) {
+    // "Never" — cancel throttle too so activity listeners become true no-ops
+    clearTimeout(_idleThrottleTimer);
+    _idleThrottleTimer = null;
+    return;
+  }
   _idleLockTimer = setTimeout(function () {
     if (!sessionStorage.getItem('cloud_vault_pw_cache')) return;
     cloudClearCachedPassword();

--- a/js/constants.js
+++ b/js/constants.js
@@ -563,6 +563,9 @@ const THEME_KEY = "appTheme";
 /** @constant {string} ACK_DISMISSED_KEY - LocalStorage key for acknowledgment dismissal */
 const ACK_DISMISSED_KEY = "ackDismissed";
 
+/** @constant {string} CLOUD_VAULT_IDLE_TIMEOUT_KEY - LocalStorage key for vault password idle lock timeout in minutes (15|30|60|120|0=never) */
+const CLOUD_VAULT_IDLE_TIMEOUT_KEY = "cloud_vault_idle_timeout";
+
 /** @constant {string} API_KEY_STORAGE_KEY - LocalStorage key for API provider information */
 const API_KEY_STORAGE_KEY = "metalApiConfig";
 
@@ -794,7 +797,7 @@ const ALLOWED_STORAGE_KEYS = [
   "cloud_sync_device_id",                      // UUID string: stable per-device identifier
   "cloud_sync_cursor",                         // Dropbox rev string: for efficient change detection
   "cloud_sync_override_backup",                // JSON: { timestamp, itemCount, appVersion, data: {...} } — pre-pull local snapshot
-  "cloud_vault_idle_timeout",                  // number string: vault password idle lock timeout in minutes (15|30|60|120|0=never)
+  CLOUD_VAULT_IDLE_TIMEOUT_KEY,                // number string: vault password idle lock timeout in minutes (15|30|60|120|0=never)
 ];
 
 // =============================================================================
@@ -1627,6 +1630,7 @@ if (typeof window !== "undefined") {
   window.MAX_TAG_LENGTH = MAX_TAG_LENGTH;
   // Multi-currency support (STACK-50)
   window.SUPPORTED_CURRENCIES = SUPPORTED_CURRENCIES;
+  window.CLOUD_VAULT_IDLE_TIMEOUT_KEY = CLOUD_VAULT_IDLE_TIMEOUT_KEY;
   window.DISPLAY_CURRENCY_KEY = DISPLAY_CURRENCY_KEY;
   window.EXCHANGE_RATES_KEY = EXCHANGE_RATES_KEY;
   window.EXCHANGE_RATE_API_URL = EXCHANGE_RATE_API_URL;

--- a/js/constants.js
+++ b/js/constants.js
@@ -286,7 +286,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.11";
+const APP_VERSION = "3.32.12";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -794,6 +794,7 @@ const ALLOWED_STORAGE_KEYS = [
   "cloud_sync_device_id",                      // UUID string: stable per-device identifier
   "cloud_sync_cursor",                         // Dropbox rev string: for efficient change detection
   "cloud_sync_override_backup",                // JSON: { timestamp, itemCount, appVersion, data: {...} } — pre-pull local snapshot
+  "cloud_vault_idle_timeout",                  // number string: vault password idle lock timeout in minutes (15|30|60|120|0=never)
 ];
 
 // =============================================================================

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1184,6 +1184,14 @@ const renderCloudBackupList = (provider, backups) => {
  */
 const bindCloudCacheListeners = () => {
   // Session-only password cache — no toggle needed, auto-caches on first use
+  var idleSelect = safeGetElement('cloudVaultIdleTimeout');
+  if (idleSelect) {
+    idleSelect.addEventListener('change', function () {
+      var key = typeof CLOUD_VAULT_IDLE_TIMEOUT_KEY !== 'undefined' ? CLOUD_VAULT_IDLE_TIMEOUT_KEY : 'cloud_vault_idle_timeout';
+      localStorage.setItem(key, this.value);
+      if (typeof _resetIdleLockTimer === 'function') _resetIdleLockTimer();
+    });
+  }
 };
 
 /**

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.12-b1771791324';
+const CACHE_NAME = 'staktrakr-v3.32.12-b1771793250';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.11-b1771788377';
+const CACHE_NAME = 'staktrakr-v3.32.12-b1771791324';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.12-b1771793250';
+const CACHE_NAME = 'staktrakr-v3.32.12-b1771793597';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.11",
+  "version": "3.32.12",
   "releaseDate": "2026-02-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — do not merge.** PR description will be updated to reflect all changes before merge.

## Changes

- **New setting**: \"Auto-lock after idle\" dropdown in Settings → Cloud Sync → Session Password Cache
  - Options: 15 minutes (default), 30 minutes, 1 hour, 2 hours, Never
- **Behaviour**: Vault password idle lock reads user preference from \`localStorage\` at arm time instead of a hardcoded 15-minute constant. Setting \"Never\" disables auto-clear entirely.
- **Storage key**: \`cloud_vault_idle_timeout\` added to \`ALLOWED_STORAGE_KEYS\` and constants comment block
- **Docs**: \`docs/tests/known-failures.md\` — new living registry of 7 known flaky/broken Playwright tests (KF-001..KF-007); smoke-test skill updated to reference it

## Linear Issues

- STAK-183: Cloud sync vault idle timeout — configurable (original restore bug already shipped in v3.32.07)
- STAK-263: Filed — follow-up Web Credential Management API approach for persistent vault password storage

## Smoke Test

Run against \`https://patch-3-32-12.staktrakr.pages.dev\` — 47 passed, 7 known failures (all pre-existing, catalogued in \`docs/tests/known-failures.md\`), 6 skipped. Core smoke/crud/calculations/ui-checks/cloud-sync all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)