### PR TITLE
v3.33.13 — Market Page Phase 2: Manifest-Driven Coins & Goldback Vendor (STAK-371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.13] - 2026-02-28
+
+### Added — Market Page Phase 2: Manifest-Driven Coins & Goldback Vendor (STAK-371)
+
+- **Added**: Manifest-driven coin discovery — API can add new coins without frontend code changes (STAK-371)
+- **Added**: 3-tier metadata resolution chain: manifest → hardcoded → goldback slug parser → default
+- **Added**: Goldback vendor chip on market cards showing goldback.com reference price with staleness indicator
+- **Added**: `GOLDBACK_WEIGHTS` table and `_parseGoldbackSlug()` for auto-deriving metadata from any goldback slug
+- **Added**: `getActiveRetailSlugs()`, `getRetailCoinMeta()`, `getVendorDisplay()` resolver functions
+- **Changed**: All rendering functions use resolver layer instead of direct constant lookups
+
+---
+
 ## [3.33.12] - 2026-02-28
 
 ### Fixed — Version Drift Correction

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,16 +1,15 @@
 ## What's New
 
+- **Market Page Phase 2 (v3.33.13)**: Manifest-driven coin discovery, 3-tier metadata resolution, Goldback vendor chip with goldback.com reference price and staleness indicator. All rendering uses resolver layer for dynamic coins
 - **Version Drift Fix (v3.33.12)**: Version number corrected after concurrent PR merge reordering
 - **Mobile Spot Entry (v3.33.10)**: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability
-- **Spot Card Label Fix (v3.33.11)**: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing "Last API Sync" when cache is disabled
 - **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge
-- **Oklahoma Goldback G1 (v3.33.07)**: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added
 
 ## Development Roadmap
 
 ### Next Up
 
-- **Market Page Phase 2**: Goldback item integration, inventory-to-market linking with auto-update retail prices
+- **Market Page Phase 3**: Inventory-to-market linking with auto-update retail prices
 - **Cloud Backup Conflict Detection (STAK-150)**: Smarter conflict resolution using item count direction, not just timestamps
 - **Accessible Table Mode (STAK-144)**: Style D with horizontal scroll, long-press to edit, 300% zoom support
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.13 &ndash; Market Page Phase 2</strong>: Manifest-driven coin discovery, 3-tier metadata resolution, Goldback vendor chip with goldback.com reference price and staleness indicator. All rendering uses resolver layer for dynamic coins</li>
     <li><strong>v3.33.12 &ndash; Version Drift Fix</strong>: Version number corrected after concurrent PR merge reordering</li>
     <li><strong>v3.33.10 &ndash; Mobile Spot Entry</strong>: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability</li>
-    <li><strong>v3.33.11 &ndash; Spot Card Label Fix</strong>: Spot timestamp compares raw storage data instead of rendered HTML, correctly showing &ldquo;Last API Sync&rdquo; when cache is disabled</li>
     <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge</li>
-    <li><strong>v3.33.07 &ndash; Oklahoma Goldback G1</strong>: Oklahoma Goldback G1 added to market prices page with APMEX and Hero Bullion vendor tracking. Goldback vendor branding added</li>
   `;
 };
 
@@ -297,9 +296,9 @@ const getEmbeddedWhatsNew = () => {
  */
 const getEmbeddedRoadmap = () => {
   return `
+    <li><strong>Market Page Phase 3</strong>: Inventory-to-market linking with auto-update retail prices</li>
     <li><strong>Cloud Backup Conflict Detection (STAK-150)</strong>: Smarter conflict resolution using item count direction, not just timestamps</li>
     <li><strong>Accessible Table Mode (STAK-144)</strong>: Style D with horizontal scroll, long-press to edit, 300% zoom support</li>
-    <li><strong>Custom Theme Editor (STAK-121)</strong>: User-defined color themes with CSS variable overrides</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.12";
+const APP_VERSION = "3.33.13";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/goldback.js
+++ b/js/goldback.js
@@ -284,6 +284,24 @@ const fetchGoldbackApiPrices = async () => {
   return { ok: true, g1_usd: g1 };
 };
 
+/**
+ * Returns the Goldback vendor reference price for a goldback slug.
+ * @param {string} slug - e.g. "goldback-oklahoma-g1"
+ * @returns {{ price: number, updatedAt: number, isStale: boolean, source: string } | null}
+ */
+const getGoldbackVendorPrice = (slug) => {
+  if (!slug || !slug.startsWith("goldback-")) return null;
+  const denomMatch = slug.match(/g([\d.]+)$/);
+  if (!denomMatch) return null;
+  const denomKey = denomMatch[1]; // "1", "5", "25", etc.
+  if (!goldbackPrices || !goldbackPrices[denomKey]) return null;
+  const entry = goldbackPrices[denomKey];
+  if (entry.price == null) return null;
+  const STALE_MS = 25 * 60 * 60 * 1000; // 25 hours
+  const isStale = !entry.updatedAt || (Date.now() - entry.updatedAt) > STALE_MS;
+  return { price: entry.price, updatedAt: entry.updatedAt, isStale, source: "goldback.com" };
+};
+
 // =============================================================================
 // GOLDBACK PRICE HISTORY MODAL
 // =============================================================================
@@ -477,6 +495,7 @@ if (typeof window !== 'undefined') {
   window.getGoldbackDenominationPrice = getGoldbackDenominationPrice;
   window.isGoldbackPricingActive = isGoldbackPricingActive;
   window.fetchGoldbackApiPrices = fetchGoldbackApiPrices;
+  window.getGoldbackVendorPrice = getGoldbackVendorPrice;
   window.showGoldbackHistoryModal = showGoldbackHistoryModal;
   window.hideGoldbackHistoryModal = hideGoldbackHistoryModal;
   window.exportGoldbackHistory = exportGoldbackHistory;

--- a/js/retail.js
+++ b/js/retail.js
@@ -92,8 +92,12 @@ let _manifestVendorMeta = null;
 /** Returns active slugs: manifest-driven (filtered to those with data) or hardcoded fallback */
 const getActiveRetailSlugs = () => {
   if (!_manifestSlugs) return RETAIL_SLUGS;
+  if (!retailPrices?.prices) return _manifestSlugs;
   return _manifestSlugs.filter((slug) => {
-    const vendors = retailPrices?.prices?.[slug]?.vendors;
+    const entry = retailPrices.prices[slug];
+    if (!entry) return false;
+    if (entry.median_price != null || entry.lowest_price != null) return true;
+    const vendors = entry.vendors;
     return vendors && Object.keys(vendors).length > 0;
   });
 };

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.13-b1772261236';
+const CACHE_NAME = 'staktrakr-v3.33.13-b1772261961';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.10-b1772259445';
+const CACHE_NAME = 'staktrakr-v3.33.13-b1772261236';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.12",
+  "version": "3.33.13",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- Manifest-driven coin discovery — API can add new coins without frontend code changes
- 3-tier metadata resolution: manifest → hardcoded → goldback slug parser → default
- Goldback vendor chip on market cards showing goldback.com reference price with staleness indicator
- `getActiveRetailSlugs()`, `getRetailCoinMeta()`, `getVendorDisplay()` resolver functions
- All rendering functions wired through resolver layer instead of direct constant lookups
- `getGoldbackVendorPrice()` in goldback.js with 25h staleness threshold

## Linear Issues

- [STAK-371: Market Page Phase 2](https://linear.app/lbruton/issue/STAK-371)

## Spec

- `.spec-workflow/specs/market-page-phase-2/` — all 6 tasks completed with implementation logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)