### PR TITLE
v3.33.12 — Version Drift Correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.12] - 2026-02-28
+
+### Fixed — Version Drift Correction
+
+- **Fixed**: Version number corrected to v3.33.12 — PR #591 (v3.33.11) merged before PR #590 (v3.33.10), reverting the version number
+
+---
+
 ## [3.33.10] - 2026-02-28
 
 ### Added — Mobile Long-Press Spot Price Entry (STAK-285)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,12 +1,10 @@
 ## What's New
 
+- **Version Drift Fix (v3.33.12)**: Version number corrected after concurrent PR merge reordering
 - **Mobile Spot Entry (v3.33.10)**: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability
 - **Spot Card Label Fix (v3.33.11)**: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing "Last API Sync" when cache is disabled
-- **Spot Card Fix (v3.33.09)**: Spot price card now shows "Last API Sync" when cache is disabled, instead of misleading "Last Cache Refresh" label
-- **Vendor Medal Fix (v3.33.08)**: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback
+- **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge
 - **Oklahoma Goldback G1 (v3.33.07)**: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added
-- **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false
-- **Daily Maintenance (v3.33.05)**: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,13 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.12 &ndash; Version Drift Fix</strong>: Version number corrected after concurrent PR merge reordering</li>
     <li><strong>v3.33.10 &ndash; Mobile Spot Entry</strong>: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability</li>
     <li><strong>v3.33.11 &ndash; Spot Card Label Fix</strong>: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing &ldquo;Last API Sync&rdquo; when cache is disabled</li>
-    <li><strong>v3.33.09 &ndash; Spot Card Fix</strong>: Spot price card now shows &ldquo;Last API Sync&rdquo; when cache is disabled, instead of misleading &ldquo;Last Cache Refresh&rdquo; label</li>
-    <li><strong>v3.33.08 &ndash; Vendor Medal Fix</strong>: Vendor medals now awarded to all in-stock vendors, not just high-confidence ones. APMEX correctly shows 2nd place on Oklahoma Goldback</li>
+    <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge</li>
     <li><strong>v3.33.07 &ndash; Oklahoma Goldback G1</strong>: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added</li>
-    <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge. Disable with ?market_list_view=false</li>
-    <li><strong>v3.33.05 &ndash; Daily Maintenance</strong>: Search cache optimized with formatted date caching. Dead code removed (downloadStorageReport, duplicate MAX_LOCAL_FILE_SIZE export)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.10";
+const APP_VERSION = "3.33.12";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.10-b1772256201';
+const CACHE_NAME = 'staktrakr-v3.33.12-b1772257815';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.10",
+  "version": "3.33.12",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Version number corrected to v3.33.12 — PR #591 (v3.33.11) merged before PR #590 (v3.33.10), reverting the version number

## Notes

Version-only bump. No functional code changes — all v3.33.11 code is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)