### PR TITLE
v3.33.14 — fix: Goldback G½ slug resolution (STAK-373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.14] - 2026-02-28
+
+### Fixed — Goldback G½ Slug Resolution (STAK-373)
+
+- **Fixed**: Goldback G½ slugs (`ghalf`) now resolved correctly on market page — regex and weight map accept both `ghalf` and `g0.5` formats (STAK-373)
+
+---
+
 ## [3.33.13] - 2026-02-28
 
 ### Added — Market Page Phase 2: Manifest-Driven Coins & Goldback Vendor (STAK-371)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Goldback G½ Fix (v3.33.14)**: Goldback G½ denominations now display correctly on market page — slug parser accepts both `ghalf` and `g0.5` formats
 - **Market Page Phase 2 (v3.33.13)**: Manifest-driven coin discovery, 3-tier metadata resolution, Goldback vendor chip with goldback.com reference price and staleness indicator. All rendering uses resolver layer for dynamic coins
 - **Version Drift Fix (v3.33.12)**: Version number corrected after concurrent PR merge reordering
 - **Mobile Spot Entry (v3.33.10)**: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability
-- **Market Page Redesign Phase 1 (v3.33.06)**: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,10 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.14 &ndash; Goldback G&frac12; Fix</strong>: Goldback G&frac12; denominations now display correctly on market page &mdash; slug parser accepts both ghalf and g0.5 formats</li>
     <li><strong>v3.33.13 &ndash; Market Page Phase 2</strong>: Manifest-driven coin discovery, 3-tier metadata resolution, Goldback vendor chip with goldback.com reference price and staleness indicator. All rendering uses resolver layer for dynamic coins</li>
     <li><strong>v3.33.12 &ndash; Version Drift Fix</strong>: Version number corrected after concurrent PR merge reordering</li>
     <li><strong>v3.33.10 &ndash; Mobile Spot Entry</strong>: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability</li>
-    <li><strong>v3.33.06 &ndash; Market Page Redesign Phase 1</strong>: New default market view with full-width list cards, inline 7-day trend charts with spike detection, vendor price chips with brand colors and medal rankings, computed MED/LOW/AVG stats, search and sort, click-to-expand charts, sponsor badge</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.13";
+const APP_VERSION = "3.33.14";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -27,7 +27,7 @@ const RETAIL_COIN_META = {
 
 /** Goldback denomination weights (troy oz) */
 const GOLDBACK_WEIGHTS = {
-  "g0.5": 0.0005, g1: 0.001, g2: 0.002, g5: 0.005,
+  "g0.5": 0.0005, ghalf: 0.0005, g1: 0.001, g2: 0.002, g5: 0.005,
   g10: 0.01, g25: 0.025, g50: 0.05,
 };
 
@@ -37,12 +37,12 @@ const GOLDBACK_WEIGHTS = {
  * @returns {{ name: string, weight: number, metal: string } | null}
  */
 const _parseGoldbackSlug = (slug) => {
-  const m = slug.match(/^goldback-(.+)-(g[\d.]+)$/);
+  const m = slug.match(/^goldback-(.+)-(g(?:[\d.]+|half))$/);
   if (!m) return null;
   const weight = GOLDBACK_WEIGHTS[m[2]];
   if (weight == null) return null;
   const state = m[1].replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-  const denom = m[2].toUpperCase();
+  const denom = m[2] === "ghalf" ? "G\u00BD" : m[2].toUpperCase();
   return { name: `${state} Goldback (${denom})`, weight, metal: "goldback" };
 };
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.13-b1772261961';
+const CACHE_NAME = 'staktrakr-v3.33.14-b1772298724';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.13",
+  "version": "3.33.14",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Goldback G½ slugs (`ghalf`) now resolved correctly on market page
- Added `ghalf: 0.0005` to `GOLDBACK_WEIGHTS` map
- Updated `_parseGoldbackSlug()` regex to accept both `ghalf` and `g0.5` formats
- `ghalf` denomination displays as "G½" (Unicode ½) instead of "GHALF"

## Root Cause

Backend (Turso `provider_vendors`) uses `goldback-{state}-ghalf` slugs, but the frontend regex `/g[\d.]+/` only matched decimal notation like `g0.5`. The `ghalf` suffix never matched, causing UNKNOWN metal and 0 troy oz weight on all G½ market cards.

## Linear Issues

- [STAK-373: bug: Market page — G½ goldback slugs not resolved (ghalf vs g0.5 mismatch)](https://linear.app/lbruton/issue/STAK-373)

🤖 Generated with [Claude Code](https://claude.com/claude-code)