### PR TITLE
fix: Persist manifest slugs for full market list on load (STAK-379)

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -727,6 +727,9 @@ const HEADER_BTN_SHOW_TEXT_KEY = "headerBtnShowText";
 /** @constant {string} RETAIL_MANIFEST_TS_KEY - LocalStorage key for market manifest generated_at timestamp */
 const RETAIL_MANIFEST_TS_KEY = "retailManifestGeneratedAt";
 
+/** @constant {string} RETAIL_MANIFEST_SLUGS_KEY - LocalStorage key for cached manifest coin slug list */
+const RETAIL_MANIFEST_SLUGS_KEY = "retailManifestSlugs";
+
 // =============================================================================
 // IMAGE PROCESSOR DEFAULTS (STACK-95)
 // =============================================================================
@@ -861,6 +864,7 @@ const ALLOWED_STORAGE_KEYS = [
   HEADER_CLOUD_SYNC_BTN_KEY,  // boolean string: "true"/"false" — cloud sync button visibility
   HEADER_BTN_SHOW_TEXT_KEY,   // boolean string: "true"/"false" — show text labels under header icons
   RETAIL_MANIFEST_TS_KEY,     // string ISO timestamp — market manifest generated_at cache
+  RETAIL_MANIFEST_SLUGS_KEY,  // JSON array: cached manifest coin slug list
   "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54) — legacy, migrated to layoutSectionConfig
   "layoutSectionConfig",      // JSON array: ordered section config [{ id, label, enabled }] (STACK-54)
   LAST_VERSION_CHECK_KEY,     // timestamp: last remote version check (STACK-67)
@@ -1787,6 +1791,7 @@ if (typeof window !== "undefined") {
   window.HEADER_CLOUD_SYNC_BTN_KEY = HEADER_CLOUD_SYNC_BTN_KEY;
   window.HEADER_BTN_SHOW_TEXT_KEY = HEADER_BTN_SHOW_TEXT_KEY;
   window.RETAIL_MANIFEST_TS_KEY = RETAIL_MANIFEST_TS_KEY;
+  window.RETAIL_MANIFEST_SLUGS_KEY = RETAIL_MANIFEST_SLUGS_KEY;
   window.RETAIL_ANOMALY_THRESHOLD = RETAIL_ANOMALY_THRESHOLD;
   window.RETAIL_SPIKE_NEIGHBOR_TOLERANCE = RETAIL_SPIKE_NEIGHBOR_TOLERANCE;
   // Disposition types for realized gains (STAK-72)

--- a/js/retail.js
+++ b/js/retail.js
@@ -441,6 +441,10 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
             ? manifest.slugs
             : null;
       _manifestCoinMeta = manifest.coins_meta || null;
+      // Persist slug list so it survives page reload
+      if (_manifestSlugs) {
+        try { localStorage.setItem(RETAIL_MANIFEST_SLUGS_KEY, JSON.stringify(_manifestSlugs)); } catch { /* ignore */ }
+      }
     } else {
       debugLog("[retail] All endpoints unreachable, using fallback slug list", "warn");
       apiBase = RETAIL_API_ENDPOINTS[0];
@@ -1855,6 +1859,11 @@ const renderRetailHistoryTable = () => {
 // ---------------------------------------------------------------------------
 
 const initRetailPrices = () => {
+  // Restore manifest slug list from localStorage (so we don't fall back to 12-item RETAIL_SLUGS)
+  try {
+    const cached = localStorage.getItem(RETAIL_MANIFEST_SLUGS_KEY);
+    if (cached) _manifestSlugs = JSON.parse(cached);
+  } catch { /* ignore */ }
   loadRetailPrices();
   loadRetailPriceHistory();
   loadRetailIntradayData();
@@ -1898,8 +1907,9 @@ const startRetailBackgroundSync = () => {
   const lastSync = retailPrices && retailPrices.lastSync ? new Date(retailPrices.lastSync).getTime() : 0;
   const isStale = Date.now() - lastSync > RETAIL_STALE_MS;
   const missingProviders = !retailProviders || Object.keys(retailProviders).length === 0;
-  if (isStale || missingProviders) {
-    debugLog(`[retail] Background sync triggered (stale=${isStale}, missingProviders=${missingProviders})`, "info");
+  const missingSlugs = !_manifestSlugs || _manifestSlugs.length === 0;
+  if (isStale || missingProviders || missingSlugs) {
+    debugLog(`[retail] Background sync triggered (stale=${isStale}, missingProviders=${missingProviders}, missingSlugs=${missingSlugs})`, "info");
     _runSilentSync();
   }
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.17-b1772339615';
+const CACHE_NAME = 'staktrakr-v3.33.17-b1772355395';
 
 
 


### PR DESCRIPTION
## Summary
- Market prices modal showed only 12 hardcoded items on page load because `_manifestSlugs` (73-item list from API) was memory-only and lost on reload
- Added `RETAIL_MANIFEST_SLUGS_KEY` to persist the slug list to localStorage
- Restores cached slugs during `initRetailPrices()` so the full list is immediately available
- Background sync now also triggers when slugs are missing (not just when prices are stale)

## Test plan
- [ ] Clear localStorage and reload — verify all items appear after first sync completes
- [ ] Reload without clearing — verify all items show immediately (from cached slugs)
- [ ] Verify "Sync Now" still works and updates the slug cache
- [ ] Verify background auto-sync triggers if slugs are missing even when prices are fresh

Closes STAK-379

🤖 Generated with [Claude Code](https://claude.com/claude-code)