### PR TITLE
v3.32.17 — STAK-270: 24hr intraday chart improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.17] - 2026-02-23
+
+### Added — STAK-270: 24hr Intraday Chart Improvements
+
+- **Improved**: 24hr intraday chart now buckets raw API windows into clean 30-min aligned slots, eliminating irregular tick spacing caused by poller timing variance
+- **Improved**: Chart X-axis now visually distinguishes hour marks (full opacity, 11px) from half-hour marks (dimmed, 9px) for faster time-at-a-glance reading
+- **Added**: Intraday table extended from 5 rows to configurable 12/24/48 rows with scrollable container and row-count dropdown
+- **Added**: Trend column (▲/▼/—) in intraday table shows price direction vs. previous 30-min slot
+
+---
+
 ## [3.32.16] - 2026-02-22
 
 ### Fixed — Market Chart Timezone + Seed Sync Automation (STAK-275, STAK-266)

--- a/data/spot-history-2026.json
+++ b/data/spot-history-2026.json
@@ -1090,5 +1090,33 @@
     "source": "seed",
     "provider": "MetalPriceAPI",
     "timestamp": "2026-02-21 12:00:00"
+  },
+  {
+    "spot": 5105.45,
+    "metal": "Gold",
+    "source": "seed",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-22 12:00:00"
+  },
+  {
+    "spot": 1766.71,
+    "metal": "Palladium",
+    "source": "seed",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-22 12:00:00"
+  },
+  {
+    "spot": 2163.5,
+    "metal": "Platinum",
+    "source": "seed",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-22 12:00:00"
+  },
+  {
+    "spot": 84.75,
+    "metal": "Silver",
+    "source": "seed",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-22 12:00:00"
   }
 ]

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **24hr Chart Improvements (v3.32.17)**: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (▲/▼/—) per slot.
 - **Market Chart Timezone Fix (v3.32.16)**: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 — syncs from live API before releases.
 - **Nitpick Polish (v3.32.15)**: API health modal now says "items tracked" instead of "coins". Desktop footer restructured — badges on top, Special thanks on its own line.
 - **API Health Stale Timestamp Fix (v3.32.14)**: Spot history and Goldback timestamps now parsed as UTC — fixes inflated staleness readings in negative-offset timezones (CST, PST, etc.). Market stale threshold raised from 15 → 30 min to match actual poller cadence.
 - **API Health Modal Fix + Three-Feed Checks (v3.32.13)**: Health modal no longer renders behind About modal. Health check now monitors market prices (15 min), spot prices (75 min), and Goldback daily separately; badges show per-feed freshness.
-- **Configurable Vault Idle Timeout (v3.32.12)**: New "Auto-lock after idle" dropdown in Settings → Cloud Sync — choose 15 min, 30 min, 1 hour, 2 hours, or Never before the vault password cache clears automatically
 ## Development Roadmap
 
 ### Next Up

--- a/index.html
+++ b/index.html
@@ -4900,11 +4900,17 @@
             <canvas id="retailViewIntradayChart" aria-label="24h intraday price chart"></canvas>
           </div>
           <p id="retailViewIntradayNoData" class="settings-subtext" style="display:none;text-align:center;padding:1rem;">No intraday data — check back after the next 15-minute sync.</p>
-          <div class="retail-view-table-wrap" style="margin-top:.5rem;">
-            <table class="retail-view-table">
-              <thead id="retailViewIntradayTableHead">
-                <tr><th>Time (local)</th></tr>
-              </thead>
+          <div class="d-flex align-items-center justify-content-between mb-1" style="gap:8px;">
+            <label for="retailViewIntradayRowCount" class="settings-subtext" id="retailViewIntradayTableLabel">Recent windows</label>
+            <select id="retailViewIntradayRowCount" class="form-select form-select-sm" style="width:auto;">
+              <option value="12">12 rows</option>
+              <option value="24" selected>24 rows</option>
+              <option value="48">48 rows</option>
+            </select>
+          </div>
+          <div style="max-height:360px;overflow-y:auto;">
+            <table class="table table-sm table-borderless mb-0">
+              <thead id="retailViewIntradayTableHead"></thead>
               <tbody id="retailViewIntradayTableBody"></tbody>
             </table>
           </div>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.17 &ndash; 24hr Chart Improvements</strong>: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (&#9650;/&#9660;/&mdash;) per slot.</li>
     <li><strong>v3.32.16 &ndash; Market Chart Timezone Fix</strong>: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 &mdash; syncs from live API before releases.</li>
     <li><strong>v3.32.15 &ndash; Nitpick Polish</strong>: API health modal now says &ldquo;items tracked&rdquo; instead of &ldquo;coins&rdquo;. Desktop footer restructured &mdash; badges on top, Special thanks on its own line.</li>
     <li><strong>v3.32.14 &ndash; API Health Stale Timestamp Fix</strong>: Spot history and Goldback timestamps now parsed as UTC &mdash; fixes inflated staleness readings in negative-offset timezones (CST, PST, etc.). Market stale threshold raised from 15 &rarr; 30 min to match actual poller cadence.</li>
     <li><strong>v3.32.13 &ndash; API Health Modal Fix + Three-Feed Checks</strong>: Health modal no longer renders behind About modal. Health check now monitors market prices (15 min), spot prices (75 min), and Goldback daily separately; badges show per-feed freshness.</li>
-    <li><strong>v3.32.12 &ndash; Configurable Vault Idle Timeout</strong>: New &ldquo;Auto-lock after idle&rdquo; dropdown in Settings &rarr; Cloud Sync &mdash; choose 15 min, 30 min, 1 hour, 2 hours, or Never before the vault password cache clears automatically</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -285,7 +285,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.16";
+const APP_VERSION = "3.32.17";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -138,8 +138,9 @@ const _bucketWindows = (windows) => {
     const key = slotDate.toISOString();
     // Keep the most recent window for each slot
     const existing = slotMap.get(key);
-    if (!existing || d.getTime() > new Date(existing.window).getTime()) {
-      slotMap.set(key, { ...w, window: key });
+    // Compare original timestamps (not slot keys) so the most recent poll wins
+    if (!existing || d.getTime() > new Date(existing._originalWindow).getTime()) {
+      slotMap.set(key, { ...w, window: key, _originalWindow: w.window });
     }
   }
   // Sort chronologically

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.17-b1771831498';
+const CACHE_NAME = 'staktrakr-v3.32.17-b1771836411';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.17-b1771831175';
+const CACHE_NAME = 'staktrakr-v3.32.17-b1771831498';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.16-b1771829051';
+const CACHE_NAME = 'staktrakr-v3.32.17-b1771831175';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/tests/retail-view-modal.spec.js
+++ b/tests/retail-view-modal.spec.js
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('_bucketWindows', () => {
+  test('empty input returns empty array', async ({ page }) => {
+    await page.goto('/');
+    const result = await page.evaluate(() => window._bucketWindows([]));
+    expect(result).toEqual([]);
+  });
+
+  test('buckets two windows in same 30-min slot to one entry (most recent wins)', async ({ page }) => {
+    await page.goto('/');
+    const result = await page.evaluate(() => window._bucketWindows([
+      { window: '2026-02-22T14:10:00Z', median: 100, low: 99, vendors: {} },
+      { window: '2026-02-22T14:25:00Z', median: 101, low: 100, vendors: {} },
+    ]));
+    expect(result.length).toBe(1);
+    expect(result[0].window).toBe('2026-02-22T14:00:00.000Z');
+    expect(result[0].median).toBe(101);
+  });
+
+  test('windows at :31 go into :30 bucket', async ({ page }) => {
+    await page.goto('/');
+    const result = await page.evaluate(() => window._bucketWindows([
+      { window: '2026-02-22T14:31:00Z', median: 100, low: 99, vendors: {} },
+    ]));
+    expect(result.length).toBe(1);
+    expect(result[0].window).toBe('2026-02-22T14:30:00.000Z');
+  });
+
+  test('windows across two slots produce two entries in chronological order', async ({ page }) => {
+    await page.goto('/');
+    const result = await page.evaluate(() => window._bucketWindows([
+      { window: '2026-02-22T14:00:00Z', median: 100, low: 99, vendors: {} },
+      { window: '2026-02-22T14:30:00Z', median: 102, low: 101, vendors: {} },
+    ]));
+    expect(result.length).toBe(2);
+    expect(result[0].window).toBe('2026-02-22T14:00:00.000Z');
+    expect(result[1].window).toBe('2026-02-22T14:30:00.000Z');
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.16",
-  "releaseDate": "2026-02-22",
+  "version": "3.32.17",
+  "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — do not merge.** QA on Cloudflare preview before merge.

## Changes

- 30-min bucketing of raw `windows_24h` — clean aligned ticks regardless of poll timing variance
- X-axis tick styling: hour marks (full opacity, 11px) vs half-hour marks (dimmed, 9px)
- Intraday table extended from 5 rows to configurable 12/24/48 rows with scrollable container
- Trend column: ▲/▼/— per slot vs. previous slot (green/red)
- Seed data updated through 2026-02-22

## Linear

- [STAK-270](https://linear.app/hextrackr/issue/STAK-270): 24hr Chart in Market Item Cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)