### PR TITLE
v3.32.13 — API Health Modal z-index Fix + Three-Feed Freshness Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.13] - 2026-02-22
+
+### Fixed — API Health Modal z-index + Three-Feed Freshness Checks
+
+- **Fixed**: API health modal now renders above the About modal (z-index raised to 10000)
+- **Improved**: API health now checks three feeds independently — market prices (15 min threshold), spot prices (75 min), and Goldback daily scrape; badges show per-feed freshness
+- **Changed**: Footer and About modal badge text now shows `✅ Market Xm · Spot Xm` format
+
+---
+
 ## [3.32.12] - 2026-02-22
 
 ### Added — Configurable Vault Password Idle Timeout (STAK-183)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **API Health Modal Fix + Three-Feed Checks (v3.32.13)**: Health modal no longer renders behind About modal. Health check now monitors market prices (15 min), spot prices (75 min), and Goldback daily separately; badges show per-feed freshness.
 - **Configurable Vault Idle Timeout (v3.32.12)**: New "Auto-lock after idle" dropdown in Settings → Cloud Sync — choose 15 min, 30 min, 1 hour, 2 hours, or Never before the vault password cache clears automatically
 - **PR #395 Review Fixes (v3.32.11)**: logItemChanges null-guard for add/delete; changeLog writes use saveDataSync(); getManifestEntries/markSynced exposed as window globals; sync toast provider fixed ("ok" not "success"); backfill catch logs warn; api-health readyState guard; safeGetElement in initSpotHistoryButtons
 - **Worktree Protocol & Branch Protection (v3.32.10)**: Agents now use isolated git worktrees (patch/VERSION) for concurrent work; main branch protected with Codacy required check; release skill creates/cleans up worktrees automatically
 - **WeakMap Search Cache Correctness (v3.32.09)**: Cache miss guard uses strict undefined check; notes edits invalidate search cache immediately; undo/redo now reflects reverted field values in search
-- **OAuth State Security Hardening (v3.32.08)**: Provider now parsed from trusted savedState after CSRF check; PKCE challenge adds .catch() to clean sessionStorage on failure; stale oauth state removed on exchange failure
 ## Development Roadmap
 
 ### Next Up

--- a/index.html
+++ b/index.html
@@ -1811,7 +1811,7 @@
        API HEALTH MODAL
        Shows manifest.json staleness status, generated_at timestamp, and coin count.
        ============================================================================= -->
-    <div class="modal" id="apiHealthModal" style="display: none">
+    <div class="modal" id="apiHealthModal" style="display: none; z-index: 10000">
       <div class="modal-content" style="max-width:480px">
         <div class="modal-header">
           <h3>API Health Status</h3>
@@ -1821,8 +1821,9 @@
           <div class="about-section">
             <div class="section-title">Status: <span id="apiHealthStatus">Checking…</span></div>
             <table style="width:100%;font-size:0.9rem;border-collapse:collapse;margin-top:0.5rem">
-              <tr><td style="padding:0.3rem 0;color:var(--text-muted)">Last updated</td><td id="apiHealthGeneratedAt" style="text-align:right">&#x2014;</td></tr>
-              <tr><td style="padding:0.3rem 0;color:var(--text-muted)">Data age</td><td id="apiHealthAge" style="text-align:right">&#x2014;</td></tr>
+              <tr><td style="padding:0.3rem 0;color:var(--text-muted)">Market prices</td><td id="apiHealthMarket" style="text-align:right">&#x2014;</td></tr>
+              <tr><td style="padding:0.3rem 0;color:var(--text-muted)">Spot prices</td><td id="apiHealthSpot" style="text-align:right">&#x2014;</td></tr>
+              <tr><td style="padding:0.3rem 0;color:var(--text-muted)">Goldback (daily)</td><td id="apiHealthGoldback" style="text-align:right">&#x2014;</td></tr>
               <tr><td style="padding:0.3rem 0;color:var(--text-muted)">Coverage</td><td id="apiHealthCoins" style="text-align:right">&#x2014;</td></tr>
             </table>
           </div>

--- a/index.html
+++ b/index.html
@@ -1809,7 +1809,8 @@
     </footer>
     <!-- =============================================================================
        API HEALTH MODAL
-       Shows manifest.json staleness status, generated_at timestamp, and coin count.
+       Shows per-feed freshness: market prices (manifest.json), spot prices
+       (spot-history-YYYY.json), and Goldback daily scrape (goldback-spot.json).
        ============================================================================= -->
     <div class="modal" id="apiHealthModal" style="display: none; z-index: 10000">
       <div class="modal-content" style="max-width:480px">

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.13 &ndash; API Health Modal Fix + Three-Feed Checks</strong>: Health modal no longer renders behind About modal. Health check now monitors market prices (15 min), spot prices (75 min), and Goldback daily separately; badges show per-feed freshness.</li>
     <li><strong>v3.32.12 &ndash; Configurable Vault Idle Timeout</strong>: New &ldquo;Auto-lock after idle&rdquo; dropdown in Settings &rarr; Cloud Sync &mdash; choose 15 min, 30 min, 1 hour, 2 hours, or Never before the vault password cache clears automatically</li>
     <li><strong>v3.32.11 &ndash; PR #395 Review Fixes</strong>: logItemChanges null-guard for add/delete; changeLog writes use saveDataSync(); getManifestEntries/markSynced exposed as window globals; sync toast provider fixed (&ldquo;ok&rdquo; not &ldquo;success&rdquo;); backfill catch logs warn; api-health readyState guard; safeGetElement in initSpotHistoryButtons</li>
     <li><strong>v3.32.10 &ndash; Worktree Protocol &amp; Branch Protection</strong>: Agents now use isolated git worktrees (patch/VERSION) for concurrent work; main branch protected with Codacy required check; release skill creates/cleans up worktrees automatically</li>
     <li><strong>v3.32.09 &ndash; WeakMap Search Cache Correctness</strong>: Cache miss guard uses strict undefined check; notes edits invalidate search cache immediately; undo/redo now reflects reverted field values in search</li>
-    <li><strong>v3.32.08 &ndash; OAuth State Security Hardening</strong>: Provider now parsed from trusted savedState after CSRF check; PKCE challenge adds .catch() to clean sessionStorage on failure; stale oauth state removed on exchange failure</li>
   `;
 };
 

--- a/js/api-health.js
+++ b/js/api-health.js
@@ -262,6 +262,9 @@ const setupApiHealthModalEvents = () => {
 
 /**
  * Main entry point — fetches health data and wires up the UI.
+ * If the modal is already open when the fetch resolves (user opened it while
+ * data was in-flight), populate it immediately rather than leaving it on
+ * the "Checking…" placeholder.
  */
 const initApiHealth = async () => {
   setupApiHealthModalEvents();
@@ -269,6 +272,11 @@ const initApiHealth = async () => {
     const health = await fetchApiHealth();
     _lastHealth  = health;
     updateHealthBadges(health);
+    // If the modal is open and showing placeholder text, push the result in now
+    const modal = safeGetElement("apiHealthModal");
+    if (modal && modal.style.display !== "none") {
+      populateApiHealthModal(health);
+    }
   } catch (err) {
     console.warn("API health check failed:", err);
     populateApiHealthModalError(err);

--- a/js/api-health.js
+++ b/js/api-health.js
@@ -242,10 +242,12 @@ let _keydownRegistered = false;
 
 /**
  * Sets up event listeners for the health modal.
+ * Uses document.getElementById directly — safeGetElement lives in init.js
+ * which loads after this file in the defer queue.
  */
 const setupApiHealthModalEvents = () => {
-  const closeBtn = safeGetElement("apiHealthCloseBtn");
-  const modal    = safeGetElement("apiHealthModal");
+  const closeBtn = document.getElementById("apiHealthCloseBtn");
+  const modal    = document.getElementById("apiHealthModal");
   if (closeBtn) closeBtn.addEventListener("click", hideApiHealthModal);
   if (modal) {
     modal.addEventListener("click", (e) => {
@@ -290,8 +292,6 @@ if (typeof window !== "undefined") {
   window.initApiHealth      = initApiHealth;
 }
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", initApiHealth);
-} else {
-  initApiHealth();
-}
+// initApiHealth() is called by init.js after safeGetElement and all DOM setup
+// are complete. Do NOT auto-init here — init.js (script #64) runs after this
+// file (script #56) in the defer queue, so safeGetElement is not yet defined.

--- a/js/constants.js
+++ b/js/constants.js
@@ -286,7 +286,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.12";
+const APP_VERSION = "3.32.13";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/init.js
+++ b/js/init.js
@@ -677,6 +677,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     debugLog("  - Settings button:", !!elements.settingsBtn);
     debugLog("  - Inventory form:", !!elements.inventoryForm);
     debugLog("  - Inventory table:", !!elements.inventoryTable);
+    // API health badge — runs after safeGetElement and all DOM setup are ready
+    if (typeof initApiHealth === 'function') initApiHealth();
+
     // Phase 16: Storage optimization pass
     if (typeof optimizeStoragePhase1C === 'function') { optimizeStoragePhase1C(); }
 

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.13-b1771798879';
+const CACHE_NAME = 'staktrakr-v3.32.13-b1771799768';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.13-b1771798150';
+const CACHE_NAME = 'staktrakr-v3.32.13-b1771798879';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.12-b1771793597';
+const CACHE_NAME = 'staktrakr-v3.32.13-b1771797852';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.13-b1771797852';
+const CACHE_NAME = 'staktrakr-v3.32.13-b1771798150';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.12",
+  "version": "3.32.13",
   "releaseDate": "2026-02-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **z-index fix**: `#apiHealthModal` now renders above `#aboutModal` (inline `z-index: 10000`)
- **Three-feed health check**: market prices (15 min), spot prices (75 min), Goldback daily (25 hr) each checked independently via `Promise.allSettled`
- **Init ordering fix**: removed auto-init from `api-health.js` (script #56); `initApiHealth()` now called from `init.js` Phase 15 (script #64) after `safeGetElement` is defined — this was the root cause of the badge stuck on "Checking API…" forever

## Root Cause (badge hang)

`api-health.js` is script #56 in the `defer` queue; `init.js` is #64. Both attach `DOMContentLoaded` listeners that fire at the same tick, but `safeGetElement` (defined in `init.js:31`) doesn't exist when `api-health.js` evaluates. `setupApiHealthModalEvents()` threw `ReferenceError: safeGetElement is not defined`, silently rejecting the `initApiHealth` promise and leaving badges in placeholder state forever.

## Files Changed

- `js/api-health.js` — rewrote to three-feed check; removed auto-init block; `setupApiHealthModalEvents` uses `document.getElementById` directly
- `js/init.js` — added `initApiHealth()` call at Phase 15
- `index.html` — modal z-index + new table rows (Market, Spot, Goldback, Coverage)

## QA Notes

- Verify badge updates within ~2s on page load (previously stuck forever)
- Open API Health modal while badge is loading → should show placeholder then auto-update
- Close and reopen modal → should show cached data immediately (no re-fetch hang)
- Verify modal opens on top of About modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)