### PR TITLE
v3.32.27 — Image Storage Expansion — Dynamic Quota, Split Gauge, sharedImageId Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.27] - 2026-02-23
+
+### Added — Image Storage Expansion — Dynamic Quota, Split Gauge, sharedImageId Foundation (STAK-305)
+
+- **Added**: Dynamic IndexedDB quota via `navigator.storage.estimate()` — replaces hardcoded 50 MB cap; adapts to 60% of available disk space (min 500 MB, max 4 GB)
+- **Added**: Persistent storage request on first photo upload — prevents browser from silently evicting user images
+- **Added**: Split storage gauge in Settings → Images → Storage — separate rows for Your Photos vs. Numista Cache, each with progress bar and byte count
+- **Added**: `sharedImageId` field on `userImages` records and `obverseSharedImageId`/`reverseSharedImageId` on inventory items — foundation for future image reuse across items
+
+---
+
 ## [3.32.26] - 2026-02-23
 
 ### Fixed — Storage Quota, Chrome Init Race, Numista Data Integrity

--- a/css/styles.css
+++ b/css/styles.css
@@ -2044,6 +2044,41 @@ input[type="submit"] {
   border-radius: var(--radius);
   color: var(--text-primary);
 }
+.storage-gauge-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.82em;
+}
+.storage-gauge-label {
+  min-width: 7rem;
+  color: var(--text-secondary);
+}
+.storage-gauge-bar-wrap {
+  flex: 1;
+  height: 6px;
+  background: var(--border, #333);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 60px;
+}
+.storage-gauge-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+  width: 0%;
+}
+.storage-gauge-size {
+  min-width: 8rem;
+  text-align: right;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.storage-gauge-persist {
+  font-size: 0.78em;
+  margin-top: 0.3rem;
+}
 .image-pattern-table {
   width: 100%;
   font-size: 0.8rem;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).
 - **Bug Fixes — Storage Quota, Chrome Init Race, Numista Data Integrity (v3.32.26)**: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome "Cannot access inventory before initialization" crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).
 - **Vendor Price Carry-Forward + OOS Legend Links (v3.32.25)**: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).
 - **Cloud Sync Reliability Fixes (v3.32.24)**: Fixed vault-overwrite race condition where debounced startup push could discard other device's changes during conflict resolution. Fixed getSyncPassword fast-path break for Simple-mode migration and Manual Backup password persistence on page reload.
 - **Cloud Settings Redesign + Unified Encryption (v3.32.23)**: Compact ≤400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.
-- **Sync UI Dark-Theme CSS Fix (v3.32.22)**: Header sync popover, mode selector, and backup warning now render correctly across all themes — corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.
 
 ## Development Roadmap
 

--- a/docs/plans/2026-02-23-image-storage-expansion-design.md
+++ b/docs/plans/2026-02-23-image-storage-expansion-design.md
@@ -1,0 +1,290 @@
+# Image Storage Expansion — Design
+
+**Date:** 2026-02-23
+**Status:** Approved — ready for implementation planning
+**Related issues:** STAK-300 (storage quota), STAK-304 (this feature)
+
+---
+
+## Problem
+
+StakTrakr enforces a self-imposed 50 MB cap on its IndexedDB image store (`_quotaBytes` in `image-cache.js`). A user with a large collection — e.g., 188 silver items × 2 sides × ~200 KB avg compressed WebP — can easily exceed this. The browser's actual quota (Chrome: 50% of disk, typically several GB) is orders of magnitude larger. Additionally:
+
+- No persistent storage is ever requested, so Chrome may silently evict IndexedDB data under storage pressure
+- Users have no visibility into how much image storage they are using
+- User-uploaded photos are excluded from encrypted backups and cannot be exported or imported independently
+- The current per-item image model has no foundation for future image reuse across items
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Quota strategy | Dynamic via `navigator.storage.estimate()` | Adapts to actual disk; no hardcoded guess |
+| Persistent storage | Request on first photo upload | Prevents silent eviction; Chrome auto-grants on engaged sites |
+| Storage gauge | Two rows: user photos + Numista cache, separately | User can act on Numista cache independently |
+| Image export format | ZIP (JSZip) + `manifest.json` + `.webp` files | WebP blobs already exist; no re-encoding; user gets real image files |
+| Encrypted backup | New "Full Backup (with images)" ZIP option; existing JSON backup unchanged | Keeps existing flow intact; avoids embedding 50+ MB in JSON |
+| Vault sync (Dropbox) | Deferred — future `vault-images.enc` alongside `vault.enc` | Embedding images in vault JSON not practical at scale |
+| Image reuse foundation | Copy-on-tag model with `sharedImageId` metadata | Keeps IndexedDB schema simple; no foreign-key graph; enables future "browse" UI |
+
+---
+
+## Section 1: Storage System
+
+### 1.1 Dynamic Quota
+
+Replace the hardcoded `_quotaBytes = 50 * 1024 * 1024` in `image-cache.js` with a startup call to `navigator.storage.estimate()`:
+
+```js
+async _initQuota() {
+  if (!navigator?.storage?.estimate) {
+    this._quotaBytes = 500 * 1024 * 1024; // 500 MB safe fallback
+    return;
+  }
+  const { quota, usage } = await navigator.storage.estimate();
+  // Use 60% of available (quota - usage), min 500 MB, max 4 GB
+  const available = (quota || 0) - (usage || 0);
+  this._quotaBytes = Math.min(
+    Math.max(available * 0.6, 500 * 1024 * 1024),
+    4 * 1024 * 1024 * 1024
+  );
+}
+```
+
+Called once during `ImageCache._ensureDb()` initialization. Result cached in `this._quotaBytes`. Falls back gracefully on `file://` where `estimate()` may return 0.
+
+### 1.2 Persistent Storage
+
+Call `navigator.storage.persist()` the first time a user uploads a photo (in `saveUserImageForItem()`). Store the result in localStorage under key `storagePersistGranted`:
+
+- `"true"` — granted; show a ✅ indicator in Settings
+- `"false"` — denied; show a one-time soft warning in Settings ("Your browser may clear images under storage pressure — consider using Full Backup regularly")
+- `null/missing` — not yet requested
+
+Do not re-request after the first attempt. Chrome typically auto-grants for `staktrakr.com` due to engagement signals. On `file://`, behavior varies; silence any errors.
+
+### 1.3 Storage Gauge (Settings Panel)
+
+Add a new **"Image Storage"** sub-section to the Settings panel, below the existing storage/backup controls. Two rows:
+
+```
+Image Storage
+─────────────────────────────────────────────────────
+📷 Your Photos     ████████░░░░░░░░  42 MB    [Export] [Import]
+🪙 Numista Cache   ██░░░░░░░░░░░░░░   8 MB             [Clear]
+
+Persistent storage: ✅ Protected  (or ⚠️ Not protected)
+```
+
+**Data source:** `imageCache.getStorageUsage()` already returns per-store counts and byte sizes. Extend it to return `userImageBytes`, `userImageCount`, `numistaBytes`, `numistaCount` separately.
+
+**Progress bar:** `used / _quotaBytes`, capped at 100%. Color: green < 70%, amber 70–90%, red > 90%.
+
+**"Clear Numista Cache":** Deletes `coinImages` and `coinMetadata` IndexedDB stores only. Confirms with "Clear Numista reference images? Your own uploaded photos are not affected." Modal. Does not touch `userImages` or `patternImages`.
+
+**Gauge refresh:** Computed once when Settings panel opens; not live-updating.
+
+---
+
+## Section 2: Data Model Foundation (Image Reuse)
+
+### 2.1 Current Model
+
+```
+userImages store: { uuid (item UUID), obverse: Blob, reverse: Blob, cachedAt, size }
+inventory item:   { ..., obverseImageUrl: string, reverseImageUrl: string }
+```
+
+`obverseImageUrl` / `reverseImageUrl` are either external HTTP URLs or ephemeral `blob://` object URLs created from IndexedDB blobs at display time.
+
+### 2.2 Foundation Added Today
+
+**`userImages` record gains one optional field:**
+
+```js
+{
+  uuid,           // item UUID — primary key, unchanged
+  obverse,        // Blob
+  reverse,        // Blob | null
+  cachedAt,
+  size,
+  sharedImageId,  // string | null — UUID of source image if this was tagged from another item
+}
+```
+
+`sharedImageId` is `null` for all original uploads. In a future patch, when a user browses and selects an existing image for a new item, the system writes a new `userImages` record with `sharedImageId` pointing to the source item's UUID. **Blobs are copied, not referenced** — no foreign-key graph, clean deletes, simple import/export.
+
+**Inventory item gains two optional fields:**
+
+```js
+{
+  ...,
+  obverseSharedImageId: string | null,  // source UUID if tagged from library
+  reverseSharedImageId: string | null,
+}
+```
+
+These fields travel with the item in backup and sync. They are ignored by the current codebase (no lookup logic today) but preserved on import. A future "browse/search/pick" modal will populate them.
+
+### 2.3 Why Copy, Not Reference
+
+- IndexedDB has no foreign keys — referential integrity would require manual bookkeeping
+- Deleting or replacing an image for item A must not affect item B
+- Export/import is straightforward: each manifest entry is self-contained
+- Storage cost: a shared 150 KB WebP copied to 10 items = 1.5 MB — negligible at 500px
+- If deduplication ever matters, it can be added in the "browse" patch without touching this schema
+
+### 2.4 What the Future "Browse" Patch Adds (Not Built Today)
+
+- A new `sharedImages` metadata index (not a store — just a view over `userImages` grouped by `sharedImageId` chains)
+- A search/pick modal in the item edit form showing thumbnail grid of existing images
+- Auto-populate `sharedImageId` on tag
+- No UI changes to image display or deletion today
+
+---
+
+## Section 3: ZIP Image Export / Import
+
+### 3.1 Library
+
+**JSZip** (~100 KB minified, loaded from CDN). Added to `index.html` script load order and `sw.js` CORE_ASSETS. No build step required.
+
+CDN URL: `https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js`
+
+Graceful fallback: if JSZip fails to load, Export/Import buttons show "Unavailable (requires network to load ZIP library)" and are disabled.
+
+### 3.2 ZIP Structure
+
+```
+staktrakr-images-2026-02-23.zip
+├── manifest.json
+└── images/
+    ├── <item-uuid>-obv.webp
+    ├── <item-uuid>-rev.webp
+    └── ...
+```
+
+File naming: `<uuid>-obv.webp` and `<uuid>-rev.webp`. UUID is the item's `uuid` field. If a record has `sharedImageId`, the file name still uses the record's own `uuid` (the item it belongs to) — the `sharedImageId` appears in the manifest only.
+
+### 3.3 `manifest.json` Schema
+
+```json
+{
+  "version": "1.0",
+  "exportedAt": "2026-02-23T22:00:00Z",
+  "appVersion": "3.32.26",
+  "totalImages": 183,
+  "images": [
+    {
+      "imageId": "<item-uuid>",
+      "itemUuid": "<item-uuid>",
+      "itemName": "2023 ASE 1 oz Silver Eagle",
+      "sharedImageId": null,
+      "obverseFile": "images/<item-uuid>-obv.webp",
+      "reverseFile": "images/<item-uuid>-rev.webp"
+    }
+  ]
+}
+```
+
+- `imageId` — same as `itemUuid` today; will diverge in the future shared-images model if an image ID is decoupled from the item UUID
+- `itemName` — human-readable label for the user browsing the ZIP; sourced from `inventory.find(i => i.uuid === record.uuid)?.name || "Unknown Item"`
+- `sharedImageId` — `null` for original uploads; populated for tagged copies
+- `reverseFile` — `null` if item has no reverse image
+
+### 3.4 Export Flow
+
+1. User clicks **Export** in the Settings storage gauge
+2. Show a loading state ("Preparing export…")
+3. Iterate all `userImages` records via `imageCache.getAllUserImages()` (new method)
+4. For each record, add `<uuid>-obv.webp` and (if present) `<uuid>-rev.webp` to the ZIP
+5. Cross-reference inventory array to populate `itemName` in manifest
+6. Write `manifest.json`
+7. Generate ZIP blob, trigger `<a download="staktrakr-images-YYYY-MM-DD.zip">` download
+
+If `inventory` is not available for name lookup (edge case), use `imageId` as the name fallback.
+
+### 3.5 Import Flow
+
+1. User clicks **Import** in Settings, selects `.zip` file
+2. Parse ZIP with JSZip; locate `manifest.json`
+3. Validate: check `version === "1.0"`, check `appVersion` is parseable
+4. Show preview: "Found 183 images for 183 items. This will add or replace images for matching items. Continue?"
+5. For each manifest entry: read obverse blob + optional reverse blob from ZIP, call `imageCache.cacheUserImage(uuid, obvBlob, revBlob)`, write `sharedImageId` if present
+6. Show result: "Imported 183 images. 0 errors."
+7. Refresh storage gauge
+
+**Conflict handling:** Import overwrites existing `userImages` for the same UUID. No merge prompt — the imported ZIP is treated as authoritative for the images it contains.
+
+**Items not in current inventory:** Image is stored anyway (UUID key still valid). If the item was deleted, the image record becomes orphaned; it will be cleaned up by the existing orphan-purge logic in `CatalogManager.purgeOrphanedMappings()` (or a new equivalent for `userImages`).
+
+---
+
+## Section 4: Full Backup with Images
+
+### 4.1 Existing Backup (Unchanged)
+
+The current **"Backup"** button produces an AES-encrypted JSON file containing inventory + settings. This is unchanged.
+
+### 4.2 New "Full Backup (with images)" Option
+
+Add a second export button in the Backup section: **"Full Backup (with images)"**. Produces a ZIP:
+
+```
+staktrakr-full-backup-2026-02-23.zip
+├── backup.enc              ← existing encrypted JSON backup, bit-for-bit identical
+└── images/
+    ├── manifest.json
+    ├── <uuid>-obv.webp
+    └── ...
+```
+
+The `backup.enc` is generated by the existing backup pipeline with no changes. The `images/` folder is the same as the standalone export (Section 3).
+
+### 4.3 Import from Full Backup ZIP
+
+The existing **"Restore"** flow accepts `.enc` files. Extend it to also accept `.zip` files:
+
+1. Detect file type by extension (`.zip`) or by attempting JSZip parse
+2. If ZIP: extract `backup.enc` and the `images/` folder
+3. Restore `backup.enc` through the existing encrypted import pipeline (no changes)
+4. If `images/` folder is present, run the image import flow (Section 3.5) after inventory is restored — order matters so `itemName` lookups work
+
+### 4.4 Vault Sync (Deferred)
+
+Dropbox vault sync stores inventory JSON in `vault.enc`. Embedding 50+ MB of image blobs in this JSON is not practical. Future design: store a parallel `vault-images.enc` in the same Dropbox folder, encrypted with the same vault key. The cloud sync code will need a second upload/download pass for this file. **This is not part of the current implementation.** A note will be left in `cloud-sync.js` and a Linear issue filed.
+
+---
+
+## Section 5: New Linear Issue
+
+File **STAK-304** to track this feature batch. The implementation plan (from `writing-plans`) will break STAK-304 into sub-tasks.
+
+---
+
+## File Impact Summary
+
+| File | Change |
+|---|---|
+| `js/image-cache.js` | Dynamic quota, `_initQuota()`, `getAllUserImages()`, `sharedImageId` field, `getStorageUsage()` per-store breakdown |
+| `js/image-export.js` | **New file** — ZIP export/import logic (JSZip wrapper, manifest generation, import flow) |
+| `js/events.js` | Call `navigator.storage.persist()` on first upload; write `sharedImageId: null` to new records |
+| `js/settings.js` (or equivalent) | Storage gauge UI, Clear Numista button, Export/Import button wiring |
+| `index.html` | JSZip script tag; storage gauge HTML in Settings panel |
+| `sw.js` | Add `image-export.js` and JSZip CDN URL to CORE_ASSETS |
+| `js/constants.js` | New storage key `STORAGE_PERSIST_GRANTED_KEY` in ALLOWED_STORAGE_KEYS; `IMAGE_ZIP_MANIFEST_VERSION` |
+| `js/types.js` | JSDoc for `sharedImageId`, `obverseSharedImageId`, `reverseSharedImageId` |
+| `js/inventory.js` | Preserve `obverseSharedImageId` / `reverseSharedImageId` through load/save cycles |
+| `js/cloud-sync.js` | Comment: vault image sync deferred to future `vault-images.enc` patch |
+
+---
+
+## Out of Scope (Future Patches)
+
+- **Vault image sync** (`vault-images.enc` in Dropbox)
+- **Browse/search/pick image modal** in item edit form
+- **Image deduplication** across items
+- **`sharedImages` metadata index** for browsing
+- **Orphan image cleanup UI** (images whose item UUID no longer exists in inventory)

--- a/index.html
+++ b/index.html
@@ -3313,7 +3313,17 @@
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">Storage</div>
                 <div id="imageStorageStats" class="image-storage-stats">
-                  <span class="stat-item">Loading...</span>
+                  <div class="storage-gauge-row">
+                    <span class="storage-gauge-label">📷 Your Photos</span>
+                    <div class="storage-gauge-bar-wrap"><div id="gaugeUserBar" class="storage-gauge-bar"></div></div>
+                    <span id="gaugeUserSize" class="storage-gauge-size">—</span>
+                  </div>
+                  <div class="storage-gauge-row">
+                    <span class="storage-gauge-label">🪙 Numista Cache</span>
+                    <div class="storage-gauge-bar-wrap"><div id="gaugeNumistaBar" class="storage-gauge-bar"></div></div>
+                    <span id="gaugeNumistaSize" class="storage-gauge-size">—</span>
+                  </div>
+                  <div id="gaugePersistLine" class="storage-gauge-persist">—</div>
                 </div>
               </div>
             </div>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>
     <li><strong>v3.32.26 &ndash; Bug Fixes &mdash; Storage Quota, Chrome Init Race, Numista Data Integrity</strong>: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome &ldquo;Cannot access inventory before initialization&rdquo; crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).</li>
     <li><strong>v3.32.25 &ndash; Vendor Price Carry-Forward + OOS Legend Links</strong>: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).</li>
     <li><strong>v3.32.24 &ndash; Cloud Sync Reliability Fixes</strong>: Fixed vault-overwrite race condition where debounced startup push could discard other device&apos;s changes during conflict resolution. Fixed getSyncPassword fast-path break for Simple-mode migration and Manual Backup password persistence on page reload.</li>
     <li><strong>v3.32.23 &ndash; Cloud Settings Redesign + Unified Encryption</strong>: Compact &le;400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.</li>
-    <li><strong>v3.32.22 &ndash; Sync UI Dark-Theme CSS Fix</strong>: Header sync popover, mode selector, and backup warning now render correctly across all themes &mdash; corrected misnamed CSS variables and replaced hardcoded light-color fallbacks.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.26";
+const APP_VERSION = "3.32.27";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -567,6 +567,12 @@ const THEME_KEY = "appTheme";
 /** @constant {string} ACK_DISMISSED_KEY - LocalStorage key for acknowledgment dismissal */
 const ACK_DISMISSED_KEY = "ackDismissed";
 
+/** @constant {string} STORAGE_PERSIST_GRANTED_KEY - LocalStorage key for storage persistence permission grant */
+const STORAGE_PERSIST_GRANTED_KEY = 'storagePersistGranted';
+
+/** @constant {string} IMAGE_ZIP_MANIFEST_VERSION - Version string for the image ZIP export manifest format */
+const IMAGE_ZIP_MANIFEST_VERSION = '1.0';
+
 /** @constant {string} CLOUD_VAULT_IDLE_TIMEOUT_KEY - LocalStorage key for vault password idle lock timeout in minutes (15|30|60|120|0=never) */
 const CLOUD_VAULT_IDLE_TIMEOUT_KEY = "cloud_vault_idle_timeout";
 
@@ -808,6 +814,7 @@ const ALLOWED_STORAGE_KEYS = [
   "cloud_sync_mode",                           // DEPRECATED: kept for migration only — will be removed after v3.33
   "cloud_dropbox_account_id",                  // string: Dropbox account_id for Simple mode key derivation
   "cloud_vault_password",                      // string: user vault password stored for persistent unlock
+  STORAGE_PERSIST_GRANTED_KEY,                         // boolean string: "true"/"false" — storage persistence grant flag
 ];
 
 // =============================================================================
@@ -1649,6 +1656,9 @@ if (typeof window !== "undefined") {
   // STAK-222: API pipeline cache keys
   window.NUMISTA_RESPONSE_CACHE_KEY = NUMISTA_RESPONSE_CACHE_KEY;
   window.PCGS_RESPONSE_CACHE_KEY = PCGS_RESPONSE_CACHE_KEY;
+  // Image storage expansion (STAK-image-storage)
+  window.STORAGE_PERSIST_GRANTED_KEY = STORAGE_PERSIST_GRANTED_KEY;
+  window.IMAGE_ZIP_MANIFEST_VERSION = IMAGE_ZIP_MANIFEST_VERSION;
 }
 
 // Expose APP_VERSION globally for non-module usage

--- a/js/events.js
+++ b/js/events.js
@@ -211,6 +211,25 @@ const updateNumistaModalDot = () => {
 };
 
 /**
+ * Request persistent storage the first time a user uploads an image.
+ * Stores the browser's response under STORAGE_PERSIST_GRANTED_KEY so the
+ * prompt fires at most once per device.
+ */
+const _requestStoragePersistOnce = async () => {
+  if (localStorage.getItem(STORAGE_PERSIST_GRANTED_KEY) !== null) return; // already asked
+  if (!navigator?.storage?.persist) {
+    localStorage.setItem(STORAGE_PERSIST_GRANTED_KEY, 'false');
+    return;
+  }
+  try {
+    const granted = await navigator.storage.persist();
+    localStorage.setItem(STORAGE_PERSIST_GRANTED_KEY, granted ? 'true' : 'false');
+  } catch {
+    localStorage.setItem(STORAGE_PERSIST_GRANTED_KEY, 'false');
+  }
+};
+
+/**
  * Save the pending upload blob(s) to IndexedDB for the given item UUID.
  * @param {string} uuid
  * @returns {Promise<boolean>}
@@ -239,6 +258,7 @@ const saveUserImageForItem = async (uuid) => {
     return false;
   }
 
+  _requestStoragePersistOnce(); // fire-and-forget — no await needed
   // Priority 2: New uploads - merge with existing or replace deleted sides
   debugLog(`saveUserImageForItem: saving images for ${uuid}`);
 

--- a/js/events.js
+++ b/js/events.js
@@ -1079,6 +1079,8 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       currency: f.currency,
       obverseImageUrl: f.obverseImageUrl || window.selectedNumistaResult?.imageUrl || oldItem.obverseImageUrl || '',
       reverseImageUrl: f.reverseImageUrl || window.selectedNumistaResult?.reverseImageUrl || oldItem.reverseImageUrl || '',
+      obverseSharedImageId: oldItem.obverseSharedImageId || null,
+      reverseSharedImageId: oldItem.reverseSharedImageId || null,
     };
 
     addCompositionOption(f.composition);
@@ -1139,6 +1141,8 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       currency: f.currency,
       obverseImageUrl: f.obverseImageUrl || window.selectedNumistaResult?.imageUrl || '',
       reverseImageUrl: f.reverseImageUrl || window.selectedNumistaResult?.reverseImageUrl || '',
+      obverseSharedImageId: null,
+      reverseSharedImageId: null,
     });
 
     typeof registerName === "function" && registerName(f.name);

--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -566,9 +566,10 @@ class ImageCache {
    * @param {string} uuid - Item UUID
    * @param {Blob} obverse - Processed obverse image blob
    * @param {Blob} [reverse] - Optional reverse image blob
+   * @param {string|null} [sharedImageId] - Source item UUID if this image was copied from another item's upload; null for original uploads
    * @returns {Promise<boolean>}
    */
-  async cacheUserImage(uuid, obverse, reverse = null) {
+  async cacheUserImage(uuid, obverse, reverse = null, sharedImageId = null) {
     if (!uuid || !obverse) {
       debugLog('ImageCache.cacheUserImage: missing uuid or obverse blob');
       return false;
@@ -593,6 +594,7 @@ class ImageCache {
       uuid,
       obverse,
       reverse: reverse || null,
+      sharedImageId: sharedImageId || null,
       cachedAt: Date.now(),
       size,
     };

--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -374,7 +374,7 @@ class ImageCache {
 
   /**
    * Calculate current storage usage across all stores.
-   * @returns {Promise<{count: number, totalBytes: number, limitBytes: number, metadataCount: number, userImageCount: number, patternImageCount: number, numistaCount: number}>}
+   * @returns {Promise<{count: number, totalBytes: number, limitBytes: number, metadataCount: number, userImageCount: number, patternImageCount: number, numistaCount: number, numistaBytes: number, userImageBytes: number, patternImageBytes: number, metadataBytes: number}>}
    */
   async getStorageUsage() {
     const result = {

--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -35,9 +35,9 @@ class ImageCache {
       const { quota = 0, usage = 0 } = await navigator.storage.estimate();
       const available = quota - usage;
       if (available <= 0) return; // file:// or estimate unavailable
-      // 60% of available space, min 500 MB, max 4 GB
+      // 60% of available space, min 500 MB (capped at available), max 4 GB
       this._quotaBytes = Math.min(
-        Math.max(available * 0.6, 500 * 1024 * 1024),
+        Math.max(available * 0.6, Math.min(available, 500 * 1024 * 1024)),
         4 * 1024 * 1024 * 1024
       );
     } catch {
@@ -408,9 +408,10 @@ class ImageCache {
     try {
       if (this._db.objectStoreNames.contains('coinMetadata')) {
         await this._iterate('coinMetadata', (rec) => {
+          const metaSize = JSON.stringify(rec).length;
           result.metadataCount++;
-          result.metadataBytes += new Blob([JSON.stringify(rec)]).size;
-          result.totalBytes += new Blob([JSON.stringify(rec)]).size;
+          result.metadataBytes += metaSize;
+          result.totalBytes += metaSize;
         });
       }
     } catch (err) {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -75,7 +75,9 @@ const createBackupZip = async () => {
         serial: item.serial,
         uuid: item.uuid,
         obverseImageUrl: item.obverseImageUrl || '',
-        reverseImageUrl: item.reverseImageUrl || ''
+        reverseImageUrl: item.reverseImageUrl || '',
+        obverseSharedImageId: item.obverseSharedImageId || null,
+        reverseSharedImageId: item.reverseSharedImageId || null
       }))
     };
     zip.file('inventory_data.json', JSON.stringify(inventoryData, null, 2));

--- a/js/types.js
+++ b/js/types.js
@@ -35,6 +35,8 @@
  * @property {string} uuid - Unique identifier for the item
  * @property {string} [obverseImageUrl] - URL for obverse image
  * @property {string} [reverseImageUrl] - URL for reverse image
+ * @property {string|null} [obverseSharedImageId] - UUID of source item if obverse image was tagged from the shared library (null for original uploads)
+ * @property {string|null} [reverseSharedImageId] - UUID of source item if reverse image was tagged from the shared library (null for original uploads)
  * @property {boolean} [collectable] - Whether item is marked as collectable
  */
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.26-b1771908759';
+const CACHE_NAME = 'staktrakr-v3.32.26-b1771908984';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771909211';
+const CACHE_NAME = 'staktrakr-v3.32.27-b1771910503';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.26-b1771908984';
+const CACHE_NAME = 'staktrakr-v3.32.26-b1771909122';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.26-b1771909122';
+const CACHE_NAME = 'staktrakr-v3.32.27-b1771909211';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.26-b1771907030';
+const CACHE_NAME = 'staktrakr-v3.32.26-b1771908759';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.26",
+  "version": "3.32.27",
   "releaseDate": "2026-02-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Dynamic quota**: `_initQuota()` in `image-cache.js` uses `navigator.storage.estimate()` to set 60% of available disk space (min 500 MB, max 4 GB) — replaces hardcoded 50 MB cap
- **Persistent storage**: `_requestStoragePersistOnce()` in `events.js` calls `navigator.storage.persist()` on first photo upload and stores result in `storagePersistGranted` localStorage key
- **Split storage gauge**: `renderImageStorageStats()` now shows two rows with progress bars — 📷 Your Photos (userImageBytes) and 🪙 Numista Cache (numistaBytes) — plus a persist status line
- **Per-store byte tracking**: `getStorageUsage()` now returns `numistaBytes`, `userImageBytes`, `patternImageBytes`, `metadataBytes` in addition to existing count fields
- **sharedImageId foundation**: `cacheUserImage()` accepts optional `sharedImageId` param (default null); inventory items gain `obverseSharedImageId`/`reverseSharedImageId` fields preserved through edit, save, backup, and export

## Linear Issues

- [STAK-305: Image storage expansion](https://linear.app/hextrackr/issue/STAK-305/image-storage-expansion-dynamic-quota-persistent-storage-split-gauge)

## QA Notes

- Open Settings → Images → Storage — two gauge rows should be visible with progress bars
- Upload a photo — check `localStorage.getItem('storagePersistGranted')` in DevTools console (should be `'true'` or `'false'`)
- Check DevTools → Application → IndexedDB → StakTrakrImages → userImages — new records should have `sharedImageId: null`
- Edit and re-save an existing item — exported JSON should contain `obverseSharedImageId: null` and `reverseSharedImageId: null`
- Test on both light and dark theme — gauge bars should be visible on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)