### PR TITLE
📝 Scribe: Remove unused formatDateOnly function

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -398,16 +398,6 @@ const formatTimestamp = (date, options = {}) => {
 };
 
 /**
- * Formats a date for display (date only, no time) using the user's timezone preference.
- *
- * @param {Date|string|number} date - Date object, ISO string, or epoch ms
- * @returns {string} Formatted date string
- */
-const formatDateOnly = (date) => {
-  return formatTimestamp(date, { hour: undefined, minute: undefined });
-};
-
-/**
  * Formats a date for display (time only, no date) using the user's timezone preference.
  *
  * @param {Date|string|number} date - Date object, ISO string, or epoch ms


### PR DESCRIPTION
💡 What: Removed `formatDateOnly` function and its JSDoc from `js/utils.js`.
🔍 Evidence: `grep -rn "formatDateOnly" js/ index.html functions/` returned 0 results outside the definition itself.
📁 Files changed: `js/utils.js`
✅ Verified: Confirmed zero remaining references after removal. Checked for exports (none found).

---
*PR created automatically by Jules for task [17346454745263849487](https://jules.google.com/task/17346454745263849487) started by @lbruton*