### PR TITLE
v3.32.18 — Cloud Sync Header Status Icon (STAK-264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.18] - 2026-02-23
+
+### Added — Cloud Sync Header Status Icon (STAK-264)
+
+- **Added**: Ambient cloud sync status icon in the header replaces the jarring on-load vault password modal — orange when password is needed (tap to unlock), green when active, gray when not yet configured (STAK-264)
+
+---
+
 ## [3.32.17] - 2026-02-23
 
 ### Added — STAK-270: 24hr Intraday Chart Improvements

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Cloud Sync Status Icon (v3.32.18)**: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.
 - **24hr Chart Improvements (v3.32.17)**: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (▲/▼/—) per slot.
 - **Market Chart Timezone Fix (v3.32.16)**: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 — syncs from live API before releases.
 - **Nitpick Polish (v3.32.15)**: API health modal now says "items tracked" instead of "coins". Desktop footer restructured — badges on top, Special thanks on its own line.
 - **API Health Stale Timestamp Fix (v3.32.14)**: Spot history and Goldback timestamps now parsed as UTC — fixes inflated staleness readings in negative-offset timezones (CST, PST, etc.). Market stale threshold raised from 15 → 30 min to match actual poller cadence.
-- **API Health Modal Fix + Three-Feed Checks (v3.32.13)**: Health modal no longer renders behind About modal. Health check now monitors market prices (15 min), spot prices (75 min), and Goldback daily separately; badges show per-feed freshness.
 ## Development Roadmap
 
 ### Next Up

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.18 &ndash; Cloud Sync Status Icon</strong>: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.</li>
     <li><strong>v3.32.17 &ndash; 24hr Chart Improvements</strong>: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (&#9650;/&#9660;/&mdash;) per slot.</li>
     <li><strong>v3.32.16 &ndash; Market Chart Timezone Fix</strong>: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 &mdash; syncs from live API before releases.</li>
     <li><strong>v3.32.15 &ndash; Nitpick Polish</strong>: API health modal now says &ldquo;items tracked&rdquo; instead of &ldquo;coins&rdquo;. Desktop footer restructured &mdash; badges on top, Special thanks on its own line.</li>
     <li><strong>v3.32.14 &ndash; API Health Stale Timestamp Fix</strong>: Spot history and Goldback timestamps now parsed as UTC &mdash; fixes inflated staleness readings in negative-offset timezones (CST, PST, etc.). Market stale threshold raised from 15 &rarr; 30 min to match actual poller cadence.</li>
-    <li><strong>v3.32.13 &ndash; API Health Modal Fix + Three-Feed Checks</strong>: Health modal no longer renders behind About modal. Health check now monitors market prices (15 min), spot prices (75 min), and Goldback daily separately; badges show per-feed freshness.</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -219,8 +219,9 @@ function updateCloudSyncHeaderBtn() {
   var dot = safeGetElement('headerCloudDot');
   if (!btn) return;
 
-  // Hide entirely when sync is explicitly disabled
-  if (!syncIsEnabled()) {
+  // Hide entirely only when sync is explicitly disabled (stored as 'false')
+  // null means never configured — show gray to promote discoverability
+  if (localStorage.getItem('cloud_sync_enabled') === 'false') {
     btn.style.display = 'none';
     return;
   }
@@ -1060,6 +1061,7 @@ function initCloudSync() {
 
   if (!syncIsEnabled()) {
     debugLog('[CloudSync] Auto-sync is disabled — poller not started');
+    updateCloudSyncHeaderBtn();
     return;
   }
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -285,7 +285,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.17";
+const APP_VERSION = "3.32.18";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 // Cache version: auto-stamped by devops/hooks/stamp-sw-cache.sh pre-commit hook
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
-const CACHE_NAME = 'staktrakr-v3.32.17-b1771836411';
+const CACHE_NAME = 'staktrakr-v3.32.18-b1771837368';
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>StakTrakr</title></head>' +

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.17",
+  "version": "3.32.18",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — do not merge.** QA the Cloudflare preview before merging to dev.

## Summary

- Added ambient cloud sync status icon to the header (between About and Settings buttons)
- Icon shows gray (not configured), orange (needs password — tap to unlock), or green (active)
- On load with no cached password: orange icon + polite toast instead of jarring modal
- Clicking orange routes through \`getSyncPassword()\` so \`_syncPasswordPromptActive\` guard is respected
- Clicking gray opens Settings → Cloud tab; clicking green shows last-synced toast
- \`updateCloudSyncHeaderBtn()\` hooked into \`updateSyncStatusIndicator()\` — zero extra wiring

## Linear Issues

- [STAK-264: Login on first load is jarring to many users](https://linear.app/hextrackr/issue/STAK-264/login-on-first-load-is-jarring-to-many-users)

## Files Changed

- \`index.html\` — \`#headerCloudSyncBtn\` + \`#headerCloudDot\` span
- \`css/styles.css\` — \`#headerCloudSyncBtn\` positioning + \`.header-cloud-dot\` gray/orange/green states
- \`js/cloud-sync.js\` — \`updateCloudSyncHeaderBtn()\`, on-load modal suppression, post-confirm push trigger
- \`js/events.js\` — click handler routing

## QA Checklist

- [ ] Sync disabled → header button hidden
- [ ] Sync enabled, fresh session (clear \`sessionStorage\`) → orange icon + toast after ~1s
- [ ] Click orange → enter password → confirm → icon turns green, push fires
- [ ] Click orange → cancel → stays orange
- [ ] Click green → toast shows "Cloud sync active"
- [ ] Click gray (not connected) → Settings opens to Cloud tab
- [ ] Disable sync in settings → button hides immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)