### PR TITLE
v3.32.37 — Wiki-First Documentation Policy

### DIFF
--- a/.claude/skills/api-infrastructure/SKILL.md
+++ b/.claude/skills/api-infrastructure/SKILL.md
@@ -63,9 +63,9 @@ Turso is a free-tier cloud libSQL database — internal to the retail poller. NO
 | `js/api-health.js` | Stale thresholds, feed URLs, `_normalizeTs` logic |
 | `docs/devops/api-infrastructure-runbook.md` | Architecture, per-feed details, diagnosis commands, Turso section if schema or credentials change |
 | `CLAUDE.md` API Infrastructure table | Feed/threshold/healthy-check summary |
-| Notion — **API Infrastructure** page | Human-readable runbook (sync from markdown) |
-| Notion — **CI/CD & Deployment** page | GHA workflow table if workflows change |
-| Notion — **Fly.io — All-in-One Container** page | If Fly config, crons, or VM spec changes |
+| StakTrakrWiki: `health.md` + `fly-container.md` | Human-readable runbook (architecture, health checks) |
+| StakTrakrWiki: `fly-container.md` (GHA section) | GHA workflow table if workflows change |
+| StakTrakrWiki: `fly-container.md` | If Fly config, crons, or VM spec changes |
 | `lbruton/StakTrakrApi` `README.md` | If endpoints, branches, or directory structure changes |
 
 ---
@@ -117,15 +117,6 @@ EOF
 | Firecrawl cloud HTTP 402 — credits exhausted | STAK-268 | Open |
 | Goldback stale ~39h | STAK-269 | Open |
 
----
 
-## Notion Pages (Infrastructure WIKI)
-
-All under **StakTrakr — Infrastructure** (parent page ID `31090430-390b-81fe-bba2-e6e0d28f181c`):
-
-| Page | Notion ID | Keep in sync with |
-|------|-----------|-------------------|
-| API Infrastructure | `31090430-390b-811b-821b-cd6388650fa5` | `docs/devops/api-infrastructure-runbook.md` |
-| Fly.io — All-in-One Container | `31090430-390b-81d2-abb4-c471d25120cf` | `devops/retail-poller/fly.toml` + `Dockerfile` |
-| CI/CD & Deployment | `31090430-390b-8122-9e0f-c2f1dd1891e2` | `.github/workflows/` |
-| Secrets & Keys | `31090430-390b-8116-8384-ccd867bf54a2` | GHA secrets + Infisical |
+> **Note:** Notion infrastructure pages are deprecated. Do not update them. StakTrakrWiki is the only target.
+> Deprecated Notion pages: API Infrastructure, Fly.io — All-in-One Container, CI/CD & Deployment, Secrets & Keys.

--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: finishing-a-development-branch
+description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+---
+
+# Finishing a Development Branch
+
+## Overview
+
+Guide completion of development work by presenting clear options and handling chosen workflow.
+
+**Core principle:** Verify tests → Wiki Update Gate → Present options → Execute choice → Clean up.
+
+**Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
+
+> **⛔ StakTrakr workflow — read before Step 2:**
+> - `patch/*` branches always PR to **`dev`** — never to `main`
+> - `dev → main` merges are ONLY allowed via Phase 4.5 of `/release`, and ONLY when the user has explicitly said "release" or "ready to ship" in this session
+> - **Completing implementation ≠ releasing.** The user decides when to release.
+
+## The Process
+
+### Step 1: Verify Tests
+
+**Before presenting options, verify tests pass:**
+
+```bash
+# Run project's test suite
+npm test / cargo test / pytest / go test ./...
+```
+
+**If tests fail:**
+```
+Tests failing (<N> failures). Must fix before completing:
+
+[Show failures]
+
+Cannot proceed with merge/PR until tests pass.
+```
+
+Stop. Don't proceed to Step 2.
+
+**If tests pass:** Continue to Step 2.
+
+### Step 2: Determine Base Branch
+
+**First, check the current branch name** — this determines the correct base:
+
+```bash
+git branch --show-current
+```
+
+| Current branch pattern | Correct base | Notes |
+|------------------------|--------------|-------|
+| `patch/*` or `patch-*` | **`dev`** | StakTrakr patch workflow — NEVER target main |
+| `feature/*`, `fix/*`, etc. | Check CLAUDE.md PR Lifecycle section | May still be `dev` |
+| `dev` | **`main`** | Only allowed via Phase 4.5, requires explicit user "release" instruction |
+
+```bash
+# Only fall back to git merge-base if branch name gives no clear signal
+git merge-base HEAD dev 2>/dev/null || git merge-base HEAD main 2>/dev/null
+```
+
+> **⛔ StakTrakr rule:** If on a `patch/*` branch, the base is **always `dev`**. Never propose merging a patch branch to `main`. If the detected base would be `main` and you are NOT on the `dev` branch, STOP and ask the user before proceeding.
+
+### Step 2.5: Wiki Update Gate (mandatory before PR)
+
+Run before creating any PR:
+
+1. **Identify changed files:**
+   ```bash
+   git diff --name-only HEAD~1..HEAD
+   ```
+
+2. **If any changed files match frontend patterns** (`js/`, `sw.js`, `index.html`):
+   → Dispatch wiki-update (invoke `wiki-update` skill as a background Task agent)
+
+3. **If any changed files match API/infrastructure patterns** (`js/api.js`, `js/api-health.js`, `docs/devops/`, `.claude/skills/api-infrastructure/`):
+   → Add a comment to the PR after creation:
+   ```
+   ⚠️ API-related change — verify StakTrakrWiki infrastructure pages are current.
+   Check: health.md, fly-container.md, spot-pipeline.md as applicable.
+   ```
+
+4. **If instruction files changed** (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`):
+   → Run `/sync-instructions` after the PR is created.
+
+This extends the wiki-update pattern from `/release` Phase 3 into the non-release commit path.
+
+### Step 3: Present Options
+
+Present exactly these 4 options:
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base-branch> locally
+2. Push and create a Pull Request → <base-branch>
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?
+```
+
+**Don't add explanation** - keep options concise.
+
+### Step 4: Execute Choice
+
+#### Option 1: Merge Locally
+
+```bash
+# Switch to base branch
+git checkout <base-branch>
+
+# Pull latest
+git pull
+
+# Merge feature branch
+git merge <feature-branch>
+
+# Verify tests on merged result
+<test command>
+
+# If tests pass
+git branch -d <feature-branch>
+```
+
+Then: Cleanup worktree (Step 5)
+
+#### Option 2: Push and Create PR
+
+```bash
+# Push branch
+git push -u origin <feature-branch>
+
+# Create PR — ALWAYS use the base determined in Step 2 (never assume main)
+gh pr create --base <base-branch> --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<2-3 bullets of what changed>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+> **⛔ Reminder:** `<base-branch>` must come from Step 2. For `patch/*` branches it is always `dev`.
+
+Then: Cleanup worktree (Step 5)
+
+#### Option 3: Keep As-Is
+
+Report: "Keeping branch <name>. Worktree preserved at <path>."
+
+**Don't cleanup worktree.**
+
+#### Option 4: Discard
+
+**Confirm first:**
+```
+This will permanently delete:
+- Branch <name>
+- All commits: <commit-list>
+- Worktree at <path>
+
+Type 'discard' to confirm.
+```
+
+Wait for exact confirmation.
+
+If confirmed:
+```bash
+git checkout <base-branch>
+git branch -D <feature-branch>
+```
+
+Then: Cleanup worktree (Step 5)
+
+### Step 5: Cleanup Worktree
+
+**For Options 1, 2, 4:**
+
+Check if in worktree:
+```bash
+git worktree list | grep $(git branch --show-current)
+```
+
+If yes:
+```bash
+git worktree remove <worktree-path>
+```
+
+**For Option 3:** Keep worktree.
+
+## Quick Reference
+
+| Option | Merge | Push | Keep Worktree | Cleanup Branch |
+|--------|-------|------|---------------|----------------|
+| 1. Merge locally | ✓ | - | - | ✓ |
+| 2. Create PR | - | ✓ | ✓ | - |
+| 3. Keep as-is | - | - | ✓ | - |
+| 4. Discard | - | - | - | ✓ (force) |
+
+## Common Mistakes
+
+**Skipping test verification**
+- **Problem:** Merge broken code, create failing PR
+- **Fix:** Always verify tests before offering options
+
+**Open-ended questions**
+- **Problem:** "What should I do next?" → ambiguous
+- **Fix:** Present exactly 4 structured options
+
+**Automatic worktree cleanup**
+- **Problem:** Remove worktree when might need it (Option 2, 3)
+- **Fix:** Only cleanup for Options 1 and 4
+
+**No confirmation for discard**
+- **Problem:** Accidentally delete work
+- **Fix:** Require typed "discard" confirmation
+
+**Defaulting to `main` as the base**
+- **Problem:** `git merge-base HEAD main` always returns `main`, even for patch branches
+- **Fix:** Check branch name first — `patch/*` → base is `dev`
+
+## Red Flags
+
+**Never:**
+- Proceed with failing tests
+- Merge without verifying tests on result
+- Delete work without confirmation
+- Force-push without explicit request
+- **Target `main` from a `patch/*` branch** — the base is always `dev` for patch branches
+- **Merge `dev → main` without explicit user "release" instruction** — this is a protected action
+
+**Always:**
+- Verify tests before offering options
+- Run the Wiki Update Gate (Step 2.5) before any PR
+- Present exactly 4 options
+- Get typed confirmation for Option 4
+- Clean up worktree for Options 1 & 4 only
+- Use the base branch determined in Step 2 — never assume `main`
+
+**Rationalization traps — STOP if you think:**
+- "The branch is based on main so I should PR to main" → check the branch name pattern first
+- "This is the final step so it should go to main" → only `dev → main` goes to main, and only on user instruction
+- "The workflow is complete, time to release" → completing implementation ≠ releasing; user decides when to release
+
+## Integration
+
+**Called by:**
+- **subagent-driven-development** (Step 7) - After all tasks complete
+- **executing-plans** (Step 5) - After all batches complete
+
+**Pairs with:**
+- **using-git-worktrees** - Cleans up worktree created by that skill

--- a/.claude/skills/wiki-search/SKILL.md
+++ b/.claude/skills/wiki-search/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: wiki-search
+description: Use when searching for documentation, architecture decisions, or operational runbooks in StakTrakrWiki. Guides indexing and querying the wiki via mcp__claude-context__search_code.
+---
+
+# Wiki Search
+
+Use `mcp__claude-context__search_code` to search StakTrakrWiki for documentation, architecture decisions, and operational runbooks. The wiki is indexed separately from the codebase — use the `path` parameter to target the right index.
+
+## When to Use Wiki Search vs. Code Search
+
+| Question type | Use |
+|---------------|-----|
+| "How does X work?" (conceptual) | Wiki search → `path: /Volumes/DATA/GitHub/StakTrakrWiki` |
+| "Where is X implemented?" (structural) | Code search → `path: /Volumes/DATA/GitHub/StakTrakr` |
+| "What are the stale thresholds for the spot feed?" | Wiki search |
+| "What calls `syncRetailPrices()`?" | Code graph context (CGC) |
+| "Where is `safeGetElement` defined?" | Code search or Grep |
+| "What does the Fly.io cron schedule look like?" | Wiki search |
+
+**Rule of thumb:** Documentation questions → wiki. Implementation questions → code.
+
+---
+
+## How to Index the Wiki
+
+Run this when the wiki has never been indexed, or after major structural updates:
+
+```
+mcp__claude-context__index_codebase
+  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  splitter: langchain
+  customExtensions: [".md"]
+```
+
+Force re-index after major wiki updates:
+
+```
+mcp__claude-context__index_codebase
+  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  splitter: langchain
+  customExtensions: [".md"]
+  force: true
+```
+
+---
+
+## Check Index Status
+
+```
+mcp__claude-context__get_indexing_status
+```
+
+The wiki should show ~19 files, ~74 chunks when fully indexed. If counts are lower than expected, run `index_codebase` with `force: true`.
+
+---
+
+## How to Search
+
+```
+mcp__claude-context__search_code
+  query: "your natural language query"
+  path: /Volumes/DATA/GitHub/StakTrakrWiki
+```
+
+---
+
+## Example Queries
+
+| Query | Expected pages |
+|-------|----------------|
+| `"API stale thresholds"` | `health.md`, `spot-pipeline.md` |
+| `"Fly.io cron schedule"` | `fly-container.md` |
+| `"Turso merge logic"` | `retail-pipeline.md` |
+| `"safeGetElement pattern"` | `dom-patterns.md` |
+| `"spot pipeline stale thresholds"` | `health.md`, `spot-pipeline.md` |
+| `"release workflow worktree"` | `release-workflow.md` |
+| `"goldback scrape daily"` | `goldback-pipeline.md` |
+| `"secrets rotation"` | `secrets.md` |
+
+---
+
+## Wiki Page Index
+
+### Infrastructure (maintained by StakTrakrApi agents)
+
+| Page | Topic |
+|------|-------|
+| `architecture-overview.md` | System diagram, repo boundaries, data feeds |
+| `retail-pipeline.md` | Dual-poller, Turso, providers.json, OOS detection |
+| `fly-container.md` | Services, cron, env vars, proxy config, deployment |
+| `home-poller.md` | Proxmox LXC setup, cron, sync process |
+| `spot-pipeline.md` | GitHub Actions, MetalPriceAPI, hourly files |
+| `goldback-pipeline.md` | Daily scrape, run-goldback.sh |
+| `providers.md` | URL strategy, year-start patterns, update process |
+| `secrets.md` | Where every secret lives, how to rotate |
+| `health.md` | Quick health checks, stale thresholds, diagnosis commands |
+
+### Frontend (maintained by StakTrakr Claude Code)
+
+| Page | Topic |
+|------|-------|
+| `frontend-overview.md` | File structure, script load order, service worker, PWA |
+| `data-model.md` | Portfolio model, storage keys, coin/entry schema |
+| `storage-patterns.md` | saveData/loadData wrappers, sync variants, key validation |
+| `dom-patterns.md` | safeGetElement, sanitizeHtml, event delegation |
+| `sync-cloud.md` | Cloud backup/restore, vault encryption, sync flow |
+| `retail-modal.md` | Coin detail modal, vendor legend, OOS detection |
+| `api-consumption.md` | Spot feed, market price feed, goldback feed, health checks |
+| `release-workflow.md` | Patch cycle, version bump, worktree pattern, ship to main |
+| `service-worker.md` | CORE_ASSETS, cache strategy, pre-commit stamp hook |
+
+---
+
+## Notes
+
+- The code index (StakTrakr repo) and wiki index are separate — both can be searched via the `path` parameter.
+- Re-index with `force: true` after major wiki restructuring to ensure accurate results.
+- Infrastructure pages are owned by StakTrakrApi Claude. For infra questions, search first, then verify with `/remember api infrastructure` if needed.
+- Raw pages accessible at: `https://raw.githubusercontent.com/lbruton/StakTrakrWiki/main/<page>.md`

--- a/.claude/skills/wiki-update/SKILL.md
+++ b/.claude/skills/wiki-update/SKILL.md
@@ -84,6 +84,26 @@ Output when done:
 Wiki updated: [list of pages pushed]
 ```
 
+## Infrastructure Page Mapping (informational)
+
+Infrastructure pages are owned by StakTrakrApi Claude. StakTrakr Claude should **flag** when they may be stale — do not rewrite them directly.
+
+| Changed file (StakTrakr) | May affect wiki page |
+|----------------------------------|---------------------------|
+| `js/api.js`, `js/api-health.js` | `api-consumption.md` |
+| `docs/devops/` | `health.md` (deprecated local runbook — wiki is authoritative) |
+| `.claude/skills/api-infrastructure/` | `architecture-overview.md` |
+| `CLAUDE.md` (API section) | `health.md`, `fly-container.md` |
+
+When any of these patterns are detected in `CHANGED`, add a note to the PR:
+```
+⚠️ API-related change — verify StakTrakrWiki infrastructure pages are current.
+Check: health.md, fly-container.md, spot-pipeline.md as applicable.
+StakTrakrApi Claude owns these pages — flag, don't rewrite.
+```
+
+---
+
 ## Integration point in release skill
 
 This skill is invoked after the version bump commit in Phase 3 of `/release patch`:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -316,6 +316,17 @@ The project uses `ruleset.xml` at the project root. PMD analyzes JavaScript for 
 | `ScopeError` | Variables used outside their declared scope |
 | `GlobalVariable` | Implicit global variable creation (missing `const`/`let`/`var`) |
 
+## Documentation Policy
+
+StakTrakrWiki (`lbruton/StakTrakrWiki`) is the single source of truth for all
+architecture, operational runbooks, and pattern documentation. Do not create
+new markdown documentation in this repo (except `docs/plans/` for planning artifacts).
+
+After any commit that changes behavior, update the relevant wiki page via `gh api`.
+Use `claude-context` to search the wiki: index path `/Volumes/DATA/GitHub/StakTrakrWiki`.
+
+---
+
 ## Review Focus Areas
 
 - **Error handling in async code**: Promise chains should have `.catch()` handlers, especially in service worker code and API calls

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !.claude/skills/wiki-update/
 !.claude/skills/wiki-audit/
 !.claude/skills/wiki-sweep/
+!.claude/skills/wiki-search/
 !.claude/skills/ship/
 !.claude/skills/brainstorming/
 .claude/commands/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,23 @@ Architecture, data pipelines, Fly.io, pollers, secrets — see `github.com/lbrut
 - Use `/wiki-audit` for background drift detection and auto-correction
 - Raw pages accessible at `raw.githubusercontent.com/lbruton/StakTrakrWiki/main/<page>.md`
 
+## Documentation Policy
+
+StakTrakrWiki (`lbruton/StakTrakrWiki`) is the single source of truth for all
+architecture, operational runbooks, and pattern documentation. Do not create
+new markdown documentation in this repo (except `docs/plans/` for planning artifacts).
+
+After any commit that changes behavior, update the relevant wiki page via `gh api`.
+Use `claude-context` to search the wiki: index path `/Volumes/DATA/GitHub/StakTrakrWiki`.
+
+```
+mcp__claude-context__search_code
+  query: "your question about how something works"
+  path: /Volumes/DATA/GitHub/StakTrakrWiki
+```
+
+---
+
 ## Commit & Pull Request Guidelines
 
 Commit message styles:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.37] - 2026-02-25
+
+### Changed — Wiki-First Documentation Policy
+
+- **Changed**: StakTrakrWiki declared as sole source of truth; Notion infrastructure pages deprecated — do not update them
+- **Changed**: `docs/devops/api-infrastructure-runbook.md` deprecated with banner; wiki pages `health.md`, `fly-container.md`, `spot-pipeline.md` are now authoritative
+- **Added**: `wiki-search` skill for indexing and querying StakTrakrWiki via `mcp__claude-context__search_code` with `path: /Volumes/DATA/GitHub/StakTrakrWiki`
+- **Changed**: `mcp__claude-context__search_code` documented in CLAUDE.md for both code and wiki search
+- **Changed**: `finishing-a-development-branch` skill updated with mandatory Wiki Update Gate before PR creation
+- **Changed**: AGENTS.md, GEMINI.md, copilot-instructions.md updated with Documentation Policy section
+
+---
+
 ## [3.32.36] - 2026-02-25
 
 ### Fixed — STAK-309/STAK-311: Numista Data Integrity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ These rules fire before any implementation, no exceptions:
 ## Code Search — Cheapest First
 
 1. `mcp__code-graph-context__*` — structural: callers, call chains, imports, dead code
-2. `mcp__claude-context__search_code` — semantic: "find code related to X"
+2. `mcp__claude-context__search_code` — semantic: "find code related to X" (path: `/Volumes/DATA/GitHub/StakTrakr`) OR wiki docs (path: `/Volumes/DATA/GitHub/StakTrakrWiki`) — e.g. "find wiki pages about spot pipeline stale thresholds"
 3. `Grep` / `Glob` — literal strings, filenames
 4. Explore agent — only after tiers 1-3 are insufficient
 
@@ -59,7 +59,7 @@ Works on `file://` and HTTP. Runtime artifact: zero build step, zero install. Se
 
 > **Separation of duties:** `StakTrakr` = frontend only. All API backend poller code, Fly.io devops, and GHA data workflows live in `lbruton/StakTrakrApi`. Do not add poller scripts, Fly.io config, or data-pipeline workflows to this repo.
 
-**Runbook:** `docs/devops/api-infrastructure-runbook.md` — full architecture, per-feed diagnosis, and quick-check commands.
+**Runbook:** See StakTrakrWiki for current runbooks: [`health.md`](https://github.com/lbruton/StakTrakrWiki/blob/main/health.md), [`fly-container.md`](https://github.com/lbruton/StakTrakrWiki/blob/main/fly-container.md), [`spot-pipeline.md`](https://github.com/lbruton/StakTrakrWiki/blob/main/spot-pipeline.md). (`docs/devops/api-infrastructure-runbook.md` is deprecated.)
 
 Three feeds served from `lbruton/StakTrakrApi` main branch via GitHub Pages at `api.staktrakr.com`:
 
@@ -168,7 +168,7 @@ All agents run on the same Mac and share the same Docker/IP stack.
 | `memento` | ✅ | ✅ | ✅ | Neo4j knowledge graph (paused for mem0 trial) |
 | `sequential-thinking` | ✅ | ✅ | ✅ | Structured reasoning |
 | `brave-search` | ✅ | ✅ | ✅ | Web search |
-| `claude-context` | ✅ | ✅ | ✅ | Semantic code search (Milvus) |
+| `claude-context` | ✅ | ✅ | ✅ | Semantic code search AND wiki documentation search (index both repos separately) |
 | `context7` | ✅ | ✅ | ✅ | Library documentation |
 | `firecrawl-local` | ✅ | ✅ | ✅ | Self-hosted scraping (port 3002) |
 | `linear` | ✅ | ✅ | ✅ | Issue tracking |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -293,6 +293,23 @@ Pages are accessible at:
 
 Use `brave-search` or `firecrawl-local` to fetch if needed. Prefer reading the raw URL directly when context permits.
 
+## Documentation Policy
+
+StakTrakrWiki (`lbruton/StakTrakrWiki`) is the single source of truth for all
+architecture, operational runbooks, and pattern documentation. Do not create
+new markdown documentation in this repo (except `docs/plans/` for planning artifacts).
+
+After any commit that changes behavior, update the relevant wiki page via `gh api`.
+Use `claude-context` to search the wiki: index path `/Volumes/DATA/GitHub/StakTrakrWiki`.
+
+```
+mcp__claude-context__search_code
+  query: "your question about how something works"
+  path: /Volumes/DATA/GitHub/StakTrakrWiki
+```
+
+---
+
 ## Cross-Agent Handoff Protocol
 
 StakTrakr uses a multi-agent development workflow. Four agents collaborate:

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Wiki-First Documentation Policy (v3.32.37)**: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.
 - **Bug Fixes — Numista Data Integrity (v3.32.36)**: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).
 - **Header Buttons Reorder (v3.32.35)**: Toggle visibility and reorder header buttons in Settings → Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).
 - **Force Refresh Button (v3.32.34)**: New button in Settings &rarr; System &rarr; App Updates. Unregisters service workers and reloads to fetch the latest version. Use if the app appears stuck on an old version after an update (STAK-324).
 - **Bug Fix — 7-Day Sparklines (v3.32.33)**: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).
-- **Cloud Backup Labels (v3.32.32)**: Backup list now shows "Inventory backup" or "Image backup" label on each row so you can tell at a glance which files contain your items vs. your photos (STAK-316).
 
 ## Development Roadmap
 

--- a/docs/devops/api-infrastructure-runbook.md
+++ b/docs/devops/api-infrastructure-runbook.md
@@ -1,3 +1,9 @@
+> ⚠️ DEPRECATED — This file is no longer the authoritative source.
+> See StakTrakrWiki: https://github.com/lbruton/StakTrakrWiki
+> Equivalent pages: health.md, fly-container.md, spot-pipeline.md,
+>   retail-pipeline.md, goldback-pipeline.md, architecture-overview.md
+> This file will be deleted after the next wiki audit confirms parity.
+
 # API Infrastructure Runbook
 
 > **Last verified:** 2026-02-23 — GH Pages serves `api` branch (not `main`); `run-goldback.sh` fixed to push `api`

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.37 &ndash; Wiki-First Documentation Policy</strong>: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.</li>
     <li><strong>v3.32.36 &ndash; Bug Fixes &mdash; Numista Data Integrity</strong>: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).</li>
     <li><strong>v3.32.35 &ndash; Header Buttons Reorder</strong>: Toggle visibility and reorder header buttons in Settings &rarr; Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).</li>
     <li><strong>v3.32.34 &ndash; Force Refresh Button</strong>: New button in Settings &rarr; System &rarr; App Updates. Unregisters service workers and reloads to fetch the latest version. Use if the app appears stuck on an old version after an update (STAK-324).</li>
     <li><strong>v3.32.33 &ndash; Bug Fix &mdash; 7-Day Sparklines</strong>: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).</li>
-    <li><strong>v3.32.32 &ndash; Cloud Backup Labels</strong>: Backup list now shows &ldquo;Inventory backup&rdquo; or &ldquo;Image backup&rdquo; label on each row so you can tell at a glance which files contain your items vs. your photos (STAK-316).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.36";
+const APP_VERSION = "3.32.37";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.36-b1772000578';
+const CACHE_NAME = 'staktrakr-v3.32.37-b1772006155';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.36",
+  "version": "3.32.37",
   "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review passes. Do NOT target main.

## Changes

- Remove Notion references from `api-infrastructure` skill; replace with StakTrakrWiki pages (`health.md`, `fly-container.md`)
- Add deprecation banner to `docs/devops/api-infrastructure-runbook.md` — wiki is now authoritative
- Update `CLAUDE.md`: `mcp__claude-context__search_code` now documented for both code and wiki search; API runbook reference replaced with wiki links; MCP parity table updated
- Add new `wiki-search` skill: guides indexing and querying StakTrakrWiki via `mcp__claude-context__search_code`
- Update `finishing-a-development-branch` skill: add mandatory Wiki Update Gate (Step 2.5) before every PR
- Update `wiki-update` skill: add infrastructure page mapping table with "flag, don't rewrite" guidance
- Update `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`: add Documentation Policy section
- Update `.gitignore` to allow tracking `wiki-search` skill

## Verification

- Zero `notion` references remain in `.claude/skills/` or instruction files
- `docs/devops/api-infrastructure-runbook.md` has deprecation banner at line 1
- `wiki-search/SKILL.md` present with indexing + query instructions
- `finishing-a-development-branch/SKILL.md` has Wiki Update Gate section

## StakTrakrWiki

Companion commit pushed to `lbruton/StakTrakrWiki` (main): Updated `README.md` Contributing section + created `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)