### PR TITLE
fix: Validate cached manifest slugs (STAK-379 follow-up)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.17-b1772355395';
+const CACHE_NAME = 'staktrakr-v3.33.17-b1772357131';
 
 
 


### PR DESCRIPTION
## Summary
- Addresses Copilot review feedback from PR #622
- Validates `JSON.parse()` result is an array before assigning to `_manifestSlugs` — prevents corrupted localStorage from crashing `getActiveRetailSlugs()`
- Cleans up bad localStorage entry if parsed value isn't an array
- Uses `Array.isArray()` guard in `missingSlugs` check for belt-and-suspenders safety

## Test plan
- [ ] Manually corrupt `retailManifestSlugs` in localStorage to a non-array value (e.g. `"hello"`) — verify it gets cleaned up on reload
- [ ] Normal flow still works: sync populates slugs, reload uses cached list

🤖 Generated with [Claude Code](https://claude.com/claude-code)