### PR TITLE
STAK-336: make Numista N# labels open catalog links

### DIFF
--- a/.spec-workflow/specs/numista-search-preview-link/design.md
+++ b/.spec-workflow/specs/numista-search-preview-link/design.md
@@ -1,0 +1,123 @@
+# Design Document
+
+## Overview
+
+This design adds a per-result Numista preview action to the existing Numista results modal so users can inspect catalog pages before applying metadata. The implementation reuses the existing popup helper (`openNumistaModal`) and keeps the apply workflow unchanged.
+
+**Release target:** `v3.32.48`.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- Preserves zero-build vanilla JS architecture.
+- Reuses existing globally loaded helpers and event wiring model.
+- Avoids framework changes, new runtime dependencies, or module system changes.
+- Keeps network behavior user-triggered (no prefetch on render).
+
+### Project Structure (structure.md)
+
+- Primary logic changes stay in existing Numista feature files:
+  - `js/catalog-api.js` for modal rendering and click behavior.
+  - `js/numista-modal.js` for safe popup URL handling if enhancement is needed.
+  - `css/styles.css` for result-row preview control styling.
+- No script load order changes required because these files already load in correct sequence (`numista-modal.js` before `catalog-api.js`).
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`openNumistaModal(numistaId, coinName)`** (`js/numista-modal.js`): Existing popup opener that already handles Numista pages and popup-blocked feedback.
+- **`renderNumistaResultCard(result, index)`** (`js/catalog-api.js`): Existing renderer where preview action can be added per card.
+- **Delegated click handler on `#numistaResultsList`** (`js/catalog-api.js`): Existing event delegation for card selection; can be extended to handle preview clicks.
+- **`escapeHtmlCatalog()`** (`js/catalog-api.js`): Existing sanitizer for HTML-inserted values.
+
+### Integration Points
+
+- **Numista result list UI**: Adds preview button/link inside each result card.
+- **Results list click delegation**: Distinguishes preview click from card-select click.
+- **URL/ID source**: Uses normalized `result.catalogId` from Numista provider output.
+
+## Architecture
+
+This is an additive UI behavior change in the existing search-results flow.
+
+```mermaid
+graph TD
+    A[showNumistaResults] --> B[renderNumistaResultCard]
+    B --> C[Preview control in each card]
+    C --> D[Delegated click handler]
+    D --> E[openNumistaModal(catalogId, name)]
+    D --> F[Existing card select behavior]
+```
+
+### Modular Design Principles
+
+- **Single File Responsibility**: Keep modal rendering/event logic in `catalog-api.js`.
+- **Component Isolation**: Add small preview control markup and scoped CSS class only.
+- **Service Layer Separation**: No API provider or data normalization changes.
+- **Utility Modularity**: Reuse existing popup utility rather than duplicating URL builders.
+
+## Components and Interfaces
+
+### Component 1: Result Card Preview Control
+
+- **Purpose:** Provide explicit "preview before apply" action on each search result.
+- **Interfaces:** HTML data attributes (`data-action="preview"`, `data-result-index`).
+- **Dependencies:** `renderNumistaResultCard`, `escapeHtmlCatalog`.
+- **Reuses:** Existing result-card structure and styles.
+
+### Component 2: Results Click Delegation Extension
+
+- **Purpose:** Route preview clicks to popup helper while preserving card selection behavior.
+- **Interfaces:** Event listener on `#numistaResultsList`.
+- **Dependencies:** `openNumistaModal`, `list._numistaResults`.
+- **Reuses:** Existing delegated click pattern in `catalog-api.js`.
+
+## Data Models
+
+### Numista Result Card Action Contract
+
+```text
+- resultIndex: number (index into list._numistaResults)
+- action: "preview" | "select" (select is implicit card click)
+- catalogId: string (from normalized result.catalogId)
+- name: string (from normalized result.name)
+```
+
+No persistent storage schema changes are required.
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Missing/invalid catalogId for a row**
+   - **Handling:** Hide or disable preview control for that row.
+   - **User Impact:** User can still select/apply the result; no modal crash.
+
+2. **Popup blocked by browser**
+   - **Handling:** Keep `openNumistaModal` fallback alert with direct URL.
+   - **User Impact:** User gets clear action to allow popups or open manually.
+
+3. **Preview click also triggers row selection**
+   - **Handling:** In delegated handler, detect preview target and `return` early.
+   - **User Impact:** Preview opens without forcing transition to field picker.
+
+## Testing Strategy
+
+### Unit Testing
+
+- Validate preview URL generation path from `catalogId` via existing helper behavior.
+- Validate delegated handler branch logic (preview vs card select).
+
+### Integration Testing
+
+- Search Numista -> results list renders preview action per row.
+- Click preview -> popup open path executes; apply flow remains available.
+
+### End-to-End Testing
+
+- Desktop and mobile viewport check:
+  - Preview control visible and tappable.
+  - Preview click does not break or close modal unexpectedly.
+  - Row select still transitions to field picker and `Fill Fields` works as before.

--- a/.spec-workflow/specs/numista-search-preview-link/requirements.md
+++ b/.spec-workflow/specs/numista-search-preview-link/requirements.md
@@ -1,0 +1,71 @@
+# Requirements Document
+
+## Introduction
+
+Users currently must apply a Numista search result blindly from the lookup modal, which can cause wrong imports when multiple similar results exist (for example different weights/years/variants). This feature adds a per-result preview link so users can inspect the Numista catalog page before applying data to their item.
+
+**Release target:** `v3.32.48` patch release.
+
+## Alignment with Product Vision
+
+This supports StakTrakr's "user-first, no-surprises" workflow by making data imports explicit and verifiable before writes occur. It reduces accidental metadata overwrites, improves trust in catalog integrations, and keeps the implementation lightweight within the existing zero-build vanilla JS architecture.
+
+## Requirements
+
+### Requirement 1: Add preview action on Numista search results
+
+**User Story:** As a collector importing metadata, I want a direct preview link for each Numista result, so that I can confirm the exact listing before applying.
+
+#### Acceptance Criteria
+
+1. WHEN Numista search results are rendered in the modal THEN the system SHALL display a preview action for each result row.
+2. WHEN a user clicks a result's preview action THEN the system SHALL open the corresponding Numista catalog page using the existing app preview/open pattern.
+3. IF a result has no valid Numista URL or numeric id THEN the system SHALL disable or hide preview for that row without breaking rendering.
+
+### Requirement 2: Keep current apply workflow unchanged
+
+**User Story:** As a user, I want the existing "Apply" action to continue working exactly as before, so that adding preview does not regress import behavior.
+
+#### Acceptance Criteria
+
+1. WHEN preview is added to result rows THEN the system SHALL preserve existing Apply button behavior and payload mapping.
+2. WHEN a user previews one or more results THEN the system SHALL still allow applying any row in the same modal session.
+3. WHEN the modal is closed or refreshed THEN the system SHALL not persist preview-only state into inventory data.
+
+### Requirement 3: Ensure safe and usable interaction
+
+**User Story:** As a user, I want preview links to be clear and safe to use, so that I can confidently verify results on desktop and mobile.
+
+#### Acceptance Criteria
+
+1. WHEN preview controls are rendered THEN the system SHALL present a clear label/icon with tooltip or accessible text (for example "Preview on Numista").
+2. WHEN preview is opened THEN the system SHALL prevent script injection by constructing destination URLs from trusted Numista identifiers/URLs only.
+3. WHEN preview fails to open (popup blocked or invalid URL) THEN the system SHALL fail gracefully without crashing the modal.
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- Keep implementation within existing Numista modal/search modules; avoid introducing new global subsystems.
+- Reuse existing modal/open-link helper patterns already used in app UI.
+- Keep script load order unchanged unless a new dependency is strictly required.
+
+### Performance
+
+- Rendering preview controls SHALL not add noticeable delay to search result rendering.
+- No additional network requests SHALL be made until user explicitly triggers preview.
+
+### Security
+
+- Preview URL generation SHALL be constrained to Numista domains/known path structure.
+- No unsanitized user-provided HTML shall be inserted while rendering preview controls.
+
+### Reliability
+
+- Modal behavior SHALL remain stable when search returns zero, partial, or malformed rows.
+- Apply/import behavior SHALL remain backward compatible.
+
+### Usability
+
+- Preview control SHALL be discoverable in each result row.
+- Interaction SHALL be usable on desktop and mobile viewport sizes already supported by the modal.

--- a/.spec-workflow/specs/numista-search-preview-link/tasks.md
+++ b/.spec-workflow/specs/numista-search-preview-link/tasks.md
@@ -1,0 +1,30 @@
+# Tasks Document
+
+Release target: `v3.32.48`.
+
+- [x] 1. Add per-result Numista preview action in search result cards
+  - File: `js/catalog-api.js`
+  - Update `renderNumistaResultCard(result, index)` to render a preview action (button/link) for each result row with accessible text/label.
+  - Ensure the control carries row/index metadata and avoids unsafe inline URL injection.
+  - Purpose: Make preview discoverable and available before Apply.
+  - _Leverage: `renderNumistaResultCard`, `escapeHtmlCatalog`, existing `.numista-result-card` markup_
+  - _Requirements: 1.1, 3.1, 3.2_
+  - _Prompt: Implement the task for spec numista-search-preview-link, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Frontend JavaScript developer focused on modal UI rendering | Task: Modify `renderNumistaResultCard()` in `js/catalog-api.js` to include a per-row preview control (e.g., icon button with label/tooltip like "Preview on Numista"). The control must be tied to the row result index and must not alter existing card-select behavior by itself. Keep output sanitized using existing escaping utilities. | Restrictions: Only edit `js/catalog-api.js` in this task. Do not change search logic, apply logic, or provider normalization. Do not add new dependencies. | _Leverage: Use existing result card renderer and escaping helper; reuse current data-result-index pattern. | _Requirements: 1.1, 3.1, 3.2 | Success: Every rendered search row has a clear preview action, with accessible label/title, and no rendering regressions in the results list. Also: set task to `[-]` before coding, run `log-implementation` after finishing, then mark task `[x]` in `tasks.md`._
+
+- [x] 2. Wire preview click behavior without breaking row selection/apply flow
+  - File: `js/catalog-api.js`
+  - Extend delegated click handling on `#numistaResultsList` so preview clicks open Numista and stop card-selection transition.
+  - Preserve existing behavior when clicking elsewhere on a result card (select row, show field picker).
+  - Purpose: Add preview interaction while keeping current apply workflow intact.
+  - _Leverage: Existing delegated click listener on `numistaResultsList`, `list._numistaResults`, `openNumistaModal()` global helper_
+  - _Requirements: 1.2, 2.1, 2.2, 3.3_
+  - _Prompt: Implement the task for spec numista-search-preview-link, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Frontend JavaScript developer focused on event delegation and modal interactions | Task: Update the existing `numistaResultsList` delegated click listener in `js/catalog-api.js` to detect preview-action clicks, open the corresponding Numista page via `openNumistaModal(catalogId, name)`, and return early so the row is not selected. For non-preview clicks, preserve current row selection and field picker transition exactly. Add graceful handling when catalog id is missing/invalid. | Restrictions: Only edit `js/catalog-api.js` in this task. Do not alter Fill Fields behavior or data-mapping logic. Keep backward compatibility with current modal flow. | _Leverage: Existing listener and result index mapping, plus the already-loaded `openNumistaModal` helper from `js/numista-modal.js`. | _Requirements: 1.2, 2.1, 2.2, 3.3 | Success: Preview opens on preview click, card selection still works on normal card click, and apply flow remains unchanged end-to-end. Also: set task to `[-]` before coding, run `log-implementation` after finishing, then mark task `[x]` in `tasks.md`._
+
+- [x] 3. Harden Numista popup URL handling and style preview control
+  - Files: `js/numista-modal.js`, `css/styles.css`
+  - In `openNumistaModal`, enforce safe catalog-id parsing/validation before composing URL and fail gracefully when invalid.
+  - Add scoped CSS for preview control (layout, hover/focus, touch target) consistent with existing Numista result card styles.
+  - Purpose: Ensure safe, usable preview behavior on desktop and mobile.
+  - _Leverage: Existing `openNumistaModal` implementation and existing `.numista-result-*` style blocks_
+  - _Requirements: 1.3, 3.1, 3.2, 3.3_
+  - _Prompt: Implement the task for spec numista-search-preview-link, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Frontend/security-minded developer with CSS polish skills | Task: (1) Improve `openNumistaModal()` in `js/numista-modal.js` to validate/normalize incoming catalog IDs before URL construction, supporting current Numista ID formats while preventing malformed values from being opened. Keep graceful popup-blocked behavior. (2) Add focused CSS rules in `css/styles.css` for the new preview control so it is clearly discoverable and accessible in the Numista result list across desktop/mobile. | Restrictions: Only edit `js/numista-modal.js` and `css/styles.css`. Do not change modal z-index/layout systems globally. Do not add frameworks or external libs. | _Leverage: Existing popup logic and result-card style section around `#numistaResultsModal`. | _Requirements: 1.3, 3.1, 3.2, 3.3 | Success: Invalid IDs are safely ignored/handled, valid IDs open correct Numista pages, popup failures are graceful, and preview control styling is readable and tappable in supported viewports. Also: set task to `[-]` before coding, run `log-implementation` after finishing, then mark task `[x]` in `tasks.md`._

--- a/css/styles.css
+++ b/css/styles.css
@@ -8831,6 +8831,7 @@ th {
   appearance: none;
   border: 0;
   background: transparent;
+  color: inherit;
   padding: 0;
   text-decoration: underline;
   text-underline-offset: 2px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -8827,6 +8827,34 @@ th {
   font-weight: 600;
 }
 
+.numista-result-id-link {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.numista-result-id-link:hover {
+  color: color-mix(in srgb, var(--primary) 75%, white 25%);
+}
+
+.numista-result-id-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.numista-result-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
 /* Field picker area */
 .numista-field-picker {
   padding: 0.5rem 0;

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1212,7 +1212,7 @@ const renderCatalogIdAction = (catalogId) => {
   const numistaUrl = buildNumistaCatalogUrl(catalogId);
   const catalogIdLabel = `N#${escapeHtmlCatalog(catalogId)}`;
   return numistaUrl
-    ? `<a class="numista-result-id numista-result-id-link" href="${escapeHtmlCatalog(numistaUrl)}" target="_blank" rel="noopener noreferrer" aria-label="Open ${catalogIdLabel} on Numista">${catalogIdLabel}</a>`
+    ? `<button type="button" class="numista-result-id numista-result-id-link" onclick="openNumistaModal('${escapeHtmlCatalog(catalogId)}','')" aria-label="Open ${catalogIdLabel} on Numista">${catalogIdLabel}</button>`
     : `<span class="numista-result-id">${catalogIdLabel}</span>`;
 };
 
@@ -2080,7 +2080,7 @@ document.addEventListener('DOMContentLoaded', function() {
   if (numistaResultsList) {
     numistaResultsList.addEventListener('click', function(e) {
       // Let N# links open Numista without also selecting the row.
-      const catalogLink = e.target.closest('a.numista-result-id-link');
+      const catalogLink = e.target.closest('.numista-result-id-link');
       if (catalogLink) {
         e.stopPropagation();
         return;

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1186,8 +1186,10 @@ const buildNumistaCatalogUrl = (catalogId) => {
   const raw = String(catalogId || '').trim();
   if (!raw) return '';
 
-  const isSet = /^S/i.test(raw);
-  const clean = raw.replace(/^[NS]?#?\s*/i, '').trim();
+  // Strip N# prefix first, THEN detect S for sets
+  const stripped = raw.replace(/^N#\s*/i, '').trim();
+  const isSet = /^S/i.test(stripped);
+  const clean = isSet ? stripped.replace(/^S/i, '').trim() : stripped;
   if (!/^\d+$/.test(clean)) return '';
 
   return isSet
@@ -1201,6 +1203,19 @@ const buildNumistaCatalogUrl = (catalogId) => {
  * @param {number} index - Index in results array
  * @returns {string} HTML string
  */
+/**
+ * Render catalog ID as a clickable link (when URL is available) or plain span.
+ * @param {string} catalogId - Raw catalog ID from Numista
+ * @returns {string} HTML string
+ */
+const renderCatalogIdAction = (catalogId) => {
+  const numistaUrl = buildNumistaCatalogUrl(catalogId);
+  const catalogIdLabel = `N#${escapeHtmlCatalog(catalogId)}`;
+  return numistaUrl
+    ? `<a class="numista-result-id numista-result-id-link" href="${escapeHtmlCatalog(numistaUrl)}" target="_blank" rel="noopener noreferrer" aria-label="Open ${catalogIdLabel} on Numista">${catalogIdLabel}</a>`
+    : `<span class="numista-result-id">${catalogIdLabel}</span>`;
+};
+
 const renderNumistaResultCard = (result, index) => {
   const placeholder = `<div class="numista-img-placeholder">🪙</div>`;
   const obverseImg = result.imageUrl
@@ -1216,11 +1231,7 @@ const renderNumistaResultCard = (result, index) => {
     result.weight ? `${result.weight}g` : '',
     result.type
   ].filter(Boolean).join(' · ');
-  const numistaUrl = buildNumistaCatalogUrl(result.catalogId);
-  const catalogIdLabel = `N#${escapeHtmlCatalog(result.catalogId)}`;
-  const catalogIdAction = numistaUrl
-    ? `<a class="numista-result-id numista-result-id-link" href="${escapeHtmlCatalog(numistaUrl)}" target="_blank" rel="noopener noreferrer" title="Open on Numista" aria-label="Open on Numista">${catalogIdLabel}</a>`
-    : `<span class="numista-result-id">${catalogIdLabel}</span>`;
+  const catalogIdAction = renderCatalogIdAction(result.catalogId);
 
   return `<div class="numista-result-card" data-result-index="${index}">
     <div class="numista-result-images">${obverseImg}${reverseImg}</div>
@@ -1254,11 +1265,7 @@ const renderNumistaSelectedItem = (result) => {
     result.weight ? `${result.weight}g` : '',
     result.type
   ].filter(Boolean).join(' · ');
-  const numistaUrl = buildNumistaCatalogUrl(result.catalogId);
-  const catalogIdLabel = `N#${escapeHtmlCatalog(result.catalogId)}`;
-  const catalogIdAction = numistaUrl
-    ? `<a class="numista-result-id numista-result-id-link" href="${escapeHtmlCatalog(numistaUrl)}" target="_blank" rel="noopener noreferrer" title="Open on Numista" aria-label="Open on Numista">${catalogIdLabel}</a>`
-    : `<span class="numista-result-id">${catalogIdLabel}</span>`;
+  const catalogIdAction = renderCatalogIdAction(result.catalogId);
 
   return `<div class="numista-result-images">${obverseImg}${reverseImg}</div>
     <div class="numista-result-info">

--- a/js/numista-modal.js
+++ b/js/numista-modal.js
@@ -13,15 +13,26 @@
  * @param {string} coinName - The name of the coin (used for window title)
  */
 function openNumistaModal(numistaId, coinName) {
-  const isSet = /^S/i.test(numistaId);
-  const cleanId = numistaId.replace(/^[NS]?#?\s*/i, '').trim();
+  const rawId = String(numistaId || '').trim();
+  if (!rawId) {
+    appAlert('Preview unavailable: missing Numista catalog id.');
+    return;
+  }
+
+  const isSet = /^S/i.test(rawId);
+  const cleanId = rawId.replace(/^[NS]?#?\s*/i, '').trim();
+  if (!/^\d+$/.test(cleanId)) {
+    appAlert('Preview unavailable: invalid Numista catalog id.');
+    return;
+  }
+
   const url = isSet
     ? `https://en.numista.com/catalogue/set.php?id=${cleanId}`
     : `https://en.numista.com/catalogue/pieces${cleanId}.html`;
 
   const popup = window.open(
     url,
-    `numista_${numistaId}`,
+    `numista_${isSet ? 'set_' : ''}${cleanId}`,
     'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no'
   );
 

--- a/js/numista-modal.js
+++ b/js/numista-modal.js
@@ -19,8 +19,10 @@ function openNumistaModal(numistaId, coinName) {
     return;
   }
 
-  const isSet = /^S/i.test(rawId);
-  const cleanId = rawId.replace(/^[NS]?#?\s*/i, '').trim();
+  // Strip N# prefix first, THEN detect S for sets
+  const stripped = rawId.replace(/^N#\s*/i, '').trim();
+  const isSet = /^S/i.test(stripped);
+  const cleanId = isSet ? stripped.replace(/^S/i, '').trim() : stripped;
   if (!/^\d+$/.test(cleanId)) {
     appAlert('Preview unavailable: invalid Numista catalog id.');
     return;

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.46-b1772095640';
+const CACHE_NAME = 'staktrakr-v3.32.46-b1772097597';
 
 
 


### PR DESCRIPTION
## Summary
- make Numista N# labels in search results direct hyperlinks to Numista catalog pages
- make N# labels in single-result picker direct hyperlinks as well
- prevent N# link clicks from triggering row-selection/picker transitions
- include spec-workflow artifacts for numista-search-preview-link

## Validation
- npx eslint js/catalog-api.js js/numista-modal.js

## Notes
- Numista blocks iframe embedding via X-Frame-Options: SAMEORIGIN, so links open directly in a new tab/window.
