### PR TITLE
fix: PR #560 review — tabnabbing + version.json sync

### DIFF
--- a/js/numista-modal.js
+++ b/js/numista-modal.js
@@ -41,6 +41,7 @@ function openNumistaModal(numistaId, coinName) {
   if (!popup) {
     appAlert(`Popup blocked! Please allow popups or manually visit:\n${url}`);
   } else {
+    popup.opener = null; // Security: prevent reverse tabnabbing
     popup.focus();
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.32.46-b1772098199';
+const CACHE_NAME = 'staktrakr-v3.32.46-b1772103690';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.32.45",
+  "version": "3.32.46",
   "releaseDate": "2026-02-26",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

Two fixes from PR #560 (dev → main) review:

- **Security**: Add `popup.opener = null` to `numista-modal.js` — the Sentinel hardening commit (c94e6dd) protected `viewModal.js` and `utils.js` but missed `numista-modal.js` (Codacy MEDIUM RISK)
- **Version sync**: Update `version.json` from 3.32.45 → 3.32.46 to match `constants.js` and `sw.js` (Copilot review finding)

## Test plan

- [ ] Numista catalog popup opens without `window.opener` access
- [ ] version.json matches APP_VERSION in constants.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)