### PR TITLE
v3.32.42 — Pattern rule promotion bug fix (STAK-339-followup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.42] - 2026-02-25
+
+### Fixed — Pattern Rule Promotion Bug
+
+- **Fixed**: "Apply to all matching items" now correctly promotes images to a pattern rule even when the item was saved previously — reads from existing per-item IDB record when no pending upload blobs are in memory (STAK-339-followup)
+- **Fixed**: Promoting to a pattern rule now removes the per-item `userImages` IDB record (avoids duplicate storage)
+
+---
+
 ## [3.32.41] - 2026-02-25
 
 ### Changed — Image Pipeline Simplification

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Pattern Rule Promotion Fix (v3.32.42)**: "Apply to all matching items" now works even when the item was saved previously. Reads from existing per-item IDB record when no pending upload blobs are available; also removes per-item record after promotion (STAK-339-followup).
 - **Image Pipeline Simplification (v3.32.41)**: Removed coinImages IDB cache layer entirely. CDN URLs on inventory items are now the sole Numista image source. Eliminates root cause of STAK-309/311/332/333/339 image bugs. Cascade is now: user upload &rarr; pattern image &rarr; CDN URL &rarr; placeholder (STAK-339).
 - **Numista Image Race Condition Fix (v3.32.40)**: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).
 - **Image Bug Fixes + API Health Refresh (v3.32.39)**: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.42 &ndash; Pattern Rule Promotion Fix</strong>: &ldquo;Apply to all matching items&rdquo; now works even when the item was saved previously. Reads from existing per-item IDB record when no pending upload blobs are available; also removes per-item record after promotion (STAK-339-followup).</li>
     <li><strong>v3.32.41 &ndash; Image Pipeline Simplification</strong>: Removed coinImages IDB cache layer entirely. CDN URLs on inventory items are now the sole Numista image source. Eliminates root cause of STAK-309/311/332/333/339 image bugs. Cascade is now: user upload &rarr; pattern image &rarr; CDN URL &rarr; placeholder (STAK-339).</li>
     <li><strong>v3.32.40 &ndash; Numista Image Race Condition Fix</strong>: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).</li>
     <li><strong>v3.32.39 &ndash; Image Bug Fixes + API Health Refresh</strong>: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.41";
+const APP_VERSION = "3.32.42";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -1227,28 +1227,49 @@ const setupItemFormListeners = () => {
         commitItemToInventory(fields, isEditing, editingIndex);
 
         // Save user-uploaded image if pending (STACK-32)
-        // Pattern toggle: create a pattern rule instead of per-item image
+        // Pattern toggle: promote images to a pattern rule instead of (or in addition to) per-item save
         let patternRuleSaved = false;
         const patternToggle = document.getElementById('imagePatternToggle');
-        if ((_pendingObverseBlob || _pendingReverseBlob) && patternToggle?.checked) {
+        const savedItem = isEditing ? inventory[savedEditIdx] : inventory[inventory.length - 1];
+        if (patternToggle?.checked) {
           try {
             const rawKeywords = (document.getElementById('imagePatternKeywords')?.value || '').trim();
             if (rawKeywords) {
-              // Convert keywords to regex: "morgan, peace" → "morgan|peace"
-              const terms = rawKeywords.split(/[,;]/).map(t => t.trim()).filter(t => t.length > 0);
-              const pattern = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
-              // Pre-generate ruleId and pass as seedImageId — the image lookup
-              // chain resolves via rule.seedImageId, not rule.id
-              const ruleId = 'custom-img-' + Date.now();
-              const result = NumistaLookup.addRule(pattern, rawKeywords, null, ruleId);
-              if (result?.success && window.imageCache?.isAvailable()) {
-                await window.imageCache.cachePatternImage(ruleId, _pendingObverseBlob, _pendingReverseBlob);
-                debugLog(`Pattern rule created: ${result.id} (images: ${ruleId}) for "${rawKeywords}"`);
+              // Resolve blobs: prefer pending upload, fall back to already-saved per-item IDB record
+              let obvBlob = _pendingObverseBlob;
+              let revBlob = _pendingReverseBlob;
+              if ((!obvBlob && !revBlob) && savedItem?.uuid && window.imageCache?.isAvailable()) {
+                const existing = await window.imageCache.getUserImage(savedItem.uuid).catch(() => null);
+                if (existing) {
+                  obvBlob = existing.obverse || null;
+                  revBlob = existing.reverse || null;
+                }
+              }
+
+              if (obvBlob || revBlob) {
+                // Convert keywords to regex: "morgan, peace" → "morgan|peace"
+                const terms = rawKeywords.split(/[,;]/).map(t => t.trim()).filter(t => t.length > 0);
+                const pattern = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+                // Pre-generate ruleId and pass as seedImageId — the image lookup
+                // chain resolves via rule.seedImageId, not rule.id
+                const ruleId = 'custom-img-' + Date.now();
+                const result = NumistaLookup.addRule(pattern, rawKeywords, null, ruleId);
+                if (result?.success && window.imageCache?.isAvailable()) {
+                  await window.imageCache.cachePatternImage(ruleId, obvBlob, revBlob);
+                  debugLog(`Pattern rule created: ${result.id} (images: ${ruleId}) for "${rawKeywords}"`);
+                  // Move: delete the per-item userImages record so it no longer appears in Per-Item section
+                  if (savedItem?.uuid) {
+                    await window.imageCache.deleteUserImage(savedItem.uuid).catch(() => {});
+                  }
+                } else {
+                  debugLog(`Failed to create pattern rule: ${result?.error}`, 'warn');
+                }
               } else {
-                debugLog(`Failed to create pattern rule: ${result?.error}`, 'warn');
+                debugLog('Pattern toggle checked but no images available to promote', 'warn');
               }
               clearUploadState();
               patternRuleSaved = true;
+              renderTable();
             }
           } catch (err) {
             console.warn('Failed to create pattern rule from modal:', err);
@@ -1258,7 +1279,6 @@ const setupItemFormListeners = () => {
         }
         if (!patternRuleSaved && (_pendingObverseBlob || _pendingReverseBlob || _deleteObverseOnSave || _deleteReverseOnSave)) {
           // Per-item save: save blobs against the item's UUID
-          const savedItem = isEditing ? inventory[savedEditIdx] : inventory[inventory.length - 1];
           if (savedItem?.uuid) {
             try {
               const saved = await saveUserImageForItem(savedItem.uuid);

--- a/js/events.js
+++ b/js/events.js
@@ -1238,11 +1238,12 @@ const setupItemFormListeners = () => {
               // Resolve blobs: prefer pending upload, fall back to already-saved per-item IDB record
               let obvBlob = _pendingObverseBlob;
               let revBlob = _pendingReverseBlob;
-              if ((!obvBlob && !revBlob) && savedItem?.uuid && window.imageCache?.isAvailable()) {
+              // Fill in missing sides from existing per-item IDB record
+              if ((!obvBlob || !revBlob) && savedItem?.uuid && window.imageCache?.isAvailable()) {
                 const existing = await window.imageCache.getUserImage(savedItem.uuid).catch(() => null);
                 if (existing) {
-                  obvBlob = existing.obverse || null;
-                  revBlob = existing.reverse || null;
+                  if (!obvBlob) obvBlob = existing.obverse || null;
+                  if (!revBlob) revBlob = existing.reverse || null;
                 }
               }
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.41-b1772040314';
+const CACHE_NAME = 'staktrakr-v3.32.42-b1772042059';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.42-b1772042059';
+const CACHE_NAME = 'staktrakr-v3.32.42-b1772044443';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.41",
+  "version": "3.32.42",
   "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

- **Fixed**: \"Apply to all matching items\" (imagePatternToggle) now correctly promotes images to a pattern rule even when the item was already saved in a prior session — reads from existing per-item `userImages` IDB record when `_pendingObverseBlob` / `_pendingReverseBlob` are null
- **Fixed**: After pattern promotion, the per-item `userImages` IDB record is deleted (avoids duplicate storage between `userImages` and `patternImages` stores)
- `renderTable()` called after promotion so the table re-renders without a page refresh

## Root Cause

The pattern promotion block in `events.js` required `_pendingObverseBlob || _pendingReverseBlob` to be truthy, but these in-memory blobs are cleared after the first save. Users who uploaded images, saved, then re-opened the edit modal and checked "Apply to all matching items" would silently fail — the condition was false and the `if` block was never entered.

## Linear Issues

- STAK-339-followup — pattern rule promotion requires pending blobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)