### PR TITLE
v3.32.36 — STAK-309/311: Numista data integrity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.36] - 2026-02-25
+
+### Fixed — STAK-309/STAK-311: Numista Data Integrity
+
+- **Fixed**: Numista image URLs no longer re-populate after being cleared in the edit form — removed stale `oldItem` fallback from the save path (STAK-309)
+- **Fixed**: Clearing the N# field now also wipes all associated Numista metadata (country, denomination, etc.) instead of silently preserving it (STAK-309)
+- **Fixed**: CDN backfill on page load removed — URLs were being re-applied from catalog cache on every reload, undoing deliberate clears (STAK-309)
+- **Fixed**: Numista images no longer cross-contaminate between items — view modal no longer mutates the live inventory item object (STAK-311)
+- **Changed**: N# field removed from custom pattern rules edit form — Numista lookup for pattern rules is handled via the pattern replacement query, not a direct catalog ID (STAK-306)
+- **Added**: "Purge Numista URLs" button in Settings → Images — removes all CDN image URLs from inventory items without touching user uploads or pattern rule images (STAK-312)
+
+---
+
 ## [3.32.35] - 2026-02-24
 
 ### Added — STAK-320: Header Buttons Reorder & Apply to Header

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,14 +1,10 @@
 ## What's New
 
+- **Bug Fixes — Numista Data Integrity (v3.32.36)**: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).
 - **Header Buttons Reorder (v3.32.35)**: Toggle visibility and reorder header buttons in Settings → Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).
 - **Force Refresh Button (v3.32.34)**: New button in Settings &rarr; System &rarr; App Updates. Unregisters service workers and reloads to fetch the latest version. Use if the app appears stuck on an old version after an update (STAK-324).
 - **Bug Fix — 7-Day Sparklines (v3.32.33)**: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).
 - **Cloud Backup Labels (v3.32.32)**: Backup list now shows "Inventory backup" or "Image backup" label on each row so you can tell at a glance which files contain your items vs. your photos (STAK-316).
-- **Code Cleanup (v3.32.31)**: Removed unused internal utility function from utils.js with zero impact on app behavior.
-- **Menu Enhancements (v3.32.30)**: Trend period labels on spot cards update with trend button. Health dots on Sync and Market buttons reflect data freshness. Vault header button opens backup/restore. Show Text toggle displays icon labels. Uniform column-flex button layout (STAK-314).
-- **Parallel Agent Workflow (v3.32.29)**: Claims-array version lock replaces binary lock — multiple agents can claim concurrent patch versions without blocking each other. Brainstorming skill now enforces worktree gate before any implementation starts.
-- **Image Storage Expansion (v3.32.27)**: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings → Images → Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse across items (STAK-305).
-- **Bug Fixes — Storage Quota, Chrome Init Race, Numista Data Integrity (v3.32.26)**: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome "Cannot access inventory before initialization" crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -3056,6 +3056,10 @@
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
                     Download URLs
                   </button>
+                  <button class="btn warning" id="purgeNumistaUrlsBtn" type="button" title="Remove all Numista CDN image URLs from inventory items (keeps user uploads and pattern images)">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                    Purge Numista URLs
+                  </button>
                   <button class="btn danger" id="clearAllImagesBtn" type="button">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
                     Clear Cache

--- a/js/about.js
+++ b/js/about.js
@@ -283,15 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.36 &ndash; Bug Fixes &mdash; Numista Data Integrity</strong>: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).</li>
     <li><strong>v3.32.35 &ndash; Header Buttons Reorder</strong>: Toggle visibility and reorder header buttons in Settings &rarr; Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).</li>
     <li><strong>v3.32.34 &ndash; Force Refresh Button</strong>: New button in Settings &rarr; System &rarr; App Updates. Unregisters service workers and reloads to fetch the latest version. Use if the app appears stuck on an old version after an update (STAK-324).</li>
     <li><strong>v3.32.33 &ndash; Bug Fix &mdash; 7-Day Sparklines</strong>: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).</li>
     <li><strong>v3.32.32 &ndash; Cloud Backup Labels</strong>: Backup list now shows &ldquo;Inventory backup&rdquo; or &ldquo;Image backup&rdquo; label on each row so you can tell at a glance which files contain your items vs. your photos (STAK-316).</li>
-    <li><strong>v3.32.31 &ndash; Code Cleanup</strong>: Removed unused internal utility function from utils.js with zero impact on app behavior.</li>
-    <li><strong>v3.32.30 &ndash; Menu Enhancements</strong>: Trend period labels on spot cards update with trend button. Health dots on Sync and Market header buttons reflect data freshness. Vault header button opens backup/restore (enable in Settings). Show Text toggle for icon labels. Uniform column-flex button layout (STAK-314).</li>
-    <li><strong>v3.32.29 &ndash; Parallel Agent Workflow</strong>: Claims-array version lock replaces binary lock &mdash; multiple agents can now hold concurrent patch versions without blocking. Brainstorming skill enforces worktree gate before any implementation starts.</li>
-    <li><strong>v3.32.27 &ndash; Image Storage Expansion</strong>: Dynamic IndexedDB quota via navigator.storage.estimate() replaces hardcoded 50 MB cap. Persistent storage request on first upload prevents silent eviction. Settings &rarr; Images &rarr; Storage shows split progress bars for Your Photos vs. Numista Cache. sharedImageId foundation for future image reuse (STAK-305).</li>
-    <li><strong>v3.32.26 &ndash; Bug Fixes &mdash; Storage Quota, Chrome Init Race, Numista Data Integrity</strong>: Fixed localStorage quota overflow for retailIntradayData on large collections. Fixed Chrome &ldquo;Cannot access inventory before initialization&rdquo; crash on page refresh. Fixed Numista N# and photos repopulating after deletion due to stale serial mapping (STAK-300, STAK-301, STAK-302).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.35";
+const APP_VERSION = "3.32.36";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/init.js
+++ b/js/init.js
@@ -485,39 +485,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     }
 
-    // Backfill CDN image URLs from local catalog cache (no API calls).
-    // Items viewed before URL persistence was added may have cached Numista
-    // data in the Local provider but no URLs on the inventory item itself.
-    try {
-      const catalogCache = JSON.parse(localStorage.getItem('staktrakr.catalog.cache') || '{}');
-      const cacheKeys = Object.keys(catalogCache);
-      const itemsWithNid = inventory.filter(i => i.numistaId).length;
-      debugLog(`[CDN Backfill] Catalog cache has ${cacheKeys.length} entries, ${itemsWithNid} items have numistaId`);
-      let backfilled = 0;
-      for (const item of inventory) {
-        const catId = item.numistaId;
-        if (!catId) continue;
-        const cached = catalogCache[catId];
-        if (!cached) {
-          debugLog(`[CDN Backfill] No cache entry for ${catId} (${(item.name || '').slice(0, 30)})`);
-          continue;
-        }
-        if (!item.obverseImageUrl && cached.imageUrl) {
-          item.obverseImageUrl = cached.imageUrl;
-          backfilled++;
-        }
-        if (!item.reverseImageUrl && cached.reverseImageUrl) {
-          item.reverseImageUrl = cached.reverseImageUrl;
-          backfilled++;
-        }
-      }
-      if (backfilled > 0) {
-        saveInventory();
-        debugLog(`[CDN Backfill] Backfilled ${backfilled} CDN image URLs from catalog cache`);
-      } else {
-        debugLog(`[CDN Backfill] Nothing to backfill (items may already have URLs or cache is empty)`);
-      }
-    } catch (e) { debugLog('[CDN Backfill] Error:', e); }
+    // CDN Backfill removed — URLs are written at save/bulk-sync time (STAK-309)
+    debugLog('[Init] Skipping CDN backfill (removed in STAK-309 fix)');
 
     // Clean up stale localStorage keys from removed systems
     try { localStorage.removeItem('seedImagesVersion'); } catch (_) { /* ignore */ }

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -502,6 +502,28 @@ const bindImageSyncListeners = () => {
     });
   }
 
+  const purgeNumistaUrlsBtn = getExistingElement('purgeNumistaUrlsBtn');
+  if (purgeNumistaUrlsBtn) {
+    purgeNumistaUrlsBtn.addEventListener('click', async () => {
+      const confirmed = await appConfirm(
+        'Remove all Numista CDN image URLs from inventory items?\nUser-uploaded images and pattern rule images are NOT affected.',
+        'Purge Numista URLs',
+      );
+      if (!confirmed) return;
+      let purged = 0;
+      for (const item of inventory) {
+        if (item.obverseImageUrl || item.reverseImageUrl) {
+          item.obverseImageUrl = '';
+          item.reverseImageUrl = '';
+          purged++;
+        }
+      }
+      if (purged > 0 && typeof saveInventory === 'function') saveInventory();
+      if (typeof renderTable === 'function') renderTable();
+      appAlert(`Purged Numista CDN URLs from ${purged} item(s).`);
+    });
+  }
+
   const syncImageUrlsBtn = getExistingElement('syncImageUrlsBtn');
   if (syncImageUrlsBtn) {
     syncImageUrlsBtn.addEventListener('click', async () => {

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -510,13 +510,13 @@ const bindImageSyncListeners = () => {
         'Purge Numista URLs',
       );
       if (!confirmed) return;
+      const isNumistaUrl = (url) => url && /numista\.com/i.test(url);
       let purged = 0;
       for (const item of inventory) {
-        if (item.obverseImageUrl || item.reverseImageUrl) {
-          item.obverseImageUrl = '';
-          item.reverseImageUrl = '';
-          purged++;
-        }
+        let changed = false;
+        if (isNumistaUrl(item.obverseImageUrl)) { item.obverseImageUrl = ''; changed = true; }
+        if (isNumistaUrl(item.reverseImageUrl)) { item.reverseImageUrl = ''; changed = true; }
+        if (changed) purged++;
       }
       if (purged > 0 && typeof saveInventory === 'function') saveInventory();
       if (typeof renderTable === 'function') renderTable();

--- a/js/settings.js
+++ b/js/settings.js
@@ -1628,7 +1628,7 @@ const renderCustomPatternRules = async () => {
     const info = document.createElement('div');
     info.className = 'pattern-rule-info';
     info.innerHTML = `<div class="rule-pattern">/${sanitizeHtml(rule.pattern)}/i</div>
-      <div class="rule-replacement">${sanitizeHtml(rule.replacement) || '\u2014'}${rule.numistaId ? ' (N#' + sanitizeHtml(String(rule.numistaId)) + ')' : ''}</div>`;
+      <div class="rule-replacement">${sanitizeHtml(rule.replacement) || '\u2014'}</div>`;
     row.appendChild(info);
 
     // Actions
@@ -1663,7 +1663,6 @@ const renderCustomPatternRules = async () => {
       <div class="edit-form-fields">
         <label>Pattern <input type="text" class="edit-pattern" value="${rule.pattern.replace(/"/g, '&quot;')}" /></label>
         <label>Replacement <input type="text" class="edit-replacement" value="${(rule.replacement || '').replace(/"/g, '&quot;')}" /></label>
-        <label>N# <input type="text" class="edit-numista-id" value="${rule.numistaId || ''}" /></label>
         <label>Obverse <input type="file" class="edit-obverse" accept="image/*" /></label>
         <label>Reverse <input type="file" class="edit-reverse" accept="image/*" /></label>
       </div>
@@ -1689,7 +1688,6 @@ const renderCustomPatternRules = async () => {
     editForm.querySelector('.edit-save-btn').addEventListener('click', async () => {
       const newPattern = editForm.querySelector('.edit-pattern').value.trim();
       const newReplacement = editForm.querySelector('.edit-replacement').value.trim();
-      const newNumistaId = editForm.querySelector('.edit-numista-id').value.trim();
 
       if (!newPattern || !newReplacement) {
         appAlert('Pattern and replacement are required.');
@@ -1699,7 +1697,6 @@ const renderCustomPatternRules = async () => {
       const result = NumistaLookup.updateRule(rule.id, {
         pattern: newPattern,
         replacement: newReplacement,
-        numistaId: newNumistaId || null
       });
 
       if (!result.success) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -1697,6 +1697,7 @@ const renderCustomPatternRules = async () => {
       const result = NumistaLookup.updateRule(rule.id, {
         pattern: newPattern,
         replacement: newReplacement,
+        numistaId: null,  // STAK-306: clear any legacy N# — edit form no longer manages it
       });
 
       if (!result.success) {

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -117,23 +117,10 @@ async function showViewModal(index) {
     }
   }
 
-  // Persist CDN URLs to the inventory item so table/card views can use them
-  // without needing an API call. Runs regardless of whether images were replaced
-  // in the modal — the URLs are valuable for card/table rendering. Never overwrite.
-  if (apiResult && (apiResult.imageUrl || apiResult.reverseImageUrl)) {
-    let urlsDirty = false;
-    if (apiResult.imageUrl && !item.obverseImageUrl) {
-      item.obverseImageUrl = apiResult.imageUrl;
-      urlsDirty = true;
-    }
-    if (apiResult.reverseImageUrl && !item.reverseImageUrl) {
-      item.reverseImageUrl = apiResult.reverseImageUrl;
-      urlsDirty = true;
-    }
-    if (urlsDirty && typeof saveInventory === 'function') {
-      saveInventory();
-    }
-  }
+  // Do NOT persist CDN URLs from the view modal back to the inventory item (STAK-311).
+  // Writing here bypasses the save-path image priority cascade and can stick URLs to
+  // items that the user has deliberately cleared. URLs are written only via the edit
+  // form save path and the bulk-sync operation.
 
   // Load Numista enrichment section
   await loadViewNumistaData(item, body, apiResult);

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.36-b1771998295';
+const CACHE_NAME = 'staktrakr-v3.32.36-b1772000578';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.35-b1771980364';
+const CACHE_NAME = 'staktrakr-v3.32.36-b1771998295';
 
 
 

--- a/tests/numista-regression.spec.js
+++ b/tests/numista-regression.spec.js
@@ -60,7 +60,10 @@ test.describe('Numista Data Integrity — Regression (STAK-309 / STAK-311)', () 
     await page.goto('/');
     await dismissAllStartupModals(page);
     // Clear inventory so each test starts clean
-    await page.evaluate(() => localStorage.removeItem('metalInventory'));
+    await page.evaluate(() => {
+      localStorage.removeItem('metalInventory');
+      localStorage.removeItem('staktrakr.catalog.cache');
+    });
   });
 
   // ── STAK-309-a: Clearing N# and URL persists through save + reload ─────────

--- a/tests/numista-regression.spec.js
+++ b/tests/numista-regression.spec.js
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+import { dismissAllStartupModals } from './test-utils.js';
+
+/**
+ * Numista Data Integrity — Regression Tests
+ *
+ * Tests for bugs STAK-309, STAK-311 where Numista image URLs / metadata
+ * re-populate after being cleared, or cross-contaminate between items.
+ *
+ * No Numista API key required — items are seeded directly into localStorage.
+ * These tests are expected to FAIL on unpatched code and PASS after the fix.
+ */
+
+/** Minimal inventory item with all required fields. */
+const makeItem = (overrides = {}) => ({
+  serial: 1,
+  name: 'Regression Test Coin',
+  metal: 'Silver',
+  type: 'Coin',
+  qty: 1,
+  weight: 1,
+  weightUnit: 'oz',
+  price: 30,
+  currency: 'USD',
+  purchaseLocation: '',
+  storageLocation: '',
+  date: '2024-01-01',
+  ...overrides,
+});
+
+/**
+ * Inject items into localStorage and reload.
+ * @param {import('@playwright/test').Page} page
+ * @param {object[]} items
+ * @param {object} [extraKeys] - Additional localStorage keys to set { key: value }
+ */
+async function seedInventory(page, items, extraKeys = {}) {
+  await page.evaluate(({ inv, extra }) => {
+    localStorage.setItem('metalInventory', JSON.stringify(inv));
+    for (const [k, v] of Object.entries(extra)) {
+      localStorage.setItem(k, JSON.stringify(v));
+    }
+  }, { inv: items, extra: extraKeys });
+  await page.reload();
+  await dismissAllStartupModals(page);
+}
+
+/** Read parsed inventory array directly from localStorage. */
+async function getInventory(page) {
+  return await page.evaluate(() => {
+    const raw = localStorage.getItem('metalInventory');
+    return raw ? JSON.parse(raw) : [];
+  });
+}
+
+// ── Test suite ──────────────────────────────────────────────────────────────
+
+test.describe('Numista Data Integrity — Regression (STAK-309 / STAK-311)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await dismissAllStartupModals(page);
+    // Clear inventory so each test starts clean
+    await page.evaluate(() => localStorage.removeItem('metalInventory'));
+  });
+
+  // ── STAK-309-a: Clearing N# and URL persists through save + reload ─────────
+
+  test('STAK-309-a: clearing N# and URL stays cleared after save and reload', async ({ page }) => {
+    // Seed catalog cache so CDN backfill (Bug C) can also be exercised on reload
+    await seedInventory(
+      page,
+      [makeItem({ numistaId: '99999', obverseImageUrl: 'https://example.com/obv.jpg' })],
+      { 'staktrakr.catalog.cache': { '99999': { imageUrl: 'https://cdn.numista.com/99999-test.jpg' } } }
+    );
+
+    // Open edit modal directly
+    await page.evaluate(() => window.editItem(0));
+    await expect(page.locator('#itemModal')).toBeVisible();
+
+    // Clear N# and URL fields
+    await page.fill('#itemCatalog', '');
+    await page.fill('#itemObverseImageUrl', '');
+
+    // Save
+    await page.locator('#itemModalSubmit').click();
+    await expect(page.locator('#itemModal')).not.toBeVisible({ timeout: 8000 });
+
+    // Verify after save — Bug A causes this to fail (URL is restored from oldItem)
+    const afterSave = await getInventory(page);
+    expect(afterSave[0].numistaId, 'numistaId should be empty after save').toBe('');
+    expect(afterSave[0].obverseImageUrl, 'obverseImageUrl should be empty after save').toBe('');
+
+    // Reload and verify again — Bug C causes URL to re-appear from catalog cache
+    await page.reload();
+    await dismissAllStartupModals(page);
+
+    const afterReload = await getInventory(page);
+    expect(afterReload[0].numistaId, 'numistaId should remain empty after reload').toBe('');
+    expect(afterReload[0].obverseImageUrl, 'obverseImageUrl should remain empty after reload').toBe('');
+  });
+
+  // ── STAK-309-b: numistaData is wiped when N# is cleared ───────────────────
+
+  test('STAK-309-b: numistaData fields are wiped when N# is cleared', async ({ page }) => {
+    await seedInventory(page, [
+      makeItem({
+        numistaId: '99998',
+        numistaData: {
+          country: 'USA',
+          denomination: '1 Dollar',
+          source: 'api',
+          updatedAt: Date.now(),
+        },
+      }),
+    ]);
+
+    // Open edit modal — populateNumistaDataFields pre-fills #numistaCountry with 'USA'
+    await page.evaluate(() => window.editItem(0));
+    await expect(page.locator('#itemModal')).toBeVisible();
+
+    // Clear only the N# field — leave numistaCountry as populated by the form
+    await page.fill('#itemCatalog', '');
+
+    // Save
+    await page.locator('#itemModalSubmit').click();
+    await expect(page.locator('#itemModal')).not.toBeVisible({ timeout: 8000 });
+
+    // Verify numistaData is empty — Bug D causes country to be preserved
+    const afterSave = await getInventory(page);
+    expect(
+      afterSave[0].numistaData?.country,
+      'numistaData.country should be cleared when N# is removed'
+    ).toBeUndefined();
+  });
+
+  // ── STAK-311: Changing N# clears old CDN image URL ────────────────────────
+
+  test('STAK-311: changing N# to a new value clears the old CDN image URL', async ({ page }) => {
+    await seedInventory(page, [
+      makeItem({
+        numistaId: '111',
+        obverseImageUrl: 'https://cdn.numista.com/catalog/photos/111.jpg',
+      }),
+    ]);
+
+    // Open edit modal — #itemObverseImageUrl is pre-filled with '111.jpg'
+    await page.evaluate(() => window.editItem(0));
+    await expect(page.locator('#itemModal')).toBeVisible();
+
+    // Change N# from '111' to '222', clear the URL field
+    await page.fill('#itemCatalog', '222');
+    await page.fill('#itemObverseImageUrl', '');
+
+    // Save
+    await page.locator('#itemModalSubmit').click();
+    await expect(page.locator('#itemModal')).not.toBeVisible({ timeout: 8000 });
+
+    // Verify — Bug A causes '111.jpg' to be restored via oldItem fallback
+    const afterSave = await getInventory(page);
+    expect(afterSave[0].numistaId, 'numistaId should be updated to 222').toBe('222');
+    expect(
+      afterSave[0].obverseImageUrl,
+      'old CDN URL should not be carried over when N# changes and URL field is blank'
+    ).toBe('');
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.35",
-  "releaseDate": "2026-02-24",
+  "version": "3.32.36",
+  "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

Fixes four compounding bugs that made Numista image URLs impossible to remove, plus cross-contamination between items:

- **Bug A (STAK-309)**: Removed `|| oldItem.obverseImageUrl` fallback from the edit save path — clearing the URL field in the form now sticks
- **Bug B (STAK-309)**: `numistaIdChanged` guard now fires when N# is cleared to `''`, so IndexedDB cache entries are purged when the user removes the catalog ID
- **Bug C (STAK-309)**: Removed CDN backfill block from `init.js` — on-load re-injection from `staktrakr.catalog.cache` was undoing deliberate clears on every page reload
- **Bug D (STAK-309)**: `parseNumistaDataFields` now returns `{}` when the N# field is cleared, wiping all associated metadata (country, denomination, etc.) instead of preserving it via `prev.country` fallback
- **Bug E (STAK-311)**: View modal no longer mutates `item.obverseImageUrl`/`item.reverseImageUrl` — API results are display/cache-only; inventory is only written via the edit form save path
- **STAK-306**: Removed N# input from the custom pattern rules edit form
- **STAK-312**: Added "Purge Numista URLs" button in Settings → Images — scoped wipe of CDN URL fields only (user uploads and pattern images unaffected)

## Regression Tests

`tests/numista-regression.spec.js` — 3 new tests (no API key required):
- `STAK-309-a`: Clearing N# + URL persists through save and reload
- `STAK-309-b`: Clearing N# wipes numistaData fields
- `STAK-311`: Changing N# clears the old CDN URL

## Linear Issues

- STAK-309: Numista N#/image/metadata re-populates after edit+save on page refresh
- STAK-311: Images cross-contaminating across items (wrong Numista images)
- STAK-306: Remove N# field from custom pattern rules form
- STAK-312: Add "Purge all Numista URLs" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)