### PR TITLE
v3.33.19 — DiffMerge Integration: selective apply for cloud sync and vault restore (STAK-190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.19] - 2026-03-01
+
+### Added — DiffMerge Integration: Selective Apply for Cloud Sync and Vault Restore (STAK-190)
+
+- **Added**: `_applyAndFinalize()` shared post-apply helper consolidating backup, inventory assignment, settings apply, save/render, pull metadata, toast summary, status indicator, and tab broadcast
+- **Changed**: Cloud sync vault-first pull uses DiffModal for selective apply instead of full overwrite via `restoreVaultData()`
+- **Changed**: Cloud sync manifest-first pull passes user selections through `_deferredVaultRestore()` for selective apply after vault download
+- **Changed**: Encrypted vault restore (.stvault) shows DiffModal preview with item and settings diffs — users choose which changes to accept
+- **Added**: E2E Playwright tests for selective apply paths covering CSV import deselection, vault restore preview, and DiffModal callback structure
+
+---
+
 ## [3.33.18] - 2026-03-01
 
 ### Added — Diff/Merge Architecture Foundation (STAK-184)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,18 +1,14 @@
 ## What's New
 
+- **DiffMerge Integration (v3.33.19)**: Selective apply for cloud sync pull and encrypted vault restore. DiffModal preview replaces full overwrite — users choose which changes to accept. Shared _applyAndFinalize helper consolidates post-apply sequence
 - **Diff/Merge Architecture Foundation (v3.33.18)**: Manifest path constants, pruning threshold storage key, diffReviewModal HTML scaffold, and diff-modal.js script registration for the reusable change-review UI
 - **Realized Gains/Losses (v3.33.17)**: Disposition workflow to mark items as Sold, Traded, Lost, Gifted, or Returned. Calculates realized gain/loss, adds disposition badges, filter toggle, portfolio summary breakdown, and CSV export columns
 - **Clone Mode Redesign (v3.33.16)**: Clone button activates clone mode on the edit modal with field-level checkboxes. Edit modal sections always visible, date N/A restyled as toggle button, Numista refresh button removed
-- **Beta Domain Toast (v3.33.15)**: Environment badge (BETA/PREVIEW/LOCAL) next to logo on non-production domains. One-time session toast explains data isolation between origins
 
 ## Development Roadmap
 
 ### Next Up
 
-- **Diff/Merge Architecture (STAK-184)**: Reusable DiffModal, manifest-first pull, import dedup consolidation — in progress
 - **Market Page Phase 3**: Inventory-to-market linking with auto-update retail prices
 - **Cloud Backup Conflict Detection (STAK-150)**: Smarter conflict resolution using item count direction, not just timestamps
-
-### Near-Term
-
 - **Accessible Table Mode (STAK-144)**: Style D with horizontal scroll, long-press to edit, 300% zoom support

--- a/js/about.js
+++ b/js/about.js
@@ -283,10 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.19 &ndash; DiffMerge Integration</strong>: Selective apply for cloud sync pull and encrypted vault restore. DiffModal preview replaces full overwrite &mdash; users choose which changes to accept. Shared _applyAndFinalize helper consolidates post-apply sequence</li>
     <li><strong>v3.33.18 &ndash; Diff/Merge Architecture Foundation</strong>: Manifest path constants, pruning threshold storage key, diffReviewModal HTML scaffold, and diff-modal.js script registration for the reusable change-review UI</li>
     <li><strong>v3.33.17 &ndash; Realized Gains/Losses</strong>: Disposition workflow to mark items as Sold, Traded, Lost, Gifted, or Returned. Calculates realized gain/loss, adds disposition badges, filter toggle, portfolio summary breakdown, and CSV export columns</li>
     <li><strong>v3.33.16 &ndash; Clone Mode Redesign</strong>: Clone button activates clone mode on the edit modal with field-level checkboxes. Edit modal sections always visible, date N/A restyled as toggle button, Numista refresh button removed</li>
-    <li><strong>v3.33.15 &ndash; Beta Domain Toast</strong>: Environment badge (BETA/PREVIEW/LOCAL) next to logo on non-production domains. One-time session toast explains data isolation between origins</li>
   `;
 };
 
@@ -296,9 +296,9 @@ const getEmbeddedWhatsNew = () => {
  */
 const getEmbeddedRoadmap = () => {
   return `
-    <li><strong>Diff/Merge Architecture (STAK-184)</strong>: Reusable DiffModal, manifest-first pull, import dedup consolidation &mdash; in progress</li>
     <li><strong>Market Page Phase 3</strong>: Inventory-to-market linking with auto-update retail prices</li>
     <li><strong>Cloud Backup Conflict Detection (STAK-150)</strong>: Smarter conflict resolution using item count direction, not just timestamps</li>
+    <li><strong>Accessible Table Mode (STAK-144)</strong>: Style D with horizontal scroll, long-press to edit, 300% zoom support</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.18";
+const APP_VERSION = "3.33.19";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -4185,7 +4185,7 @@ function _openThumbPopover(cell, item) {
 
   pop.innerHTML = `
     <div class="bulk-img-popover-header">
-      <span class="bulk-img-popover-title">${item.name ? item.name.slice(0, 28) + (item.name.length > 28 ? '…' : '') : 'Photos'}</span>
+      <span class="bulk-img-popover-title">${item.name ? sanitizeHtml(item.name.slice(0, 28) + (item.name.length > 28 ? '…' : '')) : 'Photos'}</span>
       <button class="bulk-img-popover-close" type="button" aria-label="Close">×</button>
     </div>
     <div class="bulk-img-popover-sides">

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1086,9 +1086,14 @@ const _cloudBackupWithCachedPw = (provider, password, btn) =>
  */
 const _cloudRestoreWithCachedPw = async (provider, password, fileBytes) => {
   try {
-    await vaultDecryptAndRestore(fileBytes, password);
-    if (typeof showCloudToast === 'function') showCloudToast('Restore complete. Reloading\u2026');
-    setTimeout(function () { location.reload(); }, 1200);
+    if (typeof vaultRestoreWithPreview === 'function') {
+      await vaultRestoreWithPreview(fileBytes, password);
+      // DiffModal now showing (or fallback applied if unavailable)
+    } else {
+      await vaultDecryptAndRestore(fileBytes, password);
+      if (typeof showCloudToast === 'function') showCloudToast('Restore complete. Reloading\u2026');
+      setTimeout(function () { location.reload(); }, 1200);
+    }
   } catch (err) {
     appAlert('Decryption failed. Opening password prompt.');
     openVaultModal('cloud-import', {

--- a/js/vault.js
+++ b/js/vault.js
@@ -495,6 +495,158 @@ async function vaultDecryptToData(fileBytes, password) {
   return payload;
 }
 
+/**
+ * Decrypt a .stvault file and show a DiffEngine + DiffModal preview instead
+ * of silently overwriting all data.  Falls back to the legacy full-overwrite
+ * path when DiffEngine or DiffModal are not loaded.
+ *
+ * @param {Uint8Array|ArrayBuffer} fileBytes - Raw .stvault bytes
+ * @param {string} password
+ * @returns {Promise<void>}
+ */
+async function vaultRestoreWithPreview(fileBytes, password) {
+  // 1. Decrypt without side effects
+  var payload = await vaultDecryptToData(fileBytes, password);
+
+  // 2. Guard: fall back to legacy restore if DiffEngine / DiffModal unavailable
+  if (typeof DiffEngine === 'undefined' || typeof DiffModal === 'undefined') {
+    debugLog('[Vault] DiffEngine/DiffModal not available — falling back to full restore');
+    if (typeof showToast === 'function') {
+      showToast('Diff preview unavailable — restoring full backup');
+    }
+    await restoreVaultData(payload);
+    return;
+  }
+
+  // 3. Extract inventory items from the payload
+  var backupItems = [];
+  try {
+    backupItems = JSON.parse(payload.data.metalInventory || '[]');
+  } catch (e) {
+    debugLog('[Vault] Could not parse metalInventory from backup:', e);
+  }
+
+  // 4. Compute item diff
+  var localItems = (typeof inventory !== 'undefined' && Array.isArray(inventory)) ? inventory : [];
+  var diffResult = DiffEngine.compareItems(localItems, backupItems);
+
+  // 5. Compute settings diff
+  var settingsDiff = null;
+  if (typeof DiffEngine.compareSettings === 'function') {
+    var settingsKeys = (typeof ALLOWED_STORAGE_KEYS !== 'undefined' && Array.isArray(ALLOWED_STORAGE_KEYS))
+      ? ALLOWED_STORAGE_KEYS
+      : [];
+    var localSettings = {};
+    var remoteSettings = {};
+    var payloadKeys = Object.keys(payload.data);
+
+    for (var i = 0; i < payloadKeys.length; i++) {
+      var k = payloadKeys[i];
+      // Skip inventory — handled separately via DiffEngine.compareItems
+      if (k === 'metalInventory') continue;
+      // Only include recognized storage keys
+      if (settingsKeys.indexOf(k) === -1) continue;
+
+      // Parse the remote value (vault stores raw localStorage strings)
+      var remoteVal;
+      try { remoteVal = JSON.parse(payload.data[k]); } catch (_e) { remoteVal = payload.data[k]; }
+      remoteSettings[k] = remoteVal;
+
+      // Load matching local value
+      var localVal = (typeof loadDataSync === 'function') ? loadDataSync(k, null) : null;
+      if (localVal !== null) {
+        localSettings[k] = localVal;
+      }
+    }
+
+    if (Object.keys(remoteSettings).length > 0) {
+      settingsDiff = DiffEngine.compareSettings(localSettings, remoteSettings);
+      // Omit if no changes
+      if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length === 0) {
+        settingsDiff = null;
+      }
+    }
+  }
+
+  // 6. Check for zero changes
+  var totalChanges = diffResult.added.length + diffResult.modified.length + diffResult.deleted.length;
+  if (totalChanges === 0 && !settingsDiff) {
+    if (typeof showToast === 'function') {
+      showToast('No differences found \u2014 backup matches current data');
+    }
+    return;
+  }
+
+  // 7. Build metadata from payload._meta
+  var payloadMeta = payload._meta || {};
+
+  // 8. Show DiffModal
+  DiffModal.show({
+    source: { type: 'vault', label: 'Encrypted Backup' },
+    diff: diffResult,
+    settingsDiff: settingsDiff,
+    meta: {
+      timestamp: payloadMeta.exportTimestamp || null,
+      itemCount: backupItems.length,
+      appVersion: payloadMeta.appVersion || null
+    },
+    onApply: function (selectedChanges) {
+      if (!selectedChanges || selectedChanges.length === 0) {
+        // Settings-only apply (no item changes selected but settings were checked)
+        if (settingsDiff && settingsDiff.changed) {
+          for (var si = 0; si < settingsDiff.changed.length; si++) {
+            if (typeof saveDataSync === 'function') {
+              saveDataSync(settingsDiff.changed[si].key, settingsDiff.changed[si].remoteVal);
+            }
+          }
+        }
+        if (typeof showToast === 'function') {
+          showToast('Backup restored: settings updated');
+        }
+        return;
+      }
+
+      // Apply items selectively
+      var currentInv = (typeof inventory !== 'undefined' && Array.isArray(inventory)) ? inventory : [];
+      var newInv = DiffEngine.applySelectedChanges(currentInv, selectedChanges);
+      inventory = newInv;
+
+      // Apply checked settings
+      if (settingsDiff && settingsDiff.changed) {
+        for (var si2 = 0; si2 < settingsDiff.changed.length; si2++) {
+          if (typeof saveDataSync === 'function') {
+            saveDataSync(settingsDiff.changed[si2].key, settingsDiff.changed[si2].remoteVal);
+          }
+        }
+      }
+
+      // Save & render
+      if (typeof saveInventory === 'function') saveInventory();
+      if (typeof renderTable === 'function') renderTable();
+      if (typeof renderActiveFilters === 'function') renderActiveFilters();
+      if (typeof updateStorageStats === 'function') updateStorageStats();
+
+      // Toast summary
+      var addCount = 0, modCount = 0, delCount = 0;
+      for (var j = 0; j < selectedChanges.length; j++) {
+        if (selectedChanges[j].type === 'add') addCount++;
+        else if (selectedChanges[j].type === 'modify') modCount++;
+        else if (selectedChanges[j].type === 'delete') delCount++;
+      }
+      var parts = [];
+      if (addCount > 0) parts.push(addCount + ' added');
+      if (modCount > 0) parts.push(modCount + ' updated');
+      if (delCount > 0) parts.push(delCount + ' removed');
+      if (typeof showToast === 'function') {
+        showToast('Backup restored: ' + (parts.length > 0 ? parts.join(', ') : 'no changes applied'));
+      }
+    },
+    onCancel: function () {
+      debugLog('[Vault] Restore preview cancelled');
+    }
+  });
+}
+
 // =============================================================================
 // IMAGE VAULT (STAK-181) — cloud sync for user-uploaded IndexedDB photos
 // =============================================================================
@@ -746,8 +898,8 @@ async function importEncryptedBackup(fileBytes, password) {
   }
 
   debugLog("Vault: importing with", backend, "backend");
-  await vaultDecryptAndRestore(fileBytes, password);
-  debugLog("Vault: import complete");
+  await vaultRestoreWithPreview(fileBytes, password);
+  debugLog("Vault: import complete (preview shown or fallback applied)");
 }
 
 // =============================================================================
@@ -993,24 +1145,35 @@ async function handleVaultAction() {
     showVaultStatus("info", "Decrypting\u2026");
 
     try {
+      // Determine whether the diff preview path is available
+      var hasDiffPreview = (typeof DiffEngine !== 'undefined' && typeof DiffModal !== 'undefined');
+
       await importEncryptedBackup(_vaultPendingFile, password);
       // Cache password for this browser session
       if (isCloudImport && _cloudContext && typeof cloudCachePassword === 'function') {
         cloudCachePassword(_cloudContext.provider, password);
       }
-      if (_vaultPendingImageFile) {
-        showVaultStatus("info", "Restoring photos\u2026");
-        try {
-          var imgCount = await vaultDecryptAndRestoreImages(_vaultPendingImageFile, password);
-          showVaultStatus("success", "Data and " + imgCount + " photo" + (imgCount === 1 ? "" : "s") + " restored. Reloading\u2026");
-        } catch (imgErr) {
-          // Inventory already restored — show error but still reload to apply it
-          showVaultStatus("error", "Inventory restored, but photo file failed: " + (imgErr.message || "decryption error") + ". Reloading\u2026");
-        }
+
+      if (hasDiffPreview) {
+        // DiffModal is now showing the preview — close the vault modal so
+        // the user can interact with the diff review.  No reload needed;
+        // the onApply callback inside vaultRestoreWithPreview handles save/render.
+        closeVaultModal();
       } else {
-        showVaultStatus("success", "Data restored successfully. Reloading\u2026");
+        // Fallback: full overwrite already happened, handle image vault + reload
+        if (_vaultPendingImageFile) {
+          showVaultStatus("info", "Restoring photos\u2026");
+          try {
+            var imgCount = await vaultDecryptAndRestoreImages(_vaultPendingImageFile, password);
+            showVaultStatus("success", "Data and " + imgCount + " photo" + (imgCount === 1 ? "" : "s") + " restored. Reloading\u2026");
+          } catch (imgErr) {
+            showVaultStatus("error", "Inventory restored, but photo file failed: " + (imgErr.message || "decryption error") + ". Reloading\u2026");
+          }
+        } else {
+          showVaultStatus("success", "Data restored successfully. Reloading\u2026");
+        }
+        setTimeout(function () { location.reload(); }, 1200);
       }
-      setTimeout(function () { location.reload(); }, 1200);
     } catch (err) {
       showVaultStatus("error", err.message || "Import failed.");
     } finally {
@@ -1260,6 +1423,7 @@ window.closeVaultModal = closeVaultModal;
 window.vaultEncryptToBytes = vaultEncryptToBytes;
 window.vaultEncryptToBytesScoped = vaultEncryptToBytesScoped;
 window.vaultDecryptAndRestore = vaultDecryptAndRestore;
+window.vaultRestoreWithPreview = vaultRestoreWithPreview;
 window.vaultDecryptToData = vaultDecryptToData;
 window.collectVaultData = collectVaultData;
 window.collectAndHashImageVault = collectAndHashImageVault;

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.19-b1772383931';
+const CACHE_NAME = 'staktrakr-v3.33.19-b1772386076';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.18-b1772364125';
+const CACHE_NAME = 'staktrakr-v3.33.19-b1772383931';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.18",
+  "version": "3.33.19",
   "releaseDate": "2026-03-01",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **`_applyAndFinalize()` helper**: New shared post-apply sequence in cloud-sync.js — consolidates backup, inventory assignment, settings apply, save/render, pull metadata recording, toast summary, status indicator, and tab broadcast
- **Cloud sync vault-first pull**: `showRestorePreviewModal()` onApply rewritten from full `restoreVaultData()` overwrite to `DiffEngine.applySelectedChanges()` + `_applyAndFinalize()` — users select which changes to accept
- **Cloud sync manifest-first pull**: `_deferredVaultRestore()` accepts `selectedChanges` from DiffModal, downloads vault, decrypts via `vaultDecryptToData()`, applies only selected changes
- **Encrypted vault restore**: New `vaultRestoreWithPreview()` in vault.js — decrypt → `DiffEngine.compareItems()` → `DiffEngine.compareSettings()` → `DiffModal.show()` → selective apply on user confirmation
- **Settings-listeners integration**: `_cloudRestoreWithCachedPw()` updated to use `vaultRestoreWithPreview` when available
- **No-manifest fallback verified**: Vault-first fallback path inherits selective apply automatically from rewritten `showRestorePreviewModal()`
- **E2E tests**: 5 new Playwright tests (12 total) covering CSV import deselection, vault restore preview, DiffModal callback structure — all passing

## Linear Issues

- STAK-190: Wire DiffEngine+DiffModal into cloud sync pull
- STAK-381: Vault-first pull selective apply
- STAK-193: Encrypted vault restore with DiffModal preview
- STAK-386: No-manifest fallback verification
- STAK-387: E2E tests for selective apply paths

## Spec

- `.spec-workflow/specs/diffmerge-integration/` — 6/6 tasks complete, all implementation logs filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)