### PR TITLE
v3.32.25 — STAK-299: Vendor Price Carry-Forward + OOS Legend Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.25] - 2026-02-23
+
+### Added — Vendor Price Carry-Forward + OOS Legend Links (STAK-299)
+
+- **Added**: `_forwardFillVendors` — post-bucketing enrichment pass that fills vendor gaps with the most recent known price, annotating each window with `_carriedVendors: Set`
+- **Added**: 24h chart carries forward vendor prices — carried data points render with `~` tooltip prefix and a muted/dashed dataset line; trend glyphs suppressed for carried entries
+- **Added**: "Recent windows" table carries forward vendor prices — gap windows show `~$XX.XX` in muted italic with no trend glyph
+- **Added**: OOS vendors shown in coin detail legend as clickable links — opens product page popup, `opacity: 0.5`, strikethrough last-known price, `OOS` badge in red
+- **Fixed**: Vendor legend was hidden for coins where all vendors are currently OOS — `hasAny` guard now includes availability feed check
+
+---
+
 ## [3.32.24] - 2026-02-23
 
 ### Fixed — Cloud Sync Reliability

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Vendor Price Carry-Forward + OOS Legend Links (v3.32.25)**: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).
 - **Cloud Sync Reliability Fixes (v3.32.24)**: Fixed vault-overwrite race condition where debounced startup push could discard other device's changes during conflict resolution. Fixed getSyncPassword fast-path break for Simple-mode migration and Manual Backup password persistence on page reload.
 - **Cloud Settings Redesign + Unified Encryption (v3.32.23)**: Compact ≤400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.
 - **Sync UI Dark-Theme CSS Fix (v3.32.22)**: Header sync popover, mode selector, and backup warning now render correctly across all themes — corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.
 - **Sync UX Overhaul + Simple Mode (v3.32.21)**: No more on-load password popups — choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.
-- **api2 Backup Endpoint (v3.32.20)**: Dual-endpoint fallback for all API feeds — spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal now shows per-endpoint drift benchmarking.
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.25 &ndash; Vendor Price Carry-Forward + OOS Legend Links</strong>: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).</li>
     <li><strong>v3.32.24 &ndash; Cloud Sync Reliability Fixes</strong>: Fixed vault-overwrite race condition where debounced startup push could discard other device&apos;s changes during conflict resolution. Fixed getSyncPassword fast-path break for Simple-mode migration and Manual Backup password persistence on page reload.</li>
     <li><strong>v3.32.23 &ndash; Cloud Settings Redesign + Unified Encryption</strong>: Compact &le;400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.</li>
     <li><strong>v3.32.22 &ndash; Sync UI Dark-Theme CSS Fix</strong>: Header sync popover, mode selector, and backup warning now render correctly across all themes &mdash; corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.</li>
     <li><strong>v3.32.21 &ndash; Sync UX Overhaul + Simple Mode</strong>: No more on-load password popups &mdash; choose Simple mode (Dropbox account as key, no extra password on any device) or Secure mode (vault password, zero-knowledge). Orange dot + toast replaces auto-opening modals; inline popover handles Secure-mode unlock from the header button.</li>
-    <li><strong>v3.32.20 &ndash; api2 Backup Endpoint</strong>: Dual-endpoint fallback for all API feeds &mdash; spot, market, and goldback. Primary (api.staktrakr.com) tried first with 5-second timeout; api2.staktrakr.com serves as automatic fallback. Health modal now shows per-endpoint drift benchmarking.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.24";
+const APP_VERSION = "3.32.25";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -69,13 +69,16 @@ const _buildVendorLegend = (slug) => {
     : null;
   const vendorMap = priceData ? priceData.vendors || {} : {};
   const knownVendors = typeof RETAIL_VENDOR_NAMES !== "undefined" ? Object.keys(RETAIL_VENDOR_NAMES) : [];
-  const hasAny = knownVendors.some((v) => vendorMap[v] && vendorMap[v].price != null);
+  const avail = typeof retailAvailability !== 'undefined' && retailAvailability;
+  const hasAny = knownVendors.some((v) =>
+    (vendorMap[v] && vendorMap[v].price != null) ||
+    (avail && avail[slug] && avail[slug][v] === false)
+  );
   if (!hasAny) return;
 
   knownVendors.forEach((vendorId) => {
     const vendorData = vendorMap[vendorId];
     const price = vendorData ? vendorData.price : null;
-    const avail = typeof retailAvailability !== 'undefined' && retailAvailability;
     const isOOS = avail && avail[slug] && avail[slug][vendorId] === false;
 
     // Skip vendors with no price and no OOS flag (they don't carry this coin)

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -120,7 +120,7 @@ const _buildVendorLegend = (slug) => {
       const lkp = lkpMap && lkpMap[slug] && lkpMap[slug][vendorId];
       const lad = ladMap && ladMap[slug] && ladMap[slug][vendorId];
       const priceText = document.createElement("del");
-      priceText.textContent = lkp ? `$${Number(lkp).toFixed(2)}` : '\u2014';
+      priceText.textContent = lkp != null ? `$${Number(lkp).toFixed(2)}` : '\u2014';
       priceEl.appendChild(priceText);
       const badge = document.createElement("small");
       badge.className = "text-danger ms-1";

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -311,12 +311,10 @@ const _buildIntradayChart = (slug) => {
       ? activeVendors.map((vendorId) => {
           const label = (typeof RETAIL_VENDOR_NAMES !== "undefined" && RETAIL_VENDOR_NAMES[vendorId]) || vendorId;
           const color = RETAIL_VENDOR_COLORS[vendorId] || "#94a3b8";
-          const carriedIndices = new Set(
-            bucketed.reduce((acc, w, i) => {
-              if (w._carriedVendors && w._carriedVendors.has(vendorId)) acc.push(i);
-              return acc;
-            }, [])
-          );
+          const carriedIndices = new Set();
+          bucketed.forEach((w, i) => {
+            if (w._carriedVendors && w._carriedVendors.has(vendorId)) carriedIndices.add(i);
+          });
           return {
             label,
             data: bucketed.map((w) => (w.vendors && w.vendors[vendorId] != null ? w.vendors[vendorId] : null)),
@@ -365,6 +363,7 @@ const _buildIntradayChart = (slug) => {
           tooltip: {
             callbacks: {
               label: (ctx) => {
+                if (ctx.raw == null) return null;
                 const carried = ctx.dataset._carriedIndices && ctx.dataset._carriedIndices.has(ctx.dataIndex);
                 return `${ctx.dataset.label}: ${carried ? '~' : ''}$${Number(ctx.raw).toFixed(2)}`;
               },

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -156,7 +156,7 @@ const _bucketWindows = (windows) => {
  * @returns {Array}
  */
 const _forwardFillVendors = (bucketed) => {
-  if (!bucketed || bucketed.length === 0) return bucketed;
+  if (!bucketed || bucketed.length === 0) return [];
   const knownVendors = typeof RETAIL_VENDOR_NAMES !== 'undefined' ? Object.keys(RETAIL_VENDOR_NAMES) : [];
   const lastSeen = {};
   return bucketed.map((w) => {

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771898211';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771898350';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771897977';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771898123';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771897069';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771897713';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771898350';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771898540';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771897895';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771897977';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771898540';
+const CACHE_NAME = 'staktrakr-v3.32.25-b1771898680';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771898123';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771898211';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.24-b1771897713';
+const CACHE_NAME = 'staktrakr-v3.32.24-b1771897895';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.24",
+  "version": "3.32.25",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **`_forwardFillVendors(bucketed)`** — new pure function that fills vendor price gaps with the most recent known price from an earlier window. Annotates each window with `_carriedVendors: Set<vendorId>`. Always returns a new array; zero mutation of input.
- **24h chart** — `_buildIntradayChart` now calls `_forwardFillVendors(_bucketWindows(...))`. Carried data points have a `_carriedIndices: Set` on the dataset; tooltip prefixes carried values with `~`, suppresses null raw with null guard.
- **Recent windows table** — `_buildIntradayTable` renders carried cells as `~$XX.XX` in `text-muted fst-italic` with no trend glyph; fresh cells unchanged.
- **Vendor legend (OOS)** — `_buildVendorLegend` now shows OOS vendors (`retailAvailability[slug][id] === false`) as clickable `<a>` links with `opacity: 0.5`, strikethrough last-known price, `OOS` badge in `text-danger`, and last-available date in `title`.
- **`hasAny` guard fix** — hoisted `avail` to function scope; guard now returns `true` for coins where all vendors are OOS (previously hidden).

## Linear Issues

- [STAK-299: Vendor Price Carry-Forward + OOS Legend Links](https://linear.app/staktrakr/issue/STAK-299)

🤖 Generated with [Claude Code](https://claude.com/claude-code)