### PR TITLE
🛡️ Sentinel: [HIGH] Add SRI to CDN scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,9 @@
               s.integrity = lib.integrity;
               s.crossOrigin = 'anonymous';
             }
+            s.addEventListener('error', function () {
+              console.error('[vendor] SRI/network failure: ' + label + ' — ' + lib.src);
+            });
             document.head.appendChild(s);
           }
         });

--- a/index.html
+++ b/index.html
@@ -63,13 +63,13 @@
     <!-- CDN fallbacks — only execute if the local vendor copy failed to load -->
     <script>
       window.__vendorFallbacks = [
-        { global: 'Papa',                   src: 'https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js' },
-        { global: 'jspdf',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js' },
-        { check: function() { return !!(window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.prototype.autoTable); }, src: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js' },
-        { global: 'Chart',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js' },
-        { global: 'ChartDataLabels',        src: 'https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js' },
-        { global: 'JSZip',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js' },
-        { global: 'forge',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/forge/0.10.0/forge.min.js' },
+        { global: 'Papa',                   src: 'https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js', integrity: 'sha512-dfX5uYVXzyU8+KHqj8bjo7UkOdg18PaOtpa48djpNbZHwExddghZ+ZmzWT06R5v6NSk3ZUfsH6FNEDepLx9hPQ==' },
+        { global: 'jspdf',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js', integrity: 'sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==' },
+        { check: function() { return !!(window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.prototype.autoTable); }, src: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js', integrity: 'sha512-SgWewGM3r8xXm8LNXt4ZHqKVKu/7eKrJ1aBCbMaX44xXXaCcIvCAvD2kj9qnC1lhyjAu04mcPiTzcc/CaACnUQ==' },
+        { global: 'Chart',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js', integrity: 'sha512-ElRFoEQdI5Ht6kZvyzXhYG9NqjtkmlkfYk0wr6wHxU9JEHakS7UJZNeml5ALk+8IKlU6jDgMabC3vkumRokgJA==' },
+        { global: 'ChartDataLabels',        src: 'https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js', integrity: 'sha512-JPcRR8yFa8mmCsfrw4TNte1ZvF1e3+1SdGMslZvmrzDYxS69J7J49vkFL8u6u8PlPJK+H3voElBtUCzaXj+6ig==' },
+        { global: 'JSZip',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js', integrity: 'sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==' },
+        { global: 'forge',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/forge/0.10.0/forge.min.js', integrity: 'sha512-S/UB/AdGt16YP1OyopwfVG1BO93nkwVNY7No5zfALnztixutqOuP3DGvo7G4YqB77uL791jWNjQnT/63CjOZNw==' },
       ];
       document.addEventListener('DOMContentLoaded', function () {
         window.__vendorFallbacks.forEach(function (lib) {
@@ -79,6 +79,10 @@
             console.warn('[vendor] ' + label + ' not loaded from local — falling back to CDN');
             var s = document.createElement('script');
             s.src = lib.src;
+            if (lib.integrity) {
+              s.integrity = lib.integrity;
+              s.crossOrigin = 'anonymous';
+            }
             document.head.appendChild(s);
           }
         });

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771910503';
+const CACHE_NAME = 'staktrakr-v3.32.27-b1771972919';
 
 
 


### PR DESCRIPTION
* 🚨 Severity: HIGH (Defense in Depth)
* 💡 Vulnerability: External scripts loaded from CDNs lacked integrity checks, allowing potential execution of malicious code if the CDN is compromised.
* 🎯 Impact: Compromised CDN could lead to XSS / code execution in the user's browser.
* 🔧 Fix: Added SHA-512 `integrity` hashes and `crossorigin="anonymous"` to all vendor fallback scripts in `index.html`.
* ✅ Verification: Verified hashes against cdnjs.com and updated loader logic to apply them. Tests attempted but skipped due to environment limitations.

---
*PR created automatically by Jules for task [8281060377890125687](https://jules.google.com/task/8281060377890125687) started by @lbruton*