### PR TITLE
v3.33.11 — Spot Price Card Label Root Cause Fix (STAK-274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.11] - 2026-02-28
+
+### Fixed — Spot Price Card Label Root Cause (STAK-274)
+
+- **Fixed**: Spot timestamp label now compares raw storage data (provider+timestamp) instead of rendered HTML to detect when cache and API are identical, correctly showing "Last API Sync" when cache is disabled
+
+---
+
 ## [3.33.09] - 2026-02-28
 
 ### Fixed — Spot Price Card Cache Label (STAK-274)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Spot Card Label Fix (v3.33.11)**: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing "Last API Sync" when cache is disabled
 - **Spot Card Fix (v3.33.09)**: Spot price card now shows "Last API Sync" when cache is disabled, instead of misleading "Last Cache Refresh" label
 - **Vendor Medal Fix (v3.33.08)**: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback
 - **Oklahoma Goldback G1 (v3.33.07)**: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.11 &ndash; Spot Card Label Fix</strong>: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing &ldquo;Last API Sync&rdquo; when cache is disabled</li>
     <li><strong>v3.33.09 &ndash; Spot Card Fix</strong>: Spot price card now shows &ldquo;Last API Sync&rdquo; when cache is disabled, instead of misleading &ldquo;Last Cache Refresh&rdquo; label</li>
     <li><strong>v3.33.08 &ndash; Vendor Medal Fix</strong>: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback</li>
     <li><strong>v3.33.07 &ndash; Oklahoma Goldback G1</strong>: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.09";
+const APP_VERSION = "3.33.11";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/utils.js
+++ b/js/utils.js
@@ -306,9 +306,18 @@ const updateSpotTimestamp = (metalName) => {
     return;
   }
 
-  // When cache and API show the same data (e.g. cache disabled / duration=0),
+  // Compare raw storage data — when both keys hold the same provider+timestamp
+  // (e.g. cache disabled / duration=0), the rendered HTML differs only by label text.
+  // Compare the underlying data to detect this case correctly (STAK-274).
+  const cacheData = loadDataSync(LAST_CACHE_REFRESH_KEY, null);
+  const apiData = loadDataSync(LAST_API_SYNC_KEY, null);
+  const sameUnderlying = cacheData && apiData &&
+    cacheData.provider === apiData.provider &&
+    cacheData.timestamp === apiData.timestamp;
+
+  // When cache and API have the same underlying data (e.g. cache disabled / duration=0),
   // or when only API data exists, show "Last API Sync" directly without toggle (STAK-274)
-  if (!cacheHtml || cacheHtml === apiHtml) {
+  if (!cacheHtml || sameUnderlying) {
     el.dataset.mode = "api";
     // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml, javascript.browser.security.insecure-document-method.insecure-document-method
     el.innerHTML = apiHtml || cacheHtml;

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.09-b1772254612';
+const CACHE_NAME = 'staktrakr-v3.33.11-b1772255967';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.09",
+  "version": "3.33.11",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Root cause fix**: `updateSpotTimestamp()` now compares raw storage data (provider+timestamp) from `LAST_CACHE_REFRESH_KEY` and `LAST_API_SYNC_KEY` instead of comparing rendered HTML strings
- The v3.33.09 fix compared `cacheHtml === apiHtml`, but these strings always differ because `getLastUpdateTime()` wraps them in different label text ("Last Cache Refresh" vs "Last API Sync"), even when the underlying provider+timestamp data is identical
- With this fix, when both storage keys hold the same provider and timestamp (as happens when cache is disabled / duration=0), the card correctly shows "Last API Sync" without toggle

## Linear Issues

- STAK-274: Spot Price Card Bug — deeper root cause fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)