### PR TITLE
v3.33.07 — Oklahoma Goldback G1 on Market Page (STAK-370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.07] - 2026-02-28
+
+### Added — Oklahoma Goldback G1 on Market Page
+
+- **Added**: Oklahoma Goldback G1 (`goldback-oklahoma-g1`) on market prices page with APMEX and Hero Bullion vendor tracking (STAK-370)
+- **Added**: Goldback vendor display name, brand color, and homepage URL in retail vendor config (STAK-370)
+
+---
+
 ## [3.33.06] - 2026-02-27
 
 ### Added — Market Page Redesign Phase 1

--- a/css/styles.css
+++ b/css/styles.css
@@ -11551,6 +11551,7 @@ th {
 .retail-metal-badge--silver    { background: rgba(139,147,166,0.15); color: var(--bs-secondary-color, #6c757d); }
 .retail-metal-badge--platinum  { background: rgba(6,182,212,0.15);   color: #06b6d4; }
 .retail-metal-badge--palladium { background: rgba(148,163,184,0.15); color: #94a3b8; }
+.retail-metal-badge--goldback  { background: rgba(212,160,23,0.15);  color: #d4a017; }
 /* STAK-217: Trend indicator */
 .retail-trend {
   display: inline-flex;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Oklahoma Goldback G1 (v3.33.07)**: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added
 - **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false
 - **Daily Maintenance (v3.33.05)**: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)
 - **Quick-Fix Batch (v3.33.04)**: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.07 &ndash; Oklahoma Goldback G1</strong>: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added</li>
     <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false</li>
     <li><strong>v3.33.05 &ndash; Daily Maintenance</strong>: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)</li>
     <li><strong>v3.33.04 &ndash; Quick-Fix Batch</strong>: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.06";
+const APP_VERSION = "3.33.07";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -22,7 +22,7 @@ const RETAIL_COIN_META = {
   "maple-gold":              { name: "Gold Maple Leaf",          weight: 1.0,  metal: "gold"     },
   "krugerrand-gold":         { name: "Gold Krugerrand",          weight: 1.0,  metal: "gold"     },
   "ape":                     { name: "American Platinum Eagle",   weight: 1.0, metal: "platinum" },
-  "goldback-oklahoma-g1":    { name: "Oklahoma Goldback (G1)",   weight: 1/50, metal: "goldback" },
+  "goldback-oklahoma-g1":    { name: "Oklahoma Goldback (G1)",   weight: 0.001, metal: "goldback" },
 };
 
 /** Vendor display names */
@@ -604,7 +604,7 @@ const renderRetailCards = () => {
 };
 
 /** Metal emoji icons keyed by metal name */
-const RETAIL_METAL_EMOJI = { gold: "🟡", silver: "⚪", platinum: "🔷", palladium: "⬜" };
+const RETAIL_METAL_EMOJI = { gold: "🟡", silver: "⚪", platinum: "🔷", palladium: "⬜", goldback: "🟡" };
 /**
  * Computes price trend vs. the previous history entry.
  * @param {string} slug

--- a/js/retail.js
+++ b/js/retail.js
@@ -6,6 +6,7 @@ const RETAIL_SLUGS = [
   "ase", "maple-silver", "britannia-silver", "krugerrand-silver",
   "generic-silver-round", "generic-silver-bar-10oz",
   "age", "buffalo", "maple-gold", "krugerrand-gold", "ape",
+  "goldback-oklahoma-g1",
 ];
 
 /** Coin metadata keyed by slug */
@@ -21,6 +22,7 @@ const RETAIL_COIN_META = {
   "maple-gold":              { name: "Gold Maple Leaf",          weight: 1.0,  metal: "gold"     },
   "krugerrand-gold":         { name: "Gold Krugerrand",          weight: 1.0,  metal: "gold"     },
   "ape":                     { name: "American Platinum Eagle",   weight: 1.0, metal: "platinum" },
+  "goldback-oklahoma-g1":    { name: "Oklahoma Goldback (G1)",   weight: 1/50, metal: "goldback" },
 };
 
 /** Vendor display names */
@@ -32,6 +34,7 @@ const RETAIL_VENDOR_NAMES = {
   herobullion:      "Hero",
   bullionexchanges: "BullionX",
   summitmetals:     "Summit",
+  goldback:         "Goldback",
 };
 
 /** Vendor homepage URLs for popup links */
@@ -43,6 +46,7 @@ const RETAIL_VENDOR_URLS = {
   herobullion:      "https://www.herobullion.com",
   bullionexchanges: "https://www.bullionexchanges.com",
   summitmetals:     "https://www.summitmetals.com",
+  goldback:         "https://www.goldback.com",
 };
 
 /** Per-vendor brand colors — shared with retail-view-modal.js for chart lines and card labels */
@@ -54,6 +58,7 @@ const RETAIL_VENDOR_COLORS = {
   herobullion:      "#f87171",  // red — already distinct
   bullionexchanges: "#f472b6",  // bright pink (was #ec4899)
   summitmetals:     "#22d3ee",  // bright cyan (was #06b6d4)
+  goldback:         "#d4a017",  // deep gold — goldback branding
 };
 
 /**

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.07-b1772250429';
+const CACHE_NAME = 'staktrakr-v3.33.07-b1772250873';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.06-b1772242364';
+const CACHE_NAME = 'staktrakr-v3.33.07-b1772250429';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.06",
-  "releaseDate": "2026-02-27",
+  "version": "3.33.07",
+  "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Added**: Oklahoma Goldback G1 (`goldback-oklahoma-g1`) to market prices page — APMEX and Hero Bullion vendor tracking
- **Added**: `goldback` vendor display name, brand color (#d4a017 deep gold), and homepage URL
- **Version**: 3.33.06 → 3.33.07

## Related

- StakTrakrApi PR #17: fix goldback cron + scraper URL (same STAK-370)

## Linear Issues

- STAK-370: Goldback cron missing from entrypoint + add Oklahoma G1 to market page

🤖 Generated with [Claude Code](https://claude.com/claude-code)