### PR TITLE
STAK-315: Manual .stvault Backup — Include User Images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4135,13 +4135,30 @@
           </button>
         </div>
         <div class="modal-body">
-          <div class="encryption-info">
-            <strong>Included:</strong> All inventory data, settings, API keys, and price history.
+          <div id="vaultDescExport" class="encryption-info">
+            <strong>Included:</strong> All inventory data, settings, API keys, and price history. Your photos will be saved as a separate companion file.
+          </div>
+
+          <div id="vaultDescImport" class="encryption-info" style="display:none">
+            <strong>Included:</strong> All inventory data, settings, API keys, and price history. To also restore photos, add the companion <em>-images.stvault</em> file below.
           </div>
 
           <div id="vaultFileInfo" class="encryption-info" style="display: none">
             <strong>File:</strong> <span id="vaultFileName"></span>
             (<span id="vaultFileSize"></span>)
+          </div>
+
+          <!-- Image vault companion file (import mode only) -->
+          <div id="vaultImageFileRow" style="display:none">
+            <div class="encryption-info" id="vaultImageFileInfo" style="display:none">
+              <strong>Photos:</strong> <span id="vaultImageFileName"></span>
+              (<span id="vaultImageFileSize"></span>)
+            </div>
+            <div class="settings-btn-row" id="vaultImagePickerRow">
+              <label class="btn" style="cursor:pointer" for="vaultImageImportFile">+ Add Photos File</label>
+              <small style="opacity:0.65">Optional: <em>-images.stvault</em> from the same export</small>
+            </div>
+            <input type="file" id="vaultImageImportFile" accept=".stvault" hidden />
           </div>
 
           <div class="form-row">

--- a/js/constants.js
+++ b/js/constants.js
@@ -679,6 +679,9 @@ const IMAGE_MAX_BYTES = 512000;
  */
 const VAULT_FILE_EXTENSION = '.stvault';
 
+/** Filename suffix for the companion image vault file exported alongside a backup */
+const VAULT_IMAGE_FILE_SUFFIX = '-images';
+
 // =============================================================================
 // CLOUD AUTO-SYNC CONSTANTS (STAK-149)
 // =============================================================================

--- a/js/events.js
+++ b/js/events.js
@@ -2081,6 +2081,12 @@ const setupVaultListeners = () => {
         setVaultPendingImageFile(new Uint8Array(ev.target.result));
       }
     };
+    imgReader.onerror = function () {
+      debugLog("[Vault] Failed to read image file", "error");
+      // Reset picker UI so user can try again
+      if (imgFileInfoEl) imgFileInfoEl.style.display = "none";
+      if (imgPickerRowEl) imgPickerRowEl.style.display = "";
+    };
     imgReader.readAsArrayBuffer(imgFile);
     e.target.value = "";
   }, "Vault image import file input");

--- a/js/events.js
+++ b/js/events.js
@@ -2059,6 +2059,31 @@ const setupVaultListeners = () => {
   optionalListener(cpw, "input", () => {
     if (pw) updateMatchIndicator(pw.value, cpw.value);
   }, "Vault confirm password input");
+
+  // Image vault companion file picker (import mode only)
+  const vaultImageImportFile = document.getElementById("vaultImageImportFile");
+  optionalListener(vaultImageImportFile, "change", function (e) {
+    var imgFile = e.target.files && e.target.files[0];
+    if (!imgFile) return;
+    var imgFileInfoEl = document.getElementById("vaultImageFileInfo");
+    var imgPickerRowEl = document.getElementById("vaultImagePickerRow");
+    var imgFileNameEl = document.getElementById("vaultImageFileName");
+    var imgFileSizeEl = document.getElementById("vaultImageFileSize");
+    if (imgFileNameEl) imgFileNameEl.textContent = imgFile.name;
+    if (imgFileSizeEl && typeof formatFileSize === "function") {
+      imgFileSizeEl.textContent = formatFileSize(imgFile.size);
+    }
+    if (imgFileInfoEl) imgFileInfoEl.style.display = "";
+    if (imgPickerRowEl) imgPickerRowEl.style.display = "none";
+    var imgReader = new FileReader();
+    imgReader.onload = function (ev) {
+      if (typeof setVaultPendingImageFile === "function") {
+        setVaultPendingImageFile(new Uint8Array(ev.target.result));
+      }
+    };
+    imgReader.readAsArrayBuffer(imgFile);
+    e.target.value = "";
+  }, "Vault image import file input");
 };
 
 /**

--- a/js/vault.js
+++ b/js/vault.js
@@ -682,6 +682,32 @@ async function exportEncryptedBackup(password) {
   URL.revokeObjectURL(url);
 
   debugLog("Vault: export complete,", fileBytes.length, "bytes");
+
+  // Export companion image vault if user has photos
+  var imageCount = 0;
+  try {
+    var imgVaultData = await collectAndHashImageVault();
+    if (imgVaultData && imgVaultData.imageCount > 0) {
+      var imgBytes = await vaultEncryptImageVault(password, imgVaultData.payload);
+      var imgBlob = new Blob([imgBytes], { type: "application/octet-stream" });
+      var imgUrl = URL.createObjectURL(imgBlob);
+      var imgA = document.createElement("a");
+      imgA.href = imgUrl;
+      imgA.download = "staktrakr_backup_" + timestamp + VAULT_IMAGE_FILE_SUFFIX + VAULT_FILE_EXTENSION;
+      document.body.appendChild(imgA);
+      imgA.click();
+      document.body.removeChild(imgA);
+      URL.revokeObjectURL(imgUrl);
+      imageCount = imgVaultData.imageCount;
+      debugLog("Vault: image vault export complete,", imgBytes.length, "bytes,", imageCount, "images");
+    }
+  } catch (imgErr) {
+    debugLog("[Vault] Image vault export failed:", imgErr.message, "warn");
+    // Return a flag so the caller can surface a warning
+    return { imageExportFailed: true };
+  }
+
+  return { imageCount: imageCount };
 }
 
 // =============================================================================
@@ -717,6 +743,9 @@ async function importEncryptedBackup(fileBytes, password) {
 
 /** @type {Uint8Array|null} Pending file bytes for import */
 var _vaultPendingFile = null;
+
+/** @type {Uint8Array|null} Companion image vault bytes loaded by the optional image file picker */
+var _vaultPendingImageFile = null;
 
 /** @type {object|null} Cloud context for cloud-export/cloud-import modes */
 var _cloudContext = null;
@@ -781,12 +810,19 @@ function openVaultModal(mode, fileOrOpts) {
 
   modal.setAttribute("data-vault-mode", mode);
 
+  var imageFileRowEl = safeGetElement("vaultImageFileRow");
+  var descExportEl = safeGetElement("vaultDescExport");
+  var descImportEl = safeGetElement("vaultDescImport");
+
   if (effectiveMode === "export") {
     var exportTitle = _cloudContext ? "Cloud Backup — Enter Password" : "Export Encrypted Backup";
     if (titleEl) titleEl.textContent = exportTitle;
     if (confirmRow) confirmRow.style.display = "";
     if (strengthRow) strengthRow.style.display = "";
     if (fileInfoEl) fileInfoEl.style.display = "none";
+    if (imageFileRowEl) imageFileRowEl.style.display = "none";
+    if (descExportEl) descExportEl.style.display = "";
+    if (descImportEl) descImportEl.style.display = "none";
     if (actionBtn) {
       actionBtn.textContent = _cloudContext ? "Encrypt & Upload" : "Export";
       actionBtn.className = "btn";
@@ -809,6 +845,18 @@ function openVaultModal(mode, fileOrOpts) {
         if (sizeSpan) sizeSpan.textContent = formatFileSize(file.size);
       }
     }
+    if (descExportEl) descExportEl.style.display = "none";
+    if (descImportEl) descImportEl.style.display = "";
+    // Show image file picker only for local import (not cloud import)
+    if (imageFileRowEl) {
+      imageFileRowEl.style.display = _cloudContext ? "none" : "";
+    }
+    // Reset image file state when modal opens
+    _vaultPendingImageFile = null;
+    var imgFileInfoEl = safeGetElement("vaultImageFileInfo");
+    var imgPickerRowEl = safeGetElement("vaultImagePickerRow");
+    if (imgFileInfoEl) imgFileInfoEl.style.display = "none";
+    if (imgPickerRowEl) imgPickerRowEl.style.display = "";
     if (actionBtn) {
       actionBtn.textContent = _cloudContext ? "Decrypt & Restore" : "Import";
       actionBtn.className = "btn info";
@@ -832,6 +880,7 @@ function openVaultModal(mode, fileOrOpts) {
  */
 function closeVaultModal() {
   _vaultPendingFile = null;
+  _vaultPendingImageFile = null;
   _cloudContext = null;
   closeModalById("vaultModal");
 }
@@ -896,8 +945,14 @@ async function handleVaultAction() {
         }
         if (typeof showKrakenToastIfFirst === 'function') showKrakenToastIfFirst();
       } else {
-        await exportEncryptedBackup(password);
-        showVaultStatus("success", "Backup exported successfully.");
+        var exportResult = await exportEncryptedBackup(password);
+        if (exportResult && exportResult.imageExportFailed) {
+          showVaultStatus("warning", "Inventory exported. Photo backup failed \u2014 try again or use Export Images ZIP.");
+        } else if (exportResult && exportResult.imageCount > 0) {
+          showVaultStatus("success", "Backup exported \u2014 2 files downloaded (inventory + " + exportResult.imageCount + " photo" + (exportResult.imageCount === 1 ? "" : "s") + ").");
+        } else {
+          showVaultStatus("success", "Backup exported successfully.");
+        }
       }
     } catch (err) {
       showVaultStatus("error", err.message || "Export failed.");
@@ -928,7 +983,18 @@ async function handleVaultAction() {
       if (isCloudImport && _cloudContext && typeof cloudCachePassword === 'function') {
         cloudCachePassword(_cloudContext.provider, password);
       }
-      showVaultStatus("success", "Data restored successfully. Reloading\u2026");
+      if (_vaultPendingImageFile) {
+        showVaultStatus("info", "Restoring photos\u2026");
+        try {
+          var imgCount = await vaultDecryptAndRestoreImages(_vaultPendingImageFile, password);
+          showVaultStatus("success", "Data and " + imgCount + " photo" + (imgCount === 1 ? "" : "s") + " restored. Reloading\u2026");
+        } catch (imgErr) {
+          // Inventory already restored — show error but still reload to apply it
+          showVaultStatus("error", "Inventory restored, but photo file failed: " + (imgErr.message || "decryption error") + ". Reloading\u2026");
+        }
+      } else {
+        showVaultStatus("success", "Data restored successfully. Reloading\u2026");
+      }
       setTimeout(function () { location.reload(); }, 1200);
     } catch (err) {
       showVaultStatus("error", err.message || "Import failed.");
@@ -1185,3 +1251,4 @@ window.vaultEncryptImageVault = vaultEncryptImageVault;
 window.vaultDecryptAndRestoreImages = vaultDecryptAndRestoreImages;
 window.encryptManifest = encryptManifest;
 window.decryptManifest = decryptManifest;
+window.setVaultPendingImageFile = function (bytes) { _vaultPendingImageFile = bytes; };

--- a/js/vault.js
+++ b/js/vault.js
@@ -654,7 +654,7 @@ async function vaultDecryptAndRestoreImages(fileBytes, password) {
 /**
  * Export an encrypted vault backup.
  * @param {string} password
- * @returns {Promise<void>}
+ * @returns {Promise<{imageCount: number}|{imageExportFailed: boolean}>}
  */
 async function exportEncryptedBackup(password) {
   var backend = getCryptoBackend();
@@ -702,7 +702,7 @@ async function exportEncryptedBackup(password) {
       debugLog("Vault: image vault export complete,", imgBytes.length, "bytes,", imageCount, "images");
     }
   } catch (imgErr) {
-    debugLog("[Vault] Image vault export failed:", imgErr.message, "warn");
+    debugLog("[Vault] Image vault export failed:", imgErr.message || String(imgErr), "warn");
     // Return a flag so the caller can surface a warning
     return { imageExportFailed: true };
   }
@@ -853,6 +853,8 @@ function openVaultModal(mode, fileOrOpts) {
     }
     // Reset image file state when modal opens
     _vaultPendingImageFile = null;
+    var imgInputEl = safeGetElement("vaultImageImportFile");
+    if (imgInputEl) imgInputEl.value = "";
     var imgFileInfoEl = safeGetElement("vaultImageFileInfo");
     var imgPickerRowEl = safeGetElement("vaultImagePickerRow");
     if (imgFileInfoEl) imgFileInfoEl.style.display = "none";
@@ -947,7 +949,7 @@ async function handleVaultAction() {
       } else {
         var exportResult = await exportEncryptedBackup(password);
         if (exportResult && exportResult.imageExportFailed) {
-          showVaultStatus("warning", "Inventory exported. Photo backup failed \u2014 try again or use Export Images ZIP.");
+          showVaultStatus("warning", "Inventory exported. Photo backup failed \u2014 try again or use Settings \u2192 Export Images.");
         } else if (exportResult && exportResult.imageCount > 0) {
           showVaultStatus("success", "Backup exported \u2014 2 files downloaded (inventory + " + exportResult.imageCount + " photo" + (exportResult.imageCount === 1 ? "" : "s") + ").");
         } else {

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771919047';
+const CACHE_NAME = 'staktrakr-v3.32.27-b1771920327';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771910503';
+const CACHE_NAME = 'staktrakr-v3.32.27-b1771919047';
 
 
 


### PR DESCRIPTION
## Summary

- `exportEncryptedBackup` now generates a companion `*-images.stvault` alongside the inventory vault when the user has photos in IndexedDB — zero change to users with no photos
- Import modal gains an optional **+ Add Photos File** picker (local import only, hidden for cloud restore) so inventory + images can be restored together with one password entry
- `VAULT_IMAGE_FILE_SUFFIX = '-images'` constant added; 50 MB limit intentionally not applied to the image file

## Reused infrastructure

All crypto already existed in `vault.js` — `collectAndHashImageVault`, `vaultEncryptImageVault`, `vaultDecryptAndRestoreImages`. This PR only wires them into the manual backup flow.

## Edge cases covered

- No images → single download, status message unchanged
- Image export fails → inventory still exported, warning surfaced
- Wrong password on image file → inventory already restored, error shown, page still reloads
- Large image collections (>50 MB) → no size limit on companion file
- Cloud import → image picker row hidden entirely

## Test Plan

- [ ] Export Backup with photos → confirm 2 browser downloads with correct filenames
- [ ] Export Backup with no photos → confirm 1 download, status unchanged
- [ ] Restore inventory only (no image file) → inventory restores, page reloads
- [ ] Restore inventory + load companion image file → picker row visible, filename/size shown, both restored
- [ ] Wrong password on image file → error shown, inventory already applied

Closes STAK-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)