### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce cryptographic integrity in UUID generation

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -29,8 +29,9 @@ const debugLog = (...args) => {
 
 /**
  * Generates a UUID v4 string for stable item identification.
- * Uses crypto.randomUUID() where available, with a Math.random() RFC 4122 v4 fallback
+ * Uses crypto.randomUUID() where available, with a crypto.getRandomValues() RFC 4122 v4 fallback
  * for environments (e.g. file:// protocol) that lack crypto.randomUUID.
+ * Insecure Math.random() fallback has been removed for cryptographic integrity.
  *
  * @returns {string} A UUID v4 string (e.g. "550e8400-e29b-41d4-a716-446655440000")
  */
@@ -46,12 +47,7 @@ const generateUUID = () => {
       return v.toString(16);
     });
   }
-  // RFC 4122 v4 fallback (insecure Math.random)
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  throw new Error("Secure random number generation is not available in this environment.");
 };
 
 /**


### PR DESCRIPTION
This PR addresses a medium-severity security issue identified in `.jules/sentinel.md` regarding weak UUID generation.

The `generateUUID()` function in `js/utils.js` previously included a fallback path that utilized `Math.random()` if cryptographically secure alternatives (`crypto.randomUUID()` or `crypto.getRandomValues()`) were unavailable. `Math.random()` does not provide sufficient entropy and is predictable, compromising the integrity of generated identifiers.

**Changes:**
* Removed the insecure `Math.random()` fallback inside `generateUUID`.
* The function now explicitly throws an error if a secure random number generator is unavailable, ensuring the application fails securely rather than silently operating with weak cryptography.
* Updated the JSDoc comment to reflect the removal of the fallback and the updated security posture.

---
*PR created automatically by Jules for task [10574409722217035402](https://jules.google.com/task/10574409722217035402) started by @lbruton*