### PR TITLE
v3.32.31 — STAK-321: Remove generateItemDataTable dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.31] - 2026-02-24
+
+### Removed — STAK-321: Dead code cleanup
+
+- **Removed**: `generateItemDataTable()` from `js/utils.js` — zero call sites remaining after PR #490 removed its only caller `createStorageItemModal` (STAK-321)
+
+---
+
 ## [3.32.30] - 2026-02-24
 
 ### Added — STAK-314: Menu Enhancements

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **Code Cleanup (v3.32.31)**: Removed unused internal utility function from utils.js with zero impact on app behavior. Inventory rendering optimization from PR #489 now cached for O(1) index lookups.
+- **Code Cleanup (v3.32.31)**: Removed unused internal utility function from utils.js with zero impact on app behavior.
 - **Menu Enhancements (v3.32.30)**: Trend period labels on spot cards update with trend button. Health dots on Sync and Market buttons reflect data freshness. Vault header button opens backup/restore. Show Text toggle displays icon labels. Uniform column-flex button layout (STAK-314).
 - **Parallel Agent Workflow (v3.32.29)**: Claims-array version lock replaces binary lock — multiple agents can claim concurrent patch versions without blocking each other. Brainstorming skill now enforces worktree gate before any implementation starts.
 - **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Code Cleanup (v3.32.31)**: Removed unused internal utility function from utils.js with zero impact on app behavior. Inventory rendering optimization from PR #489 now cached for O(1) index lookups.
 - **Menu Enhancements (v3.32.30)**: Trend period labels on spot cards update with trend button. Health dots on Sync and Market buttons reflect data freshness. Vault header button opens backup/restore. Show Text toggle displays icon labels. Uniform column-flex button layout (STAK-314).
 - **Parallel Agent Workflow (v3.32.29)**: Claims-array version lock replaces binary lock — multiple agents can claim concurrent patch versions without blocking each other. Brainstorming skill now enforces worktree gate before any implementation starts.
 - **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).
 - **Bug Fixes — Storage Quota, Chrome Init Race, Numista Data Integrity (v3.32.26)**: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome "Cannot access inventory before initialization" crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).
-- **Vendor Price Carry-Forward + OOS Legend Links (v3.32.25)**: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,7 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.32.31 &ndash; Code Cleanup</strong>: Removed unused internal utility function from utils.js with zero impact on app behavior. Inventory rendering optimization from PR #489 now cached for O(1) index lookups.</li>
+    <li><strong>v3.32.31 &ndash; Code Cleanup</strong>: Removed unused internal utility function from utils.js with zero impact on app behavior.</li>
     <li><strong>v3.32.30 &ndash; Menu Enhancements</strong>: Trend period labels on spot cards update with trend button. Health dots on Sync and Market header buttons reflect data freshness. Vault header button opens backup/restore (enable in Settings). Show Text toggle for icon labels. Uniform column-flex button layout (STAK-314).</li>
     <li><strong>v3.32.29 &ndash; Parallel Agent Workflow</strong>: Claims-array version lock replaces binary lock &mdash; multiple agents can now hold concurrent patch versions without blocking. Brainstorming skill enforces worktree gate before any implementation starts.</li>
     <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.31 &ndash; Code Cleanup</strong>: Removed unused internal utility function from utils.js with zero impact on app behavior. Inventory rendering optimization from PR #489 now cached for O(1) index lookups.</li>
     <li><strong>v3.32.30 &ndash; Menu Enhancements</strong>: Trend period labels on spot cards update with trend button. Health dots on Sync and Market header buttons reflect data freshness. Vault header button opens backup/restore (enable in Settings). Show Text toggle for icon labels. Uniform column-flex button layout (STAK-314).</li>
     <li><strong>v3.32.29 &ndash; Parallel Agent Workflow</strong>: Claims-array version lock replaces binary lock &mdash; multiple agents can now hold concurrent patch versions without blocking. Brainstorming skill enforces worktree gate before any implementation starts.</li>
     <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>
     <li><strong>v3.32.26 &ndash; Bug Fixes &mdash; Storage Quota, Chrome Init Race, Numista Data Integrity</strong>: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome &ldquo;Cannot access inventory before initialization&rdquo; crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).</li>
-    <li><strong>v3.32.25 &ndash; Vendor Price Carry-Forward + OOS Legend Links</strong>: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.30";
+const APP_VERSION = "3.32.31";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/utils.js
+++ b/js/utils.js
@@ -1792,61 +1792,6 @@ const getStorageItemDescription = (key) => {
 };
 
 /**
- * Generates data table for storage item
- */
-const generateItemDataTable = (item) => {
-  if (!item.parsedData) {
-    return `<div class="data-preview"><strong>Raw Data:</strong><pre>${item.value}</pre></div>`;
-  }
-  
-  if (Array.isArray(item.parsedData)) {
-    if (item.parsedData.length === 0) {
-      return '<p class="no-data">No records found</p>';
-    }
-    
-    // For inventory data, create a proper table
-    if (item.key === 'precious-metals-inventory') {
-      const headers = Object.keys(item.parsedData[0] || {});
-      return `
-        <div class="data-table-container">
-          <table class="data-table">
-            <thead>
-              <tr>${headers.map(h => `<th>${h}</th>`).join('')}</tr>
-            </thead>
-            <tbody>
-              ${item.parsedData.slice(0, 50).map(record => 
-                `<tr>${headers.map(h => `<td>${sanitizeHtml(record[h]?.toString() || '')}</td>`).join('')}</tr>`
-              ).join('')}
-            </tbody>
-          </table>
-          ${item.parsedData.length > 50 ? `<p class="truncated">Showing first 50 of ${item.parsedData.length} records</p>` : ''}
-        </div>
-      `;
-    }
-    
-    // For other arrays, show a summary
-    return `
-      <div class="array-summary">
-        <p><strong>Array with ${item.parsedData.length} items</strong></p>
-        <div class="data-preview"><pre>${JSON.stringify(item.parsedData.slice(0, 3), null, 2)}${item.parsedData.length > 3 ? '\n...and ' + (item.parsedData.length - 3) + ' more items' : ''}</pre></div>
-      </div>
-    `;
-  }
-  
-  if (typeof item.parsedData === 'object') {
-    const keys = Object.keys(item.parsedData);
-    return `
-      <div class="object-summary">
-        <p><strong>Object with ${keys.length} properties</strong></p>
-        <div class="data-preview"><pre>${JSON.stringify(item.parsedData, null, 2)}</pre></div>
-      </div>
-    `;
-  }
-  
-  return `<div class="data-preview"><pre>${JSON.stringify(item.parsedData, null, 2)}</pre></div>`;
-};
-
-/**
  * Gets enhanced CSS styles for the storage report with theme support
  */
 const getStorageReportCSS = () => {

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771970094';
+const CACHE_NAME = 'staktrakr-v3.32.31-b1771970701';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.31-b1771970701';
+const CACHE_NAME = 'staktrakr-v3.32.31-b1771973679';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.30",
+  "version": "3.32.31",
   "releaseDate": "2026-02-24",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

- **Removed**: `generateItemDataTable()` from `js/utils.js` (~54 lines) — zero call sites remaining after PR #490 removed its only caller `createStorageItemModal`
- No functional impact; purely a dead code cleanup

## Linear Issues

- [STAK-321: Remove orphaned generateItemDataTable from utils.js](https://linear.app/hextrackr/issue/STAK-321)

🤖 Generated with [Claude Code](https://claude.com/claude-code)