### PR TITLE
chore: API pipeline audit — retire spot GHA, update skills for Fly.io architecture

### DIFF
--- a/.claude/skills/api-infrastructure/SKILL.md
+++ b/.claude/skills/api-infrastructure/SKILL.md
@@ -11,11 +11,10 @@ All feeds served from `lbruton/StakTrakrApi` `main` branch via GitHub Pages at `
 
 | Feed | File | Poller | Threshold |
 |------|------|--------|-----------|
-| **Market prices** | `data/api/manifest.json` | Fly.io `staktrakr` cron (`*/30 min`) | 30 min |
-| **Spot prices** | `data/hourly/YYYY/MM/DD/HH.json` | `spot-poller.yml` GHA (`:05`, `:20`, `:35`, `:50`/hr) | 20 min |
-| **Spot prices (15-min)** | `data/15min/YYYY/MM/DD/HHMM.json` | `spot-poller.yml` GHA (`:05/:20/:35/:50`) | 20 min |
-| **Goldback** | `data/api/goldback-spot.json` | Fly.io `staktrakr` cron (daily 17:01 UTC) | 25h (info only) |
-| **Turso** | `price_snapshots` table | retail-poller only | internal write store |
+| **Market prices** | `data/api/manifest.json` | Fly.io `run-local.sh` + `run-publish.sh` | 30 min |
+| **Spot prices** | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` cron (`5,20,35,50 * * * *`) | 75 min |
+| **Goldback** | `data/api/goldback-spot.json` | Fly.io via `goldback-g1` coin in `run-local.sh` | 25h (info only) |
+| **Turso** | `price_snapshots` table | Dual-poller write-through (Fly.io `POLLER_ID=api` + home VM `POLLER_ID=home`) | internal |
 
 **Critical:** `spot-history-YYYY.json` is a **seed file** (noon UTC daily) — never use it for freshness checks. Live spot data is always in `data/hourly/`.
 
@@ -23,11 +22,12 @@ All feeds served from `lbruton/StakTrakrApi` `main` branch via GitHub Pages at `
 
 ## Fly.io Container (`staktrakr`)
 
-- **App:** `staktrakr` — region `iad`, always-on (min 1 machine, auto-stop off)
-- **Config:** `devops/retail-poller/fly.toml` + `Dockerfile`
-- **Runs:** Firecrawl + Playwright + retail-poller cron + goldback cron + serve.js
-- **NOT spot prices** — spot is pure GHA, no Docker, no Fly
-- **Deploy:** `cd devops/retail-poller && fly deploy`
+- **App:** `staktrakr` — region `dfw`, 4096MB RAM, 4 shared CPUs
+- **Config:** `StakTrakrApi/devops/fly-poller/fly.toml` + `Dockerfile` — **not in the StakTrakr repo**
+- **Runs:** Firecrawl + Playwright + Redis + RabbitMQ + PostgreSQL + retail cron + spot cron + goldback + serve.js
+- **Spot prices run here** — `run-spot.sh` at `5,20,35,50 * * * *` (NOT GHA)
+- **Deploy:** From `lbruton/StakTrakrApi` repo: `cd devops/fly-poller && fly deploy`
+- **NEVER run `fly deploy` from the StakTrakr or stakscrapr repos**
 - **Logs:** `fly logs --app staktrakr`
 - **SSH:** `fly ssh console --app staktrakr`
 
@@ -37,7 +37,7 @@ All feeds served from `lbruton/StakTrakrApi` `main` branch via GitHub Pages at `
 
 | Workflow | Repo | Schedule | Purpose |
 |----------|------|----------|---------|
-| `spot-poller.yml` | `StakTrakr` | `:05`, `:20`, `:35`, `:50` every hour | Python → MetalPriceAPI → `data/hourly/` |
+| `spot-poller.yml` | `StakTrakr` | **RETIRED 2026-02-23** — `workflow_dispatch` only | Was Python→MetalPriceAPI; now Fly.io `run-spot.sh` |
 | `Merge Poller Branches` | `StakTrakrApi` | `*/15 min` | Merges `api` → `main` → triggers GH Pages |
 
 ---
@@ -52,7 +52,6 @@ Turso is a free-tier cloud libSQL database — internal to the retail poller. NO
 - **Used by:** `price-extract.js`, `extract-vision.js`, `api-export.js` (retail-poller only)
 - **NOT used by:** spot-poller (Python GHA), goldback-scraper
 - **Free tier:** zero cost, zero ops — no action needed
-- `prices.db` is a read-only SQLite snapshot exported to StakTrakrApi each cycle (offline use only)
 
 ---
 

--- a/.claude/skills/repo-boundaries/SKILL.md
+++ b/.claude/skills/repo-boundaries/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: repo-boundaries
+description: Use when doing any cross-repo work, deploying, or when unsure which repo owns a piece of code. Maps exactly which code belongs in which repo and what each agent is allowed to do. Also use when the words fly deploy, StakTrakrApi, stakscrapr, or home poller appear in context.
+---
+
+# Repo Boundaries
+
+## Repo Ownership Map
+
+| Repo | Owns | Does NOT own |
+|------|------|--------------|
+| `lbruton/StakTrakr` | Frontend HTML/JS/CSS, `.claude/` skills, CLAUDE.md, smoke tests | Poller scripts, fly.toml, Dockerfile, devops crons |
+| `lbruton/StakTrakrApi` | ALL backend devops: fly.toml, Dockerfile, all run-*.sh, price-extract.js, api-export.js, spot-poller, providers.json | Frontend code |
+| `lbruton/stakscrapr` | Home VM full stack: identical scraper core + dashboard.js + tinyproxy/Cox residential proxy + Tailscale exit node config | fly.toml authority (StakTrakrApi owns it), `fly deploy` |
+| `lbruton/StakTrakrWiki` | Shared infrastructure documentation | Code, config, scripts |
+
+---
+
+## Deploy Rules — Read Before ANY Deploy
+
+| Action | Allowed from | Forbidden from |
+|--------|-------------|----------------|
+| `fly deploy` | `StakTrakrApi/devops/fly-poller/` on this Mac only | StakTrakr repo, stakscrapr repo, home VM, anywhere else |
+| `git push` to `api` branch (data files) | Fly.io container `run-publish.sh` only — via force-push | Local Mac, home VM, any GHA, manually |
+| PR to `StakTrakrApi` main | StakTrakr Mac Claude or stakscrapr Claude | Direct push to main |
+| `providers.json` URL fix | Direct push to `api` branch in `StakTrakrApi` | Any other method |
+
+> **⛔ NEVER run `fly deploy` from the StakTrakr repo or the stakscrapr repo.**
+> The only valid `fly deploy` path: `cd /path/to/StakTrakrApi/devops/fly-poller && fly deploy`
+
+---
+
+## Fly.io Container — Authoritative fly.toml Location
+
+**`StakTrakrApi/devops/fly-poller/fly.toml`** is the authoritative fly.toml.
+
+- 4096MB RAM, 4 shared CPUs, region dfw
+- Supervisord runs: redis, rabbitmq, postgres, playwright-service, firecrawl-api, firecrawl-worker, firecrawl-extract-worker, cron, http-server
+- **`stakscrapr/fly.toml` is STALE (2048MB)** — do not use it, do not deploy from it
+
+---
+
+## Home VM (192.168.1.48) — What stakscrapr Owns
+
+The home VM runs the **identical scraper core** (same price-extract.js, api-export.js as Fly.io) PLUS home-only additions:
+
+| Component | Purpose |
+|-----------|---------|
+| `dashboard.js` (port 3010) | Monitors both pollers via Turso `poller_runs` table + `/tmp/flyio-health.json` |
+| `check-flyio.sh` | Polls Fly.io health, writes `/tmp/flyio-health.json` for dashboard |
+| tinyproxy (port 8889) | HTTP proxy — routes Fly.io scraper traffic through Cox residential IP |
+| Tailscale exit node (`100.112.198.50`) | Fly.io container traffic exits through home residential IP for bot evasion |
+
+**stakscrapr Claude rule:** NEVER run `fly deploy`. Open a PR to `lbruton/StakTrakrApi` instead.
+
+---
+
+## StakTrakrApi devops/ Folder Map
+
+| Folder | Contains |
+|--------|---------|
+| `devops/scraper/` | Shared engine (both pollers): price-extract.js, api-export.js, capture.js, extract-vision.js, spot-poller/poller.py, package.json |
+| `devops/fly-poller/` | Fly.io deploy wrapper: fly.toml, Dockerfile, run-local.sh, run-publish.sh, run-spot.sh, run-retry.sh, run-fbp.sh, docker-entrypoint.sh, supervisord.conf |
+| `devops/home-scraper/` | Home VM additions: run-home.sh, dashboard.js, check-flyio.sh, supervisord.conf (11 services), .env.example |
+| `devops/home-vm/` | Infrastructure: tinyproxy-cox.conf, cox-auth.sh/service/timer, update-cox-proxy-ip.sh |
+
+---
+
+## Change Gate: Home VM Change → Fly.io
+
+When a code change on the home VM needs to reach Fly.io:
+
+```
+1. Home Claude edits devops/scraper/ file
+2. Opens PR to StakTrakrApi main
+3. StakTrakr Mac Claude reviews + merges
+4. StakTrakr Mac Claude: cd devops/fly-poller && fly deploy
+5. Home VM: curl raw.githubusercontent.com/StakTrakrApi/main/devops/scraper/<file> -o /opt/poller/<file>
+```
+
+**providers.json URL changes** skip steps 3–5 entirely — push directly to `api` branch (auto-synced every run).
+
+---
+
+## Dual-Poller Turso Write-Through
+
+Both pollers write to the same Turso DB (`price_snapshots` table). Only Fly.io publishes to GitHub.
+
+| Poller | POLLER_ID | Writes to | Publishes to Git |
+|--------|-----------|-----------|-----------------|
+| Fly.io container | `api` | Turso | ✅ Yes — `run-publish.sh` force-pushes to `api` branch |
+| Home VM (192.168.1.48) | `home` | Turso | ❌ No — never touches git |
+
+`readLatestPerVendor(db, coinSlug, lookbackHours=2)` — most recent row per vendor within 2h wins at publish time.

--- a/.claude/skills/retail-poller/SKILL.md
+++ b/.claude/skills/retail-poller/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: retail-poller
+description: Use when working on the retail market price poller — debugging scraping failures, wrong prices, confidence scores, providers.json config, adding vendors or coins, understanding the data pipeline, or investigating what latest.json contains.
+---
+
+# StakTrakr Retail Price Poller
+
+Reference guide for the retail market price polling system. Scrapes dealer websites, scores confidence, exports REST JSON served from the `api` branch.
+
+---
+
+## Architecture Overview
+
+```
+providers.json (api branch)
+       ↓
+price-extract.js  (Firecrawl → Turso)
+       +
+capture.js  (Browserbase/browserless → screenshots)
+       +
+extract-vision.js  (Gemini Vision → per-coin vision JSON)
+       ↓
+api-export.js  (Turso + vision JSON → data/api/ REST endpoints → api branch)
+```
+
+> **Repo:** All scripts listed in this skill live in `lbruton/StakTrakrApi` — NOT in the StakTrakr repo. Deploy: `cd StakTrakrApi/devops/fly-poller && fly deploy`.
+
+**Fly.io container is the sole scraping pipeline — no GHA cloud fallback:**
+
+| Pipeline | Browser | Role | Trigger |
+|----------|---------|------|---------|
+| **Fly.io** (`run-local.sh`) | Playwright (self-hosted, `localhost:3002`) | **Primary + only** | Every 15 min via container cron |
+
+**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). All retail scraping now runs exclusively in the Fly.io container via self-hosted Firecrawl + the home VM secondary poller.
+
+**Key constraint:** `providers.json` lives on the **`api` branch**, not `main` or `dev`.
+Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
+
+**Vision verification + fallback:** Vision runs inline — no separate follow-up step. Screenshots go to `ARTIFACT_DIR` (`/tmp/retail-screenshots/{date}` on Fly.io). `extract-vision.js` reads `MANIFEST_PATH` AND reads Firecrawl prices from Turso to pass as context in the Gemini prompt. Vision JSON writes to `DATA_DIR/retail/{slug}/{date}-vision.json` with fields: `firecrawl_by_site` (Firecrawl prices for comparison) and `agreement_by_site` (per-vendor boolean: does Vision confirm Firecrawl's price?). `api-export.js` loads via `loadVisionData()` and resolves via `resolveVendorPrice()` — 99% confidence when both agree, Vision-only fallback when Firecrawl returns null, median-based tiebreaker when they disagree. `merge-prices.js` is legacy and not called.
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `devops/retail-poller/price-extract.js` | Primary scraper — Firecrawl + Playwright fallback → Turso |
+| `devops/retail-poller/capture.js` | Screenshot capture — `BROWSER_MODE=browserless` (browserless Docker via `connectOverCDP`), `browserbase` (cloud CDP), or `local` (local Chromium). `ARTIFACT_DIR` sets output dir; writes `manifest.json`. |
+| `devops/retail-poller/extract-vision.js` | Gemini Vision price extraction from screenshots → per-coin JSON files (not Turso). Reads `MANIFEST_PATH`. |
+| `devops/retail-poller/api-export.js` | Turso + vision JSON → `data/api/` static JSON endpoints with confidence scoring |
+| `devops/retail-poller/vision-patch.js` | Standalone utility — patches `data/api/{slug}/latest.json` confidence scores using vision JSON, without Turso. For manual one-off runs. |
+| `devops/retail-poller/merge-prices.js` | **Legacy** — not called in either pipeline. Reads flat `{date}.json` files that no longer exist in Turso arch. |
+| `devops/retail-poller/db.js` | Turso helper — schema, read/write functions |
+| `devops/retail-poller/run-local.sh` | Full local run: extract → capture → vision → export → push |
+| `devops/retail-poller/run-fbp.sh` | Gap-fill run: failed vendors → FindBullionPrices scrape |
+
+---
+
+## providers.json Structure
+
+Located at `$DATA_REPO_PATH/data/retail/providers.json` on the **api branch**.
+
+```json
+{
+  "coins": {
+    "ase": {
+      "name": "American Silver Eagle",
+      "metal": "silver",
+      "weight_oz": 1,
+      "fbp_url": "https://findbullionprices.com/p/american-silver-eagle/",
+      "providers": [
+        {
+          "id": "apmex",
+          "enabled": true,
+          "url": "https://www.apmex.com/product/..."
+        },
+        {
+          "id": "sdbullion",
+          "enabled": true,
+          "url": "https://sdbullion.com/..."
+        }
+      ]
+    }
+  }
+}
+```
+
+**Coin fields:** `name`, `metal` (`silver`/`gold`/`platinum`/`palladium`), `weight_oz`, `fbp_url` (FindBullionPrices fallback URL)
+
+**Provider fields:** `id` (matches `FBP_DEALER_NAME_MAP` key in price-extract.js), `enabled`, `url`
+
+To add a new vendor: add to `FBP_DEALER_NAME_MAP` in `price-extract.js` AND add to each coin's `providers[]` in `providers.json`.
+
+---
+
+## Price Extraction Logic
+
+### Extraction Strategy (price-extract.js)
+
+Two provider groups with different strategies:
+
+**`USES_AS_LOW_AS` providers** (jmbullion, monumentmetals):
+1. Scan all `"As Low As $XX.XX"` matches → filter by weight-adjusted metal range → take **minimum**
+2. Fallback: table cell prices
+
+**All other providers** (apmex, sdbullion, etc.):
+1. Pricing table cells first (avoids picking up related-product "As Low As")
+2. Fallback: "As Low As" scan
+
+**Metal price ranges** (per oz, used to filter out accessories/spot tickers):
+```
+silver:    $40–200/oz
+gold:      $1,500–15,000/oz
+platinum:  $500–6,000/oz
+palladium: $300–6,000/oz
+```
+Range is multiplied by `weight_oz` for multi-oz products (e.g. 10oz bar = $400–2000).
+
+### SDB Fix Applied (2026-02-20)
+
+SDB pages show "As Low As" only in add-on accessories and carousel sections — NOT for the main product. The main product price is in a pricing table.
+
+**Root cause (was):** `sdbullion` was in `USES_AS_LOW_AS` → `Math.min()` picked carousel/add-on prices.
+**Fix applied:**
+1. `sdbullion` removed from `USES_AS_LOW_AS` → now uses table-first strategy (same as APMEX).
+2. `preprocessMarkdown(markdown, providerId)` added — truncates SDB markdown at `**Add on Items**` / `Customers Also Purchased` before any price extraction. Covers both Firecrawl markdown and Playwright HTML variants.
+
+### Playwright Fallback
+
+If Firecrawl returns no price, `scrapeWithPlaywright()` tries a browserless remote browser (`BROWSERLESS_URL` env var). `SLOW_PROVIDERS = {jmbullion, herobullion, summitmetals}` get an extra 4s wait.
+
+### FBP Gap-Fill
+
+After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps dealer names via `FBP_DEALER_NAME_MAP`, writes as `source: "fbp"` to Turso.
+
+`run-fbp.sh` (the PM cron at 3pm ET) runs `PATCH_GAPS=1 node price-extract.js` to fill only today's gaps.
+
+---
+
+## Turso Database
+
+**Provider:** Turso cloud (libSQL) — NOT local SQLite. Credentials in Infisical + Fly secrets (`TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`).
+
+**Dual-poller write-through:** Both Fly.io (`POLLER_ID=api`) and home VM (`POLLER_ID=home`) write to the same Turso DB. `api-export.js` uses `readLatestPerVendor()` to merge — most recent row per vendor within last 2h wins.
+
+**Table:** `price_snapshots`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `scraped_at` | TEXT | ISO8601 UTC timestamp of actual scrape |
+| `window_start` | TEXT | 15-min floor (e.g. `2026-02-20T14:15:00Z`) |
+| `coin_slug` | TEXT | Matches providers.json key (e.g. `ase`) |
+| `vendor` | TEXT | Provider id (e.g. `apmex`) |
+| `price` | REAL | null if scrape failed |
+| `source` | TEXT | `firecrawl` \| `playwright` \| `fbp` |
+| `in_stock` | INTEGER | 0 if OOS patterns matched |
+| `is_failed` | INTEGER | 1 if price is null |
+| `poller_id` | TEXT | `api` (Fly.io) or `home` (home VM) |
+
+**Window floor:** every scrape is bucketed to the nearest 15-min UTC floor. The 24h history chart uses 96 windows.
+
+---
+
+## Confidence Scoring
+
+### api-export.js (live scoring per window)
+
+`scoreVendorPrice(price, windowMedian, prevMedian)`:
+
+| Condition | Score delta |
+|-----------|-------------|
+| Base (single source) | +50 |
+| Within 3% of window median | +30 |
+| >8% from window median | -15 |
+| >10% day-over-day from prev median | -20 |
+
+**Result:** 80% = no outlier (50+30), 50% = mild outlier (50), 35% = strong outlier (50-15), 15% = outlier AND large day-over-day shift (50-15-20).
+
+### merge-prices.js (when both Firecrawl + Vision are available)
+
+`scorePrice({firecrawlPrice, visionPrice, visionConfidence, prevPrice, medianPrice})`:
+
+| Condition | Score delta |
+|-----------|-------------|
+| Both methods within 2% | +40 |
+| Both within 5% | +20 |
+| Methods disagree >5% | +5 |
+| Single method only | +50 |
+| Vision confidence high/medium/low | +15/+5/-10 |
+| Within 3% of today's median | +10 |
+| >8% from today's median | -15 |
+| >10% day-over-day | -20 |
+
+High confidence threshold: ≥70 pts.
+
+---
+
+## API Output Files
+
+Written to `$DATA_REPO_PATH/data/api/` and served from the `api` branch.
+
+| File | Contents |
+|------|---------|
+| `data/api/latest.json` | All coins, current window: `median_price`, `lowest_price`, `vendor_count` |
+| `data/api/{slug}/latest.json` | Single coin: vendors map with price + confidence, 24h windows series |
+| `data/api/{slug}/history-7d.json` | Daily aggregates, 7 days |
+| `data/api/{slug}/history-30d.json` | Daily aggregates, 30 days |
+| `data/api/manifest.json` | Coin list, last updated, window count |
+
+The StakTrakr app fetches `data/api/{slug}/latest.json` in `retail-view-modal.js` and `data/api/latest.json` in `retail.js`.
+
+---
+
+## Environment Variables
+
+| Var | Used by | Notes |
+|-----|---------|-------|
+| `DATA_REPO_PATH` | run-local.sh, run-fbp.sh | Path to git checkout of api branch |
+| `DATA_DIR` | all scripts | `$DATA_REPO_PATH/data` |
+| `FIRECRAWL_API_KEY` | price-extract.js | Cloud Firecrawl; omit for self-hosted |
+| `FIRECRAWL_BASE_URL` | price-extract.js | Self-hosted: `http://localhost:3002`; default: cloud |
+| `BROWSERLESS_URL` | price-extract.js, capture.js | `ws://host.docker.internal:3000/chromium/playwright?token=local_dev_token` — Playwright fallback in price-extract AND browserless CDP in capture.js (`BROWSER_MODE=browserless`) |
+| `BROWSER_MODE` | capture.js | `browserbase` (cloud, default in Action), `browserless` (self-hosted Docker), or `local` (local Chromium via `playwright.launch()`) |
+| `ARTIFACT_DIR` | capture.js | Screenshots output dir. Action: `DATA_DIR/retail/_artifacts/{date}`. Local: `/tmp/retail-screenshots/{date}`. capture.js writes `manifest.json` here. |
+| `MANIFEST_PATH` | extract-vision.js | Full path to `manifest.json` written by capture.js. `run-local.sh` sets this to `$ARTIFACT_DIR/manifest.json`. Action passes as `${{ steps.ctx.outputs.artifact_dir }}/manifest.json`. |
+| `BROWSERBASE_API_KEY` | capture.js | Cloud Browserbase only — not needed when using browserless Docker |
+| `BROWSERBASE_PROJECT_ID` | capture.js | Cloud Browserbase only |
+| `GEMINI_API_KEY` | extract-vision.js | Google AI Studio key for vision extraction |
+| `COINS` | all scripts | Comma-separated slug filter (default: all) |
+| `PROVIDERS` | capture.js | Comma-separated provider filter |
+| `DRY_RUN` | all scripts | `1` = skip writes |
+| `PATCH_GAPS` | price-extract.js | `1` = gap-fill mode (FBP only for failed vendors) |
+
+---
+
+## Running Locally
+
+```bash
+cd devops/retail-poller
+
+# Full run against self-hosted Firecrawl (port 3002)
+DATA_REPO_PATH=/path/to/api-branch-checkout \
+FIRECRAWL_BASE_URL=http://localhost:3002 \
+node price-extract.js
+
+# Dry-run single coin
+COINS=ase DRY_RUN=1 DATA_DIR=/path/to/api-branch/data node price-extract.js
+
+# Export API JSON from existing Turso data
+DATA_DIR=/path/to/api-branch/data node api-export.js
+
+# Gap-fill only (FBP scrape for failed vendors)
+PATCH_GAPS=1 DATA_DIR=/path/to/api-branch/data node price-extract.js
+```
+
+---
+
+## API Branch Git Safety
+
+**The api branch is a write-only output channel for the poller.** It must be treated with extra care — multiple agents (Fly.io container, home VM, manual commits) push to it concurrently.
+
+### Known Fragility: `git pull --rebase` at run start
+
+`run-local.sh` uses `git pull --rebase origin api` before each scrape. If another agent commits to the api branch **between** the poller's pull and its final push, the rebase of the local export commit will fail with:
+
+```
+fatal: It seems that there is already a rebase-merge directory
+```
+
+Every subsequent 15-minute cron tick will hit the same error and silently no-op. **Retail prices freeze while spot prices continue normally** — the key symptom.
+
+### Safer pre-run sync (recommended future fix)
+
+Replace the start-of-run `git pull --rebase` with a hard reset — since the container's local branch is regenerated from scratch every run, preserving local commits before a pull is unnecessary:
+
+```bash
+# Instead of: git pull --rebase origin api
+git fetch origin api && git reset --hard origin/api
+```
+
+Keep the final `git pull --rebase origin api` before push (that one is correct — it replays the fresh export commit on top of any commits that landed during the scrape).
+
+### Pausing GHA workflows during manual api branch work
+
+No retail GHA workflow is active. `retail-price-poller.yml` was deleted. If you need to work on the api branch manually (backfilling data, patching providers.json), the only active writers are:
+- Fly.io `run-publish.sh` (every 15 min)
+- Home VM (writes to Turso only, never pushes to git)
+
+You can safely push to the api branch without disabling any GHA workflow.
+
+### After any commit directly to the api branch
+
+**Always verify the retail-poller container recovered.** A commit to api can race with a running poll and leave a stuck rebase. After pushing any commit to api (providers.json updates, manual patches, backfill scripts):
+
+```bash
+# 1. Check container logs for rebase errors
+fly ssh console --app staktrakr -C "tail -20 /var/log/retail-poller.log"
+
+# 2. If you see "rebase-merge directory" errors:
+fly ssh console --app staktrakr -C "
+  cd /data/staktrakr-api-export
+  git rebase --abort 2>/dev/null || true
+  git fetch origin api && git reset --hard origin/api
+  echo 'API branch reset OK'
+  git log --oneline -3
+"
+
+# 3. Confirm next cron tick runs clean (watch for ~15 min)
+fly logs --app staktrakr | grep retail
+```
+
+### Verifying retail data freshness
+
+Check the api branch directly — `window_start` should be within the last 20 minutes:
+
+```bash
+curl -s https://api.staktrakr.com/data/api/ase/latest.json | python3 -m json.tool | grep window_start
+```
+
+Or check the last 5 api branch commits:
+
+```bash
+gh api "repos/lbruton/StakTrakrApi/commits?sha=api&per_page=5" \
+  --jq '.[].commit | {message: .message, date: .author.date}'
+```
+
+If the most recent `retail: YYYY-MM-DD api export` commit is >15 minutes old, the container is stuck — run the recovery steps above.
+
+### Turso row count verification
+
+If the Turso DB appears suspect, verify the row count:
+
+```bash
+# Verify Turso row count
+fly ssh console --app staktrakr -C "node -e \"
+const {createClient} = require('@libsql/client');
+const db = createClient({url: process.env.TURSO_DATABASE_URL, authToken: process.env.TURSO_AUTH_TOKEN});
+db.execute('SELECT COUNT(*) as n FROM price_snapshots').then(r => { console.log('rows:', r.rows[0].n); process.exit(0); });
+\""
+```
+
+---
+
+## Common Debugging Patterns
+
+**Low confidence on SDB prices (fixed 2026-02-20):** `sdbullion` was removed from `USES_AS_LOW_AS` and now uses table-first strategy. `preprocessMarkdown()` strips the "Add on Items" carousel before price extraction. If SDB prices still look wrong, check that the page pricing table structure hasn't changed — use `DRY_RUN=1 COINS=ase` with console logging to inspect what's extracted.
+
+**80% confidence ceiling:** Single-source only (no Vision). 50 base + 30 (within 3% of median) = 80. This is the ceiling without Vision data. Normal for Firecrawl-only runs.
+
+**15% confidence:** Vendor price is far from median AND large day-over-day change. Usually wrong extraction. Check FBP or the actual URL.
+
+**price = null:** Firecrawl got a page but no parseable price, AND Playwright fallback also failed. Check if the URL is still valid and page structure changed.
+
+**FBP fallback triggered:** Check `source: "fbp"` in Turso — means primary scrape failed. FBP prices are wire/ACH prices (lowest available).
+
+**Retail prices frozen, spot still updating:** Stuck rebase in the container. See API Branch Git Safety section above.

--- a/.claude/skills/retail-provider-fix/SKILL.md
+++ b/.claude/skills/retail-provider-fix/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: retail-provider-fix
+description: Use when retail prices are failing for a vendor — wrong prices, fractional_weight warnings, all-zeros for a provider, page-loaded-no-price errors, or after suspecting a dealer changed their site structure. Covers live Firecrawl diagnostics, interpreting extraction failures, and updating price-extract.js and providers.json.
+---
+
+# Retail Provider Fix
+
+Diagnose and fix scraping failures for individual dealers in the StakTrakr retail pipeline.
+All code lives in `StakTrakrApi/devops/retail-poller/`. All URL config is in `providers.json` on the `api` branch.
+
+---
+
+## Step 1 — Live Firecrawl Diagnostic
+
+Run directly inside the Fly.io container against the self-hosted Firecrawl at `localhost:3002`:
+
+```bash
+# Substitute URL from providers.json for the failing vendor/coin
+fly ssh console -a staktrakr -C "curl -s -X POST http://localhost:3002/v1/scrape \
+  -H 'Content-Type: application/json' \
+  -d '{\"url\":\"PROVIDER_URL_HERE\",\"formats\":[\"markdown\"],\"waitFor\":6000,\"onlyMainContent\":false}' \
+  | python3 -c \"import sys,json; d=json.load(sys.stdin); \
+    md=d.get('data',{}).get('markdown',''); \
+    w=d.get('data',{}).get('warning',''); \
+    print('WARNING:',w); print('LEN:',len(md)); print(md[:5000])\""
+```
+
+For home LXC, replace `fly ssh console -a staktrakr -C` with `ssh home-lxc`:
+```bash
+ssh home-lxc "curl -s -X POST http://localhost:3002/v1/scrape ..."
+```
+
+---
+
+## Step 2 — Interpret the Output
+
+| Symptom | Meaning | Fix category |
+|---|---|---|
+| `warning: waitFor not supported` | Self-hosted Firecrawl ignores `waitFor` — JS never renders | Force Playwright path (see §4) |
+| Markdown contains only `"Loading..."` | Product table is JS-rendered, not in static HTML | Force Playwright path |
+| Redirected to homepage URL in metadata | Bot detection — page is blocked | Playwright + residential proxy (see §5) |
+| Spot prices appear before product price | `MARKDOWN_HEADER_SKIP_PATTERNS` not matching | Update header skip regex (see §3) |
+| `fractional_weight — 1/4 oz` | Scraper found a fractional nav price before product price | Update `MARKDOWN_CUTOFF_PATTERNS` or force Playwright |
+| `page loaded, no price` | Page renders but extraction regex doesn't match | Update `extractPrice` logic for that provider |
+| `out_of_stock — PRE-ORDER` | Correct; item actually on pre-order | No fix needed unless provider is in `PREORDER_TOLERANT_PROVIDERS` |
+
+---
+
+## Step 3 — Config Map in `price-extract.js`
+
+All extraction config is in `StakTrakrApi/devops/retail-poller/price-extract.js`.
+
+| Config | Line ~| What it does |
+|---|---|---|
+| `SLOW_PROVIDERS` | 474 | Adds `waitFor:6000` to Firecrawl AND `waitForTimeout(8000)` in Playwright fallback |
+| `MARKDOWN_HEADER_SKIP_PATTERNS` | 157 | Regex matching the site header/nav — cuts everything BEFORE the match |
+| `MARKDOWN_CUTOFF_PATTERNS` | 132 | Array of regexes — cuts everything AFTER the first match (removes related products, carousels) |
+| `PREORDER_TOLERANT_PROVIDERS` | 134 | Providers where "Pre-Order" text should NOT count as OOS |
+| `USES_AS_LOW_AS` | 117 | Providers that use "As Low As" as their primary price indicator (currently empty) |
+| `FBP_DEALER_NAME_MAP` | 196 | Maps FindBullionPrices dealer display names → provider IDs |
+| `onlyMainContent` | 485 | Firecrawl flag — set `false` for JMBullion to avoid missing the price table |
+
+**URL changes go in `providers.json` on the `api` branch** — NOT in price-extract.js.
+Both pollers auto-sync providers.json before every run via `curl ... /api/data/retail/providers.json`.
+
+---
+
+## Step 4 — Self-Hosted Firecrawl `waitFor` Not Supported
+
+**This is the current state** (confirmed Feb 2026): The self-hosted Firecrawl container does not support the `waitFor` parameter. It returns the static/pre-render HTML immediately.
+
+**Consequence**: All JS-heavy SPAs (JMBullion, BullionExchanges, Monument Metals) get unrendered HTML from Firecrawl. Monument Metals and HeroBullion recover via the Playwright fallback. JMBullion does NOT recover because `fractional_weight` detection fires on the pre-render content and exits without triggering Playwright.
+
+**Fix options** (in order of preference):
+
+1. **Upgrade Firecrawl** to a version that supports `waitFor` — check `ghcr.io/firecrawl/firecrawl:latest` changelog
+2. **Force Playwright path for specific providers** — add them to a `PLAYWRIGHT_ONLY_PROVIDERS` set that skips Firecrawl entirely
+3. **Treat `fractional_weight` as Playwright trigger** — same as `price === null` in the fallback condition
+
+---
+
+## Step 5 — Bot Detection (BullionExchanges Pattern)
+
+When Firecrawl returns a redirect to the site's homepage with only a banner image, bot detection is active.
+
+**Diagnosis**: `url` in response metadata differs from `sourceURL`. e.g., `sourceURL` = product page, `url` = `bullionexchanges.com`.
+
+**Current status**: BullionExchanges redirects ALL headless browser requests to homepage.
+
+**Fix options**:
+- Playwright with residential proxy chain (`HOME_PROXY_URL_2` → Webshare) — verify tinyproxy `ConnectPort` allows 443
+- Add browser stealth headers: real user-agent, `Accept-Language`, `Sec-Fetch-*` headers
+- If Tailscale exit node is active, ALL traffic routes via home residential IP — verify `tailscale status` in container before debugging further
+
+---
+
+## Step 6 — Test Single Vendor (Dry Run)
+
+From inside the container or home LXC:
+
+```bash
+# Fly.io — SSH in then run
+fly ssh console -a staktrakr
+cd /app
+DATA_DIR=/data/staktrakr-api-export/data \
+FIRECRAWL_BASE_URL=http://localhost:3002 \
+PLAYWRIGHT_LAUNCH=1 \
+COINS=ase PROVIDERS=jmbullion \
+DRY_RUN=1 node price-extract.js
+
+# Filter to multiple vendors
+COINS=ase,age PROVIDERS=jmbullion,bullionexchanges DRY_RUN=1 node price-extract.js
+```
+
+A successful result shows `✓ jmbullion: $XXX.XX (playwright)` or `✓ jmbullion: $XXX.XX (firecrawl)`.
+
+---
+
+## Step 7 — Deploy the Fix
+
+After verifying the fix in dry-run:
+
+```bash
+# Fly.io — redeploy container (required for price-extract.js changes)
+cd /Volumes/DATA/GitHub/StakTrakrApi/devops/retail-poller
+fly deploy -a staktrakr
+
+# Home LXC — no deploy needed; run-home.sh reads price-extract.js directly
+# Just commit + pull on the home server:
+# git pull origin main && (restart cron if needed)
+
+# providers.json URL changes — push to api branch
+git checkout api
+# edit data/retail/providers.json
+git add data/retail/providers.json && git commit -m "fix(providers): update VENDOR urls"
+git push origin api
+# Both pollers pick this up automatically on next run (no redeploy needed)
+```
+
+---
+
+## Common Provider Failure Patterns
+
+### JMBullion — `fractional_weight`
+**Cause**: Firecrawl's `waitFor` not supported → product table renders as "Loading..." → no price → but header skip exposes fractional nav links or spot prices that trigger false `fractional_weight` detection.
+**Fix**: Force Playwright path; verify `MARKDOWN_HEADER_SKIP_PATTERNS.jmbullion` still matches the header timestamp format.
+
+### BullionExchanges — `page loaded, no price`
+**Cause**: Bot detection redirects to homepage; Firecrawl gets one-line banner. Playwright fallback also redirected.
+**Fix**: Check tinyproxy HTTPS CONNECT config; use Playwright with stealth headers.
+
+### Monument Metals — `out_of_stock — PRE-ORDER`
+**Cause**: Coin legitimately on pre-order (common for new-year coins Jan–Mar).
+**Fix**: Update providers.json URL to a different in-stock coin, OR wait for inventory to arrive.
+
+### SDB — wrong price from "Add on Items" carousel
+**Cause**: `sdbullion` was in `USES_AS_LOW_AS`; carousel prices bled through.
+**Fix (applied 2026-02-20)**: `sdbullion` removed from `USES_AS_LOW_AS`; `MARKDOWN_CUTOFF_PATTERNS.sdbullion` added.
+
+---
+
+## Firecrawl Engine Capabilities (Self-Hosted)
+
+The self-hosted container uses Firecrawl's `basic` engine (not `playwright`). Capabilities:
+
+| Feature | Supported |
+|---|---|
+| Static HTML fetch | ✅ |
+| `waitFor` (JS wait) | ❌ (silently ignored, warning in response) |
+| `onlyMainContent` | ✅ |
+| `formats: markdown` | ✅ |
+| Proxy (`PROXY_SERVER`) | ✅ via playwright-service |
+| `BLOCK_MEDIA` | ✅ via playwright-service env |
+
+To check current Firecrawl version in container:
+```bash
+fly ssh console -a staktrakr -C "node -e \"const p=require('/opt/firecrawl/package.json'); console.log(p.version)\""
+```

--- a/.github/workflows/spot-poller.yml
+++ b/.github/workflows/spot-poller.yml
@@ -1,70 +1,22 @@
-# Spot price poller — writes hourly data to StakTrakrApi `api` branch (api.staktrakr.com)
-# Runs four times per hour (:05, :20, :35, :50) for 15-min freshness.
-# Requires repository secrets: METAL_PRICE_API_KEY, API_PUSH_TOKEN
-#
-# Architecture: Checks out `dev` for poller code, StakTrakrApi `api` branch for data files.
-# Hourly JSON files land in data/hourly/YYYY/MM/DD/HH.json on StakTrakrApi api branch.
-name: Spot Price Poller
+# Spot price poller — RETIRED 2026-02-23
+# Spot polling moved to Fly.io container cron (run-spot.sh, 5,20,35,50 * * * *).
+# This workflow is kept ONLY for emergency manual trigger.
+# Do NOT re-enable scheduled runs — poller.py was removed from this repo.
+name: Spot Price Poller (RETIRED)
 
 on:
-  schedule:
-    - cron: '5 * * * *'   # :05 — primary run
-    - cron: '20 * * * *'  # :20 — 15-min freshness
-    - cron: '35 * * * *'  # :35 — 15-min freshness
-    - cron: '50 * * * *'  # :50 — 15-min freshness
-  workflow_dispatch: # Manual trigger for testing
+  workflow_dispatch:  # Manual trigger only — all scheduled crons removed
 
 env:
   TZ: UTC
 
 jobs:
-  poll:
+  redirect:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
-      - name: Checkout dev (for poller code)
-        uses: actions/checkout@v4
-        with:
-          ref: dev
-          path: code
-
-      - name: Checkout StakTrakrApi (for data files)
-        uses: actions/checkout@v4
-        with:
-          repository: lbruton/StakTrakrApi
-          ref: api
-          path: data-branch
-          token: ${{ secrets.API_PUSH_TOKEN }}
-          fetch-depth: 1
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install -r code/devops/spot-poller/requirements.txt
-
-      - name: Run poller (single shot with backfill)
-        env:
-          METAL_PRICE_API_KEY: ${{ secrets.METAL_PRICE_API_KEY }}
-          DATA_DIR: ${{ github.workspace }}/data-branch/data
-        run: python code/devops/spot-poller/poller.py --once
-
-      - name: Commit and push data
-        working-directory: data-branch
+      - name: Retired — use Fly.io container
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          if git diff --cached --quiet; then
-            echo "No new data to commit."
-          else
-            HOUR=$(date -u +%H)
-            DATE=$(date -u +%Y-%m-%d)
-            git commit -m "spot: ${DATE} hour ${HOUR} price data"
-            git pull --rebase origin api || true
-            git push
-          fi
+          echo "⚠️  This workflow is RETIRED."
+          echo "Spot polling runs inside the Fly.io staktrakr container at 5,20,35,50 * * * *."
+          echo "To check spot data: fly logs --app staktrakr | grep spot"
+          echo "To manually trigger: fly ssh console --app staktrakr -C '/app/run-spot.sh'"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 !.claude/skills/wiki-search/
 !.claude/skills/ship/
 !.claude/skills/brainstorming/
+!.claude/skills/retail-poller/
+!.claude/skills/retail-provider-fix/
+!.claude/skills/repo-boundaries/
 .claude/commands/
 .mcp.json
 SPRINT.md

--- a/docs/plans/2026-02-25-api-pipeline-audit-design.md
+++ b/docs/plans/2026-02-25-api-pipeline-audit-design.md
@@ -1,0 +1,187 @@
+# API Pipeline Audit — Design Document
+
+**Date:** 2026-02-25
+**Status:** Approved — ready for implementation
+
+---
+
+## Problem Statement
+
+The StakTrakr API pipeline spans four repos and two deployment targets. Over time:
+
+1. `StakTrakr` accumulated ghost `devops/` directories (no live code, only stale `.env` files)
+2. `stakscrapr` (home VM) diverged from `StakTrakrApi` into a full production stack with no clear sync contract
+3. Skills and CLAUDE.md document a Docker spot-poller container that no longer exists
+4. `spot-poller.yml` GHA is retired but skills and CLAUDE.md still list it as an active feed
+5. No explicit rule prevents an agent from running `fly deploy` from the wrong machine
+
+---
+
+## Architecture Truth (post-audit)
+
+### Repos and ownership
+
+| Repo | Owns |
+|------|------|
+| `lbruton/StakTrakr` | Frontend only — HTML, JS, CSS. No poller code, no devops. |
+| `lbruton/StakTrakrApi` | ALL backend: poller scripts (`devops/`), fly.toml, Dockerfile, GHA workflows, data files via GitHub Pages |
+| `lbruton/stakscrapr` | Home VM full stack — identical core + dashboard + tinyproxy + Tailscale exit node |
+| `lbruton/StakTrakrWiki` | Shared infrastructure documentation |
+
+### Three data feeds
+
+| Feed | File | Writer | Cadence |
+|------|------|--------|---------|
+| Market prices | `data/api/manifest.json` | Fly.io `run-publish.sh` | 15 min |
+| Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` cron | `5,20,35,50 * * * *` |
+| Goldback | `data/api/goldback-spot.json` | Fly.io (via `goldback-g1` retail coin) | 15 min |
+
+**`spot-poller.yml` GHA is RETIRED as of 2026-02-23.** Spot polling moved to Fly.io container cron. The workflow file is kept for emergency manual trigger only.
+
+**`spot-history-YYYY.json` is a seed file**, not live data. Do not use for freshness checks.
+
+### Home VM role
+
+The home VM (`192.168.1.48`) is both a **secondary scraper** and **infrastructure backbone**:
+
+- Runs identical Firecrawl + Playwright + Redis + RabbitMQ + PostgreSQL stack (supervisord)
+- Writes to same Turso DB (`POLLER_ID=home`)
+- Hosts Tailscale exit node (`100.112.198.50`) — all Fly.io scrape traffic exits through home residential Cox IP
+- Runs tinyproxy (port 8889) as the residential proxy for Fly.io
+- Runs `dashboard.js` (port 3010) monitoring both pollers via Turso + `/tmp/flyio-health.json`
+
+### Network path for scraping
+
+```
+Fly.io container
+  → Tailscale tunnel
+    → Home VM (192.168.1.48)
+      → tinyproxy (port 8889)
+        → Cox WiFi NIC
+          → Residential IP
+            → Bullion dealer sites
+```
+
+---
+
+## Proposed Folder Structure: StakTrakrApi/devops/
+
+```
+devops/
+  scraper/               ← SHARED engine (single source of truth)
+    price-extract.js
+    api-export.js
+    capture.js
+    extract-vision.js
+    spot-poller/poller.py
+    package.json
+
+  fly-poller/            ← Fly.io deploy wrapper
+    fly.toml             (4096MB, primary_region: iad, deployed to dfw)
+    Dockerfile           (COPY ../scraper/ + wrapper scripts into image)
+    run-local.sh
+    run-publish.sh
+    run-spot.sh
+    run-retry.sh
+    run-fbp.sh
+    run-goldback.sh
+    docker-entrypoint.sh
+    supervisord.conf
+
+  home-scraper/          ← Home VM additions (home-only)
+    run-home.sh
+    dashboard.js         (monitors both pollers — Turso + /tmp/flyio-health.json)
+    check-flyio.sh
+    supervisord.conf     (11 services including dashboard)
+    .env.example
+
+  home-vm/               ← Infrastructure (already exists, no change)
+    tinyproxy-cox.conf
+    cox-auth.sh/service/timer
+    update-cox-proxy-ip.sh
+```
+
+---
+
+## Change Gate
+
+### Rule by change type
+
+| Change | Where | Who deploys |
+|--------|-------|-------------|
+| Shared scraper logic | `scraper/` → PR to StakTrakrApi main | This Mac: merge + `fly deploy` |
+| Fly.io-only config | `fly-poller/` → PR to StakTrakrApi main | This Mac: merge + `fly deploy` |
+| Home-only additions | `home-scraper/` → PR to StakTrakrApi main | Home VM: pulls via curl |
+| URL fixes (providers.json) | `api` branch directly | Zero-deploy, auto-synced next cycle |
+
+### Home → Fly.io sync flow
+
+```
+Home Claude edits scraper/*.js
+  → opens PR to StakTrakrApi main
+  → This Mac reviews + merges
+  → This Mac: cd devops/fly-poller && fly deploy
+  → Home VM: curl raw.githubusercontent.com/StakTrakrApi/main/devops/scraper/<file> -o /opt/poller/<file>
+```
+
+### Safety rules encoded in CLAUDE.md files
+
+- `StakTrakrApi/CLAUDE.md`: "Only the StakTrakr Mac runs `fly deploy`. Home Claude opens PRs only."
+- `stakscrapr/CLAUDE.md`: "NEVER run `fly deploy`. Open a PR to StakTrakrApi instead."
+
+---
+
+## Changes Required
+
+### 1. StakTrakr repo
+
+| File | Change |
+|------|--------|
+| `CLAUDE.md` | Replace spot-poller.yml with retired status + Fly.io cron; fix fly.toml repo path; add hard prohibition on local Docker spot-poller; fix stakscrapr description |
+| `devops/spot-poller/` | Delete ghost directory (only `__pycache__` + stale `.env`) |
+| `devops/retail-poller/` | Delete ghost directory (only `.env` + `.DS_Store`) |
+| `.github/workflows/spot-poller.yml` | Add RETIRED comment at top |
+| `docs/devops/api-infrastructure-runbook.md` | Remove "Local Docker spot poller" section; update feed table |
+
+### 2. StakTrakr skills
+
+| Skill | Change |
+|-------|--------|
+| `seed-sync` | Remove Phase 1 Docker spot-poller section entirely |
+| `api-infrastructure` | Mark spot-poller.yml retired; add repo context to fly.toml path |
+| `retail-poller` | Remove `docker exec firecrawl-docker-retail-poller-1` commands; clarify scripts live in StakTrakrApi |
+| `retail-provider-fix` | Clarify run-home.sh lives in stakscrapr |
+
+### 3. New skills
+
+| Skill | Purpose |
+|-------|---------|
+| `repo-boundaries` | Definitive map of which code belongs in which repo; required reading before any cross-repo work |
+
+### 4. StakTrakrApi repo
+
+| File | Change |
+|------|--------|
+| `devops/retail-poller/` → `devops/fly-poller/` | Rename folder |
+| New `devops/scraper/` | Extract shared scripts from fly-poller/ |
+| New `devops/home-scraper/` | Home-specific additions (dashboard, check-flyio, run-home) |
+| `CLAUDE.md` (new or update) | Encode fly deploy safety gate |
+
+### 5. StakTrakrWiki
+
+| File | Fix |
+|------|-----|
+| `architecture-overview.md` | Update stakscrapr row: full stack, not just Claude config; fix repo boundaries table |
+| `home-poller.md` | Fix IP: 192.168.1.81 → 192.168.1.48 |
+| `architecture-overview.md` | Update devops/ folder structure to reflect new scraper/fly-poller/home-scraper split |
+
+---
+
+## Invariants (must always be true after implementation)
+
+1. `StakTrakr` repo has zero poller scripts and zero devops config
+2. `StakTrakrApi/devops/scraper/` is the single source of truth for shared scraper engine
+3. `fly deploy` is run only from this Mac, only from `StakTrakrApi/devops/fly-poller/`
+4. `spot-poller.yml` GHA is never listed as an active data source in any doc or skill
+5. No skill or CLAUDE.md references a Docker spot-poller container
+6. Home VM IP is consistently documented as `192.168.1.48`

--- a/docs/plans/2026-02-25-api-pipeline-audit.md
+++ b/docs/plans/2026-02-25-api-pipeline-audit.md
@@ -1,0 +1,665 @@
+# API Pipeline Audit — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate stale documentation, ghost directories, and broken automation across the StakTrakr ecosystem — and establish clear repo-boundary rules so agents never deploy to the wrong place.
+
+**Architecture:** Three-phase: (A) StakTrakr repo — immediate cleanup and skill rewrites; (B) StakTrakrApi repo — structural devops split into scraper/fly-poller/home-scraper; (C) StakTrakrWiki — accuracy fixes. Phases B and C are in separate repos and require separate sessions.
+
+**Tech Stack:** Shell (file deletions, git), Markdown (CLAUDE.md, skills, wiki pages)
+
+**Design doc:** `docs/plans/2026-02-25-api-pipeline-audit-design.md`
+
+**File Touch Map:**
+| Action | File | Scope |
+|--------|------|-------|
+| MODIFY | `CLAUDE.md` | Lines 69-70 (spot poller feed table), line 84 (health check command) |
+| MODIFY | `.github/workflows/spot-poller.yml` | Convert to no-op — remove active cron schedule |
+| DELETE | `devops/spot-poller/` | Ghost dir — `.env`, `__pycache__/`, `.DS_Store` only |
+| DELETE | `devops/retail-poller/` | Ghost dir — `.env`, `.DS_Store`, `node_modules/` only |
+| MODIFY | `.claude/skills/api-infrastructure/SKILL.md` | Fix spot poller writer, fly.toml repo path, retire GHA entry |
+| MODIFY | `.claude/skills/seed-sync/SKILL.md` | Remove Phase 1 Docker poller health check entirely |
+| MODIFY | `.claude/skills/retail-poller/SKILL.md` | Remove docker exec, fix SQLite→Turso, data branch→api branch |
+| CREATE | `.claude/skills/repo-boundaries/SKILL.md` | New skill — repo ownership map |
+| CREATE | `docs/plans/2026-02-25-api-pipeline-audit-design.md` | Already done |
+| [PHASE B — StakTrakrApi] | `devops/scraper/` | New shared engine folder |
+| [PHASE B — StakTrakrApi] | `devops/fly-poller/` | Rename from devops/retail-poller/ |
+| [PHASE B — StakTrakrApi] | `devops/home-scraper/` | New home-only additions folder |
+| [PHASE B — StakTrakrApi] | `CLAUDE.md` | New file — fly deploy safety gate |
+| [PHASE C — StakTrakrWiki] | `architecture-overview.md` | Update stakscrapr row and devops/ structure |
+| [PHASE C — StakTrakrWiki] | `home-poller.md` | Fix IP 192.168.1.81 → 192.168.1.48 |
+
+---
+
+## Phase A — StakTrakr Repo
+
+### Task A1: Fix CLAUDE.md spot poller feed table ← NEXT
+
+**Files:**
+- Modify: `CLAUDE.md` (lines 68–72)
+
+**Why:** CLAUDE.md currently lists `spot-poller.yml` GHA as the active spot price writer. This is wrong — spot polling moved to Fly.io `run-spot.sh` cron (`5,20,35,50 * * * *`) on 2026-02-23.
+
+**Step 1: Make the edit**
+
+Replace this block in `CLAUDE.md` (lines 68–72):
+```
+| Market prices | `data/api/manifest.json` | Fly.io retail cron (StakTrakrApi) | 30 min | `generated_at` within 30 min |
+| Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | `spot-poller.yml` GHA (StakTrakrApi) | 20 min | Last hourly file within 20 min |
+| 15-min spot | `data/15min/YYYY/MM/DD/HHMM.json` | `spot-poller.yml` GHA (StakTrakrApi) | 20 min | Last 15-min file within 20 min |
+| Goldback | `data/api/goldback-spot.json` | Fly.io goldback cron (StakTrakrApi) | 25h | `scraped_at` within 25h |
+```
+
+With:
+```
+| Market prices | `data/api/manifest.json` | Fly.io retail cron (StakTrakrApi) | 30 min | `generated_at` within 30 min |
+| Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` cron (StakTrakrApi) | 75 min | Last hourly file within 75 min |
+| Goldback | `data/api/goldback-spot.json` | Fly.io goldback cron (StakTrakrApi) | 25h | `scraped_at` within 25h |
+```
+
+Notes:
+- Remove the `15-min spot` row — `data/15min/` is referenced in old skills but does not appear in the StakTrakrApi fly-container.md or spot-pipeline.md. It's an artefact of the old GHA workflow.
+- Stale threshold for spot is 75 min (not 20 min) — `run-spot.sh` runs every 15 min but the published docs (StakTrakrWiki/spot-pipeline.md) say 75 min threshold.
+
+**Step 2: Fix health check command**
+
+Also in `CLAUDE.md`, replace line 84:
+```
+gh run list --repo lbruton/StakTrakrApi --workflow "spot-poller.yml" --limit 3
+```
+With:
+```
+fly logs --app staktrakr | grep -E 'spot|run-spot' | tail -5
+```
+
+**Step 3: Add prohibition note**
+
+Below the feed table (before the health check block), add:
+```
+**NEVER start a local Docker spot-poller container.** `devops/spot-poller/` is a ghost directory — no live code, no container. Spot polling is Fly.io container cron only (`run-spot.sh`).
+```
+
+**Step 4: Verify change looks correct**
+
+Read back the modified section and confirm no lines reference GHA spot-poller.
+
+---
+
+### Task A2: Convert spot-poller.yml to explicit no-op
+
+**Files:**
+- Modify: `.github/workflows/spot-poller.yml`
+
+**Why:** The workflow has active cron schedules (`5,20,35,50 * * * *`) but references `code/devops/spot-poller/poller.py` which no longer exists in the repo. Every scheduled run is silently failing in GitHub Actions. Must be converted to a no-op or the schedule removed.
+
+**Step 1: Replace the entire job body**
+
+Replace the current `jobs:` block with a no-op that prints a redirect message:
+
+```yaml
+# Spot price poller — RETIRED 2026-02-23
+# Spot polling moved to Fly.io container cron (run-spot.sh, 5,20,35,50 * * * *).
+# This workflow is kept ONLY for emergency manual trigger.
+# Do NOT re-enable scheduled runs — poller.py was removed from this repo.
+name: Spot Price Poller (RETIRED)
+
+on:
+  workflow_dispatch:  # Manual trigger only — all scheduled crons removed
+
+env:
+  TZ: UTC
+
+jobs:
+  redirect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retired — use Fly.io container
+        run: |
+          echo "⚠️  This workflow is RETIRED."
+          echo "Spot polling runs inside the Fly.io staktrakr container at 5,20,35,50 * * * *."
+          echo "To check spot data: fly logs --app staktrakr | grep spot"
+          echo "To manually trigger: fly ssh console --app staktrakr -C '/app/run-spot.sh'"
+```
+
+**Step 2: Verify file looks correct**
+
+Read back the file and confirm no `schedule:` cron entries remain.
+
+---
+
+### Task A3: Delete ghost devops directories
+
+**Files:**
+- Delete: `devops/spot-poller/` (contains `.env` + `__pycache__/` + `.DS_Store`)
+- Delete: `devops/retail-poller/` (contains `.env` + `node_modules/` + `.DS_Store`)
+
+**Before deleting:** Verify that any secrets in `.env` files are already in Infisical.
+
+```bash
+# Check what's in the .env files (keys only, not values)
+grep -E '^[A-Z_]+=?' devops/spot-poller/.env | cut -d= -f1
+grep -E '^[A-Z_]+=?' devops/retail-poller/.env | cut -d= -f1
+```
+
+Expected: `METAL_PRICE_API_KEY` in spot-poller/.env; `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, `FIRECRAWL_BASE_URL` or similar in retail-poller/.env. All of these are in Infisical and Fly secrets.
+
+```bash
+# Delete both ghost directories entirely
+rm -rf devops/spot-poller devops/retail-poller
+```
+
+Note: `devops/node_modules/` and `devops/cgc/` — leave these alone. cgc is the code-graph-context tool (in use). node_modules at root of devops is a local artefact.
+
+**Step 2: Check git status**
+
+```bash
+git status devops/
+```
+
+Confirm: `devops/spot-poller/` and `devops/retail-poller/` are no longer shown as untracked.
+
+---
+
+### Task A4: Update api-infrastructure skill
+
+**Files:**
+- Modify: `.claude/skills/api-infrastructure/SKILL.md`
+
+**Step 1: Replace the Three-Feed Architecture table**
+
+Replace the current table (lines 12–18):
+```
+| Feed | File | Poller | Threshold |
+|------|------|--------|-----------|
+| **Market prices** | `data/api/manifest.json` | Fly.io `staktrakr` cron (`*/30 min`) | 30 min |
+| **Spot prices** | `data/hourly/YYYY/MM/DD/HH.json` | `spot-poller.yml` GHA (`:05`, `:20`, `:35`, `:50`/hr) | 20 min |
+| **Spot prices (15-min)** | `data/15min/YYYY/MM/DD/HHMM.json` | `spot-poller.yml` GHA (`:05/:20/:35/:50`) | 20 min |
+| **Goldback** | `data/api/goldback-spot.json` | Fly.io `staktrakr` cron (daily 17:01 UTC) | 25h (info only) |
+| **Turso** | `price_snapshots` table | retail-poller only | internal write store |
+```
+
+With:
+```
+| Feed | File | Poller | Threshold |
+|------|------|--------|-----------|
+| **Market prices** | `data/api/manifest.json` | Fly.io `run-local.sh` + `run-publish.sh` | 30 min |
+| **Spot prices** | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` cron (`5,20,35,50 * * * *`) | 75 min |
+| **Goldback** | `data/api/goldback-spot.json` | Fly.io via `goldback-g1` retail coin in `run-local.sh` | 25h (info only) |
+| **Turso** | `price_snapshots` table | Dual-poller write-through (Fly.io + home VM) | internal |
+```
+
+**Step 2: Replace the Fly.io Container section**
+
+Replace lines 25–33:
+```
+- **App:** `staktrakr` — region `iad`, always-on (min 1 machine, auto-stop off)
+- **Config:** `devops/retail-poller/fly.toml` + `Dockerfile`
+- **Runs:** Firecrawl + Playwright + retail-poller cron + goldback cron + serve.js
+- **NOT spot prices** — spot is pure GHA, no Docker, no Fly
+- **Deploy:** `cd devops/retail-poller && fly deploy`
+```
+
+With:
+```
+- **App:** `staktrakr` — region `dfw`, 4096MB RAM, 4 shared CPUs
+- **Config:** `StakTrakrApi/devops/fly-poller/fly.toml` + `Dockerfile` — NOT in the StakTrakr repo
+- **Runs:** Firecrawl + Playwright + Redis + RabbitMQ + PostgreSQL + retail cron + spot cron + goldback + serve.js
+- **Also runs:** `run-spot.sh` (spot prices — NOT GHA)
+- **Deploy:** From `lbruton/StakTrakrApi` repo: `cd devops/fly-poller && fly deploy`
+- **⛔ NEVER run `fly deploy` from StakTrakr repo or stakscrapr repo**
+```
+
+**Step 3: Replace the GitHub Actions table**
+
+Replace lines 40–41:
+```
+| `spot-poller.yml` | `StakTrakr` | `:05`, `:20`, `:35`, `:50` every hour | Python → MetalPriceAPI → `data/hourly/` |
+```
+With:
+```
+| `spot-poller.yml` | `StakTrakr` | **RETIRED** — keep for emergency manual trigger only | Was Python→MetalPriceAPI; now handled by Fly.io `run-spot.sh` |
+```
+
+**Step 4: Remove the `prices.db` reference**
+
+Remove line 55 (SQLite snapshot line):
+```
+- `prices.db` is a read-only SQLite snapshot exported to StakTrakrApi each cycle (offline use only)
+```
+(Turso is the live store; `prices.db` may or may not still be committed — don't document it as a feature)
+
+---
+
+### Task A5: Rewrite seed-sync skill Phase 1
+
+**Files:**
+- Modify: `.claude/skills/seed-sync/SKILL.md`
+
+**Why:** Phase 1 tells Claude to run `docker ps --filter "name=stacktrakr-seed-poller"` and offers to `docker compose -f devops/spot-poller/docker-compose.yml up -d`. Neither container exists. This is the most dangerous stale content — an agent will try to start a Docker container that can't work.
+
+**Step 1: Replace the Phase 1 section and description**
+
+Replace the frontmatter description and Phase 1:
+```
+---
+name: seed-sync
+description: Seed data sync — check Docker spot-price poller output and stage new seed data for commit. Use before releases or after merging PRs.
+---
+
+# Seed Data Sync — StakTrakr
+
+Check the Docker spot-price poller output and stage any new seed data for commit. Can also fetch today's prices directly without Docker.
+
+## When to Use
+...
+
+## Phase 1: Docker Poller Health Check
+
+1. Run `docker ps --filter "name=stacktrakr-seed-poller"` to confirm the container is running
+...
+```
+
+With:
+```
+---
+name: seed-sync
+description: Seed data sync — fetch live spot price data and stage seed history files for commit. Use before releases or after merging PRs.
+---
+
+# Seed Data Sync — StakTrakr
+
+Fetch the latest spot prices and stage any new seed data for commit.
+
+**There is NO local Docker spot-poller container.** The `devops/spot-poller/` directory was removed. Do not attempt to start any Docker container for spot prices. Spot prices are polled exclusively by the Fly.io container (`run-spot.sh`).
+
+## When to Use
+...
+
+## Phase 1: Fetch Today's Prices (No Docker Required)
+
+Run the built-in script directly — no container needed:
+
+```bash
+python3 .claude/skills/seed-sync/update-today.py
+```
+
+This script fetches today's spot prices from MetalPriceAPI and appends them to the appropriate `data/spot-history-{year}.json` file. It reads the API key from the environment or from a `.env` file in the current directory.
+```
+
+Keep Phases 2–5 unchanged. Also update the **File Layout** section to remove the `devops/spot-poller/` block.
+
+Replace the File Layout section:
+```
+devops/spot-poller/          # Docker-based continuous poller (public)
+  ├── docker-compose.yml     # Docker Compose config
+  ├── Dockerfile             # Python 3.12 Alpine image
+  ├── poller.py              # Long-running poll loop (catchup + hourly)
+  ├── update-seed-data.py    # One-shot backfill script (CLI)
+  ├── requirements.txt       # Python dependencies
+  ├── .env.example           # API key template
+  └── README.md              # Setup and usage guide
+```
+With:
+```
+[no local spot-poller — runs inside Fly.io container at StakTrakrApi/devops/scraper/spot-poller/]
+```
+
+---
+
+### Task A6: Update retail-poller skill (docker exec → fly ssh, SQLite → Turso, data branch → api branch)
+
+**Files:**
+- Modify: `.claude/skills/retail-poller/SKILL.md`
+
+This skill has three categories of staleness:
+
+**1. All file paths missing repo context**
+
+Every path like `devops/retail-poller/price-extract.js` must become `StakTrakrApi/devops/fly-poller/price-extract.js` (or `scraper/` if Phase B is done).
+
+For now (Phase A only), add a **bold repo note at the top of the File Map section**:
+
+Add after the Architecture Overview:
+```
+> **Repo:** All scripts listed below live in `lbruton/StakTrakrApi` — NOT in the StakTrakr repo. Deploy path: `cd devops/fly-poller && fly deploy`.
+```
+
+**2. Remove all `docker exec` commands**
+
+In the **Data Branch Git Safety** section (lines ~256–355), replace all three `docker exec firecrawl-docker-retail-poller-1` blocks:
+
+Replace:
+```bash
+docker exec firecrawl-docker-retail-poller-1 tail -20 /var/log/retail-poller.log
+```
+With:
+```bash
+fly ssh console --app staktrakr -C "tail -20 /var/log/retail-poller.log"
+```
+
+Replace the `docker exec firecrawl-docker-retail-poller-1 bash -c '...'` recovery block with:
+```bash
+fly ssh console --app staktrakr -C "
+  cd /data/staktrakr-api-export
+  git rebase --abort 2>/dev/null || true
+  git fetch origin api && git reset --hard origin/api
+  echo 'Data branch reset OK'
+  git log --oneline -3
+"
+```
+
+Replace the `docker exec firecrawl-docker-retail-poller-1 tail -f` watch command with:
+```bash
+fly logs --app staktrakr | grep retail
+```
+
+Replace the SQLite verification `docker exec` block with:
+```bash
+# Verify Turso row count instead of SQLite
+fly ssh console --app staktrakr -C "node -e \"
+const {createClient} = require('@libsql/client');
+const db = createClient({url: process.env.TURSO_DATABASE_URL, authToken: process.env.TURSO_AUTH_TOKEN});
+db.execute('SELECT COUNT(*) as n FROM price_snapshots').then(r => { console.log('rows:', r.rows[0].n); process.exit(0); });
+\""
+```
+
+**3. Replace SQLite Database section**
+
+Replace the entire `## SQLite Database` section header and table with `## Turso Database`:
+
+```markdown
+## Turso Database
+
+**Provider:** Turso cloud (libSQL) — NOT SQLite. Credentials in Infisical + Fly secrets.
+
+**Table:** `price_snapshots`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `scraped_at` | TEXT | ISO8601 UTC timestamp of actual scrape |
+| `window_start` | TEXT | 15-min floor bucket |
+| `coin_slug` | TEXT | e.g. `ase`, `age` |
+| `vendor` | TEXT | Provider id (e.g. `apmex`) |
+| `price` | REAL | null if scrape failed |
+| `source` | TEXT | `firecrawl` \| `playwright` \| `fbp` |
+| `in_stock` | INTEGER | 0 if OOS patterns matched |
+| `is_failed` | INTEGER | 1 if price is null |
+| `poller_id` | TEXT | `api` (Fly.io) or `home` (home VM) |
+```
+
+**4. Replace "data branch" with "api branch" throughout**
+
+All references to "data branch" → "api branch". This is a global find-replace across the skill file.
+
+**5. Remove retail-price-poller.yml GHA references**
+
+Remove the note about `retail-price-poller.yml` being deleted — it's historical context that can confuse. Replace with:
+```
+**No GHA cloud failsafe.** All retail scraping runs exclusively in the Fly.io container via self-hosted Firecrawl + dual home VM poller. `retail-price-poller.yml` was deleted 2026-02-22.
+```
+
+**6. Update the "data branch" git safety section heading**
+
+Change `## Data Branch Git Safety` → `## API Branch Git Safety`
+
+---
+
+### Task A7: Create repo-boundaries skill
+
+**Files:**
+- Create: `.claude/skills/repo-boundaries/SKILL.md`
+
+**Step 1: Create the skill directory and file**
+
+```bash
+mkdir -p /Volumes/DATA/GitHub/StakTrakr/.claude/skills/repo-boundaries
+```
+
+Write the following content to `.claude/skills/repo-boundaries/SKILL.md`:
+
+```markdown
+---
+name: repo-boundaries
+description: Use when doing any cross-repo work, deploying, or when unsure which repo owns a piece of code. Maps exactly which code belongs in which repo and what each agent is allowed to do.
+---
+
+# Repo Boundaries
+
+## Repo Ownership Map
+
+| Repo | Owns | Does NOT own |
+|------|------|--------------|
+| `lbruton/StakTrakr` | Frontend HTML/JS/CSS, skills, CLAUDE.md, smoke tests | Poller scripts, fly.toml, Dockerfile, devops crons |
+| `lbruton/StakTrakrApi` | ALL backend devops: fly.toml, Dockerfile, all run-*.sh, price-extract.js, api-export.js, spot-poller, providers.json | Frontend code |
+| `lbruton/stakscrapr` | Home VM full stack: same core + dashboard.js + tinyproxy + Tailscale exit config | fly.toml (authoritative is StakTrakrApi), fly deploy |
+| `lbruton/StakTrakrWiki` | Shared infrastructure documentation | Code, config, scripts |
+
+## Deploy Rules
+
+| Action | Allowed from | Forbidden from |
+|--------|-------------|----------------|
+| `fly deploy` | StakTrakrApi (`devops/fly-poller/`) | StakTrakr, stakscrapr, any other repo |
+| `git push origin api` (data) | Fly.io container `run-publish.sh` only | Local Mac, home VM, GHA |
+| PR to StakTrakrApi main | StakTrakr Mac Claude, stakscrapr Claude | Nobody pushes direct to main |
+| providers.json URL fix | Direct push to `api` branch (StakTrakrApi) | Any other method |
+
+## Fly.io Container — Which Repo Has fly.toml?
+
+**`StakTrakrApi/devops/fly-poller/fly.toml`** is the authoritative fly.toml.
+
+- 4096MB RAM, 4 shared CPUs, region dfw
+- Supervisord runs: redis, rabbitmq, postgres, playwright-service, firecrawl-api, firecrawl-worker, firecrawl-extract-worker, cron, http-server
+- `stakscrapr/fly.toml` is STALE (2048MB) — do not use it for anything
+
+## Home VM — What Lives in stakscrapr?
+
+The home VM (`192.168.1.48`) runs:
+- Same Firecrawl + Playwright + Redis + RabbitMQ stack as Fly.io (via supervisord)
+- `dashboard.js` (port 3010) — monitors both pollers via Turso
+- `check-flyio.sh` — writes `/tmp/flyio-health.json` for dashboard
+- Tailscale exit node (`100.112.198.50`) — all Fly.io scrape traffic exits through home Cox residential IP
+- tinyproxy (port 8889) — HTTP proxy via Cox NIC
+
+stakscrapr Claude: NEVER run `fly deploy`. Open a PR to `lbruton/StakTrakrApi` instead.
+
+## Change Gate
+
+When home VM code changes need to flow to Fly.io:
+1. Home Claude opens PR to `StakTrakrApi` main
+2. StakTrakr Mac Claude reviews + merges
+3. StakTrakr Mac Claude runs `cd devops/fly-poller && fly deploy`
+
+## What Goes in Which devops/ Folder (StakTrakrApi)
+
+| Folder | Contains |
+|--------|---------|
+| `devops/scraper/` | Shared engine: price-extract.js, api-export.js, capture.js, extract-vision.js, spot-poller/poller.py, package.json |
+| `devops/fly-poller/` | fly.toml, Dockerfile, run-local.sh, run-publish.sh, run-spot.sh, run-retry.sh, run-fbp.sh, docker-entrypoint.sh, supervisord.conf |
+| `devops/home-scraper/` | run-home.sh, dashboard.js, check-flyio.sh, supervisord.conf (11 services), .env.example |
+| `devops/home-vm/` | tinyproxy-cox.conf, cox-auth.sh/service/timer, update-cox-proxy-ip.sh |
+```
+
+---
+
+### Task A8: Commit Phase A changes
+
+**Files:** All modified files from Tasks A1–A7
+
+**Step 1: Check git status**
+
+```bash
+git -C /Volumes/DATA/GitHub/StakTrakr status
+```
+
+Expected: Modified CLAUDE.md, .github/workflows/spot-poller.yml, skill files; deleted devops/spot-poller/, devops/retail-poller/ (as untracked removals, since they weren't tracked)
+
+**Step 2: Stage all changed files**
+
+```bash
+git -C /Volumes/DATA/GitHub/StakTrakr add CLAUDE.md
+git -C /Volumes/DATA/GitHub/StakTrakr add .github/workflows/spot-poller.yml
+git -C /Volumes/DATA/GitHub/StakTrakr add .claude/skills/api-infrastructure/SKILL.md
+git -C /Volumes/DATA/GitHub/StakTrakr add .claude/skills/seed-sync/SKILL.md
+git -C /Volumes/DATA/GitHub/StakTrakr add .claude/skills/retail-poller/SKILL.md
+git -C /Volumes/DATA/GitHub/StakTrakr add .claude/skills/repo-boundaries/SKILL.md
+git -C /Volumes/DATA/GitHub/StakTrakr add docs/plans/
+```
+
+Note: The ghost dirs (devops/spot-poller/, devops/retail-poller/) were never tracked in git (confirmed by git status at session start showing them as ??). No `git rm` needed — just delete from filesystem, done.
+
+**Step 3: Commit**
+
+```
+chore(audit): retire spot-poller GHA, remove ghost devops dirs, update skills/CLAUDE.md
+
+- Convert spot-poller.yml to no-op (was silently failing — poller.py removed)
+- Update CLAUDE.md feed table: spot polling is Fly.io run-spot.sh, not GHA
+- Delete ghost devops/spot-poller/ and devops/retail-poller/ dirs
+- api-infrastructure skill: fix spot writer, retire GHA entry, correct fly.toml repo path
+- seed-sync skill: remove Phase 1 Docker container check (container doesn't exist)
+- retail-poller skill: replace docker exec with fly ssh, SQLite→Turso, data branch→api branch
+- New repo-boundaries skill: authoritative ownership map for all 4 repos
+```
+
+**Step 4: Verify commit**
+
+```bash
+git -C /Volumes/DATA/GitHub/StakTrakr log --oneline -3
+git -C /Volumes/DATA/GitHub/StakTrakr diff HEAD~1 --stat
+```
+
+---
+
+## Phase B — StakTrakrApi Repo (Separate Session)
+
+> Run in a Claude session inside `lbruton/StakTrakrApi` repo.
+
+### Task B1: Create devops/scraper/ folder
+
+Extract shared engine files from `devops/retail-poller/` into new `devops/scraper/`:
+
+```bash
+cd /path/to/StakTrakrApi
+mkdir -p devops/scraper/spot-poller
+git mv devops/retail-poller/price-extract.js devops/scraper/
+git mv devops/retail-poller/api-export.js devops/scraper/
+git mv devops/retail-poller/capture.js devops/scraper/
+git mv devops/retail-poller/extract-vision.js devops/scraper/
+git mv devops/retail-poller/db.js devops/scraper/
+git mv devops/retail-poller/spot-poller/poller.py devops/scraper/spot-poller/
+# Copy package.json — both folders will need it
+cp devops/retail-poller/package.json devops/scraper/package.json
+```
+
+### Task B2: Create devops/fly-poller/ folder
+
+```bash
+cd /path/to/StakTrakrApi
+mkdir -p devops/fly-poller
+git mv devops/retail-poller/fly.toml devops/fly-poller/
+git mv devops/retail-poller/Dockerfile devops/fly-poller/
+git mv devops/retail-poller/run-local.sh devops/fly-poller/
+git mv devops/retail-poller/run-publish.sh devops/fly-poller/
+git mv devops/retail-poller/run-spot.sh devops/fly-poller/
+git mv devops/retail-poller/run-retry.sh devops/fly-poller/
+git mv devops/retail-poller/run-fbp.sh devops/fly-poller/
+git mv devops/retail-poller/docker-entrypoint.sh devops/fly-poller/
+git mv devops/retail-poller/supervisord.conf devops/fly-poller/
+```
+
+Update `Dockerfile` COPY paths to pull from `../scraper/`:
+```dockerfile
+COPY ../scraper/ /app/
+COPY ./ /app/
+```
+
+### Task B3: Create devops/home-scraper/ folder
+
+Fetch from `stakscrapr` repo the home-specific files that do NOT exist in `retail-poller/`:
+
+```bash
+mkdir -p devops/home-scraper
+# Copy from stakscrapr checkout (or curl from github):
+# dashboard.js, check-flyio.sh, run-home.sh
+# Create supervisord.conf for home (11 services)
+# Create .env.example
+```
+
+### Task B4: Create StakTrakrApi CLAUDE.md
+
+Create `CLAUDE.md` in root of StakTrakrApi:
+
+```markdown
+# CLAUDE.md — StakTrakrApi
+
+## Deploy Rules
+
+**`fly deploy` is run from this repo only.**
+- Always run from `devops/fly-poller/`: `cd devops/fly-poller && fly deploy`
+- Never run `fly deploy` from any other repo
+
+**Git branch rules:**
+- `api` branch = live data files (written by Fly.io `run-publish.sh` via force-push)
+- `main` branch = code source of truth (PR target)
+- Never push directly to `main` — all changes via PR
+
+## Repo Ownership
+
+See `devops/` folder map:
+- `devops/scraper/` — shared engine (both Fly.io and home VM use this code)
+- `devops/fly-poller/` — Fly.io deploy wrapper (fly.toml, Dockerfile, container scripts)
+- `devops/home-scraper/` — home VM additions (dashboard, tinyproxy, run-home.sh)
+- `devops/home-vm/` — infrastructure (tinyproxy-cox, cox-auth, sysctl)
+```
+
+### Task B5: Commit + PR for StakTrakrApi
+
+```bash
+git add devops/
+git commit -m "refactor(devops): split retail-poller into scraper/ fly-poller/ home-scraper/"
+git push origin main  # via PR — never direct
+```
+
+---
+
+## Phase C — StakTrakrWiki Repo (Separate Session)
+
+> Run in a Claude session inside `lbruton/StakTrakrWiki` repo.
+
+### Task C1: Fix architecture-overview.md
+
+Update the **Repo Boundaries** table:
+
+Replace stakscrapr row:
+```
+| `lbruton/stakscrapr` | Home LXC Claude config — CLAUDE.md, `.mcp.json`, VM-specific docs |
+```
+With:
+```
+| `lbruton/stakscrapr` | Home VM full stack — identical Firecrawl+Playwright+scraper core PLUS dashboard.js, tinyproxy/Cox residential proxy, Tailscale exit node config |
+```
+
+Update `devops/` folder references to reflect new `scraper/` + `fly-poller/` + `home-scraper/` structure.
+
+### Task C2: Fix home-poller.md IP address
+
+In `home-poller.md`, change all references to `192.168.1.81` → `192.168.1.48`.
+
+Verify against: `health.md` which uses SSH host `192.168.1.48`.
+
+### Task C3: Commit wiki changes
+
+```bash
+git add architecture-overview.md home-poller.md
+git commit -m "docs: fix stakscrapr description, fix home VM IP address"
+git push origin main
+```
+
+---
+
+## Auto-Quiz Answers
+
+1. **Which task is marked NEXT?** Task A1 — Fix CLAUDE.md spot poller feed table
+2. **Validation for NEXT?** Read back modified CLAUDE.md section — confirm no `spot-poller.yml` or `GHA` in the feed table rows, and new prohibition note is present
+3. **Commit message for NEXT?** `chore(audit): retire spot-poller GHA, remove ghost devops dirs, update skills/CLAUDE.md`
+4. **Breakpoint?** After Task A8 (commit) — pause for human review before proceeding to Phase B (StakTrakrApi repo changes)


### PR DESCRIPTION
## Summary

- **spot-poller.yml** converted to manual-trigger-only no-op (was silently failing — `poller.py` removed from repo, cron runs were erroring in GitHub Actions)
- **CLAUDE.md** feed table corrected: spot polling is Fly.io `run-spot.sh` cron, not GHA; added Docker prohibition note
- **api-infrastructure skill** — spot writer corrected, fly.toml repo-qualified to `StakTrakrApi`, GHA row marked RETIRED
- **seed-sync skill** — Phase 1 Docker container health check removed entirely (container doesn't exist)
- **retail-poller skill** — `docker exec` → `fly ssh console`, SQLite → Turso, "data branch" → "api branch" throughout
- **repo-boundaries skill** (new) — authoritative ownership map for all 4 repos, deploy rules, change gate flow
- **retail-provider-fix skill** — now tracked in git (was gitignored)
- Ghost directories `devops/spot-poller/` and `devops/retail-poller/` deleted from filesystem (were untracked)

## Design doc

`docs/plans/2026-02-25-api-pipeline-audit-design.md` — approved architecture with three-phase plan (A: StakTrakr, B: StakTrakrApi, C: Wiki)

## Test plan

- [ ] Verify CLAUDE.md feed table shows Fly.io for spot (no GHA reference)
- [ ] Verify spot-poller.yml has no `schedule:` crons — only `workflow_dispatch`
- [ ] Verify api-infrastructure skill says spot runs in Fly.io container
- [ ] Verify seed-sync skill has no Docker references
- [ ] Verify retail-poller skill uses `fly ssh console` not `docker exec`
- [ ] Verify new repo-boundaries skill exists with deploy prohibition

🤖 Generated with [Claude Code](https://claude.com/claude-code)