### PR TITLE
fix: spot timestamp race condition (STAK-274)

### DIFF
--- a/js/spot.js
+++ b/js/spot.js
@@ -85,22 +85,22 @@ const purgeSpotHistory = (days = 180) => {
  * @param {string|null} provider - Provider name if available
  * @param {string} timestamp - ISO timestamp of the event
  */
-const updateLastTimestamps = async (source, provider, timestamp) => {
+const updateLastTimestamps = (source, provider, timestamp) => {
   const apiEntry = {
     provider: provider || "API",
     timestamp,
   };
 
   if (source === "api") {
-    await saveData(LAST_API_SYNC_KEY, apiEntry);
-    await saveData(LAST_CACHE_REFRESH_KEY, apiEntry);
+    saveDataSync(LAST_API_SYNC_KEY, apiEntry);
+    saveDataSync(LAST_CACHE_REFRESH_KEY, apiEntry);
     if (typeof window.updateSpotSyncHealthDot === 'function') window.updateSpotSyncHealthDot();
   } else if (source === "cached") {
     const cacheEntry = {
       provider: provider ? `${provider} (cached)` : "Cached",
       timestamp,
     };
-    await saveData(LAST_CACHE_REFRESH_KEY, cacheEntry);
+    saveDataSync(LAST_CACHE_REFRESH_KEY, cacheEntry);
   }
 };
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.12-b1772257815';
+const CACHE_NAME = 'staktrakr-v3.33.10-b1772259445';
 
 
 


### PR DESCRIPTION
## Summary
- `updateLastTimestamps` used async `saveData` with two sequential awaits
- `recordSpot` called it without `await`, so `updateSpotTimestamp` ran between the two writes
- Result: "Last Cache Refresh" toggle appeared even when cache is disabled (duration=0)
- Fix: switched to `saveDataSync` — localStorage is synchronous anyway

## Test plan
- [ ] Set cache duration to 0 in settings
- [ ] Cmd+Shift+R to hard reload — verify "Last API Sync" label
- [ ] Click spot sync button — verify label stays "Last API Sync", no toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)