### PR TITLE
v3.32.19 — 15-Min Spot Price Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.19] - 2026-02-23
+
+### Added — 15-Min Spot Price Endpoint
+
+- **Added**: New `data/15min/YYYY/MM/DD/HHMM.json` API endpoint — immutable sub-hourly price snapshots written every 15 min by the spot poller (GHA :05/:20/:35/:50)
+- **Added**: `fetchStaktrakr15minRange()` fetches 24h of 15-min spot data into spotHistory, tagged `api-15min` and visible in the API history table
+
+---
+
 ## [3.32.18] - 2026-02-23
 
 ### Added — Cloud Sync Header Status Icon (STAK-264)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **15-Min Spot Price Endpoint (v3.32.19)**: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json — written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.
 - **Cloud Sync Status Icon (v3.32.18)**: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.
 - **24hr Chart Improvements (v3.32.17)**: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (▲/▼/—) per slot.
 - **Market Chart Timezone Fix (v3.32.16)**: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 — syncs from live API before releases.
 - **Nitpick Polish (v3.32.15)**: API health modal now says "items tracked" instead of "coins". Desktop footer restructured — badges on top, Special thanks on its own line.
-- **API Health Stale Timestamp Fix (v3.32.14)**: Spot history and Goldback timestamps now parsed as UTC — fixes inflated staleness readings in negative-offset timezones (CST, PST, etc.). Market stale threshold raised from 15 → 30 min to match actual poller cadence.
 ## Development Roadmap
 
 ### Next Up

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.19 &ndash; 15-Min Spot Price Endpoint</strong>: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json &mdash; written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.</li>
     <li><strong>v3.32.18 &ndash; Cloud Sync Status Icon</strong>: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.</li>
     <li><strong>v3.32.17 &ndash; 24hr Chart Improvements</strong>: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (&#9650;/&#9660;/&mdash;) per slot.</li>
     <li><strong>v3.32.16 &ndash; Market Chart Timezone Fix</strong>: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 &mdash; syncs from live API before releases.</li>
     <li><strong>v3.32.15 &ndash; Nitpick Polish</strong>: API health modal now says &ldquo;items tracked&rdquo; instead of &ldquo;coins&rdquo;. Desktop footer restructured &mdash; badges on top, Special thanks on its own line.</li>
-    <li><strong>v3.32.14 &ndash; API Health Stale Timestamp Fix</strong>: Spot history and Goldback timestamps now parsed as UTC &mdash; fixes inflated staleness readings in negative-offset timezones (CST, PST, etc.). Market stale threshold raised from 15 &rarr; 30 min to match actual poller cadence.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -288,7 +288,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.18";
+const APP_VERSION = "3.32.19";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = 'staktrakr-v3.32.18-b1771837368';
+const CACHE_NAME = 'staktrakr-v3.32.19-b1771838936';
 
 
 // Offline fallback for navigation requests when all cache/network strategies fail

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.18",
+  "version": "3.32.19",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — merge to dev when QA passes.** After merging to dev, run Phase 4.5 to open the dev→main PR.

## Changes

- **Added**: New `data/15min/YYYY/MM/DD/HHMM.json` API endpoint — immutable sub-hourly price snapshots written every 15 min by the spot poller (GHA :05/:20/:35/:50)
- **Added**: `fetchStaktrakr15minRange()` fetches 24h of 15-min spot data into spotHistory, tagged `api-15min` and visible in the API history table
- **Docs**: 15-min feed documented in runbook (Feed 4), api-infrastructure skill, and CLAUDE.md

## Verification

- Live endpoint confirmed: `https://api.staktrakr.com/data/15min/2026/02/23/0852.json` → 200 OK, 4 entries
- GHA run log shows: `15min: wrote 4 entries → 15min/2026/02/23/0852.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)