### PR TITLE
v3.32.23 — Cloud Settings Redesign + Unified Encryption + bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.23] - 2026-02-23
+
+### Changed — Cloud Settings Redesign + Unified Encryption
+
+- **Changed**: Cloud settings compacted to ≤400px card — Dropbox configuration moved to Advanced sub-modal
+- **Changed**: Unified encryption mode — vault password stored in browser, combined with Dropbox account for zero-knowledge encryption (replaces Simple/Secure toggle)
+- **Fixed**: Action buttons (Disconnect, Backup, Restore) use compact app button style, removed from main card view
+- **Removed**: Encryption mode selector (Simple/Secure radio buttons) — single seamless mode replaces both
+
+---
+
 ## [3.32.22] - 2026-02-23
 
 ### Fixed — Sync UI Dark-Theme CSS Fix

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,11 @@
 ## What's New
 
+- **Cloud Settings Redesign + Unified Encryption (v3.32.23)**: Compact ≤400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.
 - **Sync UI Dark-Theme CSS Fix (v3.32.22)**: Header sync popover, mode selector, and backup warning now render correctly across all themes — corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.
 - **Sync UX Overhaul + Simple Mode (v3.32.21)**: No more on-load password popups — choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.
 - **api2 Backup Endpoint (v3.32.20)**: Dual-endpoint fallback for all API feeds — spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal now shows per-endpoint drift benchmarking.
 - **15-Min Spot Price Endpoint (v3.32.19)**: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json — written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.
-- **Cloud Sync Status Icon (v3.32.18)**: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.
+
 ## Development Roadmap
 
 ### Next Up

--- a/index.html
+++ b/index.html
@@ -3091,13 +3091,11 @@
                     Connect
                   </button>
                   <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled
-                    onclick="if(typeof pushSyncVault==='function')pushSyncVault();"
                     style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                     Backup
                   </button>
                   <button class="btn cloud-restore-btn" data-provider="dropbox" disabled
-                    onclick="if(typeof pullSyncVault==='function')pullSyncVault();"
                     style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                     Restore
@@ -4211,14 +4209,12 @@
             <div class="settings-fieldset-title">Backup &amp; Restore</div>
             <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem">
               <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled
-                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
-                onclick="if(typeof pushSyncVault==='function')pushSyncVault();">
+                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                 Backup Now
               </button>
               <button class="btn cloud-restore-btn" data-provider="dropbox" disabled
-                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
-                onclick="if(typeof pullSyncVault==='function')pullSyncVault();">
+                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                 Restore
               </button>
@@ -4265,8 +4261,7 @@
             <div class="settings-fieldset-title" style="color:var(--danger,#e74c3c)">Danger Zone</div>
             <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Disconnecting removes Dropbox access from this device. Your encrypted backups on Dropbox are not deleted.</p>
             <button class="btn danger cloud-disconnect-btn" data-provider="dropbox"
-              style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
-              onclick="if(typeof disconnectCloud==='function')disconnectCloud('dropbox');">
+              style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
               Disconnect Dropbox
             </button>

--- a/index.html
+++ b/index.html
@@ -3049,8 +3049,8 @@
                 <p class="settings-subtext" style="margin:0.5rem 0 0">Supabase-powered cloud storage for StakTrakr sponsors. Zero-config encrypted sync with automatic backups.</p>
               </div>
 
-              <!-- Dropbox Provider (unified card) -->
-              <div class="cloud-provider-card" id="cloudCard_dropbox">
+<!-- Dropbox Provider — compact card -->
+              <div class="cloud-provider-card" id="cloudCard_dropbox" style="max-width:400px">
                 <div class="cloud-provider-card-header">
                   <span class="cloud-provider-card-title">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px"><path d="M6 2l6 3.6L6 9.2 0 5.6zm12 0l6 3.6-6 3.6-6-3.6zm-12 8l6 3.6-6 3.6-6-3.6zm12 0l6 3.6-6 3.6-6-3.6zM6 18.4l6-3.6 6 3.6-6 3.6z"/></svg>
@@ -3062,7 +3062,7 @@
                   </span>
                 </div>
 
-                <!-- Status rows -->
+                <!-- Connection status (shown when connected) -->
                 <div class="cloud-connection-status" id="cloudStatus_dropbox">
                   <div class="cloud-status-row">
                     <span class="cloud-status-label">Status</span>
@@ -3071,116 +3071,56 @@
                       <span class="cloud-status-text">Not connected</span>
                     </span>
                   </div>
-                  <div class="cloud-status-row">
-                    <span class="cloud-status-label">Last sync</span>
-                    <span class="cloud-status-value cloud-status-sync">Never</span>
-                  </div>
-                  <div class="cloud-status-row">
-                    <span class="cloud-status-label">Items backed up</span>
-                    <span class="cloud-status-value cloud-status-items">&mdash;</span>
-                  </div>
-                </div>
-
-                <!-- Actions -->
-                <div class="cloud-provider-card-actions">
-                  <div class="cloud-login-area">
-                    <button class="btn cloud-connect-btn" data-provider="dropbox">
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
-                      Login to Dropbox
-                    </button>
-                  </div>
-                  <button class="btn danger cloud-disconnect-btn" data-provider="dropbox" style="display:none">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
-                    Disconnect
-                  </button>
-                  <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-                    Backup Now
-                  </button>
-                  <button class="btn cloud-restore-btn" data-provider="dropbox" disabled>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-                    Restore
-                  </button>
-                </div>
-                <div class="cloud-status-detail"></div>
-                <div class="cloud-backup-list" id="cloudBackupList_dropbox" style="display:none"></div>
-
-                <!-- STAK-149: Auto-Sync Controls -->
-                <div class="cloud-autosync-section" style="margin-top:0.75rem;border-top:1px solid var(--border-color,#ddd);padding-top:0.75rem">
-                  <div class="cloud-status-row" style="align-items:center">
-                    <span class="cloud-status-label">
-                      <strong>Auto-sync</strong>
-                      <span class="settings-subtext" style="display:block;font-size:0.75rem">Sync inventory automatically on every change</span>
-                    </span>
-                    <label class="settings-toggle-switch" style="margin-left:auto">
-                      <input type="checkbox" id="cloudAutoSyncToggle" onchange="if(this.checked){enableCloudSync('dropbox');}else{disableCloudSync();}">
-                      <span class="settings-toggle-slider"></span>
-                    </label>
-                  </div>
-                  <div class="cloud-status-row" id="cloudAutoSyncStatus" style="align-items:center;margin-top:0.35rem">
-                    <span class="cloud-status-label">Status</span>
+                  <div class="cloud-status-row" id="cloudAutoSyncStatus" style="align-items:center">
+                    <span class="cloud-status-label">Sync</span>
                     <span class="cloud-status-value" style="display:flex;align-items:center;gap:0.4rem">
                       <span class="cloud-sync-dot"></span>
                       <span class="cloud-sync-status-text">Auto-sync off</span>
                     </span>
                   </div>
-                  <div class="cloud-status-row" style="align-items:center;margin-top:0.35rem">
+                  <div class="cloud-status-row" style="align-items:center">
                     <span class="cloud-status-label">Last synced</span>
                     <span class="cloud-status-value" id="cloudAutoSyncLastSync">Never</span>
                   </div>
-                  <!-- Sync Mode selector (shown only when connected + enabled) -->
-                  <div id="cloudSyncModeSection" style="display:none;margin-top:0.6rem;padding:0.5rem 0.6rem;border:1px solid var(--border);border-radius:6px;background:var(--bg-tertiary)">
-                    <div style="font-size:0.8rem;font-weight:600;margin-bottom:0.4rem;color:var(--text-primary)">Encryption Mode</div>
-                    <label style="display:flex;align-items:flex-start;gap:0.5rem;margin-bottom:0.4rem;cursor:pointer">
-                      <input type="radio" name="cloudSyncMode" id="cloudSyncModeSimple" value="simple" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('simple')">
-                      <span>
-                        <strong style="font-size:0.8rem">Simple</strong>
-                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Your Dropbox account is the key — no extra password needed on any device. (Stored in this browser; not zero-knowledge.)</span>
-                      </span>
-                    </label>
-                    <label style="display:flex;align-items:flex-start;gap:0.5rem;cursor:pointer">
-                      <input type="radio" name="cloudSyncMode" id="cloudSyncModeSecure" value="secure" style="margin-top:2px" onchange="if(typeof handleSyncModeChange==='function')handleSyncModeChange('secure')">
-                      <span>
-                        <strong style="font-size:0.8rem">Secure</strong>
-                        <span class="settings-subtext" style="display:block;font-size:0.72rem">Encrypt with your own vault password — zero-knowledge from Dropbox.</span>
-                      </span>
-                    </label>
-                    <div id="cloudSyncModeSwitchWarning" style="display:none;margin-top:0.5rem;padding:0.4rem 0.5rem;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.35);border-radius:4px;font-size:0.75rem;color:var(--text-primary)">
-                      &#x26A0;&#xFE0F; <strong>Make a manual backup first.</strong> Old syncs encrypted in the previous mode won't be readable in the new mode.
-                      <div style="margin-top:0.4rem;display:flex;gap:0.4rem">
-                        <button class="btn warning" id="cloudSyncModeConfirmBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof confirmSyncModeSwitch==='function')confirmSyncModeSwitch()">Switch Mode</button>
-                        <button class="btn" id="cloudSyncModeCancelBtn" style="font-size:0.75rem;padding:0.2rem 0.5rem" onclick="if(typeof cancelSyncModeSwitch==='function')cancelSyncModeSwitch()">Cancel</button>
-                      </div>
-                    </div>
-                  </div>
-                  <div style="margin-top:0.5rem">
-                    <button class="btn" id="cloudSyncNowBtn" disabled onclick="if(typeof pushSyncVault==='function')pushSyncVault();" style="font-size:0.8rem;padding:0.25rem 0.6rem">
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.25rem"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
-                      Sync Now
-                    </button>
-                  </div>
                 </div>
 
-                <!-- Sync History (pre-pull local snapshot) -->
-                <div class="cloud-autosync-section" style="margin-top:0.75rem;border-top:1px solid var(--border-color,#ddd);padding-top:0.75rem">
-                  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
-                    <strong style="font-size:0.85rem">Sync History</strong>
-                    <span class="settings-subtext" style="font-size:0.75rem">Last local snapshot</span>
-                  </div>
-                  <div id="cloudSyncHistorySection">
-                    <p class="settings-subtext" style="margin:0">No snapshot available.</p>
-                  </div>
-                </div>
-
-                <!-- Disclaimer -->
-                <div class="cloud-provider-disclaimer" style="display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap">
-                  <span>Backups are stored in <strong>/StakTrakr</strong> on your Dropbox. Your vault password encrypts the data &mdash; if you lose it, backups cannot be recovered.</span>
-                  <button class="btn" style="font-size:0.78rem;padding:0.2rem 0.55rem;white-space:nowrap;flex-shrink:0"
-                    onclick="if(typeof switchLogTab==='function'){switchLogTab('cloud');} if(typeof switchSettingsSection==='function'){switchSettingsSection('changelog');}">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.25rem"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-                    View Sync Log
+                <!-- Connect button (shown when disconnected) -->
+                <div class="cloud-login-area" style="margin-top:0.5rem">
+                  <button class="btn cloud-connect-btn" data-provider="dropbox" style="font-size:0.85rem;padding:0.4rem 1rem;min-height:0">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
+                    Connect Dropbox
                   </button>
                 </div>
+
+                <!-- Auto-sync toggle + action row (shown when connected) -->
+                <div class="cloud-autosync-section" style="margin-top:0.6rem;border-top:1px solid var(--border);padding-top:0.6rem">
+                  <div class="cloud-status-row" style="align-items:center">
+                    <span class="cloud-status-label"><strong>Auto-sync</strong></span>
+                    <label class="settings-toggle-switch" style="margin-left:auto">
+                      <input type="checkbox" id="cloudAutoSyncToggle" onchange="if(this.checked){enableCloudSync('dropbox');}else{disableCloudSync();}">
+                      <span class="settings-toggle-slider"></span>
+                    </label>
+                  </div>
+                </div>
+
+                <!-- Action row: Sync Now + Advanced -->
+                <div style="display:flex;gap:0.5rem;margin-top:0.6rem;align-items:center">
+                  <button class="btn" id="cloudSyncNowBtn" disabled
+                    onclick="if(typeof pushSyncVault==='function')pushSyncVault();"
+                    style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0;flex:1">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+                    Sync Now
+                  </button>
+                  <button class="btn" id="cloudSyncAdvancedBtn"
+                    onclick="if(typeof openModalById==='function')openModalById('cloudSyncAdvancedModal');"
+                    style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14"/></svg>
+                    Advanced
+                  </button>
+                </div>
+
+                <div class="cloud-status-detail"></div>
+                <div class="cloud-backup-list" id="cloudBackupList_dropbox" style="display:none"></div>
               </div>
 
               <!-- More Providers -->
@@ -3238,25 +3178,6 @@
                 </div>
               </div>
 
-              <!-- Session Cache (demoted) -->
-              <div class="settings-fieldset cloud-session-cache">
-                <div class="settings-fieldset-title">Session Password Cache</div>
-                <p class="settings-subtext">Your vault password is remembered for this browser session after the first backup or restore. Closing the browser clears it.</p>
-                <div class="cloud-status-row" style="margin-top:0.5rem">
-                  <span class="cloud-status-label">Cache status</span>
-                  <span class="cloud-status-value" id="cloudPwCacheStatus">Not cached</span>
-                </div>
-                <div class="cloud-status-row" style="margin-top:0.5rem">
-                  <label class="cloud-status-label" for="cloudVaultIdleTimeout">Auto-lock after idle</label>
-                  <select id="cloudVaultIdleTimeout" class="control-select" title="Clear cached vault password after this period of inactivity">
-                    <option value="15">15 minutes</option>
-                    <option value="30">30 minutes</option>
-                    <option value="60">1 hour</option>
-                    <option value="120">2 hours</option>
-                    <option value="0">Never</option>
-                  </select>
-                </div>
-              </div>
 
             </div>
 
@@ -4261,15 +4182,97 @@
       </div>
     </div>
 
+    <!-- Dropbox Advanced Settings Modal -->
+    <div class="modal" id="cloudSyncAdvancedModal" style="display:none" role="dialog" aria-modal="true" aria-labelledby="cloudSyncAdvancedModalTitle">
+      <div class="modal-content" style="max-width:480px;width:90%">
+        <div class="modal-header">
+          <h3 class="modal-title" id="cloudSyncAdvancedModalTitle">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px;margin-right:0.4rem"><path d="M6 2l6 3.6L6 9.2 0 5.6zm12 0l6 3.6-6 3.6-6-3.6zm-12 8l6 3.6-6 3.6-6-3.6zm12 0l6 3.6-6 3.6-6-3.6zM6 18.4l6-3.6 6 3.6-6 3.6z"/></svg>
+            Dropbox Settings
+          </h3>
+          <button class="modal-close" onclick="if(typeof closeModalById==='function')closeModalById('cloudSyncAdvancedModal')" aria-label="Close">&times;</button>
+        </div>
+        <div class="modal-body">
+
+          <!-- Backup / Restore -->
+          <div class="settings-fieldset" style="margin-bottom:0.75rem">
+            <div class="settings-fieldset-title">Backup &amp; Restore</div>
+            <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem">
+              <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled
+                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                Backup Now
+              </button>
+              <button class="btn cloud-restore-btn" data-provider="dropbox" disabled
+                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                Restore
+              </button>
+            </div>
+          </div>
+
+          <!-- Vault Password -->
+          <div class="settings-fieldset" style="margin-bottom:0.75rem">
+            <div class="settings-fieldset-title">Vault Password</div>
+            <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Remembered in this browser. Change it here — your next sync will re-encrypt your backup.</p>
+            <div style="display:flex;gap:0.4rem;align-items:flex-start">
+              <input type="password" id="cloudAdvancedNewPassword" placeholder="New password (min 8 chars)"
+                autocomplete="new-password"
+                style="flex:1;font-size:0.85rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary)">
+              <button class="btn" id="cloudAdvancedSavePasswordBtn"
+                style="font-size:0.82rem;padding:0.35rem 0.75rem;min-height:0;white-space:nowrap"
+                onclick="if(typeof handleAdvancedSavePassword==='function')handleAdvancedSavePassword()">
+                Save
+              </button>
+            </div>
+            <div id="cloudAdvancedPasswordError" style="color:var(--danger,#e74c3c);font-size:0.75rem;margin-top:0.3rem;display:none"></div>
+          </div>
+
+          <!-- Sync History -->
+          <div class="settings-fieldset" style="margin-bottom:0.75rem">
+            <div class="settings-fieldset-title">Sync History</div>
+            <div id="cloudSyncHistorySection">
+              <p class="settings-subtext" style="margin:0.3rem 0 0">No snapshot available.</p>
+            </div>
+          </div>
+
+          <!-- View Log -->
+          <div style="margin-bottom:0.75rem">
+            <button class="btn" style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
+              onclick="if(typeof switchLogTab==='function'){switchLogTab('cloud');} if(typeof switchSettingsSection==='function'){switchSettingsSection('changelog');} if(typeof closeModalById==='function')closeModalById('cloudSyncAdvancedModal');">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+              View Sync Log
+            </button>
+          </div>
+
+          <!-- Disconnect -->
+          <div class="settings-fieldset" style="border-color:var(--danger,#e74c3c);opacity:0.9">
+            <div class="settings-fieldset-title" style="color:var(--danger,#e74c3c)">Danger Zone</div>
+            <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Disconnecting removes Dropbox access from this device. Your encrypted backups on Dropbox are not deleted.</p>
+            <button class="btn danger cloud-disconnect-btn" data-provider="dropbox"
+              style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+              Disconnect Dropbox
+            </button>
+          </div>
+
+          <!-- Disclaimer -->
+          <p class="settings-subtext" style="margin:0.75rem 0 0;font-size:0.72rem">
+            Backups stored in <strong>/StakTrakr</strong> on your Dropbox. If you forget your vault password, backups cannot be recovered from Dropbox (your local data is unaffected).
+          </p>
+        </div>
+      </div>
+    </div>
+
     <!-- STAK-149: Sync Password Modal -->
     <div class="modal" id="cloudSyncPasswordModal" style="display: none">
       <div class="modal-content" style="max-width: 400px">
         <div class="modal-header">
-          <h2>Sync Password</h2>
+          <h2 id="syncPasswordModalTitle">Sync Password</h2>
           <button aria-label="Close modal" class="modal-close" id="syncPasswordCancelBtn">&times;</button>
         </div>
         <div class="modal-body">
-          <p class="settings-subtext" style="margin-bottom:1rem">Enter your vault password to encrypt your inventory before syncing. This password never leaves your device.</p>
+          <p id="syncPasswordModalSubtitle" class="settings-subtext" style="margin-bottom:1rem">Enter your vault password to encrypt your inventory before syncing. This password never leaves your device.</p>
           <div class="password-input-group">
             <input type="password" id="syncPasswordInput" placeholder="Vault password" autocomplete="current-password" style="width:100%"/>
           </div>

--- a/index.html
+++ b/index.html
@@ -4199,12 +4199,14 @@
             <div class="settings-fieldset-title">Backup &amp; Restore</div>
             <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem">
               <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled
-                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
+                onclick="if(typeof pushSyncVault==='function')pushSyncVault();">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                 Backup Now
               </button>
               <button class="btn cloud-restore-btn" data-provider="dropbox" disabled
-                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
+                onclick="if(typeof pullSyncVault==='function')pullSyncVault();">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                 Restore
               </button>
@@ -4250,7 +4252,8 @@
             <div class="settings-fieldset-title" style="color:var(--danger,#e74c3c)">Danger Zone</div>
             <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Disconnecting removes Dropbox access from this device. Your encrypted backups on Dropbox are not deleted.</p>
             <button class="btn danger cloud-disconnect-btn" data-provider="dropbox"
-              style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+              style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0"
+              onclick="if(typeof disconnectCloud==='function')disconnectCloud('dropbox');">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
               Disconnect Dropbox
             </button>

--- a/index.html
+++ b/index.html
@@ -4231,6 +4231,7 @@
             <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Remembered in this browser. Change it here — your next sync will re-encrypt your backup.</p>
             <div style="display:flex;gap:0.4rem;align-items:flex-start">
               <input type="password" id="cloudAdvancedNewPassword" placeholder="New password (min 8 chars)"
+                aria-label="New vault password"
                 autocomplete="new-password"
                 style="flex:1;font-size:0.85rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary)">
               <button class="btn" id="cloudAdvancedSavePasswordBtn"
@@ -4287,7 +4288,7 @@
           <button aria-label="Close modal" class="modal-close" id="syncPasswordCancelBtn">&times;</button>
         </div>
         <div class="modal-body">
-          <p id="syncPasswordModalSubtitle" class="settings-subtext" style="margin-bottom:1rem">Enter your vault password to encrypt your inventory before syncing. This password never leaves your device.</p>
+          <p id="syncPasswordModalSubtitle" class="settings-subtext" style="margin-bottom:1rem">Enter your vault password to encrypt your inventory before syncing. Your password is stored in this browser and combined with your Dropbox account ID to create the encryption key — it is never transmitted over the network.</p>
           <div class="password-input-group">
             <input type="password" id="syncPasswordInput" placeholder="Vault password" autocomplete="current-password" style="width:100%"/>
           </div>

--- a/index.html
+++ b/index.html
@@ -3084,11 +3084,23 @@
                   </div>
                 </div>
 
-                <!-- Connect button (shown when disconnected) -->
-                <div class="cloud-login-area" style="margin-top:0.5rem">
-                  <button class="btn cloud-connect-btn" data-provider="dropbox" style="font-size:0.85rem;padding:0.4rem 1rem;min-height:0">
+                <!-- Connect / Backup / Restore row -->
+                <div class="cloud-login-area" style="margin-top:0.5rem;display:flex;gap:0.4rem;flex-wrap:wrap">
+                  <button class="btn cloud-connect-btn" data-provider="dropbox" style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
-                    Connect Dropbox
+                    Connect
+                  </button>
+                  <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled
+                    onclick="if(typeof pushSyncVault==='function')pushSyncVault();"
+                    style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                    Backup
+                  </button>
+                  <button class="btn cloud-restore-btn" data-provider="dropbox" disabled
+                    onclick="if(typeof pullSyncVault==='function')pullSyncVault();"
+                    style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                    Restore
                   </button>
                 </div>
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.23 &ndash; Cloud Settings Redesign + Unified Encryption</strong>: Compact &le;400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.</li>
     <li><strong>v3.32.22 &ndash; Sync UI Dark-Theme CSS Fix</strong>: Header sync popover, mode selector, and backup warning now render correctly across all themes &mdash; corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.</li>
     <li><strong>v3.32.21 &ndash; Sync UX Overhaul + Simple Mode</strong>: No more on-load password popups &mdash; choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.</li>
     <li><strong>v3.32.20 &ndash; api2 Backup Endpoint</strong>: Dual-endpoint fallback for all API feeds &mdash; spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal shows per-endpoint drift benchmarking.</li>
     <li><strong>v3.32.19 &ndash; 15-Min Spot Price Endpoint</strong>: New sub-hourly price snapshots at data/15min/YYYY/MM/DD/HHMM.json &mdash; written every 15 min by the spot poller. Frontend fetchStaktrakr15minRange() loads 24h of 15-min data tagged api-15min.</li>
-    <li><strong>v3.32.18 &ndash; Cloud Sync Status Icon</strong>: Ambient header icon replaces the on-load password modal. Orange = needs password (tap to unlock), green = active, gray = not configured.</li>
   `;
 };
 

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -950,7 +950,7 @@ function syncCloudUI() {
     // Toggle login vs disconnect buttons
     var loginArea = card.querySelector('.cloud-login-area');
     var connectedBadge = card.querySelector('.cloud-connected-badge');
-    var disconnectBtn = card.querySelector('.cloud-disconnect-btn');
+    var disconnectBtn = document.querySelector('.cloud-disconnect-btn[data-provider="' + key + '"]');
     var backupListEl = document.getElementById('cloudBackupList_' + key);
 
     if (loginArea) loginArea.style.display = connected ? 'none' : '';
@@ -958,7 +958,7 @@ function syncCloudUI() {
     if (disconnectBtn) disconnectBtn.style.display = connected ? '' : 'none';
 
     // Enable/disable backup & restore buttons based on connection
-    card.querySelectorAll('.cloud-backup-btn, .cloud-restore-btn').forEach(function (btn) {
+    document.querySelectorAll('.cloud-backup-btn[data-provider="' + key + '"], .cloud-restore-btn[data-provider="' + key + '"]').forEach(function (btn) {
       btn.disabled = !connected;
     });
 
@@ -999,32 +999,6 @@ function syncCloudUI() {
       backupListEl.innerHTML = '';
     }
   });
-
-  // Update password cache status (session-only)
-  var pwStatusEl = typeof safeGetElement === 'function' ? safeGetElement('cloudPwCacheStatus') : document.getElementById('cloudPwCacheStatus');
-  if (pwStatusEl) {
-    var cached = sessionStorage.getItem('cloud_vault_pw_cache');
-    if (cached) {
-      pwStatusEl.textContent = 'Cached (this session)';
-      pwStatusEl.style.color = 'var(--success)';
-    } else {
-      pwStatusEl.textContent = 'Not cached';
-      pwStatusEl.style.color = 'var(--text-secondary)';
-    }
-  }
-
-  // Sync idle timeout select to stored preference
-  var idleSelect = safeGetElement('cloudVaultIdleTimeout');
-  if (idleSelect) {
-    var storedTimeout = localStorage.getItem(CLOUD_VAULT_IDLE_TIMEOUT_KEY);
-    var idleVal = storedTimeout !== null ? storedTimeout : '15';
-    // If stored value isn't a valid option, clamp to default and persist
-    if (!['0', '15', '30', '60', '120'].includes(idleVal)) {
-      idleVal = '15';
-      localStorage.setItem(CLOUD_VAULT_IDLE_TIMEOUT_KEY, idleVal);
-    }
-    idleSelect.value = idleVal;
-  }
 
   // STAK-149: Refresh auto-sync UI (toggle, last-synced, status dot)
   if (typeof refreshSyncUI === 'function') refreshSyncUI();

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -953,7 +953,9 @@ function syncCloudUI() {
     var disconnectBtn = document.querySelector('.cloud-disconnect-btn[data-provider="' + key + '"]');
     var backupListEl = document.getElementById('cloudBackupList_' + key);
 
-    if (loginArea) loginArea.style.display = connected ? 'none' : '';
+    // Hide only the Connect button when connected — Backup/Restore remain visible in the same row
+    var connectBtn = loginArea ? loginArea.querySelector('.cloud-connect-btn') : null;
+    if (connectBtn) connectBtn.style.display = connected ? 'none' : '';
     if (connectedBadge) connectedBadge.style.display = connected ? '' : 'none';
     if (disconnectBtn) disconnectBtn.style.display = connected ? '' : 'none';
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -209,6 +209,11 @@ function updateSyncStatusIndicator(state, detail) {
   updateCloudSyncHeaderBtn();
 }
 
+/**
+ * Updates the header cloud sync button state (green/orange/gray) based on
+ * connection status, vault password, and Dropbox account ID presence.
+ * Called on init, password change, and sync enable/disable.
+ */
 function updateCloudSyncHeaderBtn() {
   var btn = safeGetElement('headerCloudSyncBtn');
   var dot = safeGetElement('headerCloudDot');

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -443,6 +443,7 @@ async function changeVaultPassword(newPassword) {
     if (typeof showCloudToast === 'function') showCloudToast('Vault password updated — syncing now', 3000);
     return true;
   } catch (err) {
+    if (typeof debugLog === 'function') debugLog('[CloudSync] changeVaultPassword failed:', err);
     if (typeof showCloudToast === 'function') showCloudToast('Failed to update password — try again', 3000);
     return false;
   }

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.22";
+const APP_VERSION = "3.32.23";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -805,8 +805,9 @@ const ALLOWED_STORAGE_KEYS = [
   "cloud_sync_cursor",                         // Dropbox rev string: for efficient change detection
   "cloud_sync_override_backup",                // JSON: { timestamp, itemCount, appVersion, data: {...} } — pre-pull local snapshot
   CLOUD_VAULT_IDLE_TIMEOUT_KEY,                // number string: vault password idle lock timeout in minutes (15|30|60|120|0=never)
-  "cloud_sync_mode",                           // string: "simple" | "secure" — sync encryption mode
+  "cloud_sync_mode",                           // DEPRECATED: kept for migration only — will be removed after v3.33
   "cloud_dropbox_account_id",                  // string: Dropbox account_id for Simple mode key derivation
+  "cloud_vault_password",                      // string: user vault password stored for persistent unlock
 ];
 
 // =============================================================================

--- a/js/events.js
+++ b/js/events.js
@@ -2869,6 +2869,7 @@ function _openCloudSyncPopover() {
       return;
     }
     cleanup();
+    try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
     if (typeof cloudCachePassword === 'function') cloudCachePassword('dropbox', pw);
     if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
     setTimeout(function () { if (typeof pushSyncVault === 'function') pushSyncVault(); }, 100);

--- a/js/events.js
+++ b/js/events.js
@@ -2898,6 +2898,9 @@ function handleAdvancedSavePassword() {
   if (typeof changeVaultPassword === 'function') {
     changeVaultPassword(pw).then(function (ok) {
       if (!ok && errorEl) { errorEl.textContent = 'Failed to update password.'; errorEl.style.display = ''; }
+    }).catch(function (err) {
+      if (errorEl) { errorEl.textContent = 'An error occurred — try again.'; errorEl.style.display = ''; }
+      if (typeof debugLog === 'function') debugLog('[Cloud] changeVaultPassword threw:', err);
     });
   }
 }

--- a/js/events.js
+++ b/js/events.js
@@ -77,9 +77,6 @@ let _deleteObverseOnSave = false;
 /** @type {boolean} User clicked Remove on reverse — delete on save */
 let _deleteReverseOnSave = false;
 
-/** Pending sync mode selection — set before showing the switch-warning UI. */
-var _pendingSyncMode = null;
-
 /**
  * Process a user-selected image file and show preview for a specific side.
  * @param {File} file
@@ -702,34 +699,23 @@ const setupHeaderButtonListeners = () => {
   // Cloud sync header icon button (STAK-264)
   var headerCloudSyncBtn = safeGetElement('headerCloudSyncBtn');
   if (headerCloudSyncBtn) {
-    safeAttachListener(
-      headerCloudSyncBtn,
-      'click',
-      function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        var state = headerCloudSyncBtn.dataset.syncState;
-        var isSimple = localStorage.getItem('cloud_sync_mode') === 'simple';
-
-        if (state === 'orange' && !isSimple) {
-          // Secure mode needs password — open inline popover
-          _openCloudSyncPopover();
-        } else if (state === 'orange-simple') {
-          // Simple mode needs Dropbox reconnect
-          if (typeof cloudAuthStart === 'function') cloudAuthStart('dropbox');
-        } else if (state === 'green') {
-          var lp = typeof syncGetLastPush === 'function' ? syncGetLastPush() : null;
-          var msg = lp && lp.timestamp
-            ? 'Cloud sync active \u2014 last synced ' + (typeof _syncRelativeTime === 'function' ? _syncRelativeTime(lp.timestamp) : '')
-            : 'Cloud sync active';
-          if (typeof showCloudToast === 'function') showCloudToast(msg, 2500);
-        } else {
-          // Gray: not configured
-          if (typeof showSettingsModal === 'function') showSettingsModal('cloud');
-        }
-      },
-      'Cloud Sync Header Button'
-    );
+    safeAttachListener(headerCloudSyncBtn, 'click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      var state = headerCloudSyncBtn.dataset.syncState;
+      if (state === 'orange') {
+        // Needs password setup — open inline popover
+        if (typeof _openCloudSyncPopover === 'function') _openCloudSyncPopover();
+      } else if (state === 'green') {
+        var lp = typeof syncGetLastPush === 'function' ? syncGetLastPush() : null;
+        var msg = lp && lp.timestamp
+          ? 'Cloud sync active \u2014 last synced ' + (typeof _syncRelativeTime === 'function' ? _syncRelativeTime(lp.timestamp) : '')
+          : 'Cloud sync active';
+        if (typeof showCloudToast === 'function') showCloudToast(msg, 2500);
+      } else {
+        if (typeof showSettingsModal === 'function') showSettingsModal('cloud');
+      }
+    }, 'Cloud Sync Header Button');
   }
 
   // Close popover on outside click
@@ -2898,50 +2884,26 @@ function _openCloudSyncPopover() {
   }
 }
 
-/** Called when user clicks a sync mode radio — shows warning before applying. */
-function handleSyncModeChange(newMode) {
-  var currentMode = localStorage.getItem('cloud_sync_mode') || 'secure';
-  if (newMode === currentMode) return;
-
-  // Store the pending mode so confirmSyncModeSwitch knows what to apply
-  _pendingSyncMode = newMode;
-
-  var warning = safeGetElement('cloudSyncModeSwitchWarning');
-  if (warning) warning.style.display = '';
-
-  // Revert radio to current mode visually until user confirms
-  var simpleRadio = safeGetElement('cloudSyncModeSimple');
-  var secureRadio = safeGetElement('cloudSyncModeSecure');
-  if (simpleRadio) simpleRadio.checked = currentMode === 'simple';
-  if (secureRadio) secureRadio.checked = currentMode !== 'simple';
+function handleAdvancedSavePassword() {
+  var input = safeGetElement('cloudAdvancedNewPassword');
+  var errorEl = safeGetElement('cloudAdvancedPasswordError');
+  if (!input) return;
+  var pw = input.value;
+  if (!pw || pw.length < 8) {
+    if (errorEl) { errorEl.textContent = 'Password must be at least 8 characters.'; errorEl.style.display = ''; }
+    return;
+  }
+  if (errorEl) errorEl.style.display = 'none';
+  input.value = '';
+  if (typeof changeVaultPassword === 'function') {
+    changeVaultPassword(pw).then(function (ok) {
+      if (!ok && errorEl) { errorEl.textContent = 'Failed to update password.'; errorEl.style.display = ''; }
+    });
+  }
 }
-
-/** Applies the pending mode switch after user clicks "Switch Mode". */
-function confirmSyncModeSwitch() {
-  var mode = _pendingSyncMode;
-  if (!mode) return;
-  _pendingSyncMode = null;
-
-  var warning = safeGetElement('cloudSyncModeSwitchWarning');
-  if (warning) warning.style.display = 'none';
-
-  if (typeof setSyncMode === 'function') setSyncMode(mode);
-  if (typeof refreshSyncModeUI === 'function') refreshSyncModeUI();
-}
-
-/** Cancels a pending mode switch. */
-function cancelSyncModeSwitch() {
-  _pendingSyncMode = null;
-  var warning = safeGetElement('cloudSyncModeSwitchWarning');
-  if (warning) warning.style.display = 'none';
-  if (typeof refreshSyncModeUI === 'function') refreshSyncModeUI(); // resets radios
-}
+window.handleAdvancedSavePassword = handleAdvancedSavePassword;
 
 // =============================================================================
-
-window.handleSyncModeChange = handleSyncModeChange;
-window.confirmSyncModeSwitch = confirmSyncModeSwitch;
-window.cancelSyncModeSwitch = cancelSyncModeSwitch;
 
 // Early cleanup of stray localStorage entries before application initialization
 document.addEventListener('DOMContentLoaded', cleanupStorage);

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1184,14 +1184,7 @@ const renderCloudBackupList = (provider, backups) => {
  */
 const bindCloudCacheListeners = () => {
   // Session-only password cache — no toggle needed, auto-caches on first use
-  var idleSelect = safeGetElement('cloudVaultIdleTimeout');
-  if (idleSelect) {
-    idleSelect.addEventListener('change', function () {
-      var key = typeof CLOUD_VAULT_IDLE_TIMEOUT_KEY !== 'undefined' ? CLOUD_VAULT_IDLE_TIMEOUT_KEY : 'cloud_vault_idle_timeout';
-      localStorage.setItem(key, this.value);
-      if (typeof _resetIdleLockTimer === 'function') _resetIdleLockTimer();
-    });
-  }
+  // Idle timeout select removed with cloud-session-cache fieldset redesign
 };
 
 /**

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1246,7 +1246,7 @@ const bindCloudStorageListeners = () => {
 
   bindCloudCacheListeners();
 
-  panel.addEventListener('click', async function (e) {
+  var _cloudBtnHandler = async function (e) {
     var btn = e.target.closest('button');
     if (!btn) return;
     var provider = btn.dataset.provider;
@@ -1346,7 +1346,13 @@ const bindCloudStorageListeners = () => {
         }
       });
     }
-  });
+  };
+
+  panel.addEventListener('click', _cloudBtnHandler);
+
+  // Advanced modal is rendered at body level (outside settingsPanel_cloud), so it needs its own listener.
+  var advancedModal = document.getElementById('cloudSyncAdvancedModal');
+  if (advancedModal) advancedModal.addEventListener('click', _cloudBtnHandler);
 };
 
 /**

--- a/js/state.js
+++ b/js/state.js
@@ -267,7 +267,17 @@ const elements = {
 };
 
 /** @type {Array} Change log entries */
-let changeLog = JSON.parse(localStorage.getItem('changeLog') || '[]');
+let changeLog = (function () {
+  try {
+    var _raw = localStorage.getItem('changeLog');
+    if (!_raw) return [];
+    // saveDataSync may prepend 'CMP1:' for payloads ≥ 4 KB (LZString no-op prefix).
+    // Stripping it here mirrors __decompressIfNeeded in utils.js, which isn't
+    // loaded yet when state.js runs.
+    if (_raw.startsWith('CMP1:')) _raw = _raw.slice(5);
+    return JSON.parse(_raw);
+  } catch (_) { return []; }
+}());
 
 /** @type {Array} Main inventory data structure */
 let inventory = [];

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771891581';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771893529';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771888855';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771889318';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771888565';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771888855';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771890285';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771891581';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.22-b1771884895';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771888565';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771889318';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771890285';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.22",
+  "version": "3.32.23",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — do not merge.** Full QA on Cloudflare preview before merging to staktrakr.com.

## Summary

- **Cloud Settings Redesign** (STAK-149/245): New settings panel layout, Unified mode with user-chosen vault password, Advanced sub-modal, header popover
- **fix**: Backup/Restore buttons hidden when connected — was hiding entire `.cloud-login-area` row; now only hides `.cloud-connect-btn`
- **fix**: Fatal crash on tab reopen for users with large change logs — `state.js:270` bare `JSON.parse` on a `CMP1:`-prefixed value threw SyntaxError, leaving `let inventory` in TDZ and crashing init

## Commits since main

See `git log main..dev` — 15+ commits covering the full cloud redesign and post-merge bug fixes.

## QA Notes

- Connect Dropbox → card should show Connect + Backup + Restore buttons
- After connecting: Connect hides, Backup/Restore stay visible
- Heavy change-log user: tab close + reopen should no longer show "Application initialization failed"
- Vault backup/restore via manual password (Advanced modal) should work independently of sync password

🤖 Generated with [Claude Code](https://claude.com/claude-code)