### PR TITLE
fix(sync): correct getSyncPassword fast-path, add localStorage fallback for manual Backup

### DIFF
--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -315,9 +315,11 @@ function _syncRelativeTime(ts) {
  * @returns {Promise<string|null>}
  */
 function getSyncPassword() {
-  // If already have both values, return silently
+  // If getSyncPasswordSilent already has a valid key, return it immediately.
+  // Do not add a redundant localStorage check — getSyncPasswordSilent() handles
+  // both Unified mode (password+accountId) and Simple-mode migration (accountId only).
   var silent = getSyncPasswordSilent();
-  if (silent && localStorage.getItem('cloud_vault_password')) return Promise.resolve(silent);
+  if (silent) return Promise.resolve(silent);
 
   var accountId = localStorage.getItem('cloud_dropbox_account_id');
   var isNewAccount = !localStorage.getItem('cloud_vault_password');

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -797,6 +797,15 @@ async function handleRemoteChange(remoteMeta) {
     return;
   }
 
+  // Cancel any queued debounced push before showing the update/conflict modal.
+  // Without this, the debounced push can fire while the modal is open, overwriting
+  // the remote vault with stale local data. The pull then downloads our own just-pushed
+  // data instead of the remote device's changes — silently discarding them.
+  if (typeof scheduleSyncPush === 'function' && typeof scheduleSyncPush.cancel === 'function') {
+    scheduleSyncPush.cancel();
+    debugLog('[CloudSync] Cancelled queued push — remote change takes priority');
+  }
+
   var hasLocal = syncHasLocalChanges();
 
   if (!hasLocal) {

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1281,7 +1281,10 @@ const bindCloudStorageListeners = () => {
             return;
           }
         }
+        // Prefer session cache (hot path), fall back to localStorage so Backup
+        // works after a page reload without re-prompting when password is already stored.
         var cachedPw = typeof cloudGetCachedPassword === 'function' ? cloudGetCachedPassword(provider) : null;
+        if (!cachedPw) cachedPw = localStorage.getItem('cloud_vault_password') || null;
         if (cachedPw) {
           await _cloudBackupWithCachedPw(provider, cachedPw, btn);
           return;

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771894906';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771895585';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.23-b1771894673';
+const CACHE_NAME = 'staktrakr-v3.32.23-b1771894906';
 
 
 


### PR DESCRIPTION
## Summary

Two bugs surfaced by the Phase 0 code reviewer on PR #454:

### Fix 1 — `getSyncPassword()` fast-path breaks Simple-mode migration

`cloud-sync.js:320` had:
```js
if (silent && localStorage.getItem('cloud_vault_password')) return Promise.resolve(silent);
```

The second condition was redundant for Unified mode (if `silent` is truthy, `vaultPw` is already confirmed present) and **harmful** for Simple-mode migration: `getSyncPasswordSilent()` can return a valid key using `STAKTRAKR_SIMPLE_SALT` even when `cloud_vault_password` is absent — the extra `localStorage.getItem` check evaluates to null, skipping the fast-path and forcing an unnecessary re-prompt.

Fixed to: `if (silent) return Promise.resolve(silent);`

### Fix 2 — Manual Backup/Restore re-prompts after page reload

`settings-listeners.js:1284` checked `cloudGetCachedPassword()` (sessionStorage) only. After a page reload, the session cache is empty even if `cloud_vault_password` is in localStorage. The flow fell through to `openVaultModal('cloud-export')` and re-prompted the user unnecessarily.

Added `localStorage.getItem('cloud_vault_password')` as a fallback so users with a stored vault password aren't re-prompted on every page reload before doing a manual backup.

## Findings source

Code reviewer agent (Phase 0, `/pr-resolve 454`), findings #2 and #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)