### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove insecure Math.random fallback in UUID generation

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -46,12 +46,8 @@ const generateUUID = () => {
       return v.toString(16);
     });
   }
-  // RFC 4122 v4 fallback (insecure Math.random)
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  // No secure RNG available — throw rather than falling back to insecure Math.random()
+  throw new Error('Secure random number generation not available');
 };
 
 /**


### PR DESCRIPTION
**Vulnerability:** The `generateUUID` function contained a fallback to `Math.random()` when `crypto.randomUUID` and `crypto.getRandomValues` were unavailable. `Math.random()` is not cryptographically secure and can lead to predictable IDs, which is a risk for sensitive uses like OAuth state parameters.

**Fix:** The insecure fallback has been removed. The function now throws an error if a secure RNG cannot be found, ensuring that the application fails securely rather than silently downgrading security.

**Verification:**
- A test script (`tests/test-uuid-hardening.cjs`) confirmed that `generateUUID` throws an error when `crypto` is mocked as undefined.
- A Playwright verification script confirmed that the application still loads correctly in a standard environment (where `crypto` is available).

---
*PR created automatically by Jules for task [11471725773647679776](https://jules.google.com/task/11471725773647679776) started by @lbruton*