### PR TITLE
v3.33.10 — Mobile Long-Press Spot Price Entry (STAK-285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.10] - 2026-02-28
+
+### Added — Mobile Long-Press Spot Price Entry (STAK-285)
+
+- **Added**: Long-press (600ms) on spot price card opens inline manual input on mobile/touch devices, mirroring desktop Shift+click behavior (STAK-285)
+- **Changed**: Hint text updated from "Shift+click" to "Shift+click or long-press" for discoverability
+
+---
+
 ## [3.33.11] - 2026-02-28
 
 ### Fixed — Spot Price Card Label Root Cause (STAK-274)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Mobile Spot Entry (v3.33.10)**: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability
 - **Spot Card Label Fix (v3.33.11)**: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing "Last API Sync" when cache is disabled
 - **Spot Card Fix (v3.33.09)**: Spot price card now shows "Last API Sync" when cache is disabled, instead of misleading "Last Cache Refresh" label
 - **Vendor Medal Fix (v3.33.08)**: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.10 &ndash; Mobile Spot Entry</strong>: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability</li>
     <li><strong>v3.33.11 &ndash; Spot Card Label Fix</strong>: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing &ldquo;Last API Sync&rdquo; when cache is disabled</li>
     <li><strong>v3.33.09 &ndash; Spot Card Fix</strong>: Spot price card now shows &ldquo;Last API Sync&rdquo; when cache is disabled, instead of misleading &ldquo;Last Cache Refresh&rdquo; label</li>
     <li><strong>v3.33.08 &ndash; Vendor Medal Fix</strong>: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.11";
+const APP_VERSION = "3.33.10";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -2130,6 +2130,45 @@ const setupSpotPriceListeners = () => {
     true,
   );
 
+  // Long-press handler for mobile inline spot price editing (STAK-285)
+  // Mirrors shift+click behavior: hold 600ms on spot price to open manual input
+  let _spotLongPressTimer = null;
+  let _spotLongPressFired = false;
+
+  document.addEventListener("touchstart", (e) => {
+    const valueEl = e.target.closest(".spot-card-value");
+    if (!valueEl) return;
+    _spotLongPressFired = false;
+    _spotLongPressTimer = setTimeout(() => {
+      _spotLongPressFired = true;
+      const card = valueEl.closest(".spot-card");
+      if (!card || !card.dataset.metal) return;
+      e.preventDefault();
+      if (typeof startSpotInlineEdit === "function") {
+        startSpotInlineEdit(valueEl, card.dataset.metal);
+      }
+    }, 600);
+  }, { passive: false });
+
+  document.addEventListener("touchend", (e) => {
+    if (_spotLongPressTimer) {
+      clearTimeout(_spotLongPressTimer);
+      _spotLongPressTimer = null;
+    }
+    // Suppress the click/tap that follows a successful long-press
+    if (_spotLongPressFired) {
+      e.preventDefault();
+      _spotLongPressFired = false;
+    }
+  }, { passive: false });
+
+  document.addEventListener("touchmove", () => {
+    if (_spotLongPressTimer) {
+      clearTimeout(_spotLongPressTimer);
+      _spotLongPressTimer = null;
+    }
+  }, { passive: true });
+
 };
 
 /**

--- a/js/events.js
+++ b/js/events.js
@@ -2138,17 +2138,26 @@ const setupSpotPriceListeners = () => {
   document.addEventListener("touchstart", (e) => {
     const valueEl = e.target.closest(".spot-card-value");
     if (!valueEl) return;
+    // Clear any existing timer to prevent orphaned timeouts on rapid re-touch
+    if (_spotLongPressTimer) { clearTimeout(_spotLongPressTimer); _spotLongPressTimer = null; }
     _spotLongPressFired = false;
     _spotLongPressTimer = setTimeout(() => {
       _spotLongPressFired = true;
+      _spotLongPressTimer = null;
       const card = valueEl.closest(".spot-card");
       if (!card || !card.dataset.metal) return;
-      e.preventDefault();
       if (typeof startSpotInlineEdit === "function") {
         startSpotInlineEdit(valueEl, card.dataset.metal);
       }
     }, 600);
   }, { passive: false });
+
+  // Suppress context menu during long-press (preventDefault inside setTimeout is stale)
+  document.addEventListener("contextmenu", (e) => {
+    if (_spotLongPressFired || _spotLongPressTimer) {
+      e.preventDefault();
+    }
+  });
 
   document.addEventListener("touchend", (e) => {
     if (_spotLongPressTimer) {
@@ -2163,6 +2172,14 @@ const setupSpotPriceListeners = () => {
   }, { passive: false });
 
   document.addEventListener("touchmove", () => {
+    if (_spotLongPressTimer) {
+      clearTimeout(_spotLongPressTimer);
+      _spotLongPressTimer = null;
+    }
+  }, { passive: true });
+
+  // Cancel long-press when browser cancels the gesture (e.g., incoming call, scroll takeover)
+  document.addEventListener("touchcancel", () => {
     if (_spotLongPressTimer) {
       clearTimeout(_spotLongPressTimer);
       _spotLongPressTimer = null;

--- a/js/utils.js
+++ b/js/utils.js
@@ -268,7 +268,7 @@ const getLastUpdateTime = (metalName, mode = "cache") => {
 
   if (latestEntry.source === "seed") {
     const dateText = latestEntry.timestamp.slice(0, 10);
-    return `Seed \u00b7 ${dateText}<br>Shift+click price to set`;
+    return `Seed \u00b7 ${dateText}<br>Shift+click or long-press to set`;
   }
 
   if (latestEntry.source === "default") return "";
@@ -301,7 +301,7 @@ const updateSpotTimestamp = (metalName) => {
 
   // If no price data at all, show shift+click hint for discoverability
   if (!cacheHtml && !apiHtml) {
-    el.innerHTML = "Shift+click price to set";
+    el.innerHTML = "Shift+click or long-press to set";
     el.onclick = null;
     return;
   }

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.10-b1772254800';
+const CACHE_NAME = 'staktrakr-v3.33.10-b1772256201';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.11-b1772255967';
+const CACHE_NAME = 'staktrakr-v3.33.10-b1772254800';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.11",
+  "version": "3.33.10",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Added**: Long-press (600ms) on spot price card opens inline manual input on mobile/touch devices, mirroring desktop Shift+click behavior (STAK-285)
- **Changed**: Hint text updated from "Shift+click" to "Shift+click or long-press" for discoverability
- Touch move cancels the long-press to avoid conflicts with scrolling
- Follow-up click/tap suppressed after successful long-press to prevent double-action

## Linear Issues

- [STAK-285: Users on mobile have no way to set spot price](https://linear.app/lbruton/issue/STAK-285)

🤖 Generated with [Claude Code](https://claude.com/claude-code)