### PR TITLE
v3.33.03 — Clean up announcements, remove stale v3.32.x entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.03] - 2026-02-27
+
+### Fixed — Announcements Cleanup
+
+- **Fixed**: Removed stale v3.32.44/v3.32.45 entries from What's New — these were pre-release patches already rolled into v3.33.00
+- **Fixed**: Removed completed "Numista Field Origin Tracking" from roadmap — shipped in v3.33.01
+- **Fixed**: Restored "Cloud Backup Conflict Detection (STAK-150)" to roadmap as next priority
+
+---
+
 ## [3.33.02] - 2026-02-27
 
 ### Added — Cloud Sync Safety Overhaul

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,16 +1,14 @@
 ## What's New
 
-- **Cloud Sync Safety Overhaul (v3.33.02)**: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. Manifest v2 with inventory hashing. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard via BroadcastChannel (STAK-295, STAK-190, STAK-360)
-- **Numista Search Overhaul (v3.33.01)**: Per-field origin tracking with two-tier re-sync picker showing diff hints and smart defaults. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export now preserves Numista data and field metadata (STAK-345, STAK-346, STAK-354, STAK-362, STAK-363)
-- **Cloud Sync, Image Pipeline & Retail Charts (v3.33.00)**: Unified encryption for cloud sync with ambient status icons. Removed coinImages IDB cache — CDN-only Numista images. Dynamic IndexedDB quota. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Numista tags visible in edit modal and card view. Reorderable header buttons. Tabnabbing hardening across all external links
-- **Retail Anomaly Filter (v3.32.45)**: Two-pass anomaly detection in 24h retail chart — temporal spike smoothing (±5% neighbor consensus) plus cross-vendor median safety net. Anomalous table cells shown with line-through styling (STAK-325)
-- **Kilo & Pound Weight Units (v3.32.44)**: Added kilogram and pound to the weight unit dropdown. Melt values convert correctly. Table, cards, and modals all display in the chosen unit (STAK-338)
+- **Cloud Sync Safety Overhaul (v3.33.02)**: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard
+- **Numista Search Overhaul (v3.33.01)**: Per-field origin tracking with two-tier re-sync picker. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export preserves Numista data and field metadata
+- **Cloud Sync, Image Pipeline & Retail Charts (v3.33.00)**: Unified encryption for cloud sync with ambient status icons. CDN-only Numista images. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Reorderable header buttons
 
 ## Development Roadmap
 
 ### Next Up
 
-- **Numista Field Origin Tracking**: Map Numista data to standard fields with source tracking and smart re-sync picker
+- **Cloud Backup Conflict Detection (STAK-150)**: Smarter conflict resolution using item count direction, not just timestamps
 - **Accessible Table Mode (STAK-144)**: Style D with horizontal scroll, long-press to edit, 300% zoom support
 
 ### Near-Term

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,9 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.33.02 &ndash; Cloud Sync Safety Overhaul</strong>: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. Manifest v2 with inventory hashing. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard via BroadcastChannel (STAK-295, STAK-190, STAK-360)</li>
-    <li><strong>v3.33.01 &ndash; Numista Search Overhaul</strong>: Per-field origin tracking with two-tier re-sync picker showing diff hints and smart defaults. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export now preserves Numista data and field metadata (STAK-345, STAK-346, STAK-354, STAK-362, STAK-363)</li>
-    <li><strong>v3.33.00 &ndash; Cloud Sync, Image Pipeline &amp; Retail Charts</strong>: Unified encryption for cloud sync with ambient status icons. Removed coinImages IDB cache &mdash; CDN-only Numista images. Dynamic IndexedDB quota. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Numista tags visible in edit modal and card view. Reorderable header buttons. Tabnabbing hardening across all external links</li>
-    <li><strong>v3.32.45 &ndash; Retail Anomaly Filter</strong>: Two-pass anomaly detection in 24h retail chart &mdash; temporal spike smoothing (&plusmn;5% neighbor consensus) plus cross-vendor median safety net. Anomalous table cells shown with line-through styling (STAK-325)</li>
-    <li><strong>v3.32.44 &ndash; Kilo &amp; Pound Weight Units</strong>: Added kilogram and pound to the weight unit dropdown. Melt values convert correctly. Table, cards, and modals all display in the chosen unit (STAK-338)</li>
+    <li><strong>v3.33.02 &ndash; Cloud Sync Safety Overhaul</strong>: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard</li>
+    <li><strong>v3.33.01 &ndash; Numista Search Overhaul</strong>: Per-field origin tracking with two-tier re-sync picker. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export preserves Numista data and field metadata</li>
+    <li><strong>v3.33.00 &ndash; Cloud Sync, Image Pipeline &amp; Retail Charts</strong>: Unified encryption for cloud sync with ambient status icons. CDN-only Numista images. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Reorderable header buttons</li>
   `;
 };
 
@@ -297,7 +295,7 @@ const getEmbeddedWhatsNew = () => {
  */
 const getEmbeddedRoadmap = () => {
   return `
-    <li><strong>Numista Field Origin Tracking</strong>: Map Numista data to standard fields with source tracking and smart re-sync picker</li>
+    <li><strong>Cloud Backup Conflict Detection (STAK-150)</strong>: Smarter conflict resolution using item count direction, not just timestamps</li>
     <li><strong>Accessible Table Mode (STAK-144)</strong>: Style D with horizontal scroll, long-press to edit, 300% zoom support</li>
     <li><strong>Custom Theme Editor (STAK-121)</strong>: User-defined color themes with CSS variable overrides</li>
   `;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.02";
+const APP_VERSION = "3.33.03";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.02-b1772153966';
+const CACHE_NAME = 'staktrakr-v3.33.03-b1772167055';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.02",
+  "version": "3.33.03",
   "releaseDate": "2026-02-27",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- Removed stale v3.32.44 (Kilo & Pound) and v3.32.45 (Retail Anomaly Filter) entries from What's New — both were pre-release patches already consolidated into the v3.33.00 release entry
- Removed completed "Numista Field Origin Tracking" from Development Roadmap — shipped in v3.33.01
- Restored "Cloud Backup Conflict Detection (STAK-150)" as next roadmap priority
- Synced `about.js` embedded fallbacks (`getEmbeddedWhatsNew` + `getEmbeddedRoadmap`) to match `announcements.md`
- Trimmed verbose STAK references from What's New entries for cleaner display

## Files Changed

- `js/constants.js` — version bump to 3.33.03
- `CHANGELOG.md` — new section for v3.33.03
- `docs/announcements.md` — cleaned up What's New + Roadmap
- `js/about.js` — synced embedded fallbacks
- `version.json` — version bump
- `sw.js` — cache name auto-stamped by pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)