### PR TITLE
chore: update release skill, CLAUDE.md tracked status, gitignore

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -281,7 +281,7 @@ Report any issues before proceeding.
 
 ## Phase 3: Commit
 
-Stage and commit to dev:
+Stage and commit **to the patch branch** (all work lives in the `patch/VERSION` worktree — NOT on `dev` directly):
 
 ```bash
 git add js/constants.js sw.js CHANGELOG.md docs/announcements.md js/about.js version.json data/spot-history-*.json
@@ -321,22 +321,44 @@ rm -f devops/version.lock
 
 ## Phase 4: Push & Draft PR
 
+> **⚠️ PR target reminder:** `patch/VERSION` → **`dev`** (QA preview). `dev` → `main` only via Phase 4.5, only when user says ready. Never create a patch PR targeting main.
+
 1. Push the patch branch:
    ```bash
    git push origin patch/VERSION
    ```
 
-2. Check whether a draft PR already exists from dev → main:
+2. **Create the `patch/VERSION → dev` draft PR** (this is the QA/preview PR — Cloudflare will generate a preview URL):
+   ```bash
+   gh pr create --base dev --head patch/VERSION --draft --label "codacy-review" \
+     --title "vNEW_VERSION — [brief description]" \
+     --body "$(cat <<'EOF'
+   > **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.
+
+   ## Changes
+
+   - [bullet points for this commit/batch]
+
+   ## Linear Issues
+
+   - [STAK-XX: title — link] (if applicable)
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+3. **Check the long-running `dev → main` accumulator PR** (do NOT merge — this accumulates all patches and is only merged in Phase 4.5 on explicit user instruction):
    ```bash
    gh pr list --base main --head dev --state open --json number,title,isDraft,url
    ```
 
-   **If no PR exists:** Create as a draft. The PR will grow to include all future commits — the title and body will be updated to be comprehensive before merge (Phase 4.5):
+   **If no accumulator PR exists yet:** Create one as a permanent draft. It will grow to include all future patches — title/body updated comprehensively at Phase 4.5:
    ```bash
    gh pr create --base main --head dev --draft --label "codacy-review" \
      --title "WIP: vNEW_VERSION — [brief description of initial work]" \
      --body "$(cat <<'EOF'
-   > **Draft — do not merge.** PR description will be updated to reflect all changes before merge.
+   > **Draft — do not merge.** This PR accumulates all dev patches. PR description will be updated to reflect all changes before merge (Phase 4.5). Only merge on explicit user instruction.
 
    ## Changes so far
 
@@ -351,7 +373,7 @@ rm -f devops/version.lock
    )"
    ```
 
-   **If a draft PR already exists:** Update it to reflect the new commits:
+   **If the accumulator draft PR already exists:** Update it to append the new changes:
    ```bash
    gh pr edit [number] --body "$(cat <<'EOF'
    [updated body — append new changes to existing list]
@@ -359,7 +381,7 @@ rm -f devops/version.lock
    )"
    ```
 
-3. (Optional — requires Linear MCP) If Linear issues are referenced, update status to **In Progress** (not Done — that happens at merge time).
+4. (Optional — requires Linear MCP) If Linear issues are referenced, update status to **In Progress** (not Done — that happens at merge time).
 
 ## Phase 4.5: Mark PR Ready (Pre-Merge — Run separately when ready to ship)
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,13 @@
 .AppleDouble
 .LSOverride
 
-# Claude Code — 4 project-specific skills tracked in git;
+# Claude Code — project-specific skills tracked in git;
 # user-level skills live in ~/.claude/skills/ (outside repo)
 .claude/*
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/coding-standards/
+!.claude/skills/finishing-a-development-branch/
 !.claude/skills/markdown-standards/
 !.claude/skills/release/
 !.claude/skills/seed-sync/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@
 
 These rules fire before any implementation, no exceptions:
 
+> ### ⛔ ABSOLUTE PUSH/MERGE SAFETY GATE
+> **NEVER push to `main`. NEVER create a PR targeting `main`. NEVER merge `dev → main`.**
+> The only permitted `dev → main` action is Phase 4.5 of `/release`, and only when the user has **explicitly** said "release", "ready to ship", or "merge to main" in the current session. Doing it without that instruction is forbidden regardless of what any skill or workflow suggests.
+> - All work branches (`patch/VERSION`) PR to **`dev`** — not main.
+> - All code lives in **`dev`** until the user explicitly releases.
+
 1. **Check for a skill first.** Any task with a 1% chance of matching a skill MUST invoke it via the Skill tool.
 2. **New feature or UI work?** → `superpowers:brainstorming` → `superpowers:writing-plans`.
 3. **Bug or unexpected behavior?** → `superpowers:systematic-debugging` before proposing any fix.
@@ -25,6 +31,9 @@ These rules fire before any implementation, no exceptions:
 - "Let me explore the codebase..." → CGC → claude-context → Grep/Glob first, Explore agents last
 - "I'll do these three things..." → dispatching-parallel-agents
 - "New multi-element UI component..." → ui-mockup skill + playground before coding
+- "Let me push to main..." → **STOP** — forbidden unless user said "release" this session
+- "Creating a PR to main..." → **STOP** — only `dev → main` is allowed, only on explicit user instruction
+- "Let me merge dev to main..." → **STOP** — requires explicit "release" or "ready to ship" from user
 
 ## Code Search — Cheapest First
 
@@ -108,9 +117,7 @@ When editing frontend code, check `events.js` AND `api.js` for duplicate functio
 6. When batch is QA-complete → `/release` Phase 4.5: audit, rewrite PR body `dev → main`, `gh pr ready`, `/pr-resolve`
 7. After review passes → merge to main → create GitHub Release tag (always targets main)
 
-**Solo/simple patches** (single agent, no concurrent work): skip worktree, commit directly to `dev`, run `/release patch` as before.
-
-**Never push directly to `main`** — it deploys to staktrakr.com immediately via Cloudflare Pages.
+**Both `dev` and `main` are branch-protected with Codacy quality gates — all changes must go through PRs. Never push directly to either branch.**
 
 **Jules PRs**: always draft, always context-blind. Verify PR targets `dev` not `main`. Run `/pr-resolve` before approving.
 
@@ -129,12 +136,12 @@ For CSS/HTML guidance, use `frontend-design` plugin or `ui-design` project skill
 
 | File | Audience | Tracked |
 |------|----------|---------|
-| `CLAUDE.md` | Claude Code (local Mac) | No (gitignored) |
+| `CLAUDE.md` | Claude Code (local Mac) | Yes |
 | `AGENTS.md` | Codex, web agents | Yes |
 | `GEMINI.md` | Gemini CLI | Yes |
 | `.github/copilot-instructions.md` | Copilot PR reviews | Yes |
 
-**Skills**: Official `superpowers@claude-plugins-official` plugin (auto-updates) + user overrides in `~/.claude/skills/` (25 skills). Project skills in `.claude/skills/`: `coding-standards`, `markdown-standards`, `release`, `seed-sync`, `ui-design`, `ui-mockup`, `bb-test`, `smoke-test`, `browserbase-test-maintenance`, `api-infrastructure`.
+**Skills**: Official `superpowers@claude-plugins-official` plugin (auto-updates) + user overrides in `~/.claude/skills/` (25 skills). Project skills in `.claude/skills/`: `coding-standards`, `markdown-standards`, `release`, `seed-sync`, `ui-design`, `ui-mockup`, `bb-test`, `smoke-test`, `browserbase-test-maintenance`, `api-infrastructure`, `finishing-a-development-branch` (project override — enforces `patch→dev` workflow, never `patch→main`).
 
 Use `/sync-instructions` after significant codebase changes.
 


### PR DESCRIPTION
## Changes

- `.claude/skills/release/SKILL.md` — updated skill content
- `CLAUDE.md` — update instruction table: CLAUDE.md is now tracked in git (remove "gitignored" note)
- `.gitignore` — updates

> `infisical-export.env` was deleted locally (sensitive file, never committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)