### PR TITLE
📝 Scribe: Remove redundant MAX_LOCAL_FILE_SIZE assignment

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3067,7 +3067,6 @@ if (typeof window !== 'undefined') {
 
   window.cleanupStorage = cleanupStorage;
   window.checkFileSize = checkFileSize;
-  window.MAX_LOCAL_FILE_SIZE = MAX_LOCAL_FILE_SIZE;
   window.closeModalById = closeModalById;
   window.openModalById = openModalById;
   window.updateStorageStats = updateStorageStats;


### PR DESCRIPTION
💡 What: Removed redundant `window.MAX_LOCAL_FILE_SIZE = MAX_LOCAL_FILE_SIZE;` from `js/utils.js` (line 3070).
🔍 Evidence:
- `grep -rn "MAX_LOCAL_FILE_SIZE" js/` shows it is defined in `js/constants.js` and assigned to window there.
- `js/constants.js` loads before `js/utils.js` in `index.html`.
- The assignment in `js/utils.js` was effectively a no-op (assigning a global to the same global property).
📁 Files changed: `js/utils.js`
✅ Verified:
- `grep` confirms `MAX_LOCAL_FILE_SIZE` usage remains in `checkFileSize` (valid usage).
- Application load order ensures the constant is available.

---
*PR created automatically by Jules for task [11843409166895685778](https://jules.google.com/task/11843409166895685778) started by @lbruton*