### PR TITLE
v3.32.29 — Parallel agent workflow: claims-array lock + brainstorming worktree gate

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: brainstorming
+description: "Use before any new feature, enhancement, or non-trivial UI work. Explores user intent, requirements, and design before implementation. Serves as the SRPI Specification phase."
+---
+
+<!-- StakTrakr project override — adds Phase 0 worktree gate before the standard flow.
+     Superpowers body synced from: superpowers@claude-plugins-official (2026-02-24).
+     When the plugin updates brainstorming significantly, copy the updated body below. -->
+
+## Phase 0 — Worktree Gate
+
+**Run this before any other step.**
+
+StakTrakr uses isolated git worktrees to prevent agents from competing on the same files.
+This gate ensures brainstorming only proceeds when work will land in a safe location.
+
+### Check 1: Are we already in a worktree?
+
+```bash
+git rev-parse --git-common-dir   # path to main repo's .git
+git rev-parse --git-dir          # .git in main checkout; .git/worktrees/NAME in a worktree
+```
+
+If the two values differ → you are inside a worktree. ✅ Skip to the brainstorming flow below.
+
+### Check 2: Is a version lock claimed for this work?
+
+```bash
+cat devops/version.lock 2>/dev/null || echo "UNLOCKED"
+```
+
+With the claims-array format, read the `claims` array and filter out expired entries
+(`expires_at` < now). If at least one active claim exists for the work you are about to
+start → ✅ proceed.
+
+### If neither check passes — STOP
+
+```
+⛔ No worktree is active and no version lock is claimed.
+
+Starting brainstorming directly on `dev` risks writing code outside a
+patch/VERSION worktree, which breaks the multi-agent isolation protocol.
+
+Before proceeding, choose one:
+  A) Run `/start-patch`   — pick a Linear issue, claim a version, create a worktree
+  B) Run `/release patch` — claim version and create worktree directly
+  C) Continue on `dev`    — only safe if this is design-only work (no code today)
+
+Which would you like to do?
+```
+
+Wait for the user's choice. If they choose **C**, note it clearly and continue to the
+brainstorming flow below. If **A** or **B**, wait for the worktree to be created, then
+resume brainstorming from Step 1.
+
+---
+
+# Brainstorming Ideas Into Designs (SRPI Specification Phase)
+
+## Overview
+
+Turn ideas into fully formed designs and specs through collaborative dialogue — grounded in the actual codebase before a single question is asked.
+
+This skill is the **Specification** phase of the SRPI loop (Specify → Research → Plan → Implement). It ends when a design doc is committed and the writing-plans skill is invoked.
+
+## SRPI vs RPI Decision
+
+Choose the right entry point before starting:
+
+| Situation | Entry Point | Why |
+|---|---|---|
+| New feature or capability | **SRPI** — start here (brainstorming) | Unknown scope, needs design |
+| UI change with ≥3 data elements | **SRPI** — start here | Layout uncertainty |
+| Enhancement to existing behavior | **SRPI** — start here | May ripple through more files than expected |
+| Bug fix with clear root cause | **RPI** — skip to codebase-search → writing-plans | Scope is defined |
+| Tech debt / refactor with known boundary | **RPI** — skip to codebase-search → writing-plans | No design ambiguity |
+| Small refinement (single function, single file) | **RPI** — skip to codebase-search → writing-plans | YAGNI on the design doc |
+
+If in doubt, use SRPI. The design phase can be short.
+
+## Checklist
+
+Complete these steps in order:
+
+1. **Run codebase-search** — produce Codebase Impact Report and complete Auto-Quiz before anything else
+2. **Ask clarifying questions** — one at a time, grounded in Impact Report findings
+3. **Propose 2-3 approaches** — each referencing existing patterns from the Impact Report
+4. **Present design** — in sections scaled to complexity, get user approval after each section
+5. **Write design doc** — save to `docs/plans/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Transition to planning** — invoke writing-plans skill
+
+## Process Flow
+
+```dot
+digraph brainstorming {
+    "Run codebase-search → Impact Report + Auto-Quiz" [shape=box];
+    "Ask clarifying questions" [shape=box];
+    "Propose 2-3 approaches" [shape=box];
+    "Present design sections" [shape=box];
+    "User approves design?" [shape=diamond];
+    "Write design doc" [shape=box];
+    "Invoke writing-plans skill" [shape=doublecircle];
+
+    "Run codebase-search → Impact Report + Auto-Quiz" -> "Ask clarifying questions";
+    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Propose 2-3 approaches" -> "Present design sections";
+    "Present design sections" -> "User approves design?";
+    "User approves design?" -> "Present design sections" [label="no, revise"];
+    "User approves design?" -> "Write design doc" [label="yes"];
+    "Write design doc" -> "Invoke writing-plans skill";
+}
+```
+
+The terminal state is invoking writing-plans. The only skill invoked after brainstorming is writing-plans.
+
+## The Process
+
+### Step 1 — Codebase Search (mandatory first action)
+
+Invoke the codebase-search skill immediately. Do not ask clarifying questions first.
+
+Produce a **Codebase Impact Report** containing:
+- Files most likely to be touched
+- Existing patterns relevant to this feature (naming conventions, data flow, module boundaries)
+- Potential ripple effects (what else calls or depends on those files)
+- Any prior art in the codebase (similar features already built)
+
+Then complete the **Auto-Quiz** before proceeding:
+- What does the user actually want to achieve? (not just what they said)
+- Are there existing patterns in the codebase this should follow?
+- What is the smallest surface area that delivers the value?
+- What could go wrong at the seams between new and existing code?
+
+<HARD-GATE>
+Do not ask clarifying questions or propose approaches until codebase-search is complete and the Auto-Quiz is answered.
+</HARD-GATE>
+
+### Step 2 — Clarifying Questions
+
+Ask questions one at a time, grounded in Impact Report findings. Prefer multiple choice. Focus on: purpose, constraints, success criteria, edge cases the Impact Report surfaced.
+
+### Step 3 — Proposed Approaches
+
+Propose 2-3 approaches. Each approach must:
+- Reference existing patterns found in the Impact Report
+- State which files it touches (cross-check against Impact Report)
+- Describe trade-offs clearly
+- Lead with your recommendation and reasoning
+
+### Step 4 — Design Presentation
+
+Once you understand what is being built, present the design in sections scaled to complexity. Ask after each section whether it looks right. Cover: architecture, components, data flow, error handling, testing approach.
+
+## After the Design
+
+**Documentation:**
+- Write the validated design to `docs/plans/YYYY-MM-DD-<topic>-design.md`
+- Include the Impact Report file list in the design doc header
+- Commit the design document to git
+
+**Implementation:**
+- Invoke the writing-plans skill to create the implementation plan
+- Do not invoke any other skill. writing-plans is the next step.
+
+## Key Principles
+
+- **Codebase-search first, always** — never design in a vacuum
+- **One question at a time** — do not overwhelm with multiple questions
+- **Approaches reference existing patterns** — no orphan designs
+- **YAGNI ruthlessly** — remove unnecessary features from all designs
+- **Incremental validation** — present design sections, get approval before moving on

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !.claude/skills/wiki-audit/
 !.claude/skills/wiki-sweep/
 !.claude/skills/ship/
+!.claude/skills/brainstorming/
 .claude/commands/
 .mcp.json
 SPRINT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.29] - 2026-02-24
+
+### Added — Parallel Agent Workflow Improvements
+
+- **Added**: Claims-array version lock replaces binary lock — multiple agents can now hold concurrent patch versions without blocking each other (supports parallel agent development)
+- **Added**: Brainstorming skill project override with Phase 0 worktree gate — prevents implementation starting outside a `patch/VERSION` worktree
+- **Added**: `devops/version-lock-protocol.md` updated with full claims-array protocol, parallel agent example, and prune-on-read TTL rules
+
+---
+
 ## [3.32.27] - 2026-02-23
 
 ### Added — Image Storage Expansion — Dynamic Quota, Split Gauge, sharedImageId Foundation (STAK-305)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ These rules fire before any implementation, no exceptions:
 5. **Multiple independent tasks?** → `superpowers:dispatching-parallel-agents` — subagents implement, we orchestrate.
 6. **Implementing a plan?** → `superpowers:subagent-driven-development`.
 7. **PR ready?** → `/pr-resolve` with Phase 0 parallel agents before touching any threads.
+8. **Starting any implementation?** → Check `devops/version.lock` → create a worktree via `/release patch` or `/start-patch` before making any edits.
 
 **Red flags — stop and invoke the right skill:**
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Parallel Agent Workflow (v3.32.29)**: Claims-array version lock replaces binary lock — multiple agents can claim concurrent patch versions without blocking each other. Brainstorming skill now enforces worktree gate before any implementation starts.
 - **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).
 - **Bug Fixes — Storage Quota, Chrome Init Race, Numista Data Integrity (v3.32.26)**: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome "Cannot access inventory before initialization" crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).
 - **Vendor Price Carry-Forward + OOS Legend Links (v3.32.25)**: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.29 &ndash; Parallel Agent Workflow</strong>: Claims-array version lock replaces binary lock &mdash; multiple agents can now hold concurrent patch versions without blocking. Brainstorming skill enforces worktree gate before any implementation starts.</li>
     <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>
     <li><strong>v3.32.26 &ndash; Bug Fixes &mdash; Storage Quota, Chrome Init Race, Numista Data Integrity</strong>: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome &ldquo;Cannot access inventory before initialization&rdquo; crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).</li>
     <li><strong>v3.32.25 &ndash; Vendor Price Carry-Forward + OOS Legend Links</strong>: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).</li>
     <li><strong>v3.32.24 &ndash; Cloud Sync Reliability Fixes</strong>: Fixed vault-overwrite race condition where debounced startup push could discard other device&apos;s changes during conflict resolution. Fixed getSyncPassword fast-path break for Simple-mode migration and Manual Backup password persistence on page reload.</li>
-    <li><strong>v3.32.23 &ndash; Cloud Settings Redesign + Unified Encryption</strong>: Compact &le;400px Dropbox card. Backup/Restore/Disconnect/Change Password moved to Advanced sub-modal. Simplified unified encryption replaces Simple/Secure toggle.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.27";
+const APP_VERSION = "3.32.29";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771920327';
+const CACHE_NAME = 'staktrakr-v3.32.29-b1771922800';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.27",
-  "releaseDate": "2026-02-23",
+  "version": "3.32.29",
+  "releaseDate": "2026-02-24",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Claims-array version lock** — `devops/version.lock` redesigned from a binary single-holder format to a `claims` array. Multiple agents can now hold concurrent patch versions without blocking each other. Expired entries are pruned on read. Protocol documented in `devops/version-lock-protocol.md`.
- **Brainstorming worktree gate** — new project-level skill override at `.claude/skills/brainstorming/SKILL.md` adds a mandatory Phase 0 check before any brainstorming begins: verifies the agent is inside a `patch/VERSION` worktree or has an active lock claim. Stops and prompts for worktree creation if neither is true.
- **Release skill updated** — Step 0a rewritten to use the claims-array protocol (read → prune → compute next → append claim).
- **CLAUDE.md gate** — added item 8 to the mandatory pre-code checklist: check version.lock and create a worktree before making any edits.
- **Stale worktree removed** — `.claude/worktrees/stak-315-vault-images` and its non-standard branch cleaned up.
- **start-patch skill** — lock display updated to show active claims array instead of single-holder format.

## Files

- `.claude/skills/brainstorming/SKILL.md` (new)
- `.claude/skills/release/SKILL.md` (Step 0a rewritten)
- `devops/version-lock-protocol.md` (full rewrite for claims array)
- `CLAUDE.md` (item 8 added)
- `.gitignore` (brainstorming skill allowlisted)
- Version bump: `js/constants.js`, `CHANGELOG.md`, `docs/announcements.md`, `js/about.js`, `version.json`, `sw.js` (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)