### PR TITLE
v3.33.08 — Vendor Medal Ranking Fix (STAK-370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.08] - 2026-02-28
+
+### Fixed — Vendor Medal Ranking
+
+- **Fixed**: Vendor medals now awarded to all in-stock vendors with a price, not just those with confidence >= 60 (STAK-370)
+
+---
+
 ## [3.33.07] - 2026-02-28
 
 ### Added — Oklahoma Goldback G1 on Market Page

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Vendor Medal Fix (v3.33.08)**: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback
 - **Oklahoma Goldback G1 (v3.33.07)**: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added
 - **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false
 - **Daily Maintenance (v3.33.05)**: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)
 - **Quick-Fix Batch (v3.33.04)**: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system
-- **Cloud Sync Safety Overhaul (v3.33.02)**: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.08 &ndash; Vendor Medal Fix</strong>: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback</li>
     <li><strong>v3.33.07 &ndash; Oklahoma Goldback G1</strong>: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added</li>
     <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false</li>
     <li><strong>v3.33.05 &ndash; Daily Maintenance</strong>: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)</li>
     <li><strong>v3.33.04 &ndash; Quick-Fix Batch</strong>: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system</li>
-    <li><strong>v3.33.02 &ndash; Cloud Sync Safety Overhaul</strong>: Empty-vault push guard prevents data loss. Cloud-side backup-before-overwrite. Dropbox folder restructuring with migration. DiffEngine restore preview modal. Configurable backup history depth. Multi-tab sync guard</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.07";
+const APP_VERSION = "3.33.08";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -1096,7 +1096,7 @@ const _buildMarketListCard = (slug, meta, priceData, historyData) => {
         if (bHigh) return 1;
         return 0;
       });
-    const qualVendors = sortedVendors.filter(({ isAvailable, score }) => isAvailable && score != null && score >= 60);
+    const qualVendors = sortedVendors.filter(({ isAvailable, price }) => isAvailable && price != null);
     const top3Keys = qualVendors.slice(0, 3).map(({ key }) => key);
     sortedVendors.forEach(({ key, price, score, isAvailable }) => {
       const chip = document.createElement("span");

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.07-b1772250873';
+const CACHE_NAME = 'staktrakr-v3.33.08-b1772251713';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.07",
+  "version": "3.33.08",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Vendor medals now awarded to all in-stock vendors with a price, not just those with confidence >= 60
- APMEX now correctly shows 2nd place medal on Oklahoma Goldback G1 card (was unranked due to 50% confidence)
- Confidence score still determines sort order (high-confidence vendors rank first), but all in-stock vendors with a price are eligible for medals

## Linear Issues

- STAK-370: Oklahoma Goldback G1 + Goldback Poller Fix
- STAK-371: Market Page Phase 2 (created — backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)