### PR TITLE
docs(skills): add scalar localStorage exception to coding-standards

### DIFF
--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -199,14 +199,18 @@ const data = loadDataSync(LS_KEY, []);
 
 ```javascript
 // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
-var stored = localStorage.getItem(CLOUD_VAULT_IDLE_TIMEOUT_KEY);
+const stored = localStorage.getItem(CLOUD_VAULT_IDLE_TIMEOUT_KEY);
+
+// Example of setting a scalar string preference
+const timeoutMinutes = '15';
+localStorage.setItem(CLOUD_VAULT_IDLE_TIMEOUT_KEY, timeoutMinutes);
 ```
 
 Named constant must still be registered in `ALLOWED_STORAGE_KEYS` in `constants.js`.
 
 ### localStorage key whitelist
 
-Every localStorage key **must** be registered in `ALLOWED_STORAGE_KEYS` in `constants.js` before use. The security cleanup routine (`cleanupLocalStorage`) deletes any key not in this list. Forgetting to register a key means data loss on next cleanup.
+Every localStorage key **must** be registered in `ALLOWED_STORAGE_KEYS` in `constants.js` before use. The security cleanup routine (`cleanupStorage` in `js/utils.js`) deletes any key not in this list. Forgetting to register a key means data loss on next cleanup.
 
 ### Mutation cycle
 

--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -195,6 +195,15 @@ const data = loadDataSync(LS_KEY, []);
 
 **Never** use `localStorage.getItem()` / `localStorage.setItem()` directly for application data. The helpers handle JSON serialization, compression, and error recovery.
 
+**Exception — scalar string preferences:** Plain string scalar values that are NOT JSON objects or arrays (e.g., a timeout value in minutes like `'15'`, a boolean string like `'true'`) may use `localStorage.getItem/setItem` directly with a named constant key. `loadData()`/`saveData()` are async and add JSON.stringify wrapping — wrong for values that are already simple strings. Use `localStorage.getItem(NAMED_KEY_CONSTANT)` directly and add a `// nosemgrep` comment to suppress Codacy false positives:
+
+```javascript
+// nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
+var stored = localStorage.getItem(CLOUD_VAULT_IDLE_TIMEOUT_KEY);
+```
+
+Named constant must still be registered in `ALLOWED_STORAGE_KEYS` in `constants.js`.
+
 ### localStorage key whitelist
 
 Every localStorage key **must** be registered in `ALLOWED_STORAGE_KEYS` in `constants.js` before use. The security cleanup routine (`cleanupLocalStorage`) deletes any key not in this list. Forgetting to register a key means data loss on next cleanup.


### PR DESCRIPTION
## Summary

- Documents that `loadData()`/`saveData()` are async + JSON-wrapping and therefore wrong for plain scalar string preferences (timeout minutes, flag strings)
- Direct `localStorage.getItem/setItem` with a named constant is correct for scalars
- Requires `ALLOWED_STORAGE_KEYS` registration + `// nosemgrep` comment to suppress Codacy false positives
- Surfaced during v3.32.12 PR review (STAK-183 idle timeout feature)

## Files Changed

- `.claude/skills/coding-standards/SKILL.md` — 9-line exception clause added to data persistence section

🤖 Generated with [Claude Code](https://claude.com/claude-code)