### PR TITLE
v3.32.41 — Image pipeline simplification — remove coinImages IDB cache (STAK-339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.41] - 2026-02-25
+
+### Changed — Image Pipeline Simplification
+
+- **Removed**: `coinImages` IDB cache layer — CDN URLs on inventory items are now the sole Numista image source, eliminating the root cause of STAK-309/311/332/333/339 image bugs (STAK-339)
+- **Removed**: `numistaOverridePersonal` settings toggle — no longer meaningful without cached blobs to prioritize
+- **Removed**: CDN blob export/import from ZIP backup — CDN images are URLs, not local blobs
+- **Simplified**: Image resolution cascade is now: user upload → pattern image → CDN URL → placeholder
+
+---
+
 ## [3.32.40] - 2026-02-25
 
 ### Fixed — Numista Image Race Condition

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,9 @@
 ## What's New
 
+- **Image Pipeline Simplification (v3.32.41)**: Removed coinImages IDB cache layer entirely. CDN URLs on inventory items are now the sole Numista image source. Eliminates root cause of STAK-309/311/332/333/339 image bugs. Cascade is now: user upload &rarr; pattern image &rarr; CDN URL &rarr; placeholder (STAK-339).
 - **Numista Image Race Condition Fix (v3.32.40)**: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).
 - **Image Bug Fixes + API Health Refresh (v3.32.39)**: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).
 - **Home Poller SSH + Skill Updates (v3.32.38)**: New homepoller-ssh skill for direct SSH management of the home VM. Updated repo-boundaries with corrected IP and SSH workflow. Skills no longer delegate to OS-level Claude agent.
-- **Wiki-First Documentation Policy (v3.32.37)**: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.
-- **Bug Fixes — Numista Data Integrity (v3.32.36)**: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -3097,14 +3097,6 @@
                       <button type="button" class="chip-sort-btn" data-val="reverse">Rev</button>
                     </div>
                   </div>
-                  <div class="settings-card">
-                    <div class="settings-group-label">Numista override</div>
-                    <p class="settings-subtext">Numista images take priority.</p>
-                    <div class="chip-sort-toggle" id="numistaOverrideToggle">
-                      <button type="button" class="chip-sort-btn" data-val="yes">On</button>
-                      <button type="button" class="chip-sort-btn" data-val="no">Off</button>
-                    </div>
-                  </div>
                 </div>
               </div>
 

--- a/index.html
+++ b/index.html
@@ -1361,7 +1361,8 @@
               </div>
               <!-- Hidden wrapper preserved for feature-flag JS compatibility -->
               <div id="imageUrlGroup" style="display:none"></div>
-              <div id="ignorePatternImagesGroup" class="image-pattern-toggle-group">
+              <!-- ignorePatternImagesGroup hidden — per-side cascade makes this redundant (STAK-339); planned for future per-slot control -->
+              <div id="ignorePatternImagesGroup" class="image-pattern-toggle-group" style="display:none">
                 <div class="pattern-toggle-row">
                   <label class="settings-checkbox-label pattern-toggle-label">
                     <input type="checkbox" id="itemIgnorePatternImages" />
@@ -3103,7 +3104,7 @@
               <!-- ── Add Pattern Image Rule ── -->
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">Add Pattern Image Rule</div>
-                <p class="settings-subtext">Create rules that automatically assign images to items matching a name pattern.</p>
+                <p class="settings-subtext">Create rules that automatically assign images to items matching a name pattern. Per-item uploads always take priority over pattern images on a per-side basis.</p>
                 <div class="pattern-rule-form" id="patternRuleForm">
                   <div class="pattern-rule-form-row">
                     <div class="pattern-rule-field">

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.41 &ndash; Image Pipeline Simplification</strong>: Removed coinImages IDB cache layer entirely. CDN URLs on inventory items are now the sole Numista image source. Eliminates root cause of STAK-309/311/332/333/339 image bugs. Cascade is now: user upload &rarr; pattern image &rarr; CDN URL &rarr; placeholder (STAK-339).</li>
     <li><strong>v3.32.40 &ndash; Numista Image Race Condition Fix</strong>: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).</li>
     <li><strong>v3.32.39 &ndash; Image Bug Fixes + API Health Refresh</strong>: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).</li>
     <li><strong>v3.32.38 &ndash; Home Poller SSH + Skill Updates</strong>: New homepoller-ssh skill for direct SSH management of the home VM. Updated repo-boundaries with corrected IP and SSH workflow. Skills no longer delegate to OS-level Claude agent.</li>
-    <li><strong>v3.32.37 &ndash; Wiki-First Documentation Policy</strong>: StakTrakrWiki established as sole source of truth. Notion infrastructure pages deprecated. New wiki-search skill for querying docs via claude-context. finishing-a-development-branch skill updated with Wiki Update Gate before every PR.</li>
-    <li><strong>v3.32.36 &ndash; Bug Fixes &mdash; Numista Data Integrity</strong>: Fixed Numista image URLs and metadata re-populating after being cleared in the edit form. Fixed view modal cross-contaminating images between items. Removed on-load CDN backfill that undid deliberate clears. Added Purge Numista URLs button in Settings &rarr; Images (STAK-309, STAK-311, STAK-306, STAK-312).</li>
   `;
 };
 

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -1353,8 +1353,6 @@ const _loadBulkRowImages = async (tr, item) => {
       url = await imageCache.getUserImageUrl(item.uuid, side);
     } else if (resolved.source === 'pattern') {
       url = await imageCache.getPatternImageUrl(resolved.catalogId, side);
-    } else if (resolved.source === 'numista') {
-      url = await imageCache.getImageUrl(resolved.catalogId, side);
     }
     if (url) _bulkBlobUrls.add(url);
     return url;
@@ -1481,8 +1479,6 @@ const _openBulkImagePopover = (imgTd, item) => {
         url = await imageCache.getUserImageUrl(item.uuid, side);
       } else if (source === 'pattern') {
         url = await imageCache.getPatternImageUrl(rec.catalogId, side);
-      } else if (source === 'numista') {
-        url = await imageCache.getImageUrl(rec.catalogId, side);
       }
     }
 

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -1567,9 +1567,7 @@ const _openBulkImagePopover = (imgTd, item) => {
     if (!keepObv && !keepRev) {
       await imageCache.deleteUserImage(item.uuid);
     } else {
-      const obvToSave = keepObv || keepRev;
-      const revToSave = keepObv ? keepRev : null;
-      await imageCache.cacheUserImage(item.uuid, obvToSave, revToSave);
+      await imageCache.cacheUserImage(item.uuid, keepObv, keepRev);
     }
 
     const previewEl = side === 'obverse' ? obvPreview : revPreview;

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -991,13 +991,6 @@ async function _loadCardImage(img) {
       }
     }
 
-    // Numista override: CDN URLs (Numista source) win over user/pattern blobs
-    const numistaOverride = localStorage.getItem('numistaOverridePersonal') === 'true';
-    if (numistaOverride && cdnUrl) {
-      _showCardImage(img, cdnUrl);
-      return;
-    }
-
     // Try IDB resolution cascade (user → pattern → numista cache)
     if (window.imageCache?.isAvailable()) {
       const blobUrl = await imageCache.resolveImageUrlForItem(item, side);

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -5,7 +5,7 @@
  * Returns the active card style from localStorage.
  * @returns {'A'|'B'|'C'|'D'}
  */
-const getCardStyle = () => localStorage.getItem(CARD_STYLE_KEY) || 'A';
+const getCardStyle = () => localStorage.getItem(CARD_STYLE_KEY) || 'D';
 
 /**
  * Returns true when the card view (A/B/C) should be rendered instead of the table.

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -2022,16 +2022,9 @@ document.addEventListener('DOMContentLoaded', function() {
       if (selectedNumistaResult) {
         fillFormFromNumistaResult();
 
-        // Cache images + metadata in IndexedDB, then re-render so thumbnails update (STAK-337)
+        // Fire-and-forget: cache metadata in IndexedDB
         if (window.imageCache?.isAvailable() && selectedNumistaResult.catalogId &&
             window.featureFlags?.isEnabled('COIN_IMAGES')) {
-          imageCache.cacheImages(
-            selectedNumistaResult.catalogId,
-            selectedNumistaResult.imageUrl || '',
-            selectedNumistaResult.reverseImageUrl || ''
-          ).then(() => {
-            if (typeof renderTable === 'function') renderTable();
-          }).catch(e => console.warn('Image cache failed:', e));
           imageCache.cacheMetadata(
             selectedNumistaResult.catalogId,
             selectedNumistaResult

--- a/js/constants.js
+++ b/js/constants.js
@@ -804,7 +804,6 @@ const ALLOWED_STORAGE_KEYS = [
   "numistaViewFields",               // view modal Numista field visibility config (JSON object)
   TIMEZONE_KEY,                        // string: "auto" | "UTC" | IANA zone (STACK-63)
   "viewModalSectionConfig",            // JSON array: ordered view modal section config [{ id, label, enabled }]
-  "numistaOverridePersonal",           // boolean string: "true"/"false" — Numista API overrides user pattern images
   "tableImagesEnabled",                // boolean string: "true"/"false" — show thumbnail images in table rows
   "tableImageSides",                   // string: "both"|"obverse"|"reverse" — which sides to show in table (STAK-118)
   CARD_STYLE_KEY,                        // string: "A"|"B"|"C" — card view style (STAK-118)

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.40";
+const APP_VERSION = "3.32.41";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/image-cache-modal.js
+++ b/js/image-cache-modal.js
@@ -140,7 +140,7 @@ const renderEligibleItemsTable = async () => {
       delBtn.textContent = '\u2715';
       delBtn.title = 'Delete cached data';
       delBtn.addEventListener('click', async () => {
-        await imageCache.deleteImages(catalogId);
+        await imageCache.deleteMetadata(catalogId);
         logSyncActivity(`Deleted cache for ${catalogId}`, 'warn');
         await renderEligibleItemsTable();
         await renderSyncStats();
@@ -168,8 +168,7 @@ const resyncCachedEntry = async (catalogId) => {
     return resolved === catalogId;
   });
 
-  // Delete both images and metadata for a clean re-sync
-  await imageCache.deleteImages(catalogId);
+  // Delete metadata for a clean re-sync (coinImages store removed — STAK-339)
   await imageCache.deleteMetadata(catalogId);
 
   // Fetch metadata + image URLs from Numista API

--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -433,8 +433,8 @@ class ImageCache {
    * @returns {Promise<boolean>}
    */
   async cacheUserImage(uuid, obverse, reverse = null, sharedImageId = null) {
-    if (!uuid || !obverse) {
-      debugLog('ImageCache.cacheUserImage: missing uuid or obverse blob');
+    if (!uuid || (!obverse && !reverse)) {
+      debugLog('ImageCache.cacheUserImage: missing uuid or at least one image blob');
       return false;
     }
     if (!(await this._ensureDb())) {

--- a/js/image-cache.js
+++ b/js/image-cache.js
@@ -2,11 +2,12 @@
 // =============================================================================
 
 /**
- * ImageCache provides persistent IndexedDB storage for coin images (obverse/reverse)
- * and enriched Numista metadata. Images are resized and compressed to JPEG before storage.
+ * ImageCache provides persistent IndexedDB storage for user-uploaded images,
+ * pattern rule images, and enriched Numista metadata.
  *
  * Schema:
  *   DB: StakTrakrImages v3
+ *   Store "coinImages"    — keyPath: catalogId (LEGACY; retained in schema, no longer read/written)
  *   Store "coinMetadata"  — keyPath: catalogId (Numista N# string)
  *   Store "userImages"    — keyPath: uuid (item UUID string)
  *   Store "patternImages" — keyPath: ruleId (pattern rule ID string)

--- a/js/init.js
+++ b/js/init.js
@@ -156,7 +156,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.importProgressText = safeGetElement("importProgressText");
     elements.numistaImportBtn = safeGetElement("numistaImportBtn");
     elements.numistaImportFile = safeGetElement("numistaImportFile");
-    elements.numistaOverride = safeGetElement("numistaOverride");
     elements.numistaMerge = safeGetElement("numistaMerge");
       elements.numistaImportOptions = safeGetElement("numistaImportOptions");
       elements.exportCsvBtn = safeGetElement("exportCsvBtn");

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -744,7 +744,7 @@ const bindCardAndTableImageListeners = () => {
   // Card style toggle (A/B/C/D chip buttons in Appearance > Inventory)
   const cardStyleToggleEl = getExistingElement('settingsCardStyleToggle');
   if (cardStyleToggleEl) {
-    const savedStyle = localStorage.getItem(CARD_STYLE_KEY) || 'A';
+    const savedStyle = localStorage.getItem(CARD_STYLE_KEY) || 'D';
     cardStyleToggleEl.querySelectorAll('.chip-sort-btn').forEach(btn => {
       btn.classList.toggle('active', btn.dataset.style === savedStyle);
     });

--- a/js/settings.js
+++ b/js/settings.js
@@ -62,7 +62,6 @@ const switchSettingsSection = (name) => {
   // Populate Images data and sync toggles when switching to Images section (STACK-96)
   if (targetName === 'images') {
     syncChipToggle('tableImagesToggle', localStorage.getItem('tableImagesEnabled') !== 'false');
-    syncChipToggle('numistaOverrideToggle', localStorage.getItem('numistaOverridePersonal') === 'true');
     const sidesSync = safeGetElement('tableImageSidesToggle');
     if (sidesSync) {
       const curSides = localStorage.getItem('tableImageSides') || 'both';
@@ -1950,7 +1949,6 @@ const STORAGE_KEY_LABELS = {
   chipSortOrder:                   { label: 'Chip Sort Order',            icon: '⚙️', category: 'Settings' },
   numistaLookupRules:              { label: 'Numista Lookup Rules',       icon: '🔍', category: 'Settings' },
   numistaViewFields:               { label: 'Numista View Fields',        icon: '🔍', category: 'Settings' },
-  numistaOverridePersonal:         { label: 'Numista Image Priority',     icon: '🔍', category: 'Settings' },
   'staktrakr.catalog.settings':   { label: 'Catalog Settings',           icon: '🔍', category: 'Settings' },
   tableImagesEnabled:              { label: 'Table Images',               icon: '🖼', category: 'Settings' },
   tableImageSides:                 { label: 'Table Image Sides',          icon: '🖼', category: 'Settings' },

--- a/js/settings.js
+++ b/js/settings.js
@@ -338,7 +338,7 @@ const syncSettingsUI = () => {
   // Card style (STAK-118)
   const cardStyleSelect = document.getElementById('settingsCardStyle');
   if (cardStyleSelect) {
-    cardStyleSelect.value = localStorage.getItem(CARD_STYLE_KEY) || 'A';
+    cardStyleSelect.value = localStorage.getItem(CARD_STYLE_KEY) || 'D';
   }
 
   // Desktop card view toggle (STAK-118)

--- a/js/state.js
+++ b/js/state.js
@@ -98,7 +98,6 @@ const elements = {
   importProgress: null,
   importProgressText: null,
   numistaImportFile: null,
-  numistaOverride: null,
   numistaMerge: null,
 
   // Export elements

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -684,22 +684,13 @@ async function loadViewImages(item, container) {
     return { loaded: validObv || validRev, source: 'cdn' };
   }
 
-  // Use the resolution cascade (user → pattern)
-  const resolved = await imageCache.resolveImageForItem(item);
-  if (resolved) {
-    let obvUrl, revUrl;
-    if (resolved.source === 'user') {
-      obvUrl = await imageCache.getUserImageUrl(resolved.catalogId, 'obverse');
-      revUrl = await imageCache.getUserImageUrl(resolved.catalogId, 'reverse');
-    } else if (resolved.source === 'pattern') {
-      obvUrl = await imageCache.getPatternImageUrl(resolved.catalogId, 'obverse');
-      revUrl = await imageCache.getPatternImageUrl(resolved.catalogId, 'reverse');
-    }
+  // Per-side cascade: user upload → pattern → CDN URL (each side independent)
+  const obvUrl = await imageCache.resolveImageUrlForItem(item, 'obverse');
+  const revUrl = await imageCache.resolveImageUrlForItem(item, 'reverse');
 
-    if (obvUrl) { _viewModalObjectUrls.push(obvUrl); _setSlotImage(obvSlot, obvUrl); }
-    if (revUrl) { _viewModalObjectUrls.push(revUrl); _setSlotImage(revSlot, revUrl); }
-    if (obvUrl || revUrl) return { loaded: true, source: resolved.source };
-  }
+  if (obvUrl) { _viewModalObjectUrls.push(obvUrl); _setSlotImage(obvSlot, obvUrl); }
+  if (revUrl) { _viewModalObjectUrls.push(revUrl); _setSlotImage(revSlot, revUrl); }
+  if (obvUrl || revUrl) return { loaded: true, source: 'idb' };
 
   // Final fallback: CDN URLs stored on the item (validate to skip corrupted URLs)
   const validObv = ImageCache.isValidImageUrl(item.obverseImageUrl);

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -91,7 +91,7 @@ async function showViewModal(index) {
     apiResult = await _fetchNumistaResult(catalogId);
   }
 
-  // Fill images from API result when no images were loaded from IDB
+  // Fill images from API result when no images were loaded at all
   const shouldReplaceWithApi = !imagesLoaded;
 
   if (shouldReplaceWithApi && apiResult && (apiResult.imageUrl || apiResult.reverseImageUrl)) {
@@ -690,7 +690,7 @@ async function loadViewImages(item, container) {
 
   if (obvUrl) { _viewModalObjectUrls.push(obvUrl); _setSlotImage(obvSlot, obvUrl); }
   if (revUrl) { _viewModalObjectUrls.push(revUrl); _setSlotImage(revSlot, revUrl); }
-  if (obvUrl || revUrl) return { loaded: true, source: 'idb' };
+  if (obvUrl || revUrl) return { loaded: true, source: 'userOrPattern' };
 
   // Final fallback: CDN URLs stored on the item (validate to skip corrupted URLs)
   const validObv = ImageCache.isValidImageUrl(item.obverseImageUrl);

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.41-b1772036460';
+const CACHE_NAME = 'staktrakr-v3.32.41-b1772037196';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.41-b1772037196';
+const CACHE_NAME = 'staktrakr-v3.32.41-b1772038394';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.40-b1772020230';
+const CACHE_NAME = 'staktrakr-v3.32.40-b1772036090';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.41-b1772040112';
+const CACHE_NAME = 'staktrakr-v3.32.41-b1772040314';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.41-b1772038394';
+const CACHE_NAME = 'staktrakr-v3.32.41-b1772040112';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.40-b1772036090';
+const CACHE_NAME = 'staktrakr-v3.32.41-b1772036146';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.41-b1772036146';
+const CACHE_NAME = 'staktrakr-v3.32.41-b1772036460';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.40",
+  "version": "3.32.41",
   "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

### Image pipeline simplification (STAK-339)
- **Removed** `coinImages` IDB cache layer entirely — `cacheImages()`, `getImages()`, `getImageUrl()`, `hasImages()`, `_fetchAndResize()`, `exportAllCoinImages()`, `listAllCachedIds()` and related methods deleted from `image-cache.js` (~244 lines)
- **Simplified** image resolution cascade: user upload → pattern image → CDN URL → placeholder (was user → pattern → coinImages → CDN URL)
- **Removed** `numistaOverridePersonal` settings toggle from UI, constants, state, and init
- **Removed** CDN blob export/import from ZIP backup (CDN images are URLs, not local blobs)

### Per-side image cascade fix
- **Fixed** uploading one image side (e.g. obverse) no longer kills the other side's pattern/CDN image
- `resolveImageUrlForItem` now cascades independently per side: user upload for that side → pattern for that side → null
- Callers in `viewModal.js` and `bulkEdit.js` updated to use per-side resolution

### Default view fix
- **Fixed** new users now default to table view (Style D) instead of card view (Style A)

## Architecture

The `coinImages` IDB store cached blob copies of Numista CDN thumbnails locally. This was designed before CDN URLs were stored on inventory items. Both existing created dual-source ambiguity — the root cause of STAK-309, 311, 332, 333, and 339. The store schema stays at v3 (no migration), we just stop reading/writing.

The per-side cascade fix changes the resolution from item-level (pick ONE source, fetch both sides from it) to side-level (each side independently cascades through user → pattern → null). This enables mixed sources like user obverse + pattern reverse.

## Linear Issues

- STAK-339: Numista Image Upload/Download process — root cause fix
- STAK-340: Shape field follow-up (created, not in this patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)