### PR TITLE
fix(sync): catch unhandled pullSyncVault rejections, emit console.warn on changeLog parse

### DIFF
--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -961,7 +961,10 @@ function showSyncConflictModal(opts) {
     if (typeof appConfirm === 'function') {
       appConfirm(msg, 'Sync Conflict').then(function (keepMine) {
         if (keepMine) pushSyncVault();
-        else pullSyncVault(opts.remoteMeta);
+        else pullSyncVault(opts.remoteMeta).catch(function (err) {
+          debugLog('[CloudSync] pullSyncVault failed in conflict fallback:', err);
+          updateSyncStatusIndicator('error', 'Pull failed — ' + err.message);
+        });
       });
     }
     return;
@@ -1000,7 +1003,10 @@ function showSyncConflictModal(opts) {
   if (keepTheirsBtn) {
     keepTheirsBtn.onclick = function () {
       closeModal();
-      pullSyncVault(opts.remoteMeta);
+      pullSyncVault(opts.remoteMeta).catch(function (err) {
+        debugLog('[CloudSync] pullSyncVault failed on Keep Theirs:', err);
+        updateSyncStatusIndicator('error', 'Pull failed — ' + err.message);
+      });
     };
   }
   if (skipBtn) {

--- a/js/state.js
+++ b/js/state.js
@@ -276,7 +276,7 @@ let changeLog = (function () {
     // loaded yet when state.js runs.
     if (_raw.startsWith('CMP1:')) _raw = _raw.slice(5);
     return JSON.parse(_raw);
-  } catch (_) { return []; }
+  } catch (e) { console.warn('[state] changeLog parse failed — resetting to []. Error:', e); return []; }
 }());
 
 /** @type {Array} Main inventory data structure */

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771893529';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771894673';
 
 
 


### PR DESCRIPTION
## Summary

- **`cloud-sync.js`**: Two bare `pullSyncVault(opts.remoteMeta)` calls in `showSyncConflictModal` (conflict fallback appConfirm path and Keep Theirs button `onclick`) had no `.catch()`. `pullSyncVault` throws `'Not connected to cloud provider'` *before* its own `try/catch`, so a no-token pull failure became a completely silent unhandled rejection — no status indicator update, no toast, no log entry. Added `.catch()` to both callers that calls `updateSyncStatusIndicator('error', …)`.

- **`state.js`**: The `changeLog` IIFE catch block was `catch (_) { return []; }` with zero logging. Changed to `catch (e) { console.warn(…) }` so parse failures are visible in DevTools rather than silently discarded.

## Findings source

Surfaced by the Phase 0 silent-failure hunter agent during `/pr-resolve` on PR #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)