### PR TITLE
v3.33.01 — Numista Search Overhaul: fieldMeta, re-sync picker, tag controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.01] - 2026-02-27
+
+### Added — Numista Search Overhaul
+
+- **Added**: Per-field origin tracking (fieldMeta) — tracks whether each field came from Numista, PCGS, CSV import, or manual entry (STAK-363)
+- **Added**: Two-tier re-sync picker modal with diff hints and smart pre-check defaults based on field origin (STAK-345)
+- **Added**: Independent tag blacklist with Settings UI management, separate from chip grouping blacklist (STAK-354)
+- **Added**: Auto-apply Numista tags toggle — global setting with per-action override in re-sync picker (STAK-346)
+- **Added**: Backup export/import now includes numistaData and fieldMeta for complete round-trip preservation (STAK-362)
+
+---
+
 ## [3.33.00] - 2026-02-26
 
 ### Added — Cloud Sync Overhaul, Image Pipeline, Numista Integrity, Menu UX, Retail Charts

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Numista Search Overhaul (v3.33.01)**: Per-field origin tracking with two-tier re-sync picker showing diff hints and smart defaults. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export now preserves Numista data and field metadata (STAK-345, STAK-346, STAK-354, STAK-362, STAK-363)
 - **Cloud Sync, Image Pipeline & Retail Charts (v3.33.00)**: Unified encryption for cloud sync with ambient status icons. Removed coinImages IDB cache — CDN-only Numista images. Dynamic IndexedDB quota. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Numista tags visible in edit modal and card view. Reorderable header buttons. Tabnabbing hardening across all external links
 - **Retail Anomaly Filter (v3.32.45)**: Two-pass anomaly detection in 24h retail chart — temporal spike smoothing (±5% neighbor consensus) plus cross-vendor median safety net. Anomalous table cells shown with line-through styling (STAK-325)
 - **Kilo & Pound Weight Units (v3.32.44)**: Added kilogram and pound to the weight unit dropdown. Melt values convert correctly. Table, cards, and modals all display in the chosen unit (STAK-338)

--- a/index.html
+++ b/index.html
@@ -2615,6 +2615,9 @@
                       <button type="button" class="btn secondary" id="clearNumistaCacheBtn" style="font-size:0.8rem;">Clear API Cache</button>
                     </div>
                   </div>
+
+                  <!-- Numista Tag Settings (auto-apply toggle + blacklist) -->
+                  <div id="numistaTagSettingsGroup"></div>
                 </div>
               </div>
 
@@ -4904,6 +4907,7 @@
 
   <script defer src="js/debug-log.js"></script>
   <script defer src="./js/constants.js"></script>
+  <script defer src="./js/field-meta.js"></script>
   <script defer src="./js/state.js"></script>
   <script defer src="./js/utils.js"></script>
   <script defer src="./js/dialogs.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.01 &ndash; Numista Search Overhaul</strong>: Per-field origin tracking with two-tier re-sync picker showing diff hints and smart defaults. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export now preserves Numista data and field metadata (STAK-345, STAK-346, STAK-354, STAK-362, STAK-363)</li>
     <li><strong>v3.33.00 &ndash; Cloud Sync, Image Pipeline &amp; Retail Charts</strong>: Unified encryption for cloud sync with ambient status icons. Removed coinImages IDB cache &mdash; CDN-only Numista images. Dynamic IndexedDB quota. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Numista tags visible in edit modal and card view. Reorderable header buttons. Tabnabbing hardening across all external links</li>
     <li><strong>v3.32.45 &ndash; Retail Anomaly Filter</strong>: Two-pass anomaly detection in 24h retail chart &mdash; temporal spike smoothing (&plusmn;5% neighbor consensus) plus cross-vendor median safety net. Anomalous table cells shown with line-through styling (STAK-325)</li>
     <li><strong>v3.32.44 &ndash; Kilo &amp; Pound Weight Units</strong>: Added kilogram and pound to the weight unit dropdown. Melt values convert correctly. Table, cards, and modals all display in the chosen unit (STAK-338)</li>

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -605,7 +605,7 @@ class NumistaProvider extends CatalogProvider {
     // Denomination / face value
     const denomination = numistaData.value?.text || '';
 
-    return {
+    const result = {
       catalogId: numistaData.id?.toString() || '',
       name: numistaData.title || '',
       year: year.toString(),
@@ -638,6 +638,13 @@ class NumistaProvider extends CatalogProvider {
       reverseDesc: numistaData.reverse?.description || '',
       edgeDesc: numistaData.edge?.description || '',
     };
+
+    // Attach field-level origin tracking (fieldMeta) for re-sync picker
+    if (typeof window.initFieldMeta === 'function') {
+      result.fieldMeta = window.initFieldMeta(result, 'numista');
+    }
+
+    return result;
   }
 
   /**

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.00";
+const APP_VERSION = "3.33.01";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -847,6 +847,8 @@ const ALLOWED_STORAGE_KEYS = [
   STORAGE_PERSIST_GRANTED_KEY,                         // boolean string: "true"/"false" — storage persistence grant flag
   "headerBtnOrder",                                    // JSON array: header button card order (STAK-320)
   "headerAboutBtnVisible",                             // boolean string: "true"/"false" — about button visibility (STAK-320)
+  "tagBlacklist",                                      // JSON array: tags excluded from auto-tagging
+  "numista_tags_auto",                                 // boolean string: "true"/"false" — auto-tag from Numista data
 ];
 
 // =============================================================================

--- a/js/events.js
+++ b/js/events.js
@@ -1091,6 +1091,7 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       ...buildItemFields(f),
       numistaId: f.catalog,
       numistaData: f.numistaData,
+      fieldMeta: oldItem.fieldMeta || f.numistaData?.fieldMeta || undefined,
       currency: f.currency,
       // STAK-308: Use nullish coalescing — empty string is intentional (user cleared URL)
       obverseImageUrl: f.obverseImageUrl !== '' ? (f.obverseImageUrl || window.selectedNumistaResult?.imageUrl || '') : '',
@@ -1099,6 +1100,22 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       reverseSharedImageId: oldItem.reverseSharedImageId || null,
       ignorePatternImages: f.ignorePatternImages || false,
     };
+
+    // Track user-modified fields by comparing old vs new values
+    if (typeof window.markUserModified === 'function') {
+      const cur = inventory[editIdx];
+      const trackedFields = ['metal', 'composition', 'name', 'qty', 'type', 'weight',
+        'weightUnit', 'price', 'marketValue', 'date', 'purchaseLocation',
+        'storageLocation', 'serialNumber', 'notes', 'year', 'grade',
+        'gradingAuthority', 'certNumber', 'pcgsNumber', 'purity',
+        'country', 'denomination', 'shape', 'diameter', 'thickness',
+        'orientation', 'description', 'technique'];
+      for (const field of trackedFields) {
+        if (oldItem[field] !== cur[field]) {
+          window.markUserModified(cur, field);
+        }
+      }
+    }
 
     addCompositionOption(f.composition);
 
@@ -1155,6 +1172,7 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       uuid: generateUUID(),
       numistaId: f.catalog,
       numistaData: f.numistaData,
+      fieldMeta: window.selectedNumistaResult?.fieldMeta || f.numistaData?.fieldMeta || undefined,
       currency: f.currency,
       obverseImageUrl: f.obverseImageUrl !== '' ? (f.obverseImageUrl || window.selectedNumistaResult?.imageUrl || '') : '',
       reverseImageUrl: f.reverseImageUrl !== '' ? (f.reverseImageUrl || window.selectedNumistaResult?.reverseImageUrl || '') : '',

--- a/js/field-meta.js
+++ b/js/field-meta.js
@@ -56,7 +56,8 @@ function initFieldMeta(normalizedData, source) {
     const val = normalizedData[key];
 
     // Non-empty check: skip null, undefined, empty string, 0, false, empty arrays
-    if (val === null || val === undefined || val === '' || val === 0 || val === false) continue;
+    if (val === null || val === undefined || val === '' || val === false) continue;
+    if (typeof val === 'number' && val === 0) continue;
     if (Array.isArray(val) && val.length === 0) continue;
 
     meta[key] = { source: src, userModified: false };
@@ -134,7 +135,8 @@ function applyPickerSelections(item, selections, normalizedData, source) {
 
     // Apply the value from normalized data
     if (fieldName in normalizedData) {
-      item[fieldName] = normalizedData[fieldName];
+      const val = normalizedData[fieldName];
+      item[fieldName] = Array.isArray(val) ? [...val] : val;
       item.fieldMeta[fieldName] = { source: src, userModified: false };
     }
   }

--- a/js/field-meta.js
+++ b/js/field-meta.js
@@ -1,0 +1,151 @@
+/**
+ * field-meta.js — Pure-data fieldMeta CRUD module for StakTrakr
+ *
+ * Tracks per-field origin (numista, pcgs, csv-import, manual) and whether
+ * the user has manually modified each field since the last API sync.
+ *
+ * Zero DOM dependencies. No document, no window event listeners, no safeGetElement.
+ * All functions are pure data transformations.
+ *
+ * Related: catalog-api.js normalizeItemData() (field names),
+ *          diff-engine.js (pure-data module pattern reference).
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Field tier definitions for the re-sync picker modal.
+ * Tier 1: always visible. Tier 2: behind "Show more fields" toggle.
+ */
+const FIELD_TIERS = {
+  tier1: ['name', 'numistaId', 'year', 'type', 'weight', 'tags'],
+  tier2: [
+    'country', 'denomination', 'composition', 'shape', 'diameter',
+    'thickness', 'metal', 'orientation', 'description', 'grade',
+    'mintage', 'technique', 'commemorative',
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a fieldMeta object from normalized API data.
+ * Each non-empty field in normalizedData gets an entry with
+ * { source, userModified: false }.
+ *
+ * @param {object} normalizedData - Output of normalizeItemData()
+ * @param {string} source - Origin identifier ('numista', 'pcgs', 'csv-import', 'manual')
+ * @returns {object} fieldMeta map: { fieldName: { source, userModified } }
+ */
+function initFieldMeta(normalizedData, source) {
+  if (normalizedData == null || typeof normalizedData !== 'object') return {};
+
+  const src = source || 'manual';
+  const meta = {};
+
+  for (const key of Object.keys(normalizedData)) {
+    // Skip internal/metadata fields that are not user-facing inventory fields
+    if (key === 'fieldMeta' || key === 'provider' || key === 'lastUpdated') continue;
+
+    const val = normalizedData[key];
+
+    // Non-empty check: skip null, undefined, empty string, 0, false, empty arrays
+    if (val === null || val === undefined || val === '' || val === 0 || val === false) continue;
+    if (Array.isArray(val) && val.length === 0) continue;
+
+    meta[key] = { source: src, userModified: false };
+  }
+
+  return meta;
+}
+
+/**
+ * Returns the fieldMeta entry for a specific field on an item.
+ * If the item has no fieldMeta or the field has no entry, returns
+ * a legacy fallback indicating manual/user-modified data.
+ *
+ * @param {object} item - Inventory item
+ * @param {string} fieldName - Field to look up
+ * @returns {{ source: string, userModified: boolean }}
+ */
+function getFieldMeta(item, fieldName) {
+  if (
+    item != null &&
+    item.fieldMeta != null &&
+    typeof item.fieldMeta === 'object' &&
+    item.fieldMeta[fieldName] != null
+  ) {
+    return item.fieldMeta[fieldName];
+  }
+
+  // Legacy fallback — treat as manually entered and user-modified
+  return { source: 'manual', userModified: true };
+}
+
+/**
+ * Marks a field as user-modified on an item. Creates the fieldMeta
+ * object and/or field entry if absent.
+ *
+ * @param {object} item - Inventory item (mutated in place)
+ * @param {string} fieldName - Field to mark
+ */
+function markUserModified(item, fieldName) {
+  if (item == null || !fieldName) return;
+
+  if (item.fieldMeta == null || typeof item.fieldMeta !== 'object') {
+    item.fieldMeta = {};
+  }
+
+  if (item.fieldMeta[fieldName] != null) {
+    item.fieldMeta[fieldName].userModified = true;
+  } else {
+    item.fieldMeta[fieldName] = { source: 'manual', userModified: true };
+  }
+}
+
+/**
+ * Applies checked fields from the re-sync picker to an item.
+ * For each field where selections[fieldName] is true, copies the value
+ * from normalizedData to item and resets that field's meta to
+ * { source, userModified: false }.
+ *
+ * @param {object} item - Inventory item (mutated in place)
+ * @param {object} selections - Map of { fieldName: boolean } from picker
+ * @param {object} normalizedData - Normalized API data to apply from
+ * @param {string} [source='numista'] - Source identifier for fieldMeta
+ */
+function applyPickerSelections(item, selections, normalizedData, source) {
+  if (item == null || selections == null || normalizedData == null) return;
+
+  const src = source || 'numista';
+
+  if (item.fieldMeta == null || typeof item.fieldMeta !== 'object') {
+    item.fieldMeta = {};
+  }
+
+  for (const fieldName of Object.keys(selections)) {
+    if (!selections[fieldName]) continue; // unchecked — skip
+
+    // Apply the value from normalized data
+    if (fieldName in normalizedData) {
+      item[fieldName] = normalizedData[fieldName];
+      item.fieldMeta[fieldName] = { source: src, userModified: false };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+window.FIELD_TIERS = FIELD_TIERS;
+window.initFieldMeta = initFieldMeta;
+window.getFieldMeta = getFieldMeta;
+window.markUserModified = markUserModified;
+window.applyPickerSelections = applyPickerSelections;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -3297,6 +3297,8 @@ const importJson = (file, override = false) => {
         const uuid = raw.uuid || generateUUID();
         const obverseImageUrl = raw.obverseImageUrl || raw['Obverse Image URL'] || '';
         const reverseImageUrl = raw.reverseImageUrl || raw['Reverse Image URL'] || '';
+        const numistaData = raw.numistaData || undefined;
+        const fieldMeta = raw.fieldMeta || undefined;
 
         const processedItem = sanitizeImportedItem({
           metal,
@@ -3327,7 +3329,9 @@ const importJson = (file, override = false) => {
           serial,
           uuid,
           obverseImageUrl,
-          reverseImageUrl
+          reverseImageUrl,
+          ...(numistaData ? { numistaData } : {}),
+          ...(fieldMeta ? { fieldMeta } : {})
         });
 
         const validation = validateInventoryItem(processedItem);
@@ -3497,7 +3501,9 @@ const exportJson = () => {
     reverseImageUrl: item.reverseImageUrl || '',
     // Legacy fields preserved for backward compatibility
     spotPriceAtPurchase: item.spotPriceAtPurchase,
-    composition: item.composition
+    composition: item.composition,
+    numistaData: item.numistaData || null,
+    fieldMeta: item.fieldMeta || null
   }));
 
   const json = JSON.stringify(exportData, null, 2);

--- a/js/settings.js
+++ b/js/settings.js
@@ -2169,7 +2169,7 @@ const _handleStorageTinyToggle = () => {
  * Appended after the numistaBulkSyncGroup inside the Numista provider panel.
  */
 const renderNumistaTagSettings = () => {
-  const container = document.getElementById('numistaTagSettingsGroup');
+  const container = safeGetElement('numistaTagSettingsGroup');
   if (!container) return;
 
   // Clear previous render

--- a/js/tags.js
+++ b/js/tags.js
@@ -287,12 +287,14 @@ const removeFromTagBlacklist = (tag) => {
 
 // =============================================================================
 
-const applyNumistaTags = (uuid, numistaTags, persist = true) => {
+const applyNumistaTags = (uuid, numistaTags, persist = true, force = false) => {
   if (!uuid || !Array.isArray(numistaTags) || numistaTags.length === 0) return 0;
 
-  // Check global auto-apply setting
-  const autoApply = loadDataSync('numista_tags_auto', true);
-  if (!autoApply) return 0;
+  // Check global auto-apply setting (skip when force=true, e.g. from re-sync picker)
+  if (!force) {
+    const autoApply = loadDataSync('numista_tags_auto', true);
+    if (!autoApply) return 0;
+  }
 
   let added = 0;
   for (const raw of numistaTags) {

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -879,12 +879,12 @@ async function loadViewNumistaData(item, container, apiResult) {
 
       // If tags were selected, apply them through the tag system
       if (selections.tags && meta.tags && meta.tags.length > 0 && item.uuid && typeof applyNumistaTags === 'function') {
-        applyNumistaTags(item.uuid, meta.tags);
+        applyNumistaTags(item.uuid, meta.tags, true, true);
       }
 
       // Persist inventory changes
-      if (typeof saveData === 'function' && typeof inventory !== 'undefined') {
-        saveData('inventory', inventory);
+      if (typeof saveInventory === 'function') {
+        saveInventory();
       }
 
       // Rebuild the tags section in the modal
@@ -1455,7 +1455,7 @@ function _valuesMatch(current, incoming) {
       current.every((v, i) => v === incoming[i]);
   }
   // Loose numeric comparison (e.g. "26.73" vs 26.73)
-  if (current != null && incoming != null && Number(current) === Number(incoming) && !isNaN(Number(current))) return true;
+  if (current !== null && current !== undefined && incoming !== null && incoming !== undefined && Number(current) === Number(incoming) && !isNaN(Number(current))) return true;
   return false;
 }
 
@@ -1480,7 +1480,7 @@ function showResyncPicker(item, normalizedData, onConfirm, onCancel) {
   const fieldDisabled = {};
 
   // Remove any existing picker modal
-  const existingModal = document.getElementById('resyncPickerModal');
+  const existingModal = safeGetElement('resyncPickerModal');
   if (existingModal) existingModal.remove();
 
   // Backdrop
@@ -1737,9 +1737,9 @@ function showResyncPicker(item, normalizedData, onConfirm, onCancel) {
   }
 
   function _cleanup() {
-    const m = document.getElementById('resyncPickerModal');
+    const m = safeGetElement('resyncPickerModal');
     if (m) m.remove();
-    const b = document.getElementById('resyncPickerBackdrop');
+    const b = safeGetElement('resyncPickerBackdrop');
     if (b) b.remove();
   }
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.00-b1772151835';
+const CACHE_NAME = 'staktrakr-v3.33.01-b1772153203';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.00-b1772106603';
+const CACHE_NAME = 'staktrakr-v3.33.00-b1772151835';
 
 
 
@@ -30,6 +30,7 @@ const CORE_ASSETS = [
   './js/file-protocol-fix.js',
   './js/debug-log.js',
   './js/constants.js',
+  './js/field-meta.js',
   './js/state.js',
   './js/utils.js',
   './js/dialogs.js',

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.00",
-  "releaseDate": "2026-02-26",
+  "version": "3.33.01",
+  "releaseDate": "2026-02-27",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **fieldMeta architecture**: Per-field origin tracking (`source` + `userModified`) via new `js/field-meta.js` module
- **Re-sync picker modal**: Two-tier checkbox layout with diff hints, smart pre-check defaults based on field origin
- **Tag blacklist**: Independent from chip grouping blacklist, with Settings UI management
- **Auto-apply toggle**: Global setting + per-action override in re-sync picker
- **Backup export/import**: `numistaData` + `fieldMeta` included in JSON round-trip
- **Edit tracking**: `markUserModified` called on every field change in commitItemToInventory

## Files Changed (10)

| File | Change |
|------|--------|
| `js/field-meta.js` | NEW — pure-data module (138 lines) |
| `js/viewModal.js` | Re-sync picker modal (+392 lines) |
| `js/settings.js` | Tag settings UI (+167 lines) |
| `js/tags.js` | Blacklist CRUD + auto-apply gate (+85 lines) |
| `js/events.js` | fieldMeta tracking on add/edit (+18 lines) |
| `js/catalog-api.js` | initFieldMeta in normalizeItemData (+9 lines) |
| `js/inventory.js` | Export/import numistaData + fieldMeta (+10 lines) |
| `js/constants.js` | 2 new ALLOWED_STORAGE_KEYS |
| `index.html` | field-meta.js script tag + settings container |
| `sw.js` | field-meta.js in CORE_ASSETS |

## Linear Issues

- STAK-345: Re-sync picker transparency
- STAK-346: Tags optional on import
- STAK-354: Blacklisted tags in suggestions
- STAK-362: Numista data in backup export
- STAK-363: Field editability UX

## Spec

`numista-search-overhaul` — all 9 tasks complete, implementation logs recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)