### PR TITLE
docs: update announcements and about for default-on market view (STAK-369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Added**: Vendor price chips with color-coded brand labels, medal rankings for best prices, OOS strikethrough styling (STAK-369)
 - **Added**: Computed MED/LOW/AVG stats row with live vendor + history fallback (STAK-369)
 - **Added**: Card click-to-expand chart interaction, functional search filtering, sort by name/metal/price/trend (STAK-369)
-- **Added**: Feature-flagged behind `?market_list_view=true` URL parameter (STAK-369)
+- **Added**: Enabled by default — disable with `?market_list_view=false` URL parameter (STAK-369)
+- **Added**: Sponsor badge with GitHub Sponsors link in market footer (STAK-369)
+- **Fixed**: Reverse tabnabbing protection on vendor links — `popup.opener = null` + `noopener,noreferrer` (STAK-369)
+- **Fixed**: Chart.js canvas color rendering — hex value instead of CSS `var()` (STAK-369)
+- **Fixed**: Chart.js `maxTicksLimit` option (was silently ignored `maxTicksToShow`) (STAK-369)
+- **Fixed**: Accessibility — `aria-label` on market search input (STAK-369)
+- **Fixed**: Mobile breakpoint — stats column spans full width at 767px (STAK-369)
 
 ---
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **Market Page Redesign Phase 1 (v3.33.06)**: Full-width market list cards with inline 7-day trend charts, spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, click-to-expand charts. Feature-flagged behind ?market_list_view=true
+- **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false
 - **Daily Maintenance (v3.33.05)**: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)
 - **Quick-Fix Batch (v3.33.04)**: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system
 - **Cloud Sync Safety Overhaul (v3.33.02)**: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard
@@ -9,6 +9,7 @@
 
 ### Next Up
 
+- **Market Page Phase 2**: Goldback item integration, inventory-to-market linking with auto-update retail prices
 - **Cloud Backup Conflict Detection (STAK-150)**: Smarter conflict resolution using item count direction, not just timestamps
 - **Accessible Table Mode (STAK-144)**: Style D with horizontal scroll, long-press to edit, 300% zoom support
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,7 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: Full-width market list cards with inline 7-day trend charts, spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, click-to-expand charts. Feature-flagged behind ?market_list_view=true</li>
+    <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false</li>
     <li><strong>v3.33.05 &ndash; Daily Maintenance</strong>: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)</li>
     <li><strong>v3.33.04 &ndash; Quick-Fix Batch</strong>: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system</li>
     <li><strong>v3.33.02 &ndash; Cloud Sync Safety Overhaul</strong>: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard</li>

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.06-b1772241168';
+const CACHE_NAME = 'staktrakr-v3.33.06-b1772242364';
 
 
 


### PR DESCRIPTION
## Summary

- Updated What's New / announcements to reflect market list view is now **default-on** (not behind feature flag)
- Added fix entries to CHANGELOG for security, a11y, Chart.js, and mobile fixes from PR #583 review
- Updated embedded What's New in about modal to match
- Added Market Page Phase 2 to development roadmap
- SW cache stamp updated to bust stale service worker

## Test plan

- [ ] Verify announcements.md renders correctly in about modal
- [ ] Verify CHANGELOG entries are accurate
- [ ] Hard refresh clears stale service worker cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)