### PR TITLE
v3.32.46 — Beta tester bugfix batch (STAK-341, 353, 354, 355)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2523,6 +2523,18 @@ input[type="submit"] {
   flex: 1;
   min-width: 0;
 }
+.image-swap-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  padding-top: 1.2rem;
+}
+.image-swap-wrapper .btn-icon {
+  font-size: 1.1rem;
+  padding: 0.2rem 0.4rem;
+  line-height: 1;
+}
 .image-side-label {
   display: block;
   font-size: 0.75rem;
@@ -8310,6 +8322,12 @@ th {
   font-size: 0.85rem;
   min-height: 0;
   transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Solid backgrounds for OS-native <option> popups (STAK-353) */
+#inventoryForm select option {
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 #inventoryForm input:focus,

--- a/index.html
+++ b/index.html
@@ -1340,6 +1340,10 @@
                     <input id="itemObverseImageUrl" type="url" class="form-control" placeholder="https://example.com/obverse.jpg" />
                   </div>
                 </div>
+                <!-- Swap obverse/reverse button (STAK-341) -->
+                <div class="image-swap-wrapper d-none" id="swapImagesBtnWrapper">
+                  <button type="button" class="btn btn-icon" id="swapImagesBtn" title="Swap obverse &amp; reverse" aria-label="Swap obverse and reverse images">⇄</button>
+                </div>
                 <!-- Reverse -->
                 <div class="image-upload-side">
                   <span class="image-side-label">Reverse</span>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.32.44";
+const APP_VERSION = "3.32.46";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -1601,14 +1601,15 @@ const setupItemFormListeners = () => {
   const swapBtn = safeGetElement('swapImagesBtn');
   if (swapBtn) {
     swapBtn.addEventListener('click', async () => {
-      // Load cached images into pending blobs if not already present (PR #551 review)
-      // Without this, swapping existing-only images is visual-only and lost on save.
+      // Hydrate each missing side from IndexedDB before swap (PR #551 review)
+      // Must hydrate per-side (not gated on both null) to handle mixed
+      // upload+swap: user uploads one side, then swaps before saving.
       const uuid = editingIndex !== null ? inventory[editingIndex]?.uuid : null;
-      if (uuid && !_pendingObverseBlob && !_pendingReverseBlob && window.imageCache?.isAvailable()) {
+      if (uuid && (!_pendingObverseBlob || !_pendingReverseBlob) && window.imageCache?.isAvailable()) {
         try {
           const rec = await imageCache.getUserImage(uuid);
-          if (rec?.obverse) _pendingObverseBlob = rec.obverse;
-          if (rec?.reverse) _pendingReverseBlob = rec.reverse;
+          if (!_pendingObverseBlob && rec?.obverse) _pendingObverseBlob = rec.obverse;
+          if (!_pendingReverseBlob && rec?.reverse) _pendingReverseBlob = rec.reverse;
         } catch { /* ignore — blobs stay null */ }
       }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1220,7 +1220,13 @@ const startCellEdit = (idx, field, element) => {
     }
     
     // Set input value based on field type
-    if (field === 'weight' && item.weight < 1) {
+    if (field === 'weight' && item.weightUnit === 'kg') {
+      input.value = oztToKg(current).toFixed(4);
+      input.dataset.unit = 'kg';
+    } else if (field === 'weight' && item.weightUnit === 'lb') {
+      input.value = oztToLb(current).toFixed(4);
+      input.dataset.unit = 'lb';
+    } else if (field === 'weight' && (item.weightUnit === 'g' || item.weight < 1)) {
       input.value = oztToGrams(current).toFixed(2);
       input.dataset.unit = 'g';
     } else if (['weight', 'price', 'marketValue'].includes(field)) {
@@ -1255,6 +1261,10 @@ const startCellEdit = (idx, field, element) => {
       finalValue = parseFloat(value);
       if (field === 'weight' && input.dataset.unit === 'g') {
         finalValue = gramsToOzt(finalValue);
+      } else if (field === 'weight' && input.dataset.unit === 'kg') {
+        finalValue = kgToOzt(finalValue);
+      } else if (field === 'weight' && input.dataset.unit === 'lb') {
+        finalValue = lbToOzt(finalValue);
       }
     } else {
       finalValue = value.trim();
@@ -2278,10 +2288,13 @@ const editItem = (idx, logIdx = null) => {
       }
     }).catch(() => {
       showUrlPreviewFallback({ obverse: false, reverse: false });
+    }).finally(() => {
+      if (typeof updateSwapButtonVisibility === 'function') updateSwapButtonVisibility();
     });
   } else {
     // No IndexedDB — go straight to URL fallback
     showUrlPreviewFallback({ obverse: false, reverse: false });
+    if (typeof updateSwapButtonVisibility === 'function') updateSwapButtonVisibility();
   }
 
   // Update Numista API status dot (STAK-173)

--- a/js/tags.js
+++ b/js/tags.js
@@ -343,7 +343,9 @@ const showTagInput = (container, uuid, numistaTags, renderTags, onChanged) => {
   dropdown.className = 'tag-autocomplete-dropdown';
   dropdown.style.display = 'none';
 
-  const allTags = getAllUniqueTags();
+  const allTags = getAllUniqueTags().filter(t =>
+    typeof window.isBlacklisted === 'function' ? !window.isBlacklisted(t) : true
+  );
 
   const updateDropdown = () => {
     const val = input.value.trim().toLowerCase();

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.46-b1772094618';
+const CACHE_NAME = 'staktrakr-v3.32.46-b1772095640';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.46-b1772093374';
+const CACHE_NAME = 'staktrakr-v3.32.46-b1772094618';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.44-b1772075189';
+const CACHE_NAME = 'staktrakr-v3.32.46-b1772093191';
 
 
 


### PR DESCRIPTION
## Summary
- **STAK-353**: Fix glassmorphic select dropdown options showing blank white until hovered — added solid `background`/`color` to `#inventoryForm select option`
- **STAK-354**: Filter blacklisted tags from edit modal autocomplete suggestions via `window.isBlacklisted()` guard
- **STAK-355**: Add `kg` and `lb` weight unit support to inline cell editor (display + save paths) using existing `oztToKg`/`kgToOzt`/`oztToLb`/`lbToOzt` converters
- **STAK-341**: Add swap obverse/reverse button to image editor — appears only when both sides have images, swaps blobs, previews, URLs, and size info

## Files changed
| File | Change |
|------|--------|
| `css/styles.css` | `select option` solid bg rule + `.image-swap-wrapper` layout |
| `js/tags.js` | Blacklist filter on `getAllUniqueTags()` in `showTagInput()` |
| `js/inventory.js` | kg/lb cases in inline editor display + save + swap button visibility |
| `js/events.js` | `updateSwapButtonVisibility()` helper + swap click handler |
| `index.html` | Swap button HTML between obverse/reverse upload slots |
| `js/constants.js` | Version bump to 3.32.46 |

## Test plan
- [ ] Light + dark theme: select dropdowns show readable options
- [ ] Add a tag to blacklist, verify it disappears from autocomplete
- [ ] Inline-edit weight on a kg or lb item, verify correct display and save
- [ ] Edit item with both images: swap button visible, click swaps previews
- [ ] Edit item with one image: swap button hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)