### PR TITLE
WIP: v3.32.22 — Sync UX Overhaul + Simple Mode + Dark-Theme CSS Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.21] - 2026-02-23
+
+### Added — Sync UX Overhaul + Simple Mode
+
+- **Added**: "Simple" sync mode — Dropbox account acts as encryption key; no vault password needed on any device
+- **Added**: Mode selector in Settings → Cloud (Simple / Secure) with backup warning before switching modes
+- **Fixed**: Sync password modal no longer auto-opens on page load; replaced with ambient toast + orange header dot
+- **Changed**: Header cloud button is mode-aware — orange-simple reconnects Dropbox; orange (Secure) opens an inline password popover below the header button
+
+---
+
 ## [3.32.20] - 2026-02-23
 
 ### Added — api2 Backup Endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.22] - 2026-02-23
+
+### Fixed — Sync UI Dark-Theme CSS Fix
+
+- **Fixed**: Cloud sync header popover now uses correct dark-theme CSS variables (`--bg-card`, `--border`, `--bg-tertiary`) — previously appeared white/light on dark theme
+- **Fixed**: Mode selector in Settings → Cloud uses correct border and background variables across all themes
+- **Fixed**: Backup warning banner uses transparent amber tint instead of hardcoded light-yellow (`#fff8e6`)
+- **Fixed**: Popover header label uses SVG lock icon matching the app's stroke-icon style
+
+---
+
 ## [3.32.21] - 2026-02-23
 
 ### Added — Sync UX Overhaul + Simple Mode

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync UI Dark-Theme CSS Fix (v3.32.22)**: Header sync popover, mode selector, and backup warning now render correctly across all themes — corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.
 - **Sync UX Overhaul + Simple Mode (v3.32.21)**: No more on-load password popups — choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.
 - **api2 Backup Endpoint (v3.32.20)**: Dual-endpoint fallback for all API feeds — spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal now shows per-endpoint drift benchmarking.
 - **15-Min Spot Price Endpoint (v3.32.19)**: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json — written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.
 - **Cloud Sync Status Icon (v3.32.18)**: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.
-- **24hr Chart Improvements (v3.32.17)**: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (▲/▼/—) per slot.
 ## Development Roadmap
 
 ### Next Up

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync UX Overhaul + Simple Mode (v3.32.21)**: No more on-load password popups — choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.
 - **api2 Backup Endpoint (v3.32.20)**: Dual-endpoint fallback for all API feeds — spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal now shows per-endpoint drift benchmarking.
 - **15-Min Spot Price Endpoint (v3.32.19)**: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json — written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.
 - **Cloud Sync Status Icon (v3.32.18)**: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.
 - **24hr Chart Improvements (v3.32.17)**: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (▲/▼/—) per slot.
-- **Market Chart Timezone Fix (v3.32.16)**: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 — syncs from live API before releases.
 ## Development Roadmap
 
 ### Next Up

--- a/docs/plans/2026-02-23-sync-ux-overhaul-design.md
+++ b/docs/plans/2026-02-23-sync-ux-overhaul-design.md
@@ -1,0 +1,158 @@
+# Sync UX Overhaul + Simple Mode — Design
+
+**Date:** 2026-02-23
+**Status:** Approved
+**Approach:** B — UX Fix + Simple Mode
+
+---
+
+## Problem
+
+Cloud sync is unusable in its current state:
+
+1. The sync password modal auto-opens on every page load when no cached password exists.
+2. Users must re-enter their vault password each session — high friction for a background
+   sync feature.
+3. The poller can trigger a "Sync Update Available" modal within 3 seconds of load,
+   chaining to the password modal on Accept.
+
+---
+
+## Solution Overview
+
+- Add two sync modes: **Simple** (Dropbox account ID as key) and **Secure** (user vault
+  password, existing behavior).
+- **Eliminate all auto-opening modals** on page load. Toast + colored header dot are the
+  only passive prompts.
+- Replace the password modal (when triggered by header button in Secure mode) with a
+  compact inline popover.
+- Warn users to make a manual backup before switching modes.
+
+---
+
+## Sync Modes
+
+Stored in `localStorage` key `cloud_sync_mode` ("simple" | "secure").
+
+| | Simple | Secure |
+|---|---|---|
+| Encryption key | Derived from Dropbox account ID | User-defined vault password |
+| Session friction | None after OAuth connect | Must enter password each session |
+| Zero-knowledge | No | Yes |
+| Multi-device | Automatic | Same password on each device |
+
+Mode selector is shown in Settings → Cloud → Auto-Sync section, only when Dropbox is
+connected. Switching modes shows a blocking warning:
+
+> **Make a manual backup first.** Backups encrypted in your old mode cannot be decrypted
+> in the new mode. Once you switch, new syncs will use the new mode.
+
+After the user confirms, sync is re-initialized in the new mode.
+
+---
+
+## Key Derivation — Simple Mode
+
+1. After `cloudExchangeCode()` OAuth success, call Dropbox
+   `/2/users/get_current_account` to get the stable `account_id`
+   (e.g. `dbid:AAH4...`).
+2. Store `account_id` in `localStorage` as `cloud_dropbox_account_id`.
+3. In `getSimpleModeKey()`:
+
+   ```
+   key = PBKDF2(
+     password  = utf8(account_id),
+     salt      = STAKTRAKR_SIMPLE_SALT,   // fixed 16-byte constant in constants.js
+     iterations = 600_000,
+     hash      = SHA-256,
+     keylen    = 256 bits
+   )
+   ```
+
+4. The resulting key is passed as the `password` argument to the existing
+   `vaultEncryptToBytes` / `vaultDecryptAndRestore` functions — **no vault format
+   changes needed**.
+5. Because `account_id` is stable, the same key is derived on every device with the
+   same Dropbox account without any user interaction.
+
+`STAKTRAKR_SIMPLE_SALT` is a hardcoded constant (32 hex chars) in `constants.js`,
+added to `ALLOWED_STORAGE_KEYS` and the `window.` export block.
+
+---
+
+## On-Load Behavior (no auto-modals)
+
+`initCloudSync()` is updated to never open any modal automatically:
+
+| State | Behavior |
+|---|---|
+| Simple mode + connected + account ID available | Start sync immediately, no prompts |
+| Simple mode + token expired / no account ID | Toast: "Cloud sync paused — tap the cloud icon to reconnect Dropbox" |
+| Secure mode + password cached | Start sync immediately |
+| Secure mode + no cached password | Toast: "Cloud sync needs your password — tap the cloud icon to unlock" (orange dot) |
+| Sync disabled | Hide header button (existing) |
+
+The `cloudSyncPasswordModal` is not removed — it stays as a manual fallback — but
+`getSyncPassword()` is updated to never call `openModalById` automatically on load.
+The modal is only reachable by deliberate user action.
+
+---
+
+## Header Button Popover (Secure Mode)
+
+Clicking the orange header button in Secure mode opens a small inline popover:
+
+```
+┌─────────────────────────────────┐
+│  🔒 Vault Password              │
+│  [••••••••••••] [Unlock ▶]     │
+│  Cancel                         │
+└─────────────────────────────────┘
+```
+
+- `position: absolute` below `#headerCloudSyncBtn`, `z-index` above main content.
+- Dismissed on Escape, outside click, or Cancel.
+- Submit → `cloudCachePassword()` + `pushSyncVault()`.
+- In **Simple mode**, orange button means the Dropbox token expired. The popover is
+  replaced by a single "Reconnect to Dropbox" button that calls
+  `cloudAuthStart('dropbox')`.
+
+Popover HTML is a single `<div id="cloudSyncHeaderPopover">` injected near the header
+button in `index.html`.
+
+---
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `js/cloud-sync.js` | `initCloudSync()` — remove auto-modal paths; `getSyncPassword()` — mode-aware (Simple skips prompt); new `getSimpleModeKey()`; `enableCloudSync()` — fetch + store account ID for Simple |
+| `js/cloud-storage.js` | `cloudExchangeCode()` success path — fetch `account_id`, store `cloud_dropbox_account_id` |
+| `js/constants.js` | Add `STAKTRAKR_SIMPLE_SALT`; add `cloud_sync_mode` and `cloud_dropbox_account_id` to `ALLOWED_STORAGE_KEYS` and exports |
+| `js/events.js` | Header button click handler — mode-aware popover vs. reconnect vs. toast; close popover on outside click |
+| `index.html` | Sync Mode radio in Cloud settings; `#cloudSyncHeaderPopover` HTML; mode-switch warning copy |
+
+`sw.js` does not need changes (no new files added to the asset list).
+
+---
+
+## Safety Gate — Mode Switching
+
+Before any mode switch:
+
+1. Show a `showAppConfirm()` dialog with the backup warning.
+2. Only proceed after user confirms.
+3. Clear `cloud_sync_mode`, `cloud_vault_pw_cache`, and (for Simple → Secure)
+   `cloud_dropbox_account_id` from the relevant stores.
+4. Re-call `initCloudSync()` to re-initialize in the new mode.
+
+No automatic re-encryption of existing Dropbox backups. Old backups remain in their
+original encryption — users can manually restore them with the old password/mode.
+
+---
+
+## Out of Scope
+
+- Re-encrypting existing cloud backups when switching modes.
+- pCloud or Box Simple mode (Dropbox only for now).
+- Conflict resolution UX changes (handled separately).

--- a/docs/plans/2026-02-23-sync-ux-overhaul.md
+++ b/docs/plans/2026-02-23-sync-ux-overhaul.md
@@ -1,0 +1,778 @@
+# Sync UX Overhaul + Simple Mode — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate all auto-opening sync modals on page load, add a "Simple" Dropbox-account-derived encryption mode, and replace Secure-mode password entry with an inline header popover.
+
+**Architecture:** The root cause of the on-load modal is that `saveInventory()` calls `scheduleSyncPush()` during initialization, which eventually calls `getSyncPassword()`, which opens the modal. The fix splits this into `getSyncPasswordSilent()` (background, never prompts) used by `pushSyncVault()`, and interactive password collection handled exclusively through the header popover. Simple mode derives the vault encryption key from the user's stable Dropbox account ID via PBKDF2 — no user interaction ever needed.
+
+**Tech Stack:** Vanilla JS, Web Crypto API (PBKDF2 already used by vault.js), localStorage, Dropbox REST API.
+
+**Design doc:** `docs/plans/2026-02-23-sync-ux-overhaul-design.md`
+
+---
+
+## Root Cause Reference
+
+`saveInventory()` → `scheduleSyncPush()` → `pushSyncVault()` → `getSyncPassword()` → `openModalById('cloudSyncPasswordModal')`.
+
+This chain fires during app initialization. All background pushes must use `getSyncPasswordSilent()` instead, which never opens a modal.
+
+---
+
+### Task 1: Add Simple Mode Constants (`constants.js`)
+
+**Files:**
+- Modify: `js/constants.js`
+
+**Step 1: Add the Simple-mode salt constant**
+
+Find the `CLOUD_VAULT_IDLE_TIMEOUT_KEY` constant declaration (around line 571). Add below it:
+
+```js
+/** App-namespace salt for Simple mode key derivation. Never change — changing invalidates all Simple-mode syncs. */
+const STAKTRAKR_SIMPLE_SALT = '53544b52:53494d504c45:76310000';
+```
+
+**Step 2: Add the two new localStorage keys to ALLOWED_STORAGE_KEYS**
+
+Find the line `CLOUD_VAULT_IDLE_TIMEOUT_KEY,  // number string: vault password idle lock timeout...` (around line 804). Add the two new keys directly below it, before the `];`:
+
+```js
+  "cloud_sync_mode",                           // string: "simple" | "secure" — sync encryption mode
+  "cloud_dropbox_account_id",                  // string: Dropbox account_id for Simple mode key derivation
+```
+
+**Step 3: Export STAKTRAKR_SIMPLE_SALT to window**
+
+Find `window.CLOUD_VAULT_IDLE_TIMEOUT_KEY = CLOUD_VAULT_IDLE_TIMEOUT_KEY;` (around line 1637). Add below it:
+
+```js
+  window.STAKTRAKR_SIMPLE_SALT = STAKTRAKR_SIMPLE_SALT;
+```
+
+**Step 4: Verify in browser console**
+
+Open `index.html` in a browser and run:
+```js
+console.log(window.STAKTRAKR_SIMPLE_SALT); // '53544b52:53494d504c45:76310000'
+console.log(window.ALLOWED_STORAGE_KEYS.includes('cloud_sync_mode')); // true
+console.log(window.ALLOWED_STORAGE_KEYS.includes('cloud_dropbox_account_id')); // true
+```
+
+**Step 5: Commit**
+
+```bash
+git add js/constants.js
+git commit -m "feat(sync): add Simple mode constants to constants.js"
+```
+
+---
+
+### Task 2: Fetch and Store Dropbox Account ID (`cloud-storage.js`)
+
+**Files:**
+- Modify: `js/cloud-storage.js`
+
+**Step 1: Fetch account ID after OAuth token exchange**
+
+In `cloudExchangeCode()`, find the line `cloudStoreToken(provider, tokenData);` (around line 480). Add a non-blocking fetch immediately after it:
+
+```js
+    cloudStoreToken(provider, tokenData);
+
+    // Fetch Dropbox account ID for Simple mode key derivation (non-blocking, Dropbox-only)
+    if (provider === 'dropbox') {
+      fetch('https://api.dropboxapi.com/2/users/get_current_account', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + tokenData.access_token,
+          'Content-Type': 'application/json',
+        },
+        body: 'null',
+      }).then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (info) {
+          if (info && info.account_id) {
+            localStorage.setItem('cloud_dropbox_account_id', info.account_id);
+            debugLog('[CloudStorage] Stored Dropbox account ID for Simple mode');
+          }
+        })
+        .catch(function (e) { debugLog('[CloudStorage] Failed to fetch Dropbox account ID', e); });
+    }
+```
+
+**Step 2: Clear account ID on disconnect**
+
+In `cloudDisconnect()`, find `localStorage.removeItem('cloud_last_backup');` and add below it:
+
+```js
+  if (provider === 'dropbox') {
+    localStorage.removeItem('cloud_dropbox_account_id');
+  }
+```
+
+**Step 3: Manual verification**
+
+1. Open app in browser, go to Settings → Cloud
+2. Click "Connect Dropbox" and complete OAuth
+3. Open browser console and run: `localStorage.getItem('cloud_dropbox_account_id')`
+4. Expected: a string beginning with `dbid:` (e.g. `dbid:AAH4abc...`)
+5. Click "Disconnect Dropbox"
+6. Run: `localStorage.getItem('cloud_dropbox_account_id')`
+7. Expected: `null`
+
+**Step 4: Commit**
+
+```bash
+git add js/cloud-storage.js
+git commit -m "feat(sync): fetch and store Dropbox account ID for Simple mode"
+```
+
+---
+
+### Task 3: Add `getSyncPasswordSilent()` and Fix `pushSyncVault()` (`cloud-sync.js`)
+
+**Files:**
+- Modify: `js/cloud-sync.js`
+
+This is the **core bug fix**. `pushSyncVault()` currently calls the interactive `getSyncPassword()`, which can open a modal from background processes like `saveInventory()`.
+
+**Step 1: Add `getSyncPasswordSilent()` after `getSyncPassword()`**
+
+Find the closing `}` of `getSyncPassword()` (around line 405). Add the new function immediately after:
+
+```js
+/**
+ * Get the sync password/key without any user interaction.
+ * Simple mode: returns the Dropbox account ID derived key.
+ * Secure mode: returns the cached session password or null.
+ * Never opens a modal or popover — safe to call from background processes.
+ * @returns {string|null}
+ */
+function getSyncPasswordSilent() {
+  if (localStorage.getItem('cloud_sync_mode') === 'simple') {
+    var accountId = localStorage.getItem('cloud_dropbox_account_id');
+    if (!accountId) return null;
+    // Prefix with app salt to namespace away from user-chosen passwords.
+    // The vault module's own PBKDF2 derives the actual key from this string.
+    return STAKTRAKR_SIMPLE_SALT + ':' + accountId;
+  }
+  // Secure mode: return cached password or null
+  return typeof cloudGetCachedPassword === 'function'
+    ? cloudGetCachedPassword(_syncProvider)
+    : null;
+}
+```
+
+**Step 2: Update `pushSyncVault()` to use the silent getter**
+
+In `pushSyncVault()`, find (around line 453):
+
+```js
+  var password = await getSyncPassword();
+  debugLog('[CloudSync] Password obtained:', !!password);
+  if (!password) {
+    debugLog('[CloudSync] No password — push skipped');
+    return;
+  }
+```
+
+Replace with:
+
+```js
+  var password = getSyncPasswordSilent();
+  debugLog('[CloudSync] Password obtained (silent):', !!password);
+  if (!password) {
+    debugLog('[CloudSync] No password — push deferred (tap cloud icon to unlock)');
+    return;
+  }
+```
+
+**Step 3: Add window export for `getSyncPasswordSilent`**
+
+At the bottom of `cloud-sync.js`, find the exports block and add:
+
+```js
+window.getSyncPasswordSilent = getSyncPasswordSilent;
+```
+
+**Step 4: Verify no auto-modal on page load**
+
+1. Set `localStorage.setItem('cloud_sync_enabled', 'true')` in the console
+2. Connect Dropbox (so `cloud_token_dropbox` is set)
+3. Reload the page
+4. **Expected:** No password modal appears. Orange dot shows on header cloud button. A toast appears after ~1 second: "Cloud sync needs your password — tap the sync icon to unlock"
+5. **Not expected:** Any modal auto-opening
+
+**Step 5: Commit**
+
+```bash
+git add js/cloud-sync.js
+git commit -m "fix(sync): use silent password getter in pushSyncVault to prevent auto-modal"
+```
+
+---
+
+### Task 4: Update `initCloudSync()` for Simple Mode (`cloud-sync.js`)
+
+**Files:**
+- Modify: `js/cloud-sync.js`
+
+**Step 1: Add Simple mode branch to `initCloudSync()`**
+
+Find the section in `initCloudSync()` that starts with `debugLog('[CloudSync] Resuming auto-sync from previous session');` (around line 1075). Replace the entire block from that line to the end of the function body with:
+
+```js
+  debugLog('[CloudSync] Resuming auto-sync from previous session');
+
+  var isSimple = localStorage.getItem('cloud_sync_mode') === 'simple';
+
+  if (isSimple) {
+    var accountId = localStorage.getItem('cloud_dropbox_account_id');
+    updateCloudSyncHeaderBtn();
+    if (!accountId) {
+      // Simple mode connected but account ID missing — need a fresh OAuth
+      debugLog('[CloudSync] Simple mode: no account ID — showing reconnect toast');
+      setTimeout(function () {
+        if (typeof showCloudToast === 'function') {
+          showCloudToast('Cloud sync paused — tap the cloud icon to reconnect Dropbox', 5000);
+        }
+      }, 1000);
+    }
+    // Simple mode always starts the poller and polls immediately — no password needed
+    startSyncPoller();
+    setTimeout(function () { pollForRemoteChanges(); }, 3000);
+    return;
+  }
+
+  // Secure mode: check for cached session password
+  var hasCachedPw = typeof cloudGetCachedPassword === 'function'
+    ? !!cloudGetCachedPassword(_syncProvider)
+    : false;
+
+  if (!hasCachedPw) {
+    debugLog('[CloudSync] Secure mode: no cached password on load — showing toast');
+    updateCloudSyncHeaderBtn();
+    setTimeout(function () {
+      if (typeof showCloudToast === 'function') {
+        showCloudToast('Cloud sync needs your password — tap the cloud icon to unlock', 5000);
+      }
+    }, 1000);
+    // Start poller — background pushes will skip silently until password is provided
+    startSyncPoller();
+    return;
+  }
+
+  // Secure mode with cached password: full resume
+  updateCloudSyncHeaderBtn();
+  startSyncPoller();
+  setTimeout(function () { pollForRemoteChanges(); }, 3000);
+}
+```
+
+**Step 2: Verify Simple mode on page load (requires Task 2 complete)**
+
+1. Set `localStorage.setItem('cloud_sync_mode', 'simple')`, `cloud_sync_enabled` = `'true'`, ensure `cloud_dropbox_account_id` is set and `cloud_token_dropbox` is set
+2. Reload the page
+3. **Expected:** Green dot appears immediately, no prompts, sync starts. Console shows: `[CloudSync] Simple mode: ...`
+4. **Verify Secure mode still works:** Remove `cloud_sync_mode` from localStorage, reload — orange dot + toast, no modal
+
+**Step 3: Commit**
+
+```bash
+git add js/cloud-sync.js
+git commit -m "feat(sync): add Simple mode branch to initCloudSync"
+```
+
+---
+
+### Task 5: Add `setSyncMode()` and Mode UI Refresh (`cloud-sync.js`)
+
+**Files:**
+- Modify: `js/cloud-sync.js`
+
+**Step 1: Add `setSyncMode()` function**
+
+After `disableCloudSync()` (around line 1034), add:
+
+```js
+/**
+ * Switch the sync encryption mode.
+ * Called after user confirms the mode-switch warning.
+ * @param {'simple'|'secure'} mode
+ */
+function setSyncMode(mode) {
+  var currentMode = localStorage.getItem('cloud_sync_mode') || 'secure';
+  if (mode === currentMode) return;
+
+  localStorage.setItem('cloud_sync_mode', mode);
+
+  // Clear the cached password — it's mode-specific
+  if (typeof cloudClearCachedPassword === 'function') cloudClearCachedPassword();
+
+  logCloudSyncActivity('mode_switch', 'success', 'Switched to ' + mode + ' mode');
+  updateCloudSyncHeaderBtn();
+
+  if (syncIsEnabled() && typeof scheduleSyncPush === 'function') {
+    scheduleSyncPush();
+  }
+
+  var label = mode === 'simple' ? 'Simple (Dropbox account)' : 'Secure (vault password)';
+  if (typeof showCloudToast === 'function') showCloudToast('Sync mode: ' + label, 4000);
+  debugLog('[CloudSync] Sync mode switched to', mode);
+}
+```
+
+**Step 2: Add `refreshSyncModeUI()` function**
+
+Add immediately after `setSyncMode()`:
+
+```js
+/**
+ * Update the sync mode radio selector in Settings → Cloud.
+ * Called from refreshSyncUI() whenever the cloud panel is rendered.
+ */
+function refreshSyncModeUI() {
+  var modeSec = safeGetElement('cloudSyncModeSection');
+  if (!modeSec) return;
+
+  var connected = typeof cloudIsConnected === 'function' ? cloudIsConnected('dropbox') : false;
+  var enabled = syncIsEnabled();
+  modeSec.style.display = (connected && enabled) ? '' : 'none';
+
+  if (!connected || !enabled) return;
+
+  var currentMode = localStorage.getItem('cloud_sync_mode') || 'secure';
+  var simpleRadio = safeGetElement('cloudSyncModeSimple');
+  var secureRadio = safeGetElement('cloudSyncModeSecure');
+  if (simpleRadio) simpleRadio.checked = currentMode === 'simple';
+  if (secureRadio) secureRadio.checked = currentMode !== 'simple';
+
+  // Hide the confirmation warning on re-render
+  var warning = safeGetElement('cloudSyncModeSwitchWarning');
+  if (warning) warning.style.display = 'none';
+}
+```
+
+**Step 3: Call `refreshSyncModeUI()` from `refreshSyncUI()`**
+
+In `refreshSyncUI()`, add at the very end (before the closing `}`):
+
+```js
+  if (typeof refreshSyncModeUI === 'function') refreshSyncModeUI();
+```
+
+**Step 4: Export both new functions**
+
+In the exports block at the bottom of `cloud-sync.js`, add:
+
+```js
+window.setSyncMode = setSyncMode;
+window.refreshSyncModeUI = refreshSyncModeUI;
+```
+
+**Step 5: Commit**
+
+```bash
+git add js/cloud-sync.js
+git commit -m "feat(sync): add setSyncMode and refreshSyncModeUI"
+```
+
+---
+
+### Task 6: Update `updateCloudSyncHeaderBtn()` for Simple Mode States (`cloud-sync.js`)
+
+**Files:**
+- Modify: `js/cloud-sync.js`
+
+**Step 1: Replace the body of `updateCloudSyncHeaderBtn()`**
+
+Find `function updateCloudSyncHeaderBtn()` (around line 217). Replace its full body with:
+
+```js
+function updateCloudSyncHeaderBtn() {
+  var btn = safeGetElement('headerCloudSyncBtn');
+  var dot = safeGetElement('headerCloudDot');
+  if (!btn) return;
+
+  // Hide entirely only when sync is explicitly disabled
+  if (localStorage.getItem('cloud_sync_enabled') === 'false') {
+    btn.style.display = 'none';
+    return;
+  }
+
+  btn.style.display = '';
+  if (!dot) return;
+  dot.className = 'cloud-sync-dot header-cloud-dot';
+
+  var connected = typeof cloudIsConnected === 'function'
+    ? cloudIsConnected(_syncProvider)
+    : false;
+  var isSimple = localStorage.getItem('cloud_sync_mode') === 'simple';
+
+  if (isSimple) {
+    var accountId = localStorage.getItem('cloud_dropbox_account_id');
+    if (connected && accountId) {
+      dot.classList.add('header-cloud-dot--green');
+      btn.title = 'Cloud sync active (Simple mode)';
+      btn.setAttribute('aria-label', 'Cloud sync active');
+      btn.dataset.syncState = 'green';
+    } else if (connected) {
+      // Connected but account ID missing — needs re-fetch via reconnect
+      dot.classList.add('header-cloud-dot--orange');
+      btn.title = 'Cloud sync needs to reconnect to Dropbox';
+      btn.setAttribute('aria-label', 'Cloud sync needs to reconnect');
+      btn.dataset.syncState = 'orange-simple';
+    } else {
+      btn.title = 'Set up cloud sync';
+      btn.setAttribute('aria-label', 'Set up cloud sync');
+      btn.dataset.syncState = 'gray';
+    }
+    return;
+  }
+
+  // Secure mode (original behavior)
+  var hasCachedPw = typeof cloudGetCachedPassword === 'function'
+    ? !!cloudGetCachedPassword(_syncProvider)
+    : false;
+
+  if (hasCachedPw) {
+    dot.classList.add('header-cloud-dot--green');
+    btn.title = 'Cloud sync active';
+    btn.setAttribute('aria-label', 'Cloud sync active');
+    btn.dataset.syncState = 'green';
+  } else if (connected) {
+    dot.classList.add('header-cloud-dot--orange');
+    btn.title = 'Cloud sync needs your password';
+    btn.setAttribute('aria-label', 'Cloud sync needs your password');
+    btn.dataset.syncState = 'orange';
+  } else {
+    btn.title = 'Set up cloud sync';
+    btn.setAttribute('aria-label', 'Set up cloud sync');
+    btn.dataset.syncState = 'gray';
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add js/cloud-sync.js
+git commit -m "feat(sync): update header button state logic for Simple mode"
+```
+
+---
+
+### Task 7: Add Popover HTML and Mode Selector to `index.html`
+
+**Files:**
+- Modify: `index.html`
+
+**Step 1: Wrap the header cloud button in a relative-positioned div and add the popover**
+
+Find the block (around line 425):
+
+```html
+        <!-- Cloud sync status button (STAK-264) -->
+        <button class="btn theme-btn header-toggle-btn" id="headerCloudSyncBtn"
+```
+
+Replace it with the button wrapped in a div, and add the popover as a sibling:
+
+```html
+        <!-- Cloud sync status button + inline popover wrapper (STAK-264) -->
+        <div style="position:relative;display:inline-flex" id="headerCloudSyncWrapper">
+          <button class="btn theme-btn header-toggle-btn" id="headerCloudSyncBtn"
+                  title="Cloud sync status" aria-label="Cloud sync status" style="display:none;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
+            </svg>
+            <span class="cloud-sync-dot header-cloud-dot" id="headerCloudDot"></span>
+          </button>
+          <!-- Secure mode: inline password popover (never auto-opens) -->
+          <div id="cloudSyncHeaderPopover" role="dialog" aria-label="Sync password" style="display:none;position:absolute;top:calc(100% + 6px);right:0;background:var(--card-bg,#fff);border:1px solid var(--border-color,#ddd);border-radius:8px;padding:0.75rem;box-shadow:0 4px 16px rgba(0,0,0,0.18);z-index:999;min-width:240px">
+            <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.5rem;color:var(--text-primary)">&#x1F512; Vault Password</div>
+            <div style="display:flex;gap:0.4rem">
+              <input type="password" id="cloudSyncPopoverInput" placeholder="Enter password"
+                     autocomplete="current-password"
+                     style="flex:1;font-size:0.85rem;padding:0.3rem 0.5rem;border:1px solid var(--border-color,#ddd);border-radius:4px;background:var(--input-bg,#fff);color:var(--text-primary)">
+              <button class="btn success" id="cloudSyncPopoverUnlockBtn" style="font-size:0.8rem;padding:0.3rem 0.6rem">Unlock</button>
+            </div>
+            <div id="cloudSyncPopoverError" style="color:var(--danger,#e74c3c);font-size:0.75rem;margin-top:0.3rem;display:none"></div>
+            <button id="cloudSyncPopoverCancelBtn" style="background:none;border:none;color:var(--text-secondary);font-size:0.75rem;margin-top:0.4rem;cursor:pointer;padding:0">Cancel</button>
+          </div>
+        </div>
+```
+
+**Step 2: Add the Sync Mode selector in Settings → Cloud**
+
+Find the "Auto-Sync Controls" section. After the "Last synced" row div (the one containing `id="cloudAutoSyncLastSync"`, around line 3115), and before the "Sync Now" button div, add the mode selector:
+
+```html
+                  <!-- Sync Mode selector (shown only when connected + enabled) -->
+                  <div id="cloudSyncModeSection" style="display:none;margin-top:0.6rem;padding:0.5rem 0.6rem;border:1px solid var(--border-color,#ddd);border-radius:6px;background:var(--card-bg-alt,rgba(0,0,0,0.02))">
+                    <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.4rem;color:var(--text-primary)">Encryption Mode</div>
+                    <label style="display:flex;align-items:flex-start;gap:0.5rem;margin-bottom:0.4rem;cursor:pointer">
+                      <input type="radio" name="cloudSyncMode" id="cloudSyncModeSimple" value="simple" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('simple')">
+                      <span>
+                        <strong style="font-size:0.8rem">Simple</strong>
+                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Your Dropbox account is the key — no extra password needed on any device.</span>
+                      </span>
+                    </label>
+                    <label style="display:flex;align-items:flex-start;gap:0.5rem;cursor:pointer">
+                      <input type="radio" name="cloudSyncMode" id="cloudSyncModeSecure" value="secure" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('secure')">
+                      <span>
+                        <strong style="font-size:0.8rem">Secure</strong>
+                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Encrypt with your own vault password — zero-knowledge from Dropbox.</span>
+                      </span>
+                    </label>
+                    <div id="cloudSyncModeSwitchWarning" style="display:none;margin-top:0.5rem;padding:0.4rem 0.5rem;background:var(--warning-bg,#fff8e6);border:1px solid var(--warning-border,#ffc107);border-radius:4px;font-size:0.75rem;color:var(--text-primary)">
+                      &#x26A0;&#xFE0F; <strong>Make a manual backup first.</strong> Old syncs encrypted in the previous mode won't be readable in the new mode.
+                      <div style="margin-top:0.4rem;display:flex;gap:0.4rem">
+                        <button class="btn warning" id="cloudSyncModeConfirmBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof confirmSyncModeSwitch==='function')confirmSyncModeSwitch()">Switch Mode</button>
+                        <button class="btn" id="cloudSyncModeCancelBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof cancelSyncModeSwitch==='function')cancelSyncModeSwitch()">Cancel</button>
+                      </div>
+                    </div>
+                  </div>
+```
+
+**Step 3: Verify HTML renders correctly**
+
+Open app, go to Settings → Cloud → connect Dropbox → enable Auto-sync.
+Expected: Mode selector appears below "Last synced" row with "Simple" and "Secure" radio options.
+
+**Step 4: Commit**
+
+```bash
+git add index.html
+git commit -m "feat(sync): add header popover and mode selector HTML"
+```
+
+---
+
+### Task 8: Update Header Button Event Handler + Popover Logic (`events.js`)
+
+**Files:**
+- Modify: `js/events.js`
+
+**Step 1: Replace the header cloud sync button click handler**
+
+Find the existing `headerCloudSyncBtn` click handler (around line 700). Replace its entire `safeAttachListener` block with:
+
+```js
+  var headerCloudSyncBtn = safeGetElement('headerCloudSyncBtn');
+  if (headerCloudSyncBtn) {
+    safeAttachListener(
+      headerCloudSyncBtn,
+      'click',
+      function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var state = headerCloudSyncBtn.dataset.syncState;
+        var isSimple = localStorage.getItem('cloud_sync_mode') === 'simple';
+
+        if (state === 'orange' && !isSimple) {
+          // Secure mode needs password — open inline popover
+          _openCloudSyncPopover();
+        } else if (state === 'orange-simple' || (state === 'orange' && isSimple)) {
+          // Simple mode needs Dropbox reconnect
+          if (typeof cloudAuthStart === 'function') cloudAuthStart('dropbox');
+        } else if (state === 'green') {
+          var lp = typeof syncGetLastPush === 'function' ? syncGetLastPush() : null;
+          var msg = lp && lp.timestamp
+            ? 'Cloud sync active \u2014 last synced ' + _syncRelativeTimeLocal(lp.timestamp)
+            : 'Cloud sync active';
+          if (typeof showCloudToast === 'function') showCloudToast(msg, 2500);
+        } else {
+          // Gray: not configured
+          if (typeof showSettingsModal === 'function') showSettingsModal('cloud');
+        }
+      },
+      'Cloud Sync Header Button'
+    );
+  }
+
+  // Close popover on outside click
+  document.addEventListener('mousedown', function (e) {
+    var wrapper = safeGetElement('headerCloudSyncWrapper');
+    var popover = safeGetElement('cloudSyncHeaderPopover');
+    if (popover && popover.style.display !== 'none') {
+      if (wrapper && !wrapper.contains(e.target)) {
+        popover.style.display = 'none';
+      }
+    }
+  });
+```
+
+**Step 2: Add `_openCloudSyncPopover()` and `_syncRelativeTimeLocal()` helpers**
+
+Add these two functions near the bottom of `events.js`, before the last closing line:
+
+```js
+/** Open the inline Secure-mode password popover below the header cloud button. */
+function _openCloudSyncPopover() {
+  var popover = safeGetElement('cloudSyncHeaderPopover');
+  var input = safeGetElement('cloudSyncPopoverInput');
+  var unlockBtn = safeGetElement('cloudSyncPopoverUnlockBtn');
+  var cancelBtn = safeGetElement('cloudSyncPopoverCancelBtn');
+  var errorEl = safeGetElement('cloudSyncPopoverError');
+  if (!popover) return;
+
+  if (input) input.value = '';
+  if (errorEl) { errorEl.style.display = 'none'; errorEl.textContent = ''; }
+  popover.style.display = '';
+  if (input) setTimeout(function () { input.focus(); }, 50);
+
+  function cleanup() {
+    popover.style.display = 'none';
+    if (unlockBtn) unlockBtn.onclick = null;
+    if (cancelBtn) cancelBtn.onclick = null;
+    if (input) input.onkeydown = null;
+  }
+
+  function onUnlock() {
+    var pw = input ? input.value : '';
+    if (!pw || pw.length < 8) {
+      if (errorEl) {
+        errorEl.textContent = 'Password must be at least 8 characters.';
+        errorEl.style.display = '';
+      }
+      return;
+    }
+    cleanup();
+    if (typeof cloudCachePassword === 'function') cloudCachePassword('dropbox', pw);
+    if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
+    setTimeout(function () { if (typeof pushSyncVault === 'function') pushSyncVault(); }, 100);
+  }
+
+  if (unlockBtn) unlockBtn.onclick = onUnlock;
+  if (cancelBtn) cancelBtn.onclick = cleanup;
+  if (input) {
+    input.onkeydown = function (e) {
+      if (e.key === 'Enter') onUnlock();
+      if (e.key === 'Escape') cleanup();
+    };
+  }
+}
+
+/** Format a timestamp relative to now for the header toast (mirrors _syncRelativeTime in cloud-sync.js). */
+function _syncRelativeTimeLocal(ts) {
+  var diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 10) return 'just now';
+  if (diff < 60) return diff + 's ago';
+  if (diff < 3600) return Math.floor(diff / 60) + ' min ago';
+  return Math.floor(diff / 3600) + 'h ago';
+}
+```
+
+**Step 3: Add mode-switch handler functions**
+
+Add these two more functions in `events.js` (they are called from the inline `onchange` in `index.html`):
+
+```js
+/** Called when user clicks a sync mode radio — shows warning before applying. */
+function handleSyncModeChange(newMode) {
+  var currentMode = localStorage.getItem('cloud_sync_mode') || 'secure';
+  if (newMode === currentMode) return;
+
+  // Store the pending mode so confirmSyncModeSwitch knows what to apply
+  window._pendingSyncMode = newMode;
+
+  var warning = safeGetElement('cloudSyncModeSwitchWarning');
+  if (warning) warning.style.display = '';
+
+  // Revert radio to current mode visually until user confirms
+  var simpleRadio = safeGetElement('cloudSyncModeSimple');
+  var secureRadio = safeGetElement('cloudSyncModeSecure');
+  if (simpleRadio) simpleRadio.checked = currentMode === 'simple';
+  if (secureRadio) secureRadio.checked = currentMode !== 'simple';
+}
+
+/** Applies the pending mode switch after user clicks "Switch Mode". */
+function confirmSyncModeSwitch() {
+  var mode = window._pendingSyncMode;
+  if (!mode) return;
+  window._pendingSyncMode = null;
+
+  var warning = safeGetElement('cloudSyncModeSwitchWarning');
+  if (warning) warning.style.display = 'none';
+
+  if (typeof setSyncMode === 'function') setSyncMode(mode);
+  if (typeof refreshSyncModeUI === 'function') refreshSyncModeUI();
+}
+
+/** Cancels a pending mode switch. */
+function cancelSyncModeSwitch() {
+  window._pendingSyncMode = null;
+  var warning = safeGetElement('cloudSyncModeSwitchWarning');
+  if (warning) warning.style.display = 'none';
+  if (typeof refreshSyncModeUI === 'function') refreshSyncModeUI(); // resets radios
+}
+```
+
+**Step 4: Verify complete UX flow**
+
+**Scenario A — Secure mode, page reload:**
+1. `cloud_sync_enabled` = `'true'`, `cloud_sync_mode` = `'secure'` (or unset), Dropbox connected, no cached pw
+2. Reload → orange dot in header, toast after 1s, **no modal**
+3. Click orange button → password popover drops down below header button
+4. Enter password ≥8 chars, click Unlock → green dot, sync pushes
+
+**Scenario B — Simple mode, page reload:**
+1. `cloud_sync_mode` = `'simple'`, account ID stored, Dropbox connected
+2. Reload → green dot immediately, no prompts, console shows sync activity
+
+**Scenario C — Mode switch:**
+1. Go to Settings → Cloud, both radios visible
+2. Click "Simple" → warning appears with "Make a manual backup first"
+3. Click "Switch Mode" → mode changes, toast confirms, radios update
+
+**Step 5: Commit**
+
+```bash
+git add js/events.js
+git commit -m "feat(sync): add header popover, mode-switch handlers in events.js"
+```
+
+---
+
+### Task 9: Final QA Checklist
+
+**Manual verification checklist — run all scenarios before calling complete:**
+
+- [ ] Fresh page load, sync disabled: no cloud icon visible in header
+- [ ] Fresh page load, sync enabled, Secure mode, no cached pw: orange dot + toast, **zero modals**
+- [ ] Click orange dot (Secure): popover opens with password input
+- [ ] Enter < 8 chars, click Unlock: error message shown in popover
+- [ ] Enter valid password, click Unlock: popover closes, dot turns green, sync push fires
+- [ ] Press Escape in popover: popover closes, no action
+- [ ] Click outside popover: popover closes
+- [ ] Fresh page load, sync enabled, Simple mode, account ID present: green dot, no prompts
+- [ ] Simple mode, orange dot (account ID missing): click → triggers Dropbox OAuth
+- [ ] Settings → Cloud: mode selector only visible when Dropbox connected AND auto-sync enabled
+- [ ] Mode selector shows current mode checked correctly
+- [ ] Switching mode → warning shown before applying
+- [ ] "Cancel" on warning → radios revert, no mode change
+- [ ] "Switch Mode" → mode changes, toast confirms
+- [ ] `saveInventory()` no longer triggers modal (inventory edit → save → no modal)
+- [ ] "Sync Now" button works in both modes (uses cached/derived key silently)
+
+**Step: Commit notes and close**
+
+```bash
+git add .
+git commit -m "chore: final QA pass — sync UX overhaul complete"
+```
+
+---
+
+## Summary of Changes
+
+| File | What changed |
+|---|---|
+| `js/constants.js` | `STAKTRAKR_SIMPLE_SALT`, two new `ALLOWED_STORAGE_KEYS`, window export |
+| `js/cloud-storage.js` | Fetch + store `cloud_dropbox_account_id` after OAuth; clear on disconnect |
+| `js/cloud-sync.js` | `getSyncPasswordSilent()`, `setSyncMode()`, `refreshSyncModeUI()`; `pushSyncVault()` uses silent getter; `initCloudSync()` Simple branch; `updateCloudSyncHeaderBtn()` Simple states |
+| `js/events.js` | Header button handler (mode-aware); `_openCloudSyncPopover()`; `handleSyncModeChange()`, `confirmSyncModeSwitch()`, `cancelSyncModeSwitch()` |
+| `index.html` | Header button wrapped in `#headerCloudSyncWrapper` + `#cloudSyncHeaderPopover`; `#cloudSyncModeSection` in Settings |

--- a/index.html
+++ b/index.html
@@ -3135,7 +3135,7 @@
                       <input type="radio" name="cloudSyncMode" id="cloudSyncModeSimple" value="simple" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('simple')">
                       <span>
                         <strong style="font-size:0.8rem">Simple</strong>
-                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Your Dropbox account is the key — no extra password needed on any device.</span>
+                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Your Dropbox account is the key — no extra password needed on any device. (Stored in this browser; not zero-knowledge.)</span>
                       </span>
                     </label>
                     <label style="display:flex;align-items:flex-start;gap:0.5rem;cursor:pointer">

--- a/index.html
+++ b/index.html
@@ -433,12 +433,12 @@
             <span class="cloud-sync-dot header-cloud-dot" id="headerCloudDot"></span>
           </button>
           <!-- Secure mode: inline password popover (never auto-opens) -->
-          <div id="cloudSyncHeaderPopover" role="dialog" aria-label="Sync password" style="display:none;position:absolute;top:calc(100% + 6px);right:0;background:var(--card-bg,#fff);border:1px solid var(--border-color,#ddd);border-radius:8px;padding:0.75rem;box-shadow:0 4px 16px rgba(0,0,0,0.18);z-index:999;min-width:240px">
-            <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.5rem;color:var(--text-primary)">&#x1F512; Vault Password</div>
+          <div id="cloudSyncHeaderPopover" role="dialog" aria-label="Sync password" style="display:none;position:absolute;top:calc(100% + 6px);right:0;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:0.75rem;box-shadow:0 8px 32px rgba(0,0,0,0.5);z-index:999;min-width:240px">
+            <div style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;margin-bottom:0.5rem;color:var(--text-muted)"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:4px"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Vault Password</div>
             <div style="display:flex;gap:0.4rem">
               <input type="password" id="cloudSyncPopoverInput" placeholder="Enter password"
                      autocomplete="current-password"
-                     style="flex:1;font-size:0.85rem;padding:0.3rem 0.5rem;border:1px solid var(--border-color,#ddd);border-radius:4px;background:var(--input-bg,#fff);color:var(--text-primary)">
+                     style="flex:1;font-size:0.85rem;padding:0.3rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary)">
               <button class="btn success" id="cloudSyncPopoverUnlockBtn" style="font-size:0.8rem;padding:0.3rem 0.6rem">Unlock</button>
             </div>
             <div id="cloudSyncPopoverError" style="color:var(--danger,#e74c3c);font-size:0.75rem;margin-top:0.3rem;display:none"></div>
@@ -3129,7 +3129,7 @@
                     <span class="cloud-status-value" id="cloudAutoSyncLastSync">Never</span>
                   </div>
                   <!-- Sync Mode selector (shown only when connected + enabled) -->
-                  <div id="cloudSyncModeSection" style="display:none;margin-top:0.6rem;padding:0.5rem 0.6rem;border:1px solid var(--border-color,#ddd);border-radius:6px;background:var(--card-bg-alt,rgba(0,0,0,0.02))">
+                  <div id="cloudSyncModeSection" style="display:none;margin-top:0.6rem;padding:0.5rem 0.6rem;border:1px solid var(--border);border-radius:6px;background:var(--bg-tertiary)">
                     <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.4rem;color:var(--text-primary)">Encryption Mode</div>
                     <label style="display:flex;align-items:flex-start;gap:0.5rem;margin-bottom:0.4rem;cursor:pointer">
                       <input type="radio" name="cloudSyncMode" id="cloudSyncModeSimple" value="simple" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('simple')">
@@ -3145,7 +3145,7 @@
                         <span class="settings-subtext" style="display:block;font-size:0.72rem">Encrypt with your own vault password — zero-knowledge from Dropbox.</span>
                       </span>
                     </label>
-                    <div id="cloudSyncModeSwitchWarning" style="display:none;margin-top:0.5rem;padding:0.4rem 0.5rem;background:var(--warning-bg,#fff8e6);border:1px solid var(--warning-border,#ffc107);border-radius:4px;font-size:0.75rem;color:var(--text-primary)">
+                    <div id="cloudSyncModeSwitchWarning" style="display:none;margin-top:0.5rem;padding:0.4rem 0.5rem;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.35);border-radius:4px;font-size:0.75rem;color:var(--text-primary)">
                       &#x26A0;&#xFE0F; <strong>Make a manual backup first.</strong> Old syncs encrypted in the previous mode won't be readable in the new mode.
                       <div style="margin-top:0.4rem;display:flex;gap:0.4rem">
                         <button class="btn warning" id="cloudSyncModeConfirmBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof confirmSyncModeSwitch==='function')confirmSyncModeSwitch()">Switch Mode</button>

--- a/index.html
+++ b/index.html
@@ -422,15 +422,29 @@
             <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/>
           </svg>
         </button>
-        <!-- Cloud sync status button (STAK-264) -->
-        <button class="btn theme-btn header-toggle-btn" id="headerCloudSyncBtn"
-                title="Cloud sync status" aria-label="Cloud sync status" style="display:none;">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
-          </svg>
-          <span class="cloud-sync-dot header-cloud-dot" id="headerCloudDot"></span>
-        </button>
+        <!-- Cloud sync status button + inline popover wrapper (STAK-264) -->
+        <div style="position:relative;display:inline-flex" id="headerCloudSyncWrapper">
+          <button class="btn theme-btn header-toggle-btn" id="headerCloudSyncBtn"
+                  title="Cloud sync status" aria-label="Cloud sync status" style="display:none;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
+            </svg>
+            <span class="cloud-sync-dot header-cloud-dot" id="headerCloudDot"></span>
+          </button>
+          <!-- Secure mode: inline password popover (never auto-opens) -->
+          <div id="cloudSyncHeaderPopover" role="dialog" aria-label="Sync password" style="display:none;position:absolute;top:calc(100% + 6px);right:0;background:var(--card-bg,#fff);border:1px solid var(--border-color,#ddd);border-radius:8px;padding:0.75rem;box-shadow:0 4px 16px rgba(0,0,0,0.18);z-index:999;min-width:240px">
+            <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.5rem;color:var(--text-primary)">&#x1F512; Vault Password</div>
+            <div style="display:flex;gap:0.4rem">
+              <input type="password" id="cloudSyncPopoverInput" placeholder="Enter password"
+                     autocomplete="current-password"
+                     style="flex:1;font-size:0.85rem;padding:0.3rem 0.5rem;border:1px solid var(--border-color,#ddd);border-radius:4px;background:var(--input-bg,#fff);color:var(--text-primary)">
+              <button class="btn success" id="cloudSyncPopoverUnlockBtn" style="font-size:0.8rem;padding:0.3rem 0.6rem">Unlock</button>
+            </div>
+            <div id="cloudSyncPopoverError" style="color:var(--danger,#e74c3c);font-size:0.75rem;margin-top:0.3rem;display:none"></div>
+            <button id="cloudSyncPopoverCancelBtn" style="background:none;border:none;color:var(--text-secondary);font-size:0.75rem;margin-top:0.4rem;cursor:pointer;padding:0">Cancel</button>
+          </div>
+        </div>
         <button class="btn theme-btn" id="aboutBtn" title="About" aria-label="About">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -3113,6 +3127,31 @@
                   <div class="cloud-status-row" style="align-items:center;margin-top:0.35rem">
                     <span class="cloud-status-label">Last synced</span>
                     <span class="cloud-status-value" id="cloudAutoSyncLastSync">Never</span>
+                  </div>
+                  <!-- Sync Mode selector (shown only when connected + enabled) -->
+                  <div id="cloudSyncModeSection" style="display:none;margin-top:0.6rem;padding:0.5rem 0.6rem;border:1px solid var(--border-color,#ddd);border-radius:6px;background:var(--card-bg-alt,rgba(0,0,0,0.02))">
+                    <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.4rem;color:var(--text-primary)">Encryption Mode</div>
+                    <label style="display:flex;align-items:flex-start;gap:0.5rem;margin-bottom:0.4rem;cursor:pointer">
+                      <input type="radio" name="cloudSyncMode" id="cloudSyncModeSimple" value="simple" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('simple')">
+                      <span>
+                        <strong style="font-size:0.8rem">Simple</strong>
+                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Your Dropbox account is the key — no extra password needed on any device.</span>
+                      </span>
+                    </label>
+                    <label style="display:flex;align-items:flex-start;gap:0.5rem;cursor:pointer">
+                      <input type="radio" name="cloudSyncMode" id="cloudSyncModeSecure" value="secure" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('secure')">
+                      <span>
+                        <strong style="font-size:0.8rem">Secure</strong>
+                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Encrypt with your own vault password — zero-knowledge from Dropbox.</span>
+                      </span>
+                    </label>
+                    <div id="cloudSyncModeSwitchWarning" style="display:none;margin-top:0.5rem;padding:0.4rem 0.5rem;background:var(--warning-bg,#fff8e6);border:1px solid var(--warning-border,#ffc107);border-radius:4px;font-size:0.75rem;color:var(--text-primary)">
+                      &#x26A0;&#xFE0F; <strong>Make a manual backup first.</strong> Old syncs encrypted in the previous mode won't be readable in the new mode.
+                      <div style="margin-top:0.4rem;display:flex;gap:0.4rem">
+                        <button class="btn warning" id="cloudSyncModeConfirmBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof confirmSyncModeSwitch==='function')confirmSyncModeSwitch()">Switch Mode</button>
+                        <button class="btn" id="cloudSyncModeCancelBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof cancelSyncModeSwitch==='function')cancelSyncModeSwitch()">Cancel</button>
+                      </div>
+                    </div>
                   </div>
                   <div style="margin-top:0.5rem">
                     <button class="btn" id="cloudSyncNowBtn" disabled onclick="if(typeof pushSyncVault==='function')pushSyncVault();" style="font-size:0.8rem;padding:0.25rem 0.6rem">

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.21 &ndash; Sync UX Overhaul + Simple Mode</strong>: No more on-load password popups &mdash; choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.</li>
     <li><strong>v3.32.20 &ndash; api2 Backup Endpoint</strong>: Dual-endpoint fallback for all API feeds &mdash; spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal shows per-endpoint drift benchmarking.</li>
     <li><strong>v3.32.19 &ndash; 15-Min Spot Price Endpoint</strong>: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json &mdash; written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.</li>
     <li><strong>v3.32.18 &ndash; Cloud Sync Status Icon</strong>: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.</li>
     <li><strong>v3.32.17 &ndash; 24hr Chart Improvements</strong>: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (&#9650;/&#9660;/&mdash;) per slot.</li>
-    <li><strong>v3.32.16 &ndash; Market Chart Timezone Fix</strong>: 24hr price chart and table now show times in your selected timezone. seed-sync skill gains Phase 5 &mdash; syncs from live API before releases.</li>
   `;
 };
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.22 &ndash; Sync UI Dark-Theme CSS Fix</strong>: Header sync popover, mode selector, and backup warning now render correctly across all themes &mdash; corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.</li>
     <li><strong>v3.32.21 &ndash; Sync UX Overhaul + Simple Mode</strong>: No more on-load password popups &mdash; choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.</li>
     <li><strong>v3.32.20 &ndash; api2 Backup Endpoint</strong>: Dual-endpoint fallback for all API feeds &mdash; spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal shows per-endpoint drift benchmarking.</li>
     <li><strong>v3.32.19 &ndash; 15-Min Spot Price Endpoint</strong>: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json &mdash; written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.</li>
     <li><strong>v3.32.18 &ndash; Cloud Sync Status Icon</strong>: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.</li>
-    <li><strong>v3.32.17 &ndash; 24hr Chart Improvements</strong>: Intraday chart now uses clean 30-min bucketed ticks with styled hour/half-hour marks. Table extended to 12/24/48 configurable rows with trend indicators (&#9650;/&#9660;/&mdash;) per slot.</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -828,7 +828,12 @@ async function handleRemoteChange(remoteMeta) {
  * @param {object} remoteMeta - Remote sync metadata (from pollForRemoteChanges)
  */
 async function pullSyncVault(remoteMeta) {
-  var password = await getSyncPassword();
+  // Try silent key first (Simple mode or cached Secure password)
+  var password = getSyncPasswordSilent();
+  if (!password) {
+    // Secure mode with no cached password — prompt interactively
+    password = await getSyncPassword();
+  }
   if (!password) {
     debugLog('[CloudSync] Pull cancelled — no password');
     return;

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1252,3 +1252,5 @@ window.syncSaveOverrideBackup = syncSaveOverrideBackup;
 window.syncRestoreOverrideBackup = syncRestoreOverrideBackup;
 window.setSyncMode = setSyncMode;
 window.refreshSyncModeUI = refreshSyncModeUI;
+window.syncGetLastPush = syncGetLastPush;
+window._syncRelativeTime = _syncRelativeTime;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.20";
+const APP_VERSION = "3.32.21";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -570,6 +570,9 @@ const ACK_DISMISSED_KEY = "ackDismissed";
 /** @constant {string} CLOUD_VAULT_IDLE_TIMEOUT_KEY - LocalStorage key for vault password idle lock timeout in minutes (15|30|60|120|0=never) */
 const CLOUD_VAULT_IDLE_TIMEOUT_KEY = "cloud_vault_idle_timeout";
 
+/** App-namespace salt for Simple mode key derivation. Never change — changing invalidates all Simple-mode syncs. */
+const STAKTRAKR_SIMPLE_SALT = '53544b52:53494d504c45:76310000';
+
 /** @constant {string} API_KEY_STORAGE_KEY - LocalStorage key for API provider information */
 const API_KEY_STORAGE_KEY = "metalApiConfig";
 
@@ -802,6 +805,8 @@ const ALLOWED_STORAGE_KEYS = [
   "cloud_sync_cursor",                         // Dropbox rev string: for efficient change detection
   "cloud_sync_override_backup",                // JSON: { timestamp, itemCount, appVersion, data: {...} } — pre-pull local snapshot
   CLOUD_VAULT_IDLE_TIMEOUT_KEY,                // number string: vault password idle lock timeout in minutes (15|30|60|120|0=never)
+  "cloud_sync_mode",                           // string: "simple" | "secure" — sync encryption mode
+  "cloud_dropbox_account_id",                  // string: Dropbox account_id for Simple mode key derivation
 ];
 
 // =============================================================================
@@ -1635,6 +1640,7 @@ if (typeof window !== "undefined") {
   // Multi-currency support (STACK-50)
   window.SUPPORTED_CURRENCIES = SUPPORTED_CURRENCIES;
   window.CLOUD_VAULT_IDLE_TIMEOUT_KEY = CLOUD_VAULT_IDLE_TIMEOUT_KEY;
+  window.STAKTRAKR_SIMPLE_SALT = STAKTRAKR_SIMPLE_SALT;
   window.DISPLAY_CURRENCY_KEY = DISPLAY_CURRENCY_KEY;
   window.EXCHANGE_RATES_KEY = EXCHANGE_RATES_KEY;
   window.EXCHANGE_RATE_API_URL = EXCHANGE_RATE_API_URL;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.21";
+const APP_VERSION = "3.32.22";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -2932,5 +2932,9 @@ function cancelSyncModeSwitch() {
 
 // =============================================================================
 
+window.handleSyncModeChange = handleSyncModeChange;
+window.confirmSyncModeSwitch = confirmSyncModeSwitch;
+window.cancelSyncModeSwitch = cancelSyncModeSwitch;
+
 // Early cleanup of stray localStorage entries before application initialization
 document.addEventListener('DOMContentLoaded', cleanupStorage);

--- a/js/events.js
+++ b/js/events.js
@@ -739,6 +739,13 @@ const setupHeaderButtonListeners = () => {
     if (popover && popover.style.display !== 'none') {
       if (wrapper && !wrapper.contains(e.target)) {
         popover.style.display = 'none';
+        // Clear handlers so stale state doesn't persist on next open
+        var inputEl = safeGetElement('cloudSyncPopoverInput');
+        var unlockEl = safeGetElement('cloudSyncPopoverUnlockBtn');
+        var cancelEl = safeGetElement('cloudSyncPopoverCancelBtn');
+        if (inputEl) inputEl.onkeydown = null;
+        if (unlockEl) unlockEl.onclick = null;
+        if (cancelEl) cancelEl.onclick = null;
       }
     }
   });

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771859814';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771859944';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.21-b1771880681';
+const CACHE_NAME = 'staktrakr-v3.32.22-b1771884895';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771859944';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771860057';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771859703';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771859814';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771861176';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771861678';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771860313';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771860457';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771860171';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771860313';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771860057';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771860171';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771861678';
+const CACHE_NAME = 'staktrakr-v3.32.21-b1771879201';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.21-b1771879201';
+const CACHE_NAME = 'staktrakr-v3.32.21-b1771880681';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771860457';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771860759';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771855108';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771859703';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.20-b1771860759';
+const CACHE_NAME = 'staktrakr-v3.32.20-b1771861176';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.21",
+  "version": "3.32.22",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.20",
+  "version": "3.32.21",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — do not merge.** PR description will be updated to reflect all changes before merge.

## Changes so far

- **v3.32.21**: Sync UX Overhaul + Simple Mode — no auto-opening password modal; Simple mode (Dropbox account as key) + Secure mode (vault password); header popover for Secure unlock; mode selector in Settings → Cloud
- **v3.32.22**: Dark-theme CSS fix — popover + mode selector + warning banner now use correct CSS vars (`--bg-card`, `--border`, `--bg-tertiary`); SVG lock icon; amber warning tint

## Linear Issues

- STAK-280 (sync UX overhaul + Simple mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)