### PR TITLE
v3.33.15 — Beta domain toast (STAK-376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.15] - 2026-02-28
+
+### Added — Beta Domain Toast (STAK-376)
+
+- **Added**: Environment badge (BETA / PREVIEW / LOCAL) next to app logo on non-production domains
+- **Added**: One-time session toast explaining data isolation between origins (e.g. beta vs production)
+- **Added**: Domain detection for `beta.staktrakr.com`, `*.pages.dev`, `localhost`, and `file://` protocol
+
+---
+
 ## [3.33.14] - 2026-02-28
 
 ### Fixed — Goldback G½ Slug Resolution (STAK-373)

--- a/css/styles.css
+++ b/css/styles.css
@@ -538,6 +538,33 @@ section {
   border-color: var(--text-muted);
 }
 
+/* Environment badge (BETA / PREVIEW / LOCAL) — STAK-376 */
+.env-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  vertical-align: middle;
+  margin-left: 0.4rem;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+.env-badge--beta {
+  background: var(--warning, #f0ad4e);
+  color: #1a1a1a;
+}
+.env-badge--preview {
+  background: var(--info, #5bc0de);
+  color: #1a1a1a;
+}
+.env-badge--local {
+  background: var(--text-muted, #999);
+  color: #fff;
+}
+
 .storage-line a {
   margin-left: var(--spacing-sm);
 }

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Beta Domain Toast (v3.33.15)**: Environment badge (BETA/PREVIEW/LOCAL) next to logo on non-production domains. One-time session toast explains data isolation between origins
 - **Goldback G½ Fix (v3.33.14)**: Goldback G½ denominations now display correctly on market page — slug parser accepts both `ghalf` and `g0.5` formats
 - **Market Page Phase 2 (v3.33.13)**: Manifest-driven coin discovery, 3-tier metadata resolution, Goldback vendor chip with goldback.com reference price and staleness indicator. All rendering uses resolver layer for dynamic coins
 - **Version Drift Fix (v3.33.12)**: Version number corrected after concurrent PR merge reordering
-- **Mobile Spot Entry (v3.33.10)**: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -373,6 +373,7 @@
             </g>
           </svg>
         </h1>
+        <span class="env-badge" id="envBadge" style="display:none"></span>
       </div>
       <div class="app-header-actions" id="headerBtnContainer">
         <!-- Spot sync button (STAK-314) — order: 1 -->

--- a/js/about.js
+++ b/js/about.js
@@ -283,10 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.15 &ndash; Beta Domain Toast</strong>: Environment badge (BETA/PREVIEW/LOCAL) next to logo on non-production domains. One-time session toast explains data isolation between origins</li>
     <li><strong>v3.33.14 &ndash; Goldback G&frac12; Fix</strong>: Goldback G&frac12; denominations now display correctly on market page &mdash; slug parser accepts both ghalf and g0.5 formats</li>
     <li><strong>v3.33.13 &ndash; Market Page Phase 2</strong>: Manifest-driven coin discovery, 3-tier metadata resolution, Goldback vendor chip with goldback.com reference price and staleness indicator. All rendering uses resolver layer for dynamic coins</li>
     <li><strong>v3.33.12 &ndash; Version Drift Fix</strong>: Version number corrected after concurrent PR merge reordering</li>
-    <li><strong>v3.33.10 &ndash; Mobile Spot Entry</strong>: Long-press on spot price card opens manual input on mobile devices, mirroring desktop Shift+click. Hint text updated for discoverability</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.14";
+const APP_VERSION = "3.33.15";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -466,6 +466,25 @@ const BRANDING_DOMAIN_OVERRIDE =
         return BRANDING_DOMAIN_OPTIONS.domainMap[host] || null;
       })()
     : null;
+
+/** @constant {Object} ENV_LABELS - Environment badge configuration for non-production domains (STAK-376) */
+const ENV_LABELS = {
+  beta: { label: 'BETA', className: 'env-badge--beta' },
+  preview: { label: 'PREVIEW', className: 'env-badge--preview' },
+  local: { label: 'LOCAL', className: 'env-badge--local' },
+};
+
+/** Detect non-production environment from hostname/protocol (STAK-376) */
+function getEnvironmentLabel() {
+  if (typeof window === 'undefined' || !window.location) return null;
+  const host = window.location.hostname.toLowerCase();
+  const proto = window.location.protocol;
+  if (host === 'beta.staktrakr.com') return ENV_LABELS.beta;
+  if (host.endsWith('.pages.dev')) return ENV_LABELS.preview;
+  if (host === 'localhost' || host === '127.0.0.1') return ENV_LABELS.local;
+  if (proto === 'file:') return ENV_LABELS.local;
+  return null;
+}
 
 /** @constant {string} LS_KEY - LocalStorage key for inventory data */
 const LS_KEY = "metalInventory";

--- a/js/init.js
+++ b/js/init.js
@@ -71,6 +71,28 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (aboutSiteLink) aboutSiteLink.href = `https://www.${siteDomain}`;
     if (aboutSiteDomain) aboutSiteDomain.textContent = siteDomain;
 
+    // Phase 0b: Environment badge + toast for non-production origins (STAK-376)
+    const envLabel = typeof getEnvironmentLabel === 'function' ? getEnvironmentLabel() : null;
+    if (envLabel) {
+      const envBadge = document.getElementById('envBadge');
+      if (envBadge) {
+        envBadge.textContent = envLabel.label;
+        envBadge.className = 'env-badge ' + envLabel.className;
+        envBadge.style.display = '';
+      }
+      // One-time toast per session explaining data isolation
+      const toastKey = 'envToastShown';
+      if (!sessionStorage.getItem(toastKey)) {
+        sessionStorage.setItem(toastKey, '1');
+        const msg = envLabel.label === 'BETA'
+          ? 'You are on the BETA site. Your data here is separate from the main site.'
+          : envLabel.label === 'PREVIEW'
+            ? 'Preview deployment — data is separate from the main site.'
+            : 'Running locally — data is stored on this device only.';
+        setTimeout(() => { if (typeof showToast === 'function') showToast(msg, 5000); }, 1500);
+      }
+    }
+
     // Phase 1: Initialize Core DOM Elements
     debugLog("Phase 1: Initializing core DOM elements...");
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.14-b1772298724';
+const CACHE_NAME = 'staktrakr-v3.33.15-b1772303834';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.14",
+  "version": "3.33.15",
   "releaseDate": "2026-02-28",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- Environment badge (BETA / PREVIEW / LOCAL) next to app logo on non-production domains
- One-time session toast explaining data isolation between origins (beta vs production localStorage)
- Domain detection: `beta.staktrakr.com` → amber BETA, `*.pages.dev` → blue PREVIEW, `localhost`/`file://` → gray LOCAL
- Production (`www.staktrakr.com`) shows no badge or toast

## Files Modified

| File | Change |
|---|---|
| `js/constants.js` | `ENV_LABELS` map + `getEnvironmentLabel()` |
| `index.html` | `#envBadge` span after logo |
| `js/init.js` | Phase 0b: detect env, show badge, fire toast |
| `css/styles.css` | `.env-badge` + variant classes |
| + 5 version bump files | v3.33.14 → v3.33.15 |

## Linear Issues

- STAK-376: Beta domain toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)