### PR TITLE
v3.33.09 — Spot Price Card Cache Label Fix (STAK-274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.09] - 2026-02-28
+
+### Fixed — Spot Price Card Cache Label (STAK-274)
+
+- **Fixed**: Spot price card shows "Last API Sync" directly when cache is disabled (duration=0) or when cache and API timestamps are identical, instead of misleading "Last Cache Refresh" label
+
+---
+
 ## [3.33.08] - 2026-02-28
 
 ### Fixed — Vendor Medal Ranking

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Spot Card Fix (v3.33.09)**: Spot price card now shows "Last API Sync" when cache is disabled, instead of misleading "Last Cache Refresh" label
 - **Vendor Medal Fix (v3.33.08)**: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback
 - **Oklahoma Goldback G1 (v3.33.07)**: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added
 - **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false
 - **Daily Maintenance (v3.33.05)**: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)
-- **Quick-Fix Batch (v3.33.04)**: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.09 &ndash; Spot Card Fix</strong>: Spot price card now shows &ldquo;Last API Sync&rdquo; when cache is disabled, instead of misleading &ldquo;Last Cache Refresh&rdquo; label</li>
     <li><strong>v3.33.08 &ndash; Vendor Medal Fix</strong>: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback</li>
     <li><strong>v3.33.07 &ndash; Oklahoma Goldback G1</strong>: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added</li>
     <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false</li>
     <li><strong>v3.33.05 &ndash; Daily Maintenance</strong>: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)</li>
-    <li><strong>v3.33.04 &ndash; Quick-Fix Batch</strong>: NGC cert lookup extracts numeric grade only. Fractional troy ounce weights display correctly as oz. Cloud Sync button added to reorderable header system</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.08";
+const APP_VERSION = "3.33.09";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/utils.js
+++ b/js/utils.js
@@ -306,6 +306,26 @@ const updateSpotTimestamp = (metalName) => {
     return;
   }
 
+  // When cache and API show the same data (e.g. cache disabled / duration=0),
+  // or when only API data exists, show "Last API Sync" directly without toggle (STAK-274)
+  if (!cacheHtml || cacheHtml === apiHtml) {
+    el.dataset.mode = "api";
+    // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
+    el.innerHTML = apiHtml || cacheHtml;
+    el.onclick = null;
+    return;
+  }
+
+  // When only cache data exists (no API sync yet), show cache without toggle
+  if (!apiHtml) {
+    el.dataset.mode = "cache";
+    // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
+    el.innerHTML = cacheHtml;
+    el.onclick = null;
+    return;
+  }
+
+  // Both cache and API have different data — show cache first with click-to-toggle
   el.dataset.mode = "cache";
   el.dataset.cache = cacheHtml;
   el.dataset.api = apiHtml;

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.08-b1772251713';
+const CACHE_NAME = 'staktrakr-v3.33.09-b1772254612';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.08",
+  "version": "3.33.09",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Spot price card shows "Last API Sync" directly when cache is disabled (duration=0) or when cache and API timestamps are identical, instead of misleading "Last Cache Refresh" label (STAK-274)
- When only one timestamp source exists, the click-to-toggle behavior is removed (no confusing toggle between identical values)

## Linear Issues

- [STAK-274: Spot Price Card Bug](https://linear.app/lbruton/issue/STAK-274)

🤖 Generated with [Claude Code](https://claude.com/claude-code)