### PR TITLE
v3.32.38 — Home Poller SSH skill + skill updates

### DIFF
--- a/.claude/skills/api-infrastructure/SKILL.md
+++ b/.claude/skills/api-infrastructure/SKILL.md
@@ -14,7 +14,7 @@ All feeds served from `lbruton/StakTrakrApi` `main` branch via GitHub Pages at `
 | **Market prices** | `data/api/manifest.json` | Fly.io `run-local.sh` + `run-publish.sh` | 30 min |
 | **Spot prices** | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` cron (`5,20,35,50 * * * *`) | 75 min |
 | **Goldback** | `data/api/goldback-spot.json` | Fly.io via `goldback-g1` coin in `run-local.sh` | 25h (info only) |
-| **Turso** | `price_snapshots` table | Dual-poller write-through (Fly.io `POLLER_ID=api` + home VM `POLLER_ID=home`) | internal |
+| **Turso** | `price_snapshots` table | Dual-poller write-through (Fly.io `POLLER_ID=api` + home VM `POLLER_ID=home`). Home VM: `ssh -T homepoller` — see `homepoller-ssh` skill | internal |
 
 **Critical:** `spot-history-YYYY.json` is a **seed file** (noon UTC daily) — never use it for freshness checks. Live spot data is always in `data/hourly/`.
 

--- a/.claude/skills/homepoller-ssh/SKILL.md
+++ b/.claude/skills/homepoller-ssh/SKILL.md
@@ -63,9 +63,9 @@ ssh -T homepoller 'curl -sf http://localhost:3002/v1/scrape -X POST -H "Content-
 | Restart all supervisord services | `ssh -T homepoller 'sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf restart all'` |
 | Restart single service | `ssh -T homepoller 'sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf restart <name>'` |
 | Clear stuck lockfile | `ssh -T homepoller 'sudo rm -f /tmp/retail-poller.lock'` |
-| Fix log permissions | `ssh -T homepoller 'sudo touch /var/log/retail-poller.log && sudo chmod 666 /var/log/retail-poller.log'` |
+| Fix log permissions | `ssh -T homepoller 'sudo touch /var/log/retail-poller.log && sudo chown stakpoller:stakpoller /var/log/retail-poller.log && sudo chmod 664 /var/log/retail-poller.log'` |
 | View cron schedule | `ssh -T homepoller 'cat /etc/cron.d/retail-poller'` |
-| View .env (secrets) | `ssh -T homepoller 'cat /opt/poller/.env'` |
+| Check .env key names (no values) | `ssh -T homepoller 'grep -oP "^[A-Z_]+" /opt/poller/.env'` |
 | Check disk usage | `ssh -T homepoller 'df -h /'` |
 | Check Node version | `ssh -T homepoller 'node --version'` |
 

--- a/.claude/skills/homepoller-ssh/SKILL.md
+++ b/.claude/skills/homepoller-ssh/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: homepoller-ssh
+description: Use when troubleshooting the home poller, checking service health, viewing logs, restarting services, updating poller code, or running any command on the home VM. Also use when the words home poller, homepoller, 192.168.1.81, supervisord, retail-poller.log, or residential proxy appear in context.
+---
+
+# Home Poller SSH
+
+Direct SSH access from this Mac to the home poller VM. Replaces the old workflow of delegating to a Claude agent running in the home VM's terminal.
+
+## Connection
+
+| Alias | Network | Host | Latency |
+|-------|---------|------|---------|
+| `homepoller` | LAN | 192.168.1.81 | ~0.5ms |
+| `homepoller-ts` | Tailscale | 100.112.198.50 | ~36ms |
+
+**Always use `-T`** (no PTY) for non-interactive commands — prevents duplicate output:
+
+```bash
+ssh -T homepoller '<command>'
+```
+
+Use `homepoller-ts` as fallback when off the home LAN or when LAN connectivity is unreliable.
+
+**User:** `stakpoller` — has `NOPASSWD: ALL` sudo via `/etc/sudoers.d/stakpoller`.
+
+**Key:** `~/.ssh/stakpoller_ed25519` — sourced from Infisical prod environment (`STAKPOLLER_SSH_PRIVATE_KEY`). Config: `~/.ssh/config`.
+
+---
+
+## Quick Diagnostics
+
+```bash
+# Service health (supervisord — 5 services)
+ssh -T homepoller 'sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf status'
+
+# Service health (systemd — 7 services)
+ssh -T homepoller 'systemctl is-active redis-server rabbitmq-server cron tailscaled tinyproxy grafana-server prometheus'
+
+# Recent poller log
+ssh -T homepoller 'tail -50 /var/log/retail-poller.log'
+
+# Dashboard / metrics logs
+ssh -T homepoller 'sudo tail -20 /var/log/supervisor/dashboard.log'
+ssh -T homepoller 'sudo tail -20 /var/log/supervisor/metrics-exporter.log'
+
+# Check if poller lock is stuck
+ssh -T homepoller 'ls -la /tmp/retail-poller.lock 2>/dev/null || echo "No lock"'
+
+# Test single coin
+ssh -T homepoller 'COINS=ase bash /opt/poller/run-home.sh'
+
+# Check Firecrawl/Playwright
+ssh -T homepoller 'curl -sf http://localhost:3002/v1/scrape -X POST -H "Content-Type: application/json" -d "{\"url\":\"https://example.com\"}" | head -c 200'
+```
+
+---
+
+## Common Tasks
+
+| Task | Command |
+|------|---------|
+| Restart all supervisord services | `ssh -T homepoller 'sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf restart all'` |
+| Restart single service | `ssh -T homepoller 'sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf restart <name>'` |
+| Clear stuck lockfile | `ssh -T homepoller 'sudo rm -f /tmp/retail-poller.lock'` |
+| Fix log permissions | `ssh -T homepoller 'sudo touch /var/log/retail-poller.log && sudo chmod 666 /var/log/retail-poller.log'` |
+| View cron schedule | `ssh -T homepoller 'cat /etc/cron.d/retail-poller'` |
+| View .env (secrets) | `ssh -T homepoller 'cat /opt/poller/.env'` |
+| Check disk usage | `ssh -T homepoller 'df -h /'` |
+| Check Node version | `ssh -T homepoller 'node --version'` |
+
+---
+
+## Updating Poller Code
+
+Pull latest from StakTrakrApi main branch:
+
+```bash
+ssh -T homepoller 'bash -s' << 'SCRIPT'
+BASE=https://raw.githubusercontent.com/lbruton/StakTrakrApi/main/devops/retail-poller
+cd /opt/poller
+for f in price-extract.js capture.js db.js turso-client.js merge-prices.js api-export.js \
+         serve.js vision-patch.js extract-vision.js import-from-log.js goldback-scraper.js \
+         run-home.sh run-fbp.sh run-spot.sh run-publish.sh run-goldback.sh monitor-oos.sh package.json; do
+  curl -sf "$BASE/$f" -o "$f" || echo "WARN: $f not found upstream"
+done
+npm install
+echo "Update complete"
+SCRIPT
+```
+
+---
+
+## Stack Reference
+
+| Component | Manager | Port |
+|-----------|---------|------|
+| Firecrawl API | supervisord | localhost:3002 |
+| Firecrawl Worker | supervisord | — |
+| Playwright Service | supervisord | localhost:3003 |
+| Dashboard | supervisord | 0.0.0.0:3010 |
+| Metrics Exporter | supervisord | 0.0.0.0:9100 |
+| Redis | systemd | localhost:6379 |
+| RabbitMQ | systemd | localhost:5672 |
+| Grafana | systemd | 0.0.0.0:3000 |
+| Prometheus | systemd | 0.0.0.0:9090 |
+| tinyproxy | systemd | 0.0.0.0:8888 |
+| Tailscale | systemd | tailscale0 |
+| Cron | systemd | — |
+
+**Key paths:** `/opt/poller/` (scripts), `/var/log/retail-poller.log` (poller), `/var/log/supervisor/` (services), `/etc/supervisor/conf.d/staktrakr.conf` (supervisord config).
+
+---
+
+## Common Mistakes
+
+**Running without `-T`**: Commands output twice (once from PTY, once from stdout). Always `ssh -T`.
+
+**Forgetting sudo for supervisorctl**: The supervisord socket requires root. Always prefix with `sudo`.
+
+**Editing files on the VM directly**: Poller source is owned by `StakTrakrApi`. Edit there, then curl-update on the VM. Only home-only files (dashboard.js, check-flyio.sh, supervisord config) should be edited directly.
+
+**Using the wrong supervisorctl path**: Must include `-c /etc/supervisor/supervisord.conf` — the default config path doesn't work on this VM.

--- a/.claude/skills/repo-boundaries/SKILL.md
+++ b/.claude/skills/repo-boundaries/SKILL.md
@@ -77,7 +77,7 @@ When a code change on the home VM needs to reach Fly.io:
 2. Open PR to StakTrakrApi main
 3. Review + merge
 4. cd StakTrakrApi/devops/fly-poller && fly deploy
-5. Update home VM via SSH: ssh -T homepoller 'curl -sf https://raw.githubusercontent.com/.../devops/scraper/<file> -o /opt/poller/<file>'
+5. Update home VM via SSH: ssh -T homepoller 'curl -sf https://raw.githubusercontent.com/.../devops/retail-poller/<file> -o /opt/poller/<file>'
 ```
 
 **providers.json URL changes** skip steps 3–5 entirely — push directly to `api` branch (auto-synced every run).

--- a/.claude/skills/repo-boundaries/SKILL.md
+++ b/.claude/skills/repo-boundaries/SKILL.md
@@ -11,7 +11,7 @@ description: Use when doing any cross-repo work, deploying, or when unsure which
 |------|------|--------------|
 | `lbruton/StakTrakr` | Frontend HTML/JS/CSS, `.claude/` skills, CLAUDE.md, smoke tests | Poller scripts, fly.toml, Dockerfile, devops crons |
 | `lbruton/StakTrakrApi` | ALL backend devops: fly.toml, Dockerfile, all run-*.sh, price-extract.js, api-export.js, spot-poller, providers.json | Frontend code |
-| `lbruton/stakscrapr` | Home VM full stack: identical scraper core + dashboard.js + tinyproxy/Cox residential proxy + Tailscale exit node config | fly.toml authority (StakTrakrApi owns it), `fly deploy` |
+| `lbruton/stakscrapr` | Home VM config repo: CLAUDE.md, env templates, home-only additions (dashboard.js, tinyproxy config). **Managed via SSH from this Mac** — see `homepoller-ssh` skill | fly.toml authority (StakTrakrApi owns it), `fly deploy` |
 | `lbruton/StakTrakrWiki` | Shared infrastructure documentation | Code, config, scripts |
 
 ---
@@ -22,7 +22,7 @@ description: Use when doing any cross-repo work, deploying, or when unsure which
 |--------|-------------|----------------|
 | `fly deploy` | `StakTrakrApi/devops/fly-poller/` on this Mac only | StakTrakr repo, stakscrapr repo, home VM, anywhere else |
 | `git push` to `api` branch (data files) | Fly.io container `run-publish.sh` only — via force-push | Local Mac, home VM, any GHA, manually |
-| PR to `StakTrakrApi` main | StakTrakr Mac Claude or stakscrapr Claude | Direct push to main |
+| PR to `StakTrakrApi` main | StakTrakr Mac Claude (via SSH or local) | Direct push to main |
 | `providers.json` URL fix | Direct push to `api` branch in `StakTrakrApi` | Any other method |
 
 > **⛔ NEVER run `fly deploy` from the StakTrakr repo or the stakscrapr repo.**
@@ -40,7 +40,9 @@ description: Use when doing any cross-repo work, deploying, or when unsure which
 
 ---
 
-## Home VM (192.168.1.48) — What stakscrapr Owns
+## Home VM (192.168.1.81) — SSH-Managed
+
+> **Access:** `ssh -T homepoller '<cmd>'` (LAN) or `ssh -T homepoller-ts '<cmd>'` (Tailscale). See `homepoller-ssh` skill for full reference.
 
 The home VM runs the **identical scraper core** (same price-extract.js, api-export.js as Fly.io) PLUS home-only additions:
 
@@ -48,10 +50,10 @@ The home VM runs the **identical scraper core** (same price-extract.js, api-expo
 |-----------|---------|
 | `dashboard.js` (port 3010) | Monitors both pollers via Turso `poller_runs` table + `/tmp/flyio-health.json` |
 | `check-flyio.sh` | Polls Fly.io health, writes `/tmp/flyio-health.json` for dashboard |
-| tinyproxy (port 8889) | HTTP proxy — routes Fly.io scraper traffic through Cox residential IP |
-| Tailscale exit node (`100.112.198.50`) | Fly.io container traffic exits through home residential IP for bot evasion |
+| tinyproxy (port 8888) | HTTP proxy — routes Fly.io scraper traffic through residential IP |
+| Tailscale (`100.112.198.50`) | Fly.io container traffic exits through home residential IP for bot evasion |
 
-**stakscrapr Claude rule:** NEVER run `fly deploy`. Open a PR to `lbruton/StakTrakrApi` instead.
+**Rule:** NEVER run `fly deploy` on the home VM. Open a PR to `lbruton/StakTrakrApi` instead.
 
 ---
 
@@ -71,11 +73,11 @@ The home VM runs the **identical scraper core** (same price-extract.js, api-expo
 When a code change on the home VM needs to reach Fly.io:
 
 ```
-1. Home Claude edits devops/scraper/ file
-2. Opens PR to StakTrakrApi main
-3. StakTrakr Mac Claude reviews + merges
-4. StakTrakr Mac Claude: cd devops/fly-poller && fly deploy
-5. Home VM: curl raw.githubusercontent.com/StakTrakrApi/main/devops/scraper/<file> -o /opt/poller/<file>
+1. Edit devops/scraper/ file in StakTrakrApi repo (on this Mac)
+2. Open PR to StakTrakrApi main
+3. Review + merge
+4. cd StakTrakrApi/devops/fly-poller && fly deploy
+5. Update home VM via SSH: ssh -T homepoller 'curl -sf https://raw.githubusercontent.com/.../devops/scraper/<file> -o /opt/poller/<file>'
 ```
 
 **providers.json URL changes** skip steps 3–5 entirely — push directly to `api` branch (auto-synced every run).
@@ -89,6 +91,6 @@ Both pollers write to the same Turso DB (`price_snapshots` table). Only Fly.io p
 | Poller | POLLER_ID | Writes to | Publishes to Git |
 |--------|-----------|-----------|-----------------|
 | Fly.io container | `api` | Turso | ✅ Yes — `run-publish.sh` force-pushes to `api` branch |
-| Home VM (192.168.1.48) | `home` | Turso | ❌ No — never touches git |
+| Home VM (192.168.1.81) | `home` | Turso | ❌ No — never touches git |
 
 `readLatestPerVendor(db, coinSlug, lookbackHours=2)` — most recent row per vendor within 2h wins at publish time.

--- a/.claude/skills/retail-poller/SKILL.md
+++ b/.claude/skills/retail-poller/SKILL.md
@@ -31,7 +31,7 @@ api-export.js  (Turso + vision JSON → data/api/ REST endpoints → api branch)
 |----------|---------|------|---------|
 | **Fly.io** (`run-local.sh`) | Playwright (self-hosted, `localhost:3002`) | **Primary + only** | Every 15 min via container cron |
 
-**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). All retail scraping now runs exclusively in the Fly.io container via self-hosted Firecrawl + the home VM secondary poller.
+**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). All retail scraping now runs exclusively in the Fly.io container via self-hosted Firecrawl + the home VM secondary poller. **Home VM is SSH-accessible** — see `homepoller-ssh` skill for diagnostics.
 
 **Key constraint:** `providers.json` lives on the **`api` branch**, not `main` or `dev`.
 Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
@@ -141,7 +141,7 @@ After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPric
 
 **Provider:** Turso cloud (libSQL) — NOT local SQLite. Credentials in Infisical + Fly secrets (`TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`).
 
-**Dual-poller write-through:** Both Fly.io (`POLLER_ID=api`) and home VM (`POLLER_ID=home`) write to the same Turso DB. `api-export.js` uses `readLatestPerVendor()` to merge — most recent row per vendor within last 2h wins.
+**Dual-poller write-through:** Both Fly.io (`POLLER_ID=api`) and home VM at 192.168.1.81 (`POLLER_ID=home`) write to the same Turso DB. `api-export.js` uses `readLatestPerVendor()` to merge — most recent row per vendor within last 2h wins. To check home poller logs: `ssh -T homepoller 'tail -50 /var/log/retail-poller.log'`.
 
 **Table:** `price_snapshots`
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 !.claude/skills/retail-poller/
 !.claude/skills/retail-provider-fix/
 !.claude/skills/repo-boundaries/
+!.claude/skills/homepoller-ssh/
 .claude/commands/
 .mcp.json
 SPRINT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.38] - 2026-02-25
+
+### Added — Home Poller SSH Skill + Skill Updates
+
+- **Added**: `homepoller-ssh` skill — SSH reference for direct access to the home poller VM (192.168.1.81) via `stakpoller` user with NOPASSWD sudo
+- **Changed**: `repo-boundaries` skill — fixed IP (192.168.1.48 → 192.168.1.81), replaced stakscrapr Claude delegation with SSH commands, corrected tinyproxy port (8889 → 8888)
+- **Changed**: `retail-poller` and `api-infrastructure` skills — added SSH diagnostic references for home VM
+- **Changed**: CLAUDE.md — added home poller SSH quick reference and `homepoller-ssh` to skills list
+
+---
+
 ## [3.32.37] - 2026-02-25
 
 ### Changed — Wiki-First Documentation Policy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Three feeds served from `lbruton/StakTrakrApi` main branch via GitHub Pages at `
 
 **No active failures as of 2026-02-22.** `sync-api-repos.yml` and `retail-price-poller.yml` deleted — both are gone.
 
+**Home poller SSH:** `ssh -T homepoller '<cmd>'` (LAN) or `ssh -T homepoller-ts '<cmd>'` (Tailscale). Full reference in `homepoller-ssh` skill. User `stakpoller` has NOPASSWD sudo.
+
 **Quick health check:**
 ```bash
 # One-liner — paste into terminal
@@ -143,7 +145,7 @@ For CSS/HTML guidance, use `frontend-design` plugin or `ui-design` project skill
 | `GEMINI.md` | Gemini CLI | Yes |
 | `.github/copilot-instructions.md` | Copilot PR reviews | Yes |
 
-**Skills**: Official `superpowers@claude-plugins-official` plugin (auto-updates) + user overrides in `~/.claude/skills/` (25 skills). Project skills in `.claude/skills/`: `coding-standards`, `markdown-standards`, `release`, `seed-sync`, `ui-design`, `ui-mockup`, `bb-test`, `smoke-test`, `browserbase-test-maintenance`, `api-infrastructure`, `finishing-a-development-branch` (project override — enforces `patch→dev` workflow, never `patch→main`).
+**Skills**: Official `superpowers@claude-plugins-official` plugin (auto-updates) + user overrides in `~/.claude/skills/` (25 skills). Project skills in `.claude/skills/`: `coding-standards`, `markdown-standards`, `release`, `seed-sync`, `ui-design`, `ui-mockup`, `bb-test`, `smoke-test`, `browserbase-test-maintenance`, `api-infrastructure`, `homepoller-ssh`, `finishing-a-development-branch` (project override — enforces `patch→dev` workflow, never `patch→main`).
 
 Use `/sync-instructions` after significant codebase changes.
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Home Poller SSH + Skill Updates (v3.32.38)**: New homepoller-ssh skill for direct SSH management of the home VM. Updated repo-boundaries with corrected IP and SSH workflow. Skills no longer delegate to OS-level Claude agent.
 - **Wiki-First Documentation Policy (v3.32.37)**: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.
 - **Bug Fixes — Numista Data Integrity (v3.32.36)**: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).
 - **Header Buttons Reorder (v3.32.35)**: Toggle visibility and reorder header buttons in Settings → Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).
 - **Force Refresh Button (v3.32.34)**: New button in Settings &rarr; System &rarr; App Updates. Unregisters service workers and reloads to fetch the latest version. Use if the app appears stuck on an old version after an update (STAK-324).
-- **Bug Fix — 7-Day Sparklines (v3.32.33)**: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.38 &ndash; Home Poller SSH + Skill Updates</strong>: New homepoller-ssh skill for direct SSH management of the home VM. Updated repo-boundaries with corrected IP and SSH workflow. Skills no longer delegate to OS-level Claude agent.</li>
     <li><strong>v3.32.37 &ndash; Wiki-First Documentation Policy</strong>: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.</li>
     <li><strong>v3.32.36 &ndash; Bug Fixes &mdash; Numista Data Integrity</strong>: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).</li>
     <li><strong>v3.32.35 &ndash; Header Buttons Reorder</strong>: Toggle visibility and reorder header buttons in Settings &rarr; Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).</li>
     <li><strong>v3.32.34 &ndash; Force Refresh Button</strong>: New button in Settings &rarr; System &rarr; App Updates. Unregisters service workers and reloads to fetch the latest version. Use if the app appears stuck on an old version after an update (STAK-324).</li>
-    <li><strong>v3.32.33 &ndash; Bug Fix &mdash; 7-Day Sparklines</strong>: Fresh load sparklines now draw a full 7-day curve. Hourly backfill extends to 7 days on first load to bridge the LBMA seed data lag (STAK-303).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.37";
+const APP_VERSION = "3.32.38";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.37-b1772006155';
+const CACHE_NAME = 'staktrakr-v3.32.38-b1772011903';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.37",
+  "version": "3.32.38",
   "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **New skill: `homepoller-ssh`** — SSH reference for direct access to the home poller VM (192.168.1.81) via `stakpoller` user with NOPASSWD sudo. Includes diagnostics, common tasks, service stack reference.
- **Updated `repo-boundaries`** — Fixed IP (192.168.1.48 → 192.168.1.81), replaced stakscrapr Claude delegation with SSH commands, corrected tinyproxy port (8889 → 8888), updated Change Gate workflow.
- **Updated `retail-poller`** — Added SSH diagnostic reference for home VM dual-poller troubleshooting.
- **Updated `api-infrastructure`** — Added SSH note for home VM access in Turso dual-poller row.
- **Updated `CLAUDE.md`** — Added home poller SSH quick reference, `homepoller-ssh` listed in skills.
- **StakTrakrWiki `home-poller.md`** — Added SSH Remote Management section, updated user to `stakpoller`.

## Context

Replaces the old workflow of delegating to a Claude agent running in the home VM's terminal. Claude Code can now SSH directly into the home poller box via `ssh -T homepoller '<cmd>'` for all troubleshooting, service management, and code updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)