### PR TITLE
Sentinel: [HIGH] Fix DOM XSS vulnerability in inventory popover

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -4093,7 +4093,7 @@ function _openThumbPopover(cell, item) {
 
   pop.innerHTML = `
     <div class="bulk-img-popover-header">
-      <span class="bulk-img-popover-title">${item.name ? item.name.slice(0, 28) + (item.name.length > 28 ? '…' : '') : 'Photos'}</span>
+      <span class="bulk-img-popover-title">${item.name ? sanitizeHtml(item.name.slice(0, 28) + (item.name.length > 28 ? '…' : '')) : 'Photos'}</span>
       <button class="bulk-img-popover-close" type="button" aria-label="Close">×</button>
     </div>
     <div class="bulk-img-popover-sides">

--- a/patch.cjs
+++ b/patch.cjs
@@ -1,0 +1,7 @@
+const fs = require('fs');
+let code = fs.readFileSync('js/inventory.js', 'utf8');
+code = code.replace(
+  '<span class="bulk-img-popover-title">${item.name ? item.name.slice(0, 28) + (item.name.length > 28 ? \'…\' : \'\') : \'Photos\'}</span>',
+  '<span class="bulk-img-popover-title">${item.name ? sanitizeHtml(item.name.slice(0, 28) + (item.name.length > 28 ? \'…\' : \'\')) : \'Photos\'}</span>'
+);
+fs.writeFileSync('js/inventory.js', code);


### PR DESCRIPTION
- Severity: HIGH
- Vulnerability: `item.name` was being unsafely injected into a template string assigned to `innerHTML` within `openThumbPopover`. If an item's name contained malicious HTML (e.g. `<img src=x onerror=...>`), it would execute when hovering over the item's image thumbnail.
- Impact: Client-side XSS. Malicious payload could execute arbitrary JavaScript in the context of the StakTrakr origin, potentially allowing exfiltration of localStorage secrets (e.g., API keys, OAuth tokens) or vault modifications if the inventory was imported from an untrusted source or synced.
- Fix: Wrapped `item.name` string interpolation with the existing `sanitizeHtml()` utility function.
- Verification: Executed Playwright script to simulate popover trigger with malicious name payload, verified the payload did not execute and rendered safely.

---
*PR created automatically by Jules for task [16785103161931880284](https://jules.google.com/task/16785103161931880284) started by @lbruton*