### PR TITLE
v3.32.32 — STAK-316: Cloud backup file type label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.32] - 2026-02-24
+
+### Added — STAK-316: Cloud backup file type label
+
+- **Added**: File type label ("Inventory backup" / "Image backup") in each cloud backup row, derived from filename — makes it easy to distinguish between `.stvault` inventory and image backup files at a glance (STAK-316)
+
+---
+
 ## [3.32.30] - 2026-02-24
 
 ### Added — STAK-314: Menu Enhancements

--- a/css/styles.css
+++ b/css/styles.css
@@ -3051,6 +3051,13 @@ input[type="submit"] {
   flex-shrink: 0;
   margin-left: 0.5rem;
 }
+.cloud-backup-type {
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  opacity: 0.8;
+}
 .cloud-backup-delete-btn {
   flex-shrink: 0;
   padding: 0.3rem 0.5rem;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Cloud Backup Labels (v3.32.32)**: Backup list now shows "Inventory backup" or "Image backup" label on each row so you can tell at a glance which files contain your items vs. your photos (STAK-316).
 - **Menu Enhancements (v3.32.30)**: Trend period labels on spot cards update with trend button. Health dots on Sync and Market buttons reflect data freshness. Vault header button opens backup/restore. Show Text toggle displays icon labels. Uniform column-flex button layout (STAK-314).
 - **Parallel Agent Workflow (v3.32.29)**: Claims-array version lock replaces binary lock — multiple agents can claim concurrent patch versions without blocking each other. Brainstorming skill now enforces worktree gate before any implementation starts.
 - **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).
 - **Bug Fixes — Storage Quota, Chrome Init Race, Numista Data Integrity (v3.32.26)**: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome "Cannot access inventory before initialization" crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).
-- **Vendor Price Carry-Forward + OOS Legend Links (v3.32.25)**: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.32 &ndash; Cloud Backup Labels</strong>: Backup list now shows &ldquo;Inventory backup&rdquo; or &ldquo;Image backup&rdquo; label on each row so you can tell at a glance which files contain your items vs. your photos (STAK-316).</li>
     <li><strong>v3.32.30 &ndash; Menu Enhancements</strong>: Trend period labels on spot cards update with trend button. Health dots on Sync and Market header buttons reflect data freshness. Vault header button opens backup/restore (enable in Settings). Show Text toggle for icon labels. Uniform column-flex button layout (STAK-314).</li>
     <li><strong>v3.32.29 &ndash; Parallel Agent Workflow</strong>: Claims-array version lock replaces binary lock &mdash; multiple agents can now hold concurrent patch versions without blocking. Brainstorming skill enforces worktree gate before any implementation starts.</li>
     <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>
     <li><strong>v3.32.26 &ndash; Bug Fixes &mdash; Storage Quota, Chrome Init Race, Numista Data Integrity</strong>: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome &ldquo;Cannot access inventory before initialization&rdquo; crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).</li>
-    <li><strong>v3.32.25 &ndash; Vendor Price Carry-Forward + OOS Legend Links</strong>: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.30";
+const APP_VERSION = "3.32.32";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1191,6 +1191,7 @@ const renderCloudBackupList = (provider, backups) => {
     const sizeStr = b.size < 1024 ? b.size + ' B' :
       b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
         (b.size / 1048576).toFixed(1) + ' MB';
+    const label = b.name.includes('images') ? 'Image backup' : 'Inventory backup';
     const safeProvider = sanitizeHtml(provider);
     const safeFilename = sanitizeHtml(b.name);
     return '<div class="cloud-backup-row">' +
@@ -1198,6 +1199,7 @@ const renderCloudBackupList = (provider, backups) => {
         '" data-filename="' + safeFilename + '" data-size="' + b.size + '">' +
         '<span class="cloud-backup-name" title="' + safeFilename + '">' + sanitizeHtml(dateStr) + '</span>' +
         '<span class="cloud-backup-size">' + sanitizeHtml(sizeStr) + '</span>' +
+        '<span class="cloud-backup-type">' + label + '</span>' +
       '</button>' +
       '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
         '" data-filename="' + safeFilename + '" title="Delete this backup from Dropbox" aria-label="Delete ' + safeFilename + '">' +

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1191,7 +1191,7 @@ const renderCloudBackupList = (provider, backups) => {
     const sizeStr = b.size < 1024 ? b.size + ' B' :
       b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
         (b.size / 1048576).toFixed(1) + ' MB';
-    const label = b.name.includes('images') ? 'Image backup' : 'Inventory backup';
+    const label = b.name.includes(VAULT_IMAGE_FILE_SUFFIX) ? 'Image backup' : 'Inventory backup';
     const safeProvider = sanitizeHtml(provider);
     const safeFilename = sanitizeHtml(b.name);
     return '<div class="cloud-backup-row">' +

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771970094';
+const CACHE_NAME = 'staktrakr-v3.32.32-b1771971551';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.32-b1771971551';
+const CACHE_NAME = 'staktrakr-v3.32.32-b1771973846';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.30",
+  "version": "3.32.32",
   "releaseDate": "2026-02-24",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

- **Added**: "Inventory backup" / "Image backup" label on each cloud backup row in Settings → Cloud Storage
- Label is derived from filename — files containing `images` in the name are image backups, all others are inventory backups
- New `.cloud-backup-type` CSS rule added to `css/styles.css` alongside `.cloud-backup-size`

## QA

- Connect to Dropbox, go to Settings → Cloud Storage → Backup list
- Verify each row shows the correct type label ("Inventory backup" or "Image backup")

## Linear Issues

- [STAK-316](https://linear.app/hextrackr/issue/STAK-316)

🤖 Generated with [Claude Code](https://claude.com/claude-code)