### PR TITLE
v3.32.33 — STAK-303: Fix 7-day sparklines straight line on fresh load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.33] - 2026-02-24
+
+### Fixed — STAK-303: 7-day sparklines straight line on fresh load
+
+- **Fixed**: 7-day sparklines now draw a full curved historical line on fresh load by extending the automatic hourly backfill from 24 h to 7 days when no recent hourly data is present — seed bundle LBMA data can lag ~9 days, leaving the 7-day window empty (STAK-303)
+
+---
+
 ## [3.32.30] - 2026-02-24
 
 ### Added — STAK-314: Menu Enhancements

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Bug Fix — 7-Day Sparklines (v3.32.33)**: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).
 - **Menu Enhancements (v3.32.30)**: Trend period labels on spot cards update with trend button. Health dots on Sync and Market buttons reflect data freshness. Vault header button opens backup/restore. Show Text toggle displays icon labels. Uniform column-flex button layout (STAK-314).
 - **Parallel Agent Workflow (v3.32.29)**: Claims-array version lock replaces binary lock — multiple agents can claim concurrent patch versions without blocking each other. Brainstorming skill now enforces worktree gate before any implementation starts.
 - **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).
 - **Bug Fixes — Storage Quota, Chrome Init Race, Numista Data Integrity (v3.32.26)**: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome "Cannot access inventory before initialization" crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).
-- **Vendor Price Carry-Forward + OOS Legend Links (v3.32.25)**: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.33 &ndash; Bug Fix &mdash; 7-Day Sparklines</strong>: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).</li>
     <li><strong>v3.32.30 &ndash; Menu Enhancements</strong>: Trend period labels on spot cards update with trend button. Health dots on Sync and Market header buttons reflect data freshness. Vault header button opens backup/restore (enable in Settings). Show Text toggle for icon labels. Uniform column-flex button layout (STAK-314).</li>
     <li><strong>v3.32.29 &ndash; Parallel Agent Workflow</strong>: Claims-array version lock replaces binary lock &mdash; multiple agents can now hold concurrent patch versions without blocking. Brainstorming skill enforces worktree gate before any implementation starts.</li>
     <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>
     <li><strong>v3.32.26 &ndash; Bug Fixes &mdash; Storage Quota, Chrome Init Race, Numista Data Integrity</strong>: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome &ldquo;Cannot access inventory before initialization&rdquo; crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).</li>
-    <li><strong>v3.32.25 &ndash; Vendor Price Carry-Forward + OOS Legend Links</strong>: Carry-forward prices in 24h chart and table show ~$XX.XX in muted style when vendor data is missing for a window. OOS vendors now appear in coin legend as clickable links with strikethrough last-known price and OOS badge (STAK-299).</li>
   `;
 };
 

--- a/js/api.js
+++ b/js/api.js
@@ -235,7 +235,7 @@ const fetchStaktrakr15minRange = async (slotsBack = 96) => {
  * @returns {Promise<number>} Count of new entries added
  */
 const backfillStaktrakrHourly = async () => {
-  const oneDayAgo = Date.now() - 24 * 3600_000;
+  const oneDayAgo = Date.now() - 24 * 3600000;
   const hasRecentHourly = spotHistory.some(
     (e) => e.source === 'api-hourly' && new Date(e.timestamp).getTime() >= oneDayAgo
   );

--- a/js/api.js
+++ b/js/api.js
@@ -226,12 +226,21 @@ const fetchStaktrakr15minRange = async (slotsBack = 96) => {
 
 
 /**
- * Backfills the last 24 hours of hourly spot data from StakTrakr into spotHistory.
+ * Backfills hourly spot data from StakTrakr into spotHistory.
+ * On a fresh load (no recent api-hourly entries), extends to 7 days to populate
+ * the sparkline window — the seed bundle can lag by ~9 days (LBMA data delay),
+ * so 24 h alone is not enough to draw a 7-day sparkline (STAK-303).
+ * On subsequent loads, only backfills the last 24 h for efficiency.
  * Only runs when STAKTRAKR is the primary provider (rank 1) and sync succeeded.
  * @returns {Promise<number>} Count of new entries added
  */
 const backfillStaktrakrHourly = async () => {
-  const { newCount, fetchCount } = await fetchStaktrakrHourlyRange(24);
+  const oneDayAgo = Date.now() - 24 * 3600_000;
+  const hasRecentHourly = spotHistory.some(
+    (e) => e.source === 'api-hourly' && new Date(e.timestamp).getTime() >= oneDayAgo
+  );
+  const hoursBack = hasRecentHourly ? 24 : 7 * 24;
+  const { newCount, fetchCount } = await fetchStaktrakrHourlyRange(hoursBack);
   // Track usage per file fetched (each file = 1 API request)
   if (fetchCount > 0) {
     const config = loadApiConfig();

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.30";
+const APP_VERSION = "3.32.33";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.27-b1771970094';
+const CACHE_NAME = 'staktrakr-v3.32.33-b1771973197';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.33-b1771973197';
+const CACHE_NAME = 'staktrakr-v3.32.33-b1771975018';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.30",
+  "version": "3.32.33",
   "releaseDate": "2026-02-24",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

- **Fixed**: 7-day sparklines draw a full curved historical line on fresh load — `backfillStaktrakrHourly` now detects when there is no recent `api-hourly` data in `spotHistory` and extends the backfill window from 24 h to 7×24 h (168 h). On subsequent loads, the efficient 24 h path is used unchanged.

## Root Cause

The seed bundle (`spot-history-bundle.js`) contains LBMA data that can lag by ~9 days. On 2026-02-24, the most recent bundle entry was `2026-02-15` — outside the 7-day sparkline cutoff of `2026-02-17`. The automatic 24-hour backfill only provided 1–2 distinct calendar days, producing a 2-point straight diagonal in the sparkline.

## Linear Issues

- [STAK-303](https://linear.app/staktrakr/issue/STAK-303) — 7-day sparklines show straight line (fresh load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)