### PR TITLE
v3.32.40 — Numista image race condition fix (STAK-337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.40] - 2026-02-25
+
+### Fixed — Numista Image Race Condition
+
+- **Fixed**: Numista images now appear in table/card views immediately after applying — cacheImages re-renders on completion instead of fire-and-forget (STAK-337)
+
+---
+
 ## [3.32.39] - 2026-02-25
 
 ### Fixed — Image Bug Fixes + API Health Refresh

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Numista Image Race Condition Fix (v3.32.40)**: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).
 - **Image Bug Fixes + API Health Refresh (v3.32.39)**: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).
 - **Home Poller SSH + Skill Updates (v3.32.38)**: New homepoller-ssh skill for direct SSH management of the home VM. Updated repo-boundaries with corrected IP and SSH workflow. Skills no longer delegate to OS-level Claude agent.
 - **Wiki-First Documentation Policy (v3.32.37)**: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.
 - **Bug Fixes — Numista Data Integrity (v3.32.36)**: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).
-- **Header Buttons Reorder (v3.32.35)**: Toggle visibility and reorder header buttons in Settings → Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.40 &ndash; Numista Image Race Condition Fix</strong>: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).</li>
     <li><strong>v3.32.39 &ndash; Image Bug Fixes + API Health Refresh</strong>: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).</li>
     <li><strong>v3.32.38 &ndash; Home Poller SSH + Skill Updates</strong>: New homepoller-ssh skill for direct SSH management of the home VM. Updated repo-boundaries with corrected IP and SSH workflow. Skills no longer delegate to OS-level Claude agent.</li>
     <li><strong>v3.32.37 &ndash; Wiki-First Documentation Policy</strong>: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.</li>
     <li><strong>v3.32.36 &ndash; Bug Fixes &mdash; Numista Data Integrity</strong>: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).</li>
-    <li><strong>v3.32.35 &ndash; Header Buttons Reorder</strong>: Toggle visibility and reorder header buttons in Settings &rarr; Appearance with the new checkbox table. Order applies to the live header and persists across sessions (STAK-320).</li>
   `;
 };
 

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -2022,14 +2022,16 @@ document.addEventListener('DOMContentLoaded', function() {
       if (selectedNumistaResult) {
         fillFormFromNumistaResult();
 
-        // Fire-and-forget: cache images + metadata in IndexedDB
+        // Cache images + metadata in IndexedDB, then re-render so thumbnails update (STAK-337)
         if (window.imageCache?.isAvailable() && selectedNumistaResult.catalogId &&
             window.featureFlags?.isEnabled('COIN_IMAGES')) {
           imageCache.cacheImages(
             selectedNumistaResult.catalogId,
             selectedNumistaResult.imageUrl || '',
             selectedNumistaResult.reverseImageUrl || ''
-          ).catch(e => console.warn('Image cache failed:', e));
+          ).then(cached => {
+            if (cached && typeof renderTable === 'function') renderTable();
+          }).catch(e => console.warn('Image cache failed:', e));
           imageCache.cacheMetadata(
             selectedNumistaResult.catalogId,
             selectedNumistaResult

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -2029,8 +2029,8 @@ document.addEventListener('DOMContentLoaded', function() {
             selectedNumistaResult.catalogId,
             selectedNumistaResult.imageUrl || '',
             selectedNumistaResult.reverseImageUrl || ''
-          ).then(cached => {
-            if (cached && typeof renderTable === 'function') renderTable();
+          ).then(() => {
+            if (typeof renderTable === 'function') renderTable();
           }).catch(e => console.warn('Image cache failed:', e));
           imageCache.cacheMetadata(
             selectedNumistaResult.catalogId,

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.39";
+const APP_VERSION = "3.32.40";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.40-b1772019766';
+const CACHE_NAME = 'staktrakr-v3.32.40-b1772020230';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.39-b1772016736';
+const CACHE_NAME = 'staktrakr-v3.32.40-b1772019766';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.39",
+  "version": "3.32.40",
   "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Numista images now appear in table/card views immediately after applying a Numista result — `cacheImages()` triggers `renderTable()` on completion instead of fire-and-forget (STAK-337)
- Race condition: user clicks Fill → `cacheImages` starts async (1-3s download) → modal closes → table renders → IDB empty → no thumbnails. Fix: `.then(() => renderTable())` after cacheImages resolves.

## Linear Issues

- [STAK-337: Numista images not loading when entering N# manually](https://linear.app/hextrackr/issue/STAK-337)

🤖 Generated with [Claude Code](https://claude.com/claude-code)