### PR TITLE
v3.33.04 — Quick-Fix Batch: NGC Lookup, Fractional Oz, Cloud Sync Reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.04] - 2026-02-27
+
+### Fixed — Quick-Fix Batch (NGC Lookup, Fractional Oz, Cloud Sync Reorder)
+
+- **Fixed**: NGC cert lookup link now extracts numeric grade only — e.g. "65" instead of "MS 65 CAM" (STAK-357)
+- **Fixed**: Fractional troy ounce weights display as "0.25 oz" instead of auto-converting to grams (STAK-361)
+- **Added**: Cloud Sync button registered in reorderable header system — toggle and reorder via Settings (STAK-365)
+
+---
+
 ## [3.33.03] - 2026-02-27
 
 ### Fixed — Announcements Cleanup

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Quick-Fix Batch (v3.33.04)**: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system
 - **Cloud Sync Safety Overhaul (v3.33.02)**: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard
 - **Numista Search Overhaul (v3.33.01)**: Per-field origin tracking with two-tier re-sync picker. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export preserves Numista data and field metadata
 - **Cloud Sync, Image Pipeline & Retail Charts (v3.33.00)**: Unified encryption for cloud sync with ambient status icons. CDN-only Numista images. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Reorderable header buttons

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.04 &ndash; Quick-Fix Batch</strong>: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system</li>
     <li><strong>v3.33.02 &ndash; Cloud Sync Safety Overhaul</strong>: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard</li>
     <li><strong>v3.33.01 &ndash; Numista Search Overhaul</strong>: Per-field origin tracking with two-tier re-sync picker. Independent tag blacklist with Settings management. Auto-apply toggle for Numista tags. Backup export preserves Numista data and field metadata</li>
     <li><strong>v3.33.00 &ndash; Cloud Sync, Image Pipeline &amp; Retail Charts</strong>: Unified encryption for cloud sync with ambient status icons. CDN-only Numista images. 24h retail intraday chart with anomaly filtering. Kilogram and pound weight units. Reorderable header buttons</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.03";
+const APP_VERSION = "3.33.04";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -678,6 +678,9 @@ const HEADER_VAULT_BTN_KEY = "headerVaultBtnVisible";
 /** @constant {string} HEADER_RESTORE_BTN_KEY - LocalStorage key for header restore button visibility */
 const HEADER_RESTORE_BTN_KEY = "headerRestoreBtnVisible";
 
+/** @constant {string} HEADER_CLOUD_SYNC_BTN_KEY - LocalStorage key for header cloud sync button visibility */
+const HEADER_CLOUD_SYNC_BTN_KEY = "headerCloudSyncBtnVisible";
+
 /** @constant {string} HEADER_BTN_SHOW_TEXT_KEY - LocalStorage key for show-text-under-icons toggle */
 const HEADER_BTN_SHOW_TEXT_KEY = "headerBtnShowText";
 
@@ -815,6 +818,7 @@ const ALLOWED_STORAGE_KEYS = [
   HEADER_MARKET_BTN_KEY,      // boolean string: "true"/"false" — header market button visibility
   HEADER_VAULT_BTN_KEY,       // boolean string: null=show, "false"=hide, "true"=show — vault button visibility
   HEADER_RESTORE_BTN_KEY,     // boolean string: "true"/"false" — restore button visibility
+  HEADER_CLOUD_SYNC_BTN_KEY,  // boolean string: "true"/"false" — cloud sync button visibility
   HEADER_BTN_SHOW_TEXT_KEY,   // boolean string: "true"/"false" — show text labels under header icons
   RETAIL_MANIFEST_TS_KEY,     // string ISO timestamp — market manifest generated_at cache
   "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54) — legacy, migrated to layoutSectionConfig
@@ -1718,6 +1722,7 @@ if (typeof window !== "undefined") {
   // Header button visibility keys (STAK-314)
   window.HEADER_VAULT_BTN_KEY = HEADER_VAULT_BTN_KEY;
   window.HEADER_RESTORE_BTN_KEY = HEADER_RESTORE_BTN_KEY;
+  window.HEADER_CLOUD_SYNC_BTN_KEY = HEADER_CLOUD_SYNC_BTN_KEY;
   window.HEADER_BTN_SHOW_TEXT_KEY = HEADER_BTN_SHOW_TEXT_KEY;
   window.RETAIL_MANIFEST_TS_KEY = RETAIL_MANIFEST_TS_KEY;
   window.RETAIL_ANOMALY_THRESHOLD = RETAIL_ANOMALY_THRESHOLD;

--- a/js/settings.js
+++ b/js/settings.js
@@ -1139,6 +1139,7 @@ const applyHeaderToggleVisibility = () => {
     syncBtn:     'headerSyncBtn',
     vaultBtn:    'headerVaultBtn',
     restoreBtn:  'headerRestoreBtn',
+    cloudSyncBtn: 'headerCloudSyncWrapper',
     aboutBtn:    'aboutBtn',
     settingsBtn: 'settingsBtn',
   };
@@ -1160,9 +1161,6 @@ const applyHeaderToggleVisibility = () => {
       const btn = container.querySelector(`#${btnId}`);
       if (btn) container.append(btn);
     }
-    // Cloud sync wrapper is position-managed by the cloud feature; keep it first
-    const cloudWrapper = container.querySelector('#headerCloudSyncWrapper');
-    if (cloudWrapper) container.prepend(cloudWrapper);
   }
 
   // Show text toggle
@@ -1187,12 +1185,13 @@ const getHeaderBtnConfig = () => {
     syncBtn:     (() => { const v = localStorage.getItem(HEADER_SYNC_BTN_KEY); return v !== null ? v === 'true' : true; })(),
     vaultBtn:    (() => { const v = localStorage.getItem(HEADER_VAULT_BTN_KEY); return v !== null ? v === 'true' : true; })(),
     restoreBtn:  localStorage.getItem(HEADER_RESTORE_BTN_KEY) !== 'false',
+    cloudSyncBtn: (() => { const v = localStorage.getItem(HEADER_CLOUD_SYNC_BTN_KEY); return v !== null ? v === 'true' : true; })(),
     aboutBtn:    localStorage.getItem('headerAboutBtnVisible') !== 'false',
   };
   const labelMap = {
     themeBtn: 'Theme', currencyBtn: 'Currency', marketBtn: 'Market',
     trendBtn: 'Trend', syncBtn: 'Spot Sync', vaultBtn: 'Backup',
-    restoreBtn: 'Restore', aboutBtn: 'About',
+    restoreBtn: 'Restore', cloudSyncBtn: 'Cloud Sync', aboutBtn: 'About',
   };
   const defaultOrder = Object.keys(vis);
   const savedOrder = (() => {
@@ -1222,6 +1221,7 @@ const saveHeaderBtnConfig = (cfg) => {
     syncBtn:     HEADER_SYNC_BTN_KEY,
     vaultBtn:    HEADER_VAULT_BTN_KEY,
     restoreBtn:  HEADER_RESTORE_BTN_KEY,
+    cloudSyncBtn: HEADER_CLOUD_SYNC_BTN_KEY,
     aboutBtn:    'headerAboutBtnVisible',
   };
   for (const item of cfg) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -818,9 +818,6 @@ const formatWeight = (ozt, weightUnit) => {
   if (weightUnit === 'g') {
     return `${oztToGrams(weight).toFixed(2)} g`;
   }
-  if (weight < 1) {
-    return `${oztToGrams(weight).toFixed(2)} g`;
-  }
   return `${weight.toFixed(2)} oz`;
 };
 

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -256,7 +256,7 @@ function _buildImageCertGrade(item, authority, certNum, pcgsNo) {
       e.stopPropagation();
       const url = hasCoinFacts
         ? _buildPcgsCoinFactsUrl(item.grade || '', pcgsNo)
-        : certUrlTemplate.replace(/\{certNumber\}/g, encodeURIComponent(certNum)).replace(/\{grade\}/g, encodeURIComponent(item.grade || ''));
+        : certUrlTemplate.replace(/\{certNumber\}/g, encodeURIComponent(certNum)).replace(/\{grade\}/g, encodeURIComponent((item.grade || '').match(/\d+/)?.[0] || ''));
       const popupName = `cert_${authority}_${certNum || pcgsNo}`.replace(/[^a-zA-Z0-9_]/g, '_');
       const popup = window.open(url, popupName, 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
       if (popup) {

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -256,7 +256,7 @@ function _buildImageCertGrade(item, authority, certNum, pcgsNo) {
       e.stopPropagation();
       const url = hasCoinFacts
         ? _buildPcgsCoinFactsUrl(item.grade || '', pcgsNo)
-        : certUrlTemplate.replace(/\{certNumber\}/g, encodeURIComponent(certNum)).replace(/\{grade\}/g, encodeURIComponent((item.grade || '').match(/\d+/)?.[0] || ''));
+        : certUrlTemplate.replace(/\{certNumber\}/g, encodeURIComponent(certNum)).replace(/\{grade\}/g, encodeURIComponent(_extractNumericGrade(item.grade)));
       const popupName = `cert_${authority}_${certNum || pcgsNo}`.replace(/[^a-zA-Z0-9_]/g, '_');
       const popup = window.open(url, popupName, 'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no');
       if (popup) {
@@ -270,8 +270,12 @@ function _buildImageCertGrade(item, authority, certNum, pcgsNo) {
   return gradeSpan;
 }
 
+function _extractNumericGrade(gradeText) {
+  return (gradeText || '').match(/\d+/)?.[0] || '';
+}
+
 function _buildPcgsCoinFactsUrl(gradeText, pcgsNo) {
-  const gradeNum = gradeText.match(/\d+/)?.[0] || '';
+  const gradeNum = _extractNumericGrade(gradeText);
   return gradeNum
     ? `https://www.pcgs.com/coinfacts/coin/detail/${encodeURIComponent(pcgsNo)}/${encodeURIComponent(gradeNum)}`
     : `https://www.pcgs.com/coinfacts/coin/${encodeURIComponent(pcgsNo)}`;
@@ -558,7 +562,7 @@ function _attachGradingCertLink(certItem, item) {
   if (!item.gradingAuthority || typeof CERT_LOOKUP_URLS === 'undefined' || !CERT_LOOKUP_URLS[item.gradingAuthority]) return;
   const url = CERT_LOOKUP_URLS[item.gradingAuthority]
     .replace(/{certNumber}/g, encodeURIComponent(item.certNumber))
-    .replace(/{grade}/g, encodeURIComponent(item.grade || ''));
+    .replace(/{grade}/g, encodeURIComponent(_extractNumericGrade(item.grade)));
   const valEl = certItem.querySelector('.view-detail-value');
   if (!valEl) return;
   valEl.textContent = '';

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.04-b1772182478';
+const CACHE_NAME = 'staktrakr-v3.33.04-b1772183043';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.03-b1772167055';
+const CACHE_NAME = 'staktrakr-v3.33.04-b1772182478';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.03",
+  "version": "3.33.04",
   "releaseDate": "2026-02-27",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: NGC cert lookup link extracts numeric grade only — "65" instead of "MS 65 CAM" (STAK-357)
- **Fixed**: Fractional troy ounce weights display as "0.25 oz" instead of auto-converting to grams (STAK-361)
- **Added**: Cloud Sync button registered in reorderable header system — toggle and reorder via Settings (STAK-365)

## Linear Issues

- STAK-357: NGC Lookup Link on view modal
- STAK-361: Fractional troy ounce auto-convert to grams
- STAK-365: Cloud menu item always at the front

🤖 Generated with [Claude Code](https://claude.com/claude-code)