### PR TITLE
v3.32.44 — Add kilo and pound weight units (STAK-338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.44] - 2026-02-25
+
+### Added — Kilo and Pound Weight Units
+
+- **Added**: Kilogram (kg) and pound (lb) weight units in add/edit/bulk-edit dropdowns (STAK-338)
+- **Added**: Eager conversion to troy ounces on save with reverse conversion for display — follows existing gram pattern
+- **Fixed**: Weight tooltip in inventory table now uses explicit unit lookup instead of `weight < 1` heuristic
+- **Fixed**: Card view weight chip now uses `formatWeight()` for correct unit display across all 5 unit types
+
+---
+
 ## [3.32.43] - 2026-02-25
 
 ### Fixed — Numista Tag Rendering + Per-Item Tag Deletion

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Kilo &amp; Pound Weight Units (v3.32.44)**: Added kilogram and pound to the weight unit dropdown. Melt values convert correctly. Table, cards, and modals all display in the chosen unit (STAK-338).
 - **Numista Tag Fixes (v3.32.43)**: Tags now visible in edit modal and card views. All tags (including Numista-applied) are removable per-item — no more stuck "Armour", "Bird", or "Marsupial" tags (STAK-343, STAK-344).
 - **Pattern Rule Promotion Fix (v3.32.42)**: "Apply to all matching items" now works even when the item was saved previously. Reads from existing per-item IDB record when no pending upload blobs are available; also removes per-item record after promotion (STAK-339-followup).
 - **Image Pipeline Simplification (v3.32.41)**: Removed coinImages IDB cache layer entirely. CDN URLs on inventory items are now the sole Numista image source. Eliminates root cause of STAK-309/311/332/333/339 image bugs. Cascade is now: user upload &rarr; pattern image &rarr; CDN URL &rarr; placeholder (STAK-339).
 - **Numista Image Race Condition Fix (v3.32.40)**: Numista images now appear in table and card views immediately after applying a result. Previously images only showed after a page refresh due to a fire-and-forget race condition (STAK-337).
-- **Image Bug Fixes + API Health Refresh (v3.32.39)**: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields and sets per-item pattern opt-out flag. API health badge uses cache-busting to defeat service worker staleness (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -1247,6 +1247,8 @@
                 <select id="itemWeightUnit">
                   <option value="oz">ounce</option>
                   <option value="g">gram</option>
+                  <option value="kg">kilogram</option>
+                  <option value="lb">pound</option>
                   <option value="gb">goldback</option>
                 </select>
               </div>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.32.44 &ndash; Kilo &amp; Pound Weight Units</strong>: Added kilogram and pound to the weight unit dropdown. Melt values convert correctly. Table, cards, and modals all display in the chosen unit (STAK-338).</li>
     <li><strong>v3.32.43 &ndash; Numista Tag Fixes</strong>: Tags now visible in edit modal and card views. All tags (including Numista-applied) are removable per-item &mdash; no more stuck tags (STAK-343, STAK-344).</li>
     <li><strong>v3.32.42 &ndash; Pattern Rule Promotion Fix</strong>: &ldquo;Apply to all matching items&rdquo; now works even when the item was saved previously. Reads from existing per-item IDB record when no pending upload blobs are available; also removes per-item record after promotion (STAK-339-followup).</li>
     <li><strong>v3.32.41 &ndash; Image Pipeline Simplification</strong>: Removed coinImages IDB cache layer entirely. CDN URLs on inventory items are now the sole Numista image source. Eliminates root cause of STAK-309/311/332/333/339 image bugs (STAK-339).</li>
     <li><strong>v3.32.40 &ndash; Numista Image Race Condition Fix</strong>: Numista images now appear in table and card views immediately after applying a result (STAK-337).</li>
-    <li><strong>v3.32.39 &ndash; Image Bug Fixes + API Health Refresh</strong>: Fixed CDN URL writeback in resync and bulk cache. Remove button now clears URL fields. API health badge uses cache-busting (STAK-333, STAK-308, STAK-332, STAK-311, STAK-334).</li>
   `;
 };
 

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -181,6 +181,8 @@ const BULK_EDITABLE_FIELDS = [
     options: [
       { value: 'oz', label: 'ounce' },
       { value: 'g',  label: 'gram' },
+      { value: 'kg', label: 'kilogram' },
+      { value: 'lb', label: 'pound' },
       { value: 'gb', label: 'goldback' }
     ] },
   { id: 'purity',           label: 'Purity',             inputType: 'select',

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -1034,6 +1034,16 @@ const applyBulkEdit = async () => {
       if (!isNaN(grams)) {
         valuesToApply.weight = String(gramsToOzt(grams));
       }
+    } else if (effectiveUnit === 'kg') {
+      const kg = parseFloat(valuesToApply.weight);
+      if (!isNaN(kg)) {
+        valuesToApply.weight = String(kgToOzt(kg));
+      }
+    } else if (effectiveUnit === 'lb') {
+      const lb = parseFloat(valuesToApply.weight);
+      if (!isNaN(lb)) {
+        valuesToApply.weight = String(lbToOzt(lb));
+      }
     }
   }
 

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -561,8 +561,7 @@ const _cardChipsHTML = (item, small = false) => {
   if (item.grade) h += `<span class="cv-chip cv-chip-grade"${s}>${sanitizeHtml(item.grade)}</span>`;
   const qty = Number(item.qty) || 1;
   if (qty > 1) h += `<span class="cv-chip cv-chip-qty"${s}>x${qty}</span>`;
-  const _wUnit = (item.weightUnit || 'oz').toLowerCase() === 'gb' ? 'gb' : (item.weightUnit || 'oz');
-  h += `<span class="cv-chip cv-chip-weight"${s}>${sanitizeHtml(item.weight || '')} ${sanitizeHtml(_wUnit)}</span>`;
+  h += `<span class="cv-chip cv-chip-weight"${s}>${sanitizeHtml(formatWeight(item.weight, item.weightUnit))}</span>`;
 
   // STAK-343: Inline tags in card view (show first 2, ellipsis if more)
   const _cardTags = typeof getItemTags === 'function' ? getItemTags(item.uuid) : [];

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -129,7 +129,7 @@ const renderChangeLog = () => {
           if (snap && typeof snap === 'object' && snap.name) {
             const fmtFn = typeof formatCurrency === 'function' ? formatCurrency : (v) => '$' + Number(v).toFixed(2);
             const parts = [snap.metal, snap.type, snap.name];
-            if (snap.weight) parts.push(snap.weight + (snap.weightUnit === 'g' ? 'g' : ' oz'));
+            if (snap.weight) parts.push(snap.weight + ({ g: 'g', kg: 'kg', lb: 'lb', gb: ' gb' }[snap.weightUnit] || ' oz'));
             if (snap.price) parts.push(fmtFn(snap.price));
             displayOld = sanitizeHtml(parts.filter(Boolean).join(' \u00B7 '));
           }

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -129,7 +129,7 @@ const renderChangeLog = () => {
           if (snap && typeof snap === 'object' && snap.name) {
             const fmtFn = typeof formatCurrency === 'function' ? formatCurrency : (v) => '$' + Number(v).toFixed(2);
             const parts = [snap.metal, snap.type, snap.name];
-            if (snap.weight) parts.push(snap.weight + ({ g: 'g', kg: 'kg', lb: 'lb', gb: ' gb' }[snap.weightUnit] || ' oz'));
+            if (snap.weight) parts.push(typeof formatWeight === 'function' ? formatWeight(snap.weight, snap.weightUnit) : snap.weight + ' oz');
             if (snap.price) parts.push(fmtFn(snap.price));
             displayOld = sanitizeHtml(parts.filter(Boolean).join(' \u00B7 '));
           }

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.43";
+const APP_VERSION = "3.32.44";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -531,6 +531,12 @@ const GB_ESTIMATE_MODIFIER_KEY = "goldback-estimate-modifier";
 
 /** @constant {number} GB_TO_OZT - Conversion factor: 1 Goldback = 0.001 troy oz 24K gold */
 const GB_TO_OZT = 0.001;
+
+/** @constant {number} KG_TO_OZT - Conversion factor: 1 kilogram = 32.15075 troy ounces */
+const KG_TO_OZT = 32.15075;
+
+/** @constant {number} LB_TO_OZT - Conversion factor: 1 avoirdupois pound = 14.58333 troy ounces */
+const LB_TO_OZT = 14.58333;
 
 /**
  * Standard Goldback denominations with gold content.

--- a/js/events.js
+++ b/js/events.js
@@ -860,7 +860,7 @@ const setupTableSortListeners = () => {
  * Parses weight from form input, handling Goldback denominations,
  * fractions, and gram-to-troy-oz conversion.
  * @param {string} weightRaw - Raw weight input value
- * @param {string} weightUnit - Unit: 'oz', 'g', or 'gb'
+ * @param {string} weightUnit - Unit: 'oz', 'g', 'kg', 'lb', or 'gb'
  * @param {boolean} isEditing - Whether in edit mode
  * @param {Object} existingItem - Existing item (edit mode)
  * @returns {number} Weight in troy ounces (or denomination value for gb)
@@ -872,6 +872,10 @@ const parseWeight = (weightRaw, weightUnit, isEditing, existingItem) => {
   let weight = parseFraction(weightRaw);
   if (weightUnit === 'g') {
     weight = gramsToOzt(weight);
+  } else if (weightUnit === 'kg') {
+    weight = kgToOzt(weight);
+  } else if (weightUnit === 'lb') {
+    weight = lbToOzt(weight);
   }
   // gb: weight stays as raw denomination value (conversion happens in computeMeltValue)
   return isNaN(weight) ? 0 : parseFloat(weight.toFixed(6));

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,5 +1,8 @@
 // INVENTORY FUNCTIONS
 
+/** Weight unit → tooltip label mapping (hoisted to avoid per-row allocation in renderTable) */
+const WEIGHT_UNIT_TOOLTIPS = { oz: 'Troy ounces (ozt)', g: 'Grams (g)', kg: 'Kilograms (kg)', lb: 'Pounds (lb)', gb: 'Goldback denomination' };
+
 /** Blob URLs created by _enhanceTableThumbnails — revoked on each re-render */
 let _thumbBlobUrls = [];
 
@@ -1661,7 +1664,7 @@ const renderTable = () => {
         </div>
       </td>
       <td class="shrink" data-column="qty" data-label="Qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
-      <td class="shrink" data-column="weight" data-label="Weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight, item.weightUnit), ({ oz: 'Troy ounces (ozt)', g: 'Grams (g)', kg: 'Kilograms (kg)', lb: 'Pounds (lb)', gb: 'Goldback denomination' }[item.weightUnit] || 'Troy ounces (ozt)'))}</td>
+      <td class="shrink" data-column="weight" data-label="Weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight, item.weightUnit), WEIGHT_UNIT_TOOLTIPS[item.weightUnit] || 'Troy ounces (ozt)')}</td>
       <td class="shrink" data-column="purchasePrice" data-label="Purchase" title="Purchase Price (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
         <a href="#" class="ebay-buy-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? ' ' + item.year : '') + ' ' + item.name)}" title="Search eBay active listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${formatCurrency(purchasePrice)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1661,7 +1661,7 @@ const renderTable = () => {
         </div>
       </td>
       <td class="shrink" data-column="qty" data-label="Qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
-      <td class="shrink" data-column="weight" data-label="Weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight, item.weightUnit), item.weightUnit === 'gb' ? 'Goldback denomination' : item.weight < 1 ? 'Grams (g)' : 'Troy ounces (ozt)')}</td>
+      <td class="shrink" data-column="weight" data-label="Weight">${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight, item.weightUnit), ({ oz: 'Troy ounces (ozt)', g: 'Grams (g)', kg: 'Kilograms (kg)', lb: 'Pounds (lb)', gb: 'Goldback denomination' }[item.weightUnit] || 'Troy ounces (ozt)'))}</td>
       <td class="shrink" data-column="purchasePrice" data-label="Purchase" title="Purchase Price (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
         <a href="#" class="ebay-buy-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? ' ' + item.year : '') + ' ' + item.name)}" title="Search eBay active listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${formatCurrency(purchasePrice)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
@@ -2127,9 +2127,16 @@ const editItem = (idx, logIdx = null) => {
     elements.itemWeightUnit.value = 'gb';
     if (denomSelect) denomSelect.value = String(parseFloat(item.weight));
     if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
-  } else if (item.weight < 1) {
+  } else if (item.weightUnit === 'kg') {
+    elements.itemWeight.value = parseFloat(oztToKg(item.weight).toFixed(4));
+    elements.itemWeightUnit.value = 'kg';
+    if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
+  } else if (item.weightUnit === 'lb') {
+    elements.itemWeight.value = parseFloat(oztToLb(item.weight).toFixed(4));
+    elements.itemWeightUnit.value = 'lb';
+    if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
+  } else if (item.weightUnit === 'g' || item.weight < 1) {
     const grams = oztToGrams(item.weight);
-    // Show up to 4 decimal places for sub-gram precision, strip trailing zeros
     elements.itemWeight.value = parseFloat(grams.toFixed(4));
     elements.itemWeightUnit.value = 'g';
     if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
@@ -2421,7 +2428,15 @@ const duplicateItem = (idx) => {
     elements.itemWeightUnit.value = 'gb';
     if (denomSelect) denomSelect.value = String(parseFloat(item.weight));
     if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
-  } else if (item.weight < 1) {
+  } else if (item.weightUnit === 'kg') {
+    elements.itemWeight.value = parseFloat(oztToKg(item.weight).toFixed(4));
+    elements.itemWeightUnit.value = 'kg';
+    if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
+  } else if (item.weightUnit === 'lb') {
+    elements.itemWeight.value = parseFloat(oztToLb(item.weight).toFixed(4));
+    elements.itemWeightUnit.value = 'lb';
+    if (typeof toggleGbDenomPicker === 'function') toggleGbDenomPicker();
+  } else if (item.weightUnit === 'g' || item.weight < 1) {
     const grams = oztToGrams(item.weight);
     elements.itemWeight.value = parseFloat(grams.toFixed(4));
     elements.itemWeightUnit.value = 'g';

--- a/js/utils.js
+++ b/js/utils.js
@@ -764,6 +764,38 @@ const gramsToOzt = (grams) => grams / 31.1035;
 const oztToGrams = (ozt) => ozt * 31.1035;
 
 /**
+ * Converts kilograms to troy ounces
+ *
+ * @param {number} kg - Weight in kilograms
+ * @returns {number} Weight in troy ounces
+ */
+const kgToOzt = (kg) => kg * KG_TO_OZT;
+
+/**
+ * Converts troy ounces to kilograms
+ *
+ * @param {number} ozt - Weight in troy ounces
+ * @returns {number} Weight in kilograms
+ */
+const oztToKg = (ozt) => ozt / KG_TO_OZT;
+
+/**
+ * Converts avoirdupois pounds to troy ounces
+ *
+ * @param {number} lb - Weight in pounds
+ * @returns {number} Weight in troy ounces
+ */
+const lbToOzt = (lb) => lb * LB_TO_OZT;
+
+/**
+ * Converts troy ounces to avoirdupois pounds
+ *
+ * @param {number} ozt - Weight in troy ounces
+ * @returns {number} Weight in pounds
+ */
+const oztToLb = (ozt) => ozt / LB_TO_OZT;
+
+/**
  * Formats a weight in troy ounces to either grams or ounces.
  * If weightUnit is 'gb', displays as Goldback denomination (no gram auto-conversion).
  *
@@ -777,6 +809,12 @@ const formatWeight = (ozt, weightUnit) => {
     return `${(w % 1 === 0) ? w : w.toFixed(1)} gb`;
   }
   const weight = parseFloat(ozt);
+  if (weightUnit === 'kg') {
+    return `${oztToKg(weight).toFixed(4)} kg`;
+  }
+  if (weightUnit === 'lb') {
+    return `${oztToLb(weight).toFixed(4)} lb`;
+  }
   if (weightUnit === 'g') {
     return `${oztToGrams(weight).toFixed(2)} g`;
   }

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.44-b1772074482';
+const CACHE_NAME = 'staktrakr-v3.32.44-b1772075189';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.43-b1772060856';
+const CACHE_NAME = 'staktrakr-v3.32.44-b1772074482';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.43",
+  "version": "3.32.44",
   "releaseDate": "2026-02-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Added**: Kilogram (kg) and pound (lb) weight units in add/edit/bulk-edit dropdowns
- **Added**: Eager conversion to troy ounces on save (`parseWeight`) with reverse conversion for display (`formatWeight`) — follows existing gram pattern
- **Added**: `KG_TO_OZT` (32.15075) and `LB_TO_OZT` (14.58333) constants + 4 converter functions
- **Fixed**: Weight tooltip in inventory table uses explicit unit lookup instead of `weight < 1` heuristic
- **Fixed**: Card view weight chip uses `formatWeight()` for correct display across all 5 unit types
- **Fixed**: Edit/duplicate form pre-fill correctly reverse-converts ozt to kg/lb for the input field
- **Fixed**: Changelog snapshot labels handle all 5 weight unit types

## Linear Issues

- [STAK-338: Add kilo and pound weight units](https://linear.app/hextrackr/issue/STAK-338)

## Files Changed (12)

`js/constants.js`, `js/utils.js`, `js/events.js`, `js/inventory.js`, `js/bulkEdit.js`, `js/card-view.js`, `js/changeLog.js`, `js/about.js`, `index.html`, `CHANGELOG.md`, `docs/announcements.md`, `version.json`

## Spec Workflow

Full spec at `.spec-workflow/specs/weight-unit-expansion/` (Requirements → Design → Tasks — all approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)