### PR TITLE
feat: migrate wiki into in-repo /wiki/ with Docsify (STAK-390)

### DIFF
--- a/.claude/skills/wiki-audit/SKILL.md
+++ b/.claude/skills/wiki-audit/SKILL.md
@@ -1,132 +1,278 @@
 ---
 name: wiki-audit
-description: Background audit of StakTrakrWiki — cross-checks all frontend pages against the current codebase, opens a PR with corrections, and reports results. Dispatches a background Task agent and returns immediately. Use /wiki-audit to trigger.
-allowed-tools: Bash, Read, Task
+description: Audit in-repo wiki/ pages against the codebase — validates frontmatter, cross-checks claims, fixes stale content. Changes commit with the current branch.
+allowed-tools: Bash, Read, Edit, Glob, Grep
 ---
 
 # Wiki Audit
 
-Spawns a background Task agent that reads every frontend wiki page, cross-checks
-key claims against the StakTrakr codebase, fixes any stale content, and opens a
-PR on StakTrakrWiki with corrections.
+Reads every wiki page in the `wiki/` subfolder, validates frontmatter, cross-checks
+key claims against the StakTrakr codebase, fixes stale content in place, and reports
+results. All changes are committed to the current branch — no cross-repo PRs needed.
 
-**Returns immediately.** Check `lbruton/StakTrakrWiki/pulls` for results.
+**Prerequisite:** Must be on a feature/fix branch or in a worktree. If on a protected
+branch (`dev` or `main`), warn the user and exit without making changes.
 
 ## How to invoke
 
-Run `/wiki-audit`. The background agent handles everything.
+Run `/wiki-audit`. The agent handles everything in the current working tree.
 
-## Audit checks (the background agent runs these)
+---
 
-### 1. Script count — `frontend-overview.md`
+## Pre-flight Check
+
 ```bash
-ACTUAL=$(grep -c '<script' /Volumes/DATA/GitHub/StakTrakr/index.html)
+ROOT=$(git rev-parse --show-toplevel)
+BRANCH=$(git branch --show-current)
+
+# Safety: refuse to edit on protected branches
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "dev" ]; then
+  echo "ERROR: wiki-audit cannot edit directly on '$BRANCH'."
+  echo "Create a worktree or feature branch first."
+  exit 1
+fi
+
+echo "Auditing wiki/ on branch: $BRANCH"
+echo "Project root: $ROOT"
+```
+
+---
+
+## Phase 1: Frontmatter Validation
+
+For every `wiki/*.md` file, validate the YAML frontmatter contains all required fields
+and that referenced files exist on disk.
+
+### Required frontmatter fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string | Page title |
+| `category` | string | One of: `frontend`, `infrastructure`, `meta` |
+| `owner` | string | One of: `staktrakr`, `staktrakr-api` |
+| `lastUpdated` | string | Version string (e.g., `v3.33.18`) |
+| `date` | string | ISO date (`YYYY-MM-DD`) |
+| `sourceFiles` | list | Source file paths (may be empty `[]` for infra/meta pages) |
+| `relatedPages` | list | Related wiki page filenames (may be empty `[]`) |
+
+### Validation checks
+
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+
+for page in "$ROOT"/wiki/*.md; do
+  filename=$(basename "$page")
+
+  # Skip non-content files
+  case "$filename" in
+    README.md|CHANGELOG.md|_sidebar.md|index.html) continue ;;
+  esac
+
+  echo "--- Validating: $filename ---"
+
+  # 1. Check frontmatter delimiters exist
+  # 2. Check each required field is present
+  # 3. Check category is valid enum
+  # 4. Check owner is valid enum
+  # 5. Check date format is YYYY-MM-DD
+done
+```
+
+### sourceFiles existence check
+
+For each entry in `sourceFiles`, verify the file exists on disk relative to `$ROOT`:
+
+```bash
+# For each sourceFile entry in frontmatter:
+if [ ! -f "$ROOT/$SOURCE_FILE" ]; then
+  echo "BROKEN: $filename references '$SOURCE_FILE' — file not found"
+fi
+```
+
+### relatedPages existence check
+
+For each entry in `relatedPages`, verify the wiki page exists:
+
+```bash
+# For each relatedPage entry in frontmatter:
+if [ ! -f "$ROOT/wiki/$RELATED_PAGE" ]; then
+  echo "BROKEN: $filename references related page '$RELATED_PAGE' — not found"
+fi
+```
+
+---
+
+## Phase 2: Content Cross-checks
+
+Run the following checks against the codebase. For each check, compare the wiki
+page's claims against the actual code.
+
+### Check 1: Script count — `frontend-overview.md`
+
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+ACTUAL=$(grep -c '<script' "$ROOT/index.html")
+echo "Actual script tags in index.html: $ACTUAL"
 # Verify frontend-overview.md states the correct count
 ```
 
-### 2. ALLOWED_STORAGE_KEYS — `data-model.md`
+### Check 2: ALLOWED_STORAGE_KEYS — `data-model.md`
+
 ```bash
-grep -A 60 'ALLOWED_STORAGE_KEYS = \[' /Volumes/DATA/GitHub/StakTrakr/js/constants.js
+grep -A 60 'ALLOWED_STORAGE_KEYS = \[' "$ROOT/js/constants.js"
 # Verify data-model.md accurately describes the storage key pattern
 # (does not need to list every key — should direct readers to constants.js)
 ```
 
-### 3. CORE_ASSETS — `service-worker.md`
+### Check 3: CORE_ASSETS — `service-worker.md`
+
 ```bash
-grep -A 80 'CORE_ASSETS = \[' /Volumes/DATA/GitHub/StakTrakr/sw.js | head -85
+grep -A 80 'CORE_ASSETS = \[' "$ROOT/sw.js" | head -85
 # Verify service-worker.md describes CORE_ASSETS correctly
 ```
 
-### 4. Retail globals — `retail-modal.md`
+### Check 4: Retail globals — `retail-modal.md`
+
 ```bash
-grep 'window\.' /Volumes/DATA/GitHub/StakTrakr/js/retail.js | grep -v '//' | head -20
+grep 'window\.' "$ROOT/js/retail.js" | grep -v '//' | head -20
 # Verify retail-modal.md lists the correct window.* exports
 ```
 
-### 5. API endpoints — `api-consumption.md`
+### Check 5: API endpoints — `api-consumption.md`
+
 ```bash
-grep 'api\.staktrakr\|api2\.staktrakr' /Volumes/DATA/GitHub/StakTrakr/js/api.js | head -10
+grep 'api\.staktrakr\|api2\.staktrakr' "$ROOT/js/api.js" | head -10
 # Verify endpoint names/URLs in wiki match code
 ```
 
-### 6. APP_VERSION in release-workflow.md
+### Check 6: APP_VERSION — `release-workflow.md`
+
 ```bash
-grep 'APP_VERSION' /Volumes/DATA/GitHub/StakTrakr/js/constants.js | grep 'const APP_VERSION'
+grep 'const APP_VERSION' "$ROOT/js/constants.js"
 # Verify release-workflow.md references the correct version format
 ```
 
-### 7. Last-updated timestamps
+### Check 7: Last-updated version freshness
+
 ```bash
-# Verify each page's "> **Last updated:**" version matches or is close to
-# the current APP_VERSION — flag pages more than 2 versions behind
-grep 'APP_VERSION' /Volumes/DATA/GitHub/StakTrakr/js/constants.js | grep 'const APP_VERSION'
+CURRENT_VERSION=$(grep 'const APP_VERSION' "$ROOT/js/constants.js" | grep -o "'[^']*'" | tr -d "'")
+echo "Current APP_VERSION: $CURRENT_VERSION"
+
+for page in "$ROOT"/wiki/*.md; do
+  filename=$(basename "$page")
+  case "$filename" in
+    README.md|CHANGELOG.md|_sidebar.md|index.html) continue ;;
+  esac
+
+  PAGE_VERSION=$(awk '/^lastUpdated:/{print $2}' "$page")
+  echo "$filename: lastUpdated=$PAGE_VERSION"
+done
+# Flag pages more than 2 patch versions behind current
 ```
 
-## Fix via PR
+### Check 8: sourceFiles coverage — cross-reference
 
-Branch protection requires all changes go through a PR. Never push directly to `main`.
+For each frontend page (`owner: staktrakr`), verify that the `sourceFiles` listed
+in frontmatter are still the correct source files for that page's topic. If a source
+file has been renamed, split, or deleted, flag the discrepancy.
+
+### Check 9: Sidebar completeness — `_sidebar.md`
+
+```bash
+# Count content pages (exclude README, CHANGELOG, _sidebar, index.html)
+CONTENT_PAGES=$(ls "$ROOT"/wiki/*.md | xargs -I{} basename {} | grep -v -E '^(README|CHANGELOG|_sidebar)\.md$' | sort)
+SIDEBAR_LINKS=$(grep -oE '\([^)]*\.md\)' "$ROOT/wiki/_sidebar.md" | tr -d '()' | sort)
+
+# Diff to find pages missing from sidebar
+comm -23 <(echo "$CONTENT_PAGES") <(echo "$SIDEBAR_LINKS")
+```
+
+---
+
+## Phase 3: Fix Stale Content
 
 For each page with stale or incorrect content:
 
-1. Re-read the relevant source files
-2. Rewrite only the stale sections (preserve overall structure)
-3. Update the `> **Last updated:**` line
-4. Commit to a branch and open a PR:
+1. **Re-read the relevant source files** from the current working tree
+2. **Rewrite only the stale sections** — preserve overall structure, voice, and
+   organization
+3. **Update frontmatter:**
+   - `lastUpdated:` set to current `APP_VERSION`
+   - `date:` set to today's date
+   - Fix any broken `sourceFiles` or `relatedPages` references
+4. **Update the inline header** to match frontmatter
+5. **Fix missing required frontmatter fields** — add with sensible defaults
+
+### Ownership rules
+
+- Pages with `owner: staktrakr` — audit AND fix
+- Pages with `owner: staktrakr-api` — audit but **flag only**, do not rewrite
+  content (infrastructure pages are owned by StakTrakrApi Claude)
+- If `owner` field is missing, infer from `category`: `frontend` = staktrakr,
+  `infrastructure` = staktrakr-api, `meta` = staktrakr
+
+---
+
+## Phase 4: Commit and Report
 
 ```bash
-cd /Volumes/DATA/GitHub/StakTrakrWiki
-git pull origin main
-BRANCH="wiki-audit/$(date +%Y%m%d)"
-git checkout -b "$BRANCH"
+ROOT=$(git rev-parse --show-toplevel)
 
-# Copy corrected pages into repo
-cp /tmp/PAGENAME.md ./PAGENAME.md
-# ... repeat for each fixed page
+# Stage all wiki changes
+git add "$ROOT/wiki/"
 
-git add -A
-git commit -m "audit: fix stale content in [list of pages]
+# Check if there are actual changes
+if git diff --cached --quiet "$ROOT/wiki/"; then
+  echo "Wiki audit: all pages verified OK — no changes needed."
+else
+  git commit -m "docs: wiki audit — fix stale content
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
-git push -u origin "$BRANCH"
+  echo "Wiki audit: committed fixes to current branch."
+fi
+```
 
-gh pr create --repo lbruton/StakTrakrWiki \
-  --title "[audit] $(date +%Y-%m-%d) — fix stale wiki content" \
-  --body "$(cat <<'EOF'
-## Summary
-Automated wiki audit found stale content in the following pages.
+---
 
-## Pages fixed
-- [list each page with what changed]
+## Report Format
 
-## Pages verified OK
+Output a structured report regardless of whether changes were made:
+
+```
+## Wiki Audit Report — YYYY-MM-DD
+
+### Frontmatter Validation
+- X pages checked
+- Y frontmatter issues found (list each)
+- Z broken sourceFile references (list each)
+- W broken relatedPage references (list each)
+
+### Content Cross-checks
+- Script count: [PASS/FAIL] (expected: N, wiki says: M)
+- ALLOWED_STORAGE_KEYS: [PASS/FAIL]
+- CORE_ASSETS: [PASS/FAIL]
+- Retail globals: [PASS/FAIL]
+- API endpoints: [PASS/FAIL]
+- APP_VERSION format: [PASS/FAIL]
+- Version freshness: X pages current, Y pages stale
+
+### Pages Fixed
+- [list each page with brief description of fix]
+
+### Pages Flagged (infrastructure-owned, not edited)
+- [list infrastructure pages that may be stale]
+
+### Pages Verified OK
 - [list accurate pages]
-
-Generated by `/wiki-audit` skill.
-EOF
-)"
-
-git checkout main
 ```
 
-## Report
+---
 
-The PR body serves as the audit report. If no pages need fixing, create a GitHub
-issue instead to record that the audit passed:
+## Edge Cases
 
-```bash
-gh issue create --repo lbruton/StakTrakrWiki \
-  --title "[audit] $(date +%Y-%m-%d) — all pages verified OK" \
-  --body "## Wiki Audit Report — $(date +%Y-%m-%d)
-
-### Pages verified OK
-- [list pages that were accurate]
-
-No corrections needed.
-"
-```
-
-## Write access policy
-
-All changes go through a PR — branch protection on `main` requires review.
-Mark genuinely uncertain sections with `> ⚠️ NEEDS VERIFICATION` rather than
-leaving stale content. The PR description serves as the audit report.
+- **Protected branch detected:** Output error and exit. Do not make any changes.
+- **No wiki/ directory:** Output error: `"wiki/ directory not found at $ROOT/wiki/"`
+- **Frontmatter missing entirely:** Add complete frontmatter block with all required
+  fields, inferring values from page content and filename.
+- **Page with no content after frontmatter:** Flag as empty but do not delete.
+- **Binary files in wiki/:** Skip non-`.md` files silently (e.g., `index.html`).

--- a/.claude/skills/wiki-search/SKILL.md
+++ b/.claude/skills/wiki-search/SKILL.md
@@ -1,57 +1,74 @@
 ---
 name: wiki-search
-description: Use when searching for documentation, architecture decisions, or operational runbooks in StakTrakrWiki. Guides indexing and querying the wiki via mcp__claude-context__search_code.
+description: Search in-repo wiki/ documentation via mcp__claude-context__search_code. No external repo needed.
 ---
 
 # Wiki Search
 
-Use `mcp__claude-context__search_code` to search StakTrakrWiki for documentation, architecture decisions, and operational runbooks. The wiki is indexed separately from the codebase — use the `path` parameter to target the right index.
+Use `mcp__claude-context__search_code` to search the in-repo `wiki/` subfolder for
+documentation, architecture decisions, and operational runbooks. The wiki lives
+inside the StakTrakr repo — no external repository or `git pull` needed.
+
+---
 
 ## When to Use Wiki Search vs. Code Search
 
 | Question type | Use |
 |---------------|-----|
-| "How does X work?" (conceptual) | Wiki search → `path: /Volumes/DATA/GitHub/StakTrakrWiki` |
-| "Where is X implemented?" (structural) | Code search → `path: /Volumes/DATA/GitHub/StakTrakr` |
+| "How does X work?" (conceptual) | Wiki search — `$ROOT/wiki/` |
+| "Where is X implemented?" (structural) | Code search — `$ROOT/` |
 | "What are the stale thresholds for the spot feed?" | Wiki search |
 | "What calls `syncRetailPrices()`?" | Code graph context (CGC) |
 | "Where is `safeGetElement` defined?" | Code search or Grep |
 | "What does the Fly.io cron schedule look like?" | Wiki search |
+| "What's the release workflow?" | Wiki search |
+| "What retail globals are exported?" | Wiki search first, then verify with code search |
 
-**Rule of thumb:** Documentation questions → wiki. Implementation questions → code.
+**Rule of thumb:** Documentation questions go to wiki. Implementation questions go to code.
 
 ---
 
-## Before Any Wiki Work — Pull + Index
+## Determine the Wiki Path
 
-**Mandatory before lookups or edits.** The wiki repo must be current locally before indexing.
-
-### Step 1: Pull remote
+The wiki is at `$ROOT/wiki/` where `$ROOT` is the project root. Detect it dynamically:
 
 ```bash
-cd /Volumes/DATA/GitHub/StakTrakrWiki && git pull origin main
+ROOT=$(git rev-parse --show-toplevel)
+WIKI_PATH="$ROOT/wiki"
+echo "Wiki path: $WIKI_PATH"
 ```
 
-### Step 2: Index (or re-index)
+For StakTrakr, this resolves to `/Volumes/DATA/GitHub/StakTrakr/wiki/` (or the
+equivalent worktree path if running inside a worktree).
+
+---
+
+## How to Index
+
+Index the wiki subfolder for semantic search. Since the wiki is in-repo, it stays
+current with the branch you are on — no `git pull` needed.
+
+### Standard index
 
 ```
 mcp__claude-context__index_codebase
-  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  path: $ROOT/wiki
   splitter: langchain
   customExtensions: [".md"]
 ```
 
-Force re-index after major wiki updates:
+### Force re-index (after major wiki changes)
 
 ```
 mcp__claude-context__index_codebase
-  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  path: $ROOT/wiki
   splitter: langchain
   customExtensions: [".md"]
   force: true
 ```
 
-**Do not skip the pull.** Another session or agent may have pushed changes since your last index.
+The wiki should show ~29 content files and ~120+ chunks when fully indexed.
+If counts are significantly lower, re-index with `force: true`.
 
 ---
 
@@ -61,7 +78,8 @@ mcp__claude-context__index_codebase
 mcp__claude-context__get_indexing_status
 ```
 
-The wiki should show ~22 files, ~90+ chunks when fully indexed. If counts are lower than expected, run `index_codebase` with `force: true`.
+Look for the wiki path in the status output. If not indexed yet, run the index
+command above.
 
 ---
 
@@ -70,18 +88,21 @@ The wiki should show ~22 files, ~90+ chunks when fully indexed. If counts are lo
 ```
 mcp__claude-context__search_code
   query: "your natural language query"
-  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  path: $ROOT/wiki
 ```
+
+Replace `$ROOT` with the actual resolved path (e.g., `/Volumes/DATA/GitHub/StakTrakr/wiki`
+or the worktree equivalent).
 
 ---
 
 ## Example Queries
 
-| Query | Expected pages |
+| Query | Expected Pages |
 |-------|----------------|
 | `"API stale thresholds"` | `health.md`, `spot-pipeline.md` |
-| `"Fly.io cron schedule"` | `fly-container.md` |
-| `"Turso merge logic"` | `retail-pipeline.md` |
+| `"Fly.io cron schedule"` | `fly-container.md`, `cron-schedule.md` |
+| `"Turso merge logic"` | `retail-pipeline.md`, `turso-schema.md` |
 | `"safeGetElement pattern"` | `dom-patterns.md` |
 | `"spot pipeline stale thresholds"` | `health.md`, `spot-pipeline.md` |
 | `"release workflow worktree"` | `release-workflow.md` |
@@ -90,29 +111,17 @@ mcp__claude-context__search_code
 | `"REST API confidence scoring"` | `rest-api-reference.md` |
 | `"cron timeline minute by minute"` | `cron-schedule.md` |
 | `"secrets rotation"` | `secrets.md` |
+| `"ALLOWED_STORAGE_KEYS"` | `data-model.md`, `storage-patterns.md` |
+| `"cloud sync backup restore"` | `sync-cloud.md`, `backup-restore.md` |
+| `"retail modal vendor legend"` | `retail-modal.md`, `vendor-quirks.md` |
+| `"service worker cache strategy"` | `service-worker.md` |
+| `"image capture pipeline"` | `image-pipeline.md` |
 
 ---
 
 ## Wiki Page Index
 
-### Infrastructure (maintained by StakTrakrApi agents)
-
-| Page | Topic |
-|------|-------|
-| `architecture-overview.md` | System diagram, repo boundaries, data feeds |
-| `rest-api-reference.md` | Complete endpoint map, schemas, confidence tiers, vendor reference |
-| `turso-schema.md` | Database tables, indexes, key query patterns, data volume estimates |
-| `cron-schedule.md` | Full timeline view of spot/retail/publish cron interleaving |
-| `retail-pipeline.md` | Dual-poller, Turso, providers.json, OOS detection, T1–T5 resilience |
-| `fly-container.md` | Services, cron, env vars, proxy config, deployment |
-| `home-poller.md` | Proxmox LXC setup, cron, sync process |
-| `spot-pipeline.md` | MetalPriceAPI, hourly/15min files, backfill logic |
-| `goldback-pipeline.md` | Per-state slugs (8 states × 7 denominations), denomination generation |
-| `providers.md` | URL strategy, year-start patterns, update process |
-| `secrets.md` | Where every secret lives, how to rotate |
-| `health.md` | Quick health checks, stale thresholds, diagnosis commands |
-
-### Frontend (maintained by StakTrakr Claude Code)
+### Frontend (owner: staktrakr)
 
 | Page | Topic |
 |------|-------|
@@ -125,15 +134,68 @@ mcp__claude-context__search_code
 | `api-consumption.md` | Spot feed, market price feed, goldback feed, health checks |
 | `release-workflow.md` | Patch cycle, version bump, worktree pattern, ship to main |
 | `service-worker.md` | CORE_ASSETS, cache strategy, pre-commit stamp hook |
+| `backup-restore.md` | Backup/restore flow, file format, cloud storage integration |
+| `image-pipeline.md` | Image capture, processing, storage pipeline |
+
+### Infrastructure (owner: staktrakr-api)
+
+| Page | Topic |
+|------|-------|
+| `architecture-overview.md` | System diagram, repo boundaries, data feeds |
+| `rest-api-reference.md` | Complete endpoint map, schemas, confidence tiers, vendor reference |
+| `turso-schema.md` | Database tables, indexes, key query patterns, data volume estimates |
+| `cron-schedule.md` | Full timeline view of spot/retail/publish cron interleaving |
+| `retail-pipeline.md` | Dual-poller, Turso, providers.json, OOS detection, T1-T5 resilience |
+| `fly-container.md` | Services, cron, env vars, proxy config, deployment |
+| `home-poller.md` | Proxmox LXC setup, cron, sync process |
+| `spot-pipeline.md` | MetalPriceAPI, hourly/15min files, backfill logic |
+| `goldback-pipeline.md` | Per-state slugs (8 states x 7 denominations), denomination generation |
+| `providers.md` | URL strategy, year-start patterns, update process |
+| `secrets.md` | Where every secret lives, how to rotate |
+| `health.md` | Quick health checks, stale thresholds, diagnosis commands |
+| `vendor-quirks.md` | Vendor-specific URL patterns and scraping behaviors |
+| `provider-database.md` | Provider DB reference and configuration |
+| `poller-parity.md` | Comparison between Fly.io and home poller setups |
+
+### Meta
+
+| Page | Topic |
+|------|-------|
+| `README.md` | Wiki index page with page table |
+| `_sidebar.md` | Navigation sidebar for wiki browsing |
+| `CHANGELOG.md` | Wiki change history |
+
+---
+
+## Fallback: Direct Grep
+
+If semantic search returns no results or the index is unavailable, fall back to
+direct Grep:
+
+```
+Grep
+  pattern: "your search term"
+  path: $ROOT/wiki
+  glob: "*.md"
+  output_mode: content
+```
+
+This works without any indexing but only matches literal strings and regex — no
+semantic understanding.
 
 ---
 
 ## Notes
 
-- **StakTrakrWiki is the single source of truth** for all project documentation — architecture, patterns, operations, and runbooks.
-- The code index (StakTrakr repo) and wiki index are separate — both can be searched via the `path` parameter.
-- **Always pull before indexing** — another session may have pushed changes.
-- Re-index with `force: true` after major wiki restructuring to ensure accurate results.
-- Infrastructure pages are owned by StakTrakrApi Claude. For infra questions, search first, then verify with `/remember api infrastructure` if needed.
-- Raw pages accessible at: `https://raw.githubusercontent.com/lbruton/StakTrakrWiki/main/<page>.md`
-- Wiki changes should be committed and pushed via `git commit` + `git push origin main` (or PR for large rewrites).
+- **The wiki is in-repo.** No `git pull` from an external repo is needed. The wiki
+  content matches the branch you are on.
+- **Worktree awareness:** If running inside a worktree, `git rev-parse --show-toplevel`
+  returns the worktree root, so `$ROOT/wiki/` automatically resolves correctly.
+- **Both indexes coexist.** The code index (`$ROOT/`) and wiki index (`$ROOT/wiki/`)
+  are separate — use the `path` parameter to target the right one.
+- **Re-index after sweeps.** After `/wiki-sweep` rewrites many pages, re-index with
+  `force: true` to ensure search results are current.
+- **Infrastructure pages** are owned by StakTrakrApi Claude. For infra questions,
+  search first, then verify with `/remember api infrastructure` if needed.
+- **Raw file access:** Wiki pages can be read directly with the Read tool at
+  `$ROOT/wiki/<page>.md` — no special tooling required.

--- a/.claude/skills/wiki-sweep/SKILL.md
+++ b/.claude/skills/wiki-sweep/SKILL.md
@@ -1,106 +1,248 @@
 ---
 name: wiki-sweep
-description: Full re-population of all 9 frontend wiki pages in StakTrakrWiki. Dispatches 9 parallel background agents, one per page. Use after major refactors, large feature batches, or when wiki-audit finds widespread staleness. Not part of normal patch workflow.
-allowed-tools: Bash, Read, Task
+description: Full re-population of all wiki/ pages. Dispatches parallel agents grouped by category. Use after major refactors or widespread staleness.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
 ---
 
 # Wiki Sweep
 
-Re-populates all 9 frontend wiki pages from scratch by dispatching 9 parallel
-background agents. Each agent reads the relevant source files and rewrites its page.
-All changes go through a single PR — branch protection requires review.
-Use when multiple pages are stale simultaneously.
+Re-populates ALL wiki pages from scratch by dispatching parallel background agents
+grouped by category. Each agent reads the relevant source files and rewrites its
+assigned pages. All changes are committed to the current branch — no cross-repo PRs.
 
-**Warning:** Overwrites all 9 frontend pages. Only run when warranted.
+**Warning:** Overwrites all content wiki pages. Only run when warranted.
 For single-page updates, use `/wiki-update` instead.
 
-## When to use
+---
+
+## When to Use
 
 - After a major refactor touching multiple subsystems
 - After a large feature batch (3+ patches) with no wiki updates
 - When `/wiki-audit` reports widespread staleness (5+ pages behind)
 - When onboarding a new agent context that needs a fresh wiki baseline
+- After migrating the wiki into the repo (initial population)
 
-## Steps
+---
 
-### Step 1: Confirm current APP_VERSION
+## Pre-flight Checks
 
-```bash
-grep 'const APP_VERSION' /Volumes/DATA/GitHub/StakTrakr/js/constants.js
-```
-
-Use this version in all `> **Last updated:**` headers.
-
-### Step 2: Create sweep branch
+### Step 1: Confirm branch safety
 
 ```bash
-cd /Volumes/DATA/GitHub/StakTrakrWiki
-git pull origin main
-BRANCH="wiki-sweep/$(date +%Y%m%d)"
-git checkout -b "$BRANCH"
+ROOT=$(git rev-parse --show-toplevel)
+BRANCH=$(git branch --show-current)
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "dev" ]; then
+  echo "ERROR: wiki-sweep cannot run on protected branch '$BRANCH'."
+  echo "Create a worktree or feature branch first."
+  exit 1
+fi
+
+echo "Sweep target: $ROOT/wiki/"
+echo "Branch: $BRANCH"
 ```
 
-### Step 3: Dispatch 9 parallel background agents
+### Step 2: Confirm current APP_VERSION
 
-Launch all at once using the Task tool with `run_in_background: true`.
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+grep 'const APP_VERSION' "$ROOT/js/constants.js"
+```
 
-Each agent follows the page spec from `docs/plans/2026-02-23-wiki-system.md`.
-Each agent writes its page to `/Volumes/DATA/GitHub/StakTrakrWiki/PAGENAME.md` (local file, NOT gh api).
+Use this version in all frontmatter `lastUpdated` fields and inline headers.
 
-| Agent | Page | Source files |
+---
+
+## Agent Groups
+
+Dispatch agents in three groups. Each group runs in parallel. Within each group,
+agents can also run in parallel (one agent per page).
+
+### Group 1: Frontend Pages (11 pages)
+
+| Agent | Page | Source Files |
 |-------|------|-------------|
-| 1 | `frontend-overview.md` | `index.html`, `js/constants.js`, `sw.js`, `CLAUDE.md` |
-| 2 | `data-model.md` | `js/constants.js`, `js/utils.js` |
-| 3 | `storage-patterns.md` | `js/utils.js`, `js/constants.js` |
-| 4 | `dom-patterns.md` | `js/utils.js`, `CLAUDE.md`, `js/about.js`, `js/init.js` |
-| 5 | `sync-cloud.md` | `js/cloud-sync.js`, `js/cloud-storage.js` |
-| 6 | `retail-modal.md` | `js/retail-view-modal.js`, `js/retail.js` |
-| 7 | `api-consumption.md` | `js/api.js`, `js/api-health.js` |
-| 8 | `release-workflow.md` | `.claude/skills/release/SKILL.md`, `.claude/skills/ship/SKILL.md`, `devops/` |
-| 9 | `service-worker.md` | `sw.js`, `devops/hooks/stamp-sw-cache.sh` |
+| F1 | `frontend-overview.md` | `index.html`, `js/constants.js`, `sw.js`, `js/file-protocol-fix.js` |
+| F2 | `data-model.md` | `js/constants.js`, `js/utils.js` |
+| F3 | `storage-patterns.md` | `js/utils.js`, `js/constants.js` |
+| F4 | `dom-patterns.md` | `js/utils.js`, `CLAUDE.md`, `js/about.js`, `js/init.js` |
+| F5 | `sync-cloud.md` | `js/cloud-sync.js`, `js/cloud-storage.js` |
+| F6 | `retail-modal.md` | `js/retail-view-modal.js`, `js/retail.js` |
+| F7 | `api-consumption.md` | `js/api.js`, `js/api-health.js` |
+| F8 | `release-workflow.md` | `.claude/skills/release/SKILL.md`, `.claude/skills/ship/SKILL.md`, `devops/` |
+| F9 | `service-worker.md` | `sw.js`, `devops/hooks/stamp-sw-cache.sh` |
+| F10 | `backup-restore.md` | `js/backup.js`, `js/restore.js`, `js/cloud-storage.js` |
+| F11 | `image-pipeline.md` | `js/image-*.js`, `js/capture.js` |
 
-### Step 4: Wait for all agents to report DONE
+### Group 2: Infrastructure Pages (15 pages)
 
-Each agent outputs `DONE: PAGENAME.md written` when complete.
+| Agent | Page | Source Files | Notes |
+|-------|------|-------------|-------|
+| I1 | `architecture-overview.md` | `CLAUDE.md`, `AGENTS.md` | System diagram, repo boundaries |
+| I2 | `rest-api-reference.md` | `js/api.js` | Endpoint map, schemas |
+| I3 | `turso-schema.md` | (StakTrakrApi-owned) | DB tables, indexes |
+| I4 | `cron-schedule.md` | (StakTrakrApi-owned) | Cron timeline |
+| I5 | `retail-pipeline.md` | (StakTrakrApi-owned) | Dual-poller, Turso |
+| I6 | `fly-container.md` | (StakTrakrApi-owned) | Fly.io services |
+| I7 | `home-poller.md` | (StakTrakrApi-owned) | Proxmox LXC setup |
+| I8 | `spot-pipeline.md` | (StakTrakrApi-owned) | MetalPriceAPI, hourly files |
+| I9 | `goldback-pipeline.md` | (StakTrakrApi-owned) | Per-state slugs |
+| I10 | `providers.md` | (StakTrakrApi-owned) | URL strategy |
+| I11 | `secrets.md` | (StakTrakrApi-owned) | Secret rotation |
+| I12 | `health.md` | (StakTrakrApi-owned) | Health checks |
+| I13 | `vendor-quirks.md` | `js/retail.js`, `js/api.js` | Vendor-specific behaviors |
+| I14 | `provider-database.md` | (StakTrakrApi-owned) | Provider DB reference |
+| I15 | `poller-parity.md` | (StakTrakrApi-owned) | Poller comparison |
 
-### Step 5: Update README.md table if needed
+**Important:** For infrastructure pages owned by StakTrakrApi (`owner: staktrakr-api`),
+the sweep agent should:
+1. Read the existing page content
+2. Update only the frontmatter fields (`lastUpdated`, `date`)
+3. Verify structural integrity (headings, links)
+4. Do NOT rewrite the technical content — that is owned by StakTrakrApi Claude
+5. Flag any sections that appear stale based on cross-referencing with StakTrakr code
 
-If any page was renamed or added, update the README.md page table directly in the local repo.
+### Group 3: Meta Pages (3 pages)
 
-### Step 6: Commit, push, and open PR
+| Agent | Page | Source Files | Notes |
+|-------|------|-------------|-------|
+| M1 | `README.md` | All `wiki/*.md` | Page index table, links |
+| M2 | `_sidebar.md` | All `wiki/*.md` | Navigation sidebar |
+| M3 | `CHANGELOG.md` | `wiki/CHANGELOG.md` | Append new entry only |
+
+---
+
+## Agent Instructions (each agent follows this template)
+
+### For frontend pages (Group 1)
+
+Each agent:
+
+1. **Read source files** listed in the agent table above
+2. **Read existing page** if it exists (to preserve good content)
+3. **Rewrite the page** from scratch with this structure:
+
+```markdown
+---
+title: [Page Title]
+category: frontend
+owner: staktrakr
+lastUpdated: vCURRENT_VERSION
+date: YYYY-MM-DD
+sourceFiles:
+  - file1.js
+  - file2.js
+relatedPages:
+  - related-page.md
+---
+# [Title]
+
+> **Last updated:** vCURRENT_VERSION — YYYY-MM-DD
+> **Source files:** `file1.js`, `file2.js`
+
+## Overview
+[Concise description of what this subsystem does and why it exists]
+
+## Key Rules (read before touching this area)
+[Numbered list of critical constraints — the things that cause bugs when violated]
+
+## Architecture
+[How the code is structured, key functions, data flow]
+
+## Common Mistakes
+[Patterns that regularly cause bugs, with explanations of why]
+
+## Related Pages
+[Links to related wiki pages with brief descriptions of the relationship]
+```
+
+4. **Write the page** to `$ROOT/wiki/PAGENAME.md`
+5. **Report:** `DONE: PAGENAME.md written`
+
+### For infrastructure pages (Group 2)
+
+Each agent:
+
+1. **Read the existing page**
+2. **Update frontmatter only** (`lastUpdated`, `date`)
+3. **Verify structural integrity** — check for broken links, missing sections
+4. **Flag stale sections** by adding inline comments if needed
+5. **Do NOT rewrite technical content** — owned by StakTrakrApi Claude
+6. **Report:** `DONE: PAGENAME.md verified (infra-owned, frontmatter updated)`
+
+### For meta pages (Group 3)
+
+Each agent:
+
+1. **README.md:** Regenerate the page index table from all `wiki/*.md` files.
+   Read each page's frontmatter to build the table with title, category, owner,
+   and last-updated info. Preserve any introductory text above the table.
+
+2. **_sidebar.md:** Regenerate the navigation sidebar. Group pages by category
+   (frontend, infrastructure, meta). Alphabetize within each group.
+
+3. **CHANGELOG.md:** Append a new entry for this sweep:
+   ```markdown
+   ## YYYY-MM-DD — Full sweep (vVERSION)
+   - Rewrote all frontend pages from current codebase
+   - Updated infrastructure page frontmatter
+   - Regenerated README and sidebar
+   ```
+
+---
+
+## Step 4: Wait for all agents to report DONE
+
+Each agent outputs `DONE: PAGENAME.md written` (or `verified`) when complete.
+Wait for all agents in all three groups before proceeding.
+
+---
+
+## Step 5: Commit
 
 ```bash
-cd /Volumes/DATA/GitHub/StakTrakrWiki
-git add -A
-git commit -m "sweep: rewrite all 9 frontend wiki pages
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+git add wiki/
+git commit -m "docs: full wiki sweep — rewrite all pages from codebase
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
-git push -u origin "$BRANCH"
-
-gh pr create --repo lbruton/StakTrakrWiki \
-  --title "sweep: full wiki re-population $(date +%Y-%m-%d)" \
-  --body "$(cat <<'EOF'
-## Summary
-Full re-population of all 9 frontend wiki pages from current codebase.
-
-## Pages rewritten
-- frontend-overview.md
-- data-model.md
-- storage-patterns.md
-- dom-patterns.md
-- sync-cloud.md
-- retail-modal.md
-- api-consumption.md
-- release-workflow.md
-- service-worker.md
-
-Generated by `/wiki-sweep` skill.
-EOF
-)"
-
-git checkout main
 ```
 
-### Step 7: Run wiki-audit to verify
+---
 
-After the PR is merged, run `/wiki-audit` to confirm all pages are accurate.
+## Step 6: Verify with wiki-audit
+
+After the sweep commit, run `/wiki-audit` to confirm all pages are accurate and
+frontmatter is valid. This catches any agent errors.
+
+---
+
+## Edge Cases
+
+- **New source file with no wiki page:** Flag it in the sweep report:
+  `"No wiki page covers [file] — consider creating one."`
+- **Wiki page with no matching source files:** Flag pages where ALL `sourceFiles`
+  are missing from disk — the page may be orphaned.
+- **Concurrent patches:** If a patch lands while the sweep is running, the sweep
+  branch may need to rebase. Standard git conflict resolution applies.
+- **Page deletion:** The sweep does NOT delete pages. If a page should be removed,
+  flag it in the report and let the user decide.
+- **Large pages:** Some infrastructure pages (e.g., `rest-api-reference.md`) may
+  be very large. Agents should read the full page but focus frontmatter updates
+  only for infra-owned pages.
+
+---
+
+## Page Count Summary
+
+| Category | Count | Action |
+|----------|-------|--------|
+| Frontend | 11 | Full rewrite from source |
+| Infrastructure | 15 | Frontmatter update + structural verify |
+| Meta | 3 | Regenerate (README, sidebar, changelog) |
+| **Total** | **29** | |
+
+Non-content files skipped: `index.html` (wiki landing page, not a content doc).

--- a/.claude/skills/wiki-update/SKILL.md
+++ b/.claude/skills/wiki-update/SKILL.md
@@ -1,53 +1,118 @@
 ---
 name: wiki-update
-description: Update StakTrakrWiki pages affected by the current patch. Called from /release patch Phase 3 after the version bump commit. Dispatches a background subagent — does not block PR creation. Triggers on any release patch that touches JS, CSS, skill, or devops files.
-allowed-tools: Bash, Read, Task
+description: Update in-repo wiki pages affected by the current patch. Called from /release patch Phase 3. Reads YAML frontmatter sourceFiles for change detection. Edits wiki/*.md directly — no cross-repo PRs.
+allowed-tools: Bash, Read, Edit, Glob, Grep
 ---
 
 # Wiki Update
 
 Called automatically from `/release patch` Phase 3 after the version bump commit.
-Identifies which wiki pages are affected by this patch's diff and rewrites only
-those pages. Runs as a background Task agent — Phase 4 (PR creation) does not wait.
+Identifies which wiki pages are affected by this patch's diff, rewrites only those
+pages, and commits the changes with the same patch branch. No separate PR needed.
 
-## File → Page Mapping
+Runs as a background Task agent — Phase 4 (PR creation) does not wait.
+
+---
+
+## Change Detection: Primary Method (Frontmatter sourceFiles)
+
+Parse YAML frontmatter from every `wiki/*.md` file. Each page declares its source
+files in the `sourceFiles` array. Cross-reference against changed files to find
+affected pages.
+
+### Step 1: Get changed files and project root
+
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+CHANGED=$(git diff HEAD~1 --name-only)
+echo "Project root: $ROOT"
+echo "Changed files:"
+echo "$CHANGED"
+```
+
+### Step 2: Parse frontmatter sourceFiles from all wiki pages
+
+For each `wiki/*.md` file, extract the `sourceFiles` list from YAML frontmatter:
+
+```bash
+for page in "$ROOT"/wiki/*.md; do
+  # Extract sourceFiles block between frontmatter delimiters
+  awk '/^---$/{n++; next} n==1 && /^sourceFiles:/{found=1; next} n==1 && found && /^  - /{print FILENAME, $2; next} found && !/^  -/{found=0}' "$page"
+done
+```
+
+For each page, if ANY of its declared `sourceFiles` appear in `CHANGED`, that page
+needs updating.
+
+### Step 3: Handle empty sourceFiles
+
+Pages with `sourceFiles: []` are infrastructure-owned or meta pages. Skip them
+during automatic updates. Flag them if related patterns are detected (see
+Infrastructure section below).
+
+---
+
+## Change Detection: Fallback Method (Hardcoded Mapping)
+
+If frontmatter parsing fails or as a secondary cross-check, use this hardcoded
+mapping table:
 
 | Source file pattern | Wiki page(s) |
 |---------------------|-------------|
 | `index.html`, `sw.js`, `js/constants.js` | `frontend-overview.md` |
 | `js/constants.js`, `js/utils.js` | `data-model.md` |
-| `js/utils.js` | `storage-patterns.md`, `dom-patterns.md` |
+| `js/utils.js`, `js/constants.js` | `storage-patterns.md` |
+| `js/utils.js`, `js/about.js`, `js/init.js` | `dom-patterns.md` |
 | `js/cloud-sync.js`, `js/cloud-storage.js` | `sync-cloud.md` |
 | `js/retail-view-modal.js`, `js/retail.js`, `js/retail-*.js` | `retail-modal.md` |
 | `js/api.js`, `js/api-health.js` | `api-consumption.md` |
 | `.claude/skills/release/`, `.claude/skills/ship/`, `devops/` | `release-workflow.md` |
 | `sw.js`, `devops/hooks/stamp-sw-cache.sh` | `service-worker.md` |
+| `js/backup.js`, `js/restore.js` | `backup-restore.md` |
+| `js/image-*.js`, `js/capture.js` | `image-pipeline.md` |
 
-## Steps
+**Use the frontmatter method as primary.** The hardcoded table is a fallback for
+pages with missing or malformed frontmatter.
 
-### Step 1: Identify affected pages
+---
 
-```bash
-CHANGED=$(git diff HEAD~1 --name-only)
-echo "Changed files:"
-echo "$CHANGED"
-```
+## Step 4: Rewrite affected pages
 
-Walk the mapping table above. Collect the set of wiki pages to update.
+For each affected page:
 
-If no source files match any pattern (e.g. pure data or image change), exit with:
-`Wiki update: no relevant files changed — skipping.`
+1. **Read the relevant source files** from the current working tree
+2. **Read the existing wiki page** to preserve structure and non-stale content
+3. **Rewrite only the sections that reference changed code** — preserve the page's
+   overall structure, voice, and organization
+4. **Update frontmatter fields:**
+   - `lastUpdated:` set to the new `APP_VERSION`
+   - `date:` set to today's date (`YYYY-MM-DD`)
+   - Verify `sourceFiles` is still accurate; add/remove entries if the patch changed
+     which files are relevant
+5. **Update the inline header** to match frontmatter:
+   ```markdown
+   > **Last updated:** vNEW_VERSION — YYYY-MM-DD
+   ```
 
-### Step 2: For each affected page, rewrite it
-
-Re-read the relevant source files from the current working tree.
-Use the same structure as the initial sweep:
+### Page structure (preserve this layout)
 
 ```markdown
+---
+title: [Page Title]
+category: [frontend|infrastructure|meta]
+owner: [staktrakr|staktrakr-api]
+lastUpdated: vNEW_VERSION
+date: YYYY-MM-DD
+sourceFiles:
+  - file1.js
+  - file2.js
+relatedPages:
+  - other-page.md
+---
 # [Title]
 
 > **Last updated:** vNEW_VERSION — YYYY-MM-DD
-> **Source files:** `js/filename.js`, ...
+> **Source files:** `file1.js`, `file2.js`
 
 ## Overview
 ## Key Rules (read before touching this area)
@@ -56,71 +121,70 @@ Use the same structure as the initial sweep:
 ## Related Pages
 ```
 
-**Update the `> **Last updated:**` line** with the new version and today's date.
+---
 
-### Step 3: Push changes via PR to StakTrakrWiki
+## Step 5: Commit with the patch
 
-Branch protection requires all changes go through a PR. Never push directly to `main`.
+Wiki changes are committed as part of the same patch branch. No separate PR needed.
 
 ```bash
-# 1. Pull latest and create a branch
-cd /Volumes/DATA/GitHub/StakTrakrWiki
-git pull origin main
-BRANCH="wiki-update/vVERSION-$(date +%Y%m%d)"
-git checkout -b "$BRANCH"
+ROOT=$(git rev-parse --show-toplevel)
+git add "$ROOT/wiki/"
+# Changes will be included in the patch commit or as a follow-up commit
+# on the same branch — the release skill handles the actual commit
+```
 
-# 2. Copy updated pages into the repo
-cp /tmp/PAGENAME.md ./PAGENAME.md
-# ... repeat for each affected page
+If wiki changes happen after the version bump commit, add a follow-up commit:
 
-# 3. Commit and push
-git add -A
-git commit -m "sync: vVERSION — update PAGENAME [, PAGENAME2, ...]
+```bash
+git add "$ROOT/wiki/"
+git commit -m "docs: update wiki pages for vVERSION
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
-git push -u origin "$BRANCH"
-
-# 4. Create PR for review
-gh pr create --repo lbruton/StakTrakrWiki \
-  --title "sync: vVERSION wiki update" \
-  --body "$(cat <<'EOF'
-## Summary
-- Updated wiki pages to reflect vVERSION changes
-
-## Pages updated
-- [list each page with brief description]
-
-Generated by `/wiki-update` skill.
-EOF
-)"
-
-# 5. Return to main
-git checkout main
 ```
 
-### Step 4: Report
+---
 
-Output when done:
+## Infrastructure Pages — Flag Only
+
+Infrastructure pages are owned by StakTrakrApi Claude. StakTrakr Claude should
+**flag** when they may be stale — do not rewrite them directly.
+
+### Infrastructure page indicators
+
+| Changed file (StakTrakr) | May affect wiki page | Owner |
+|--------------------------|----------------------|-------|
+| `js/api.js`, `js/api-health.js` | `api-consumption.md` (frontend-owned, OK to edit) | staktrakr |
+| `js/api.js`, `js/api-health.js` | `health.md`, `rest-api-reference.md` | staktrakr-api |
+| `.claude/skills/api-infrastructure/` | `architecture-overview.md` | staktrakr-api |
+| `CLAUDE.md` (API section) | `health.md`, `fly-container.md` | staktrakr-api |
+
+When any infrastructure-owned page may be affected, output a warning:
+
 ```
-Wiki PR created: [PR URL] — [list of pages updated]
+WARNING: API-related change detected — the following infrastructure wiki pages
+may need updating by StakTrakrApi Claude:
+- health.md
+- fly-container.md
+- spot-pipeline.md (as applicable)
+These pages are owned by staktrakr-api — flagging only, not rewriting.
 ```
 
-## Infrastructure Page Mapping (informational)
+### How to identify infrastructure pages
 
-Infrastructure pages are owned by StakTrakrApi Claude. StakTrakr Claude should **flag** when they may be stale — do not rewrite them directly.
+Check the `owner` field in frontmatter. Pages with `owner: staktrakr-api` are
+infrastructure-owned. Pages with `owner: staktrakr` are frontend-owned and safe
+to rewrite.
 
-| Changed file (StakTrakr) | May affect wiki page |
-|----------------------------------|---------------------------|
-| `js/api.js`, `js/api-health.js` | `api-consumption.md` |
-| `docs/devops/` | `health.md` (deprecated local runbook — wiki is authoritative) |
-| `.claude/skills/api-infrastructure/` | `architecture-overview.md` |
-| `CLAUDE.md` (API section) | `health.md`, `fly-container.md` |
+---
 
-When any of these patterns are detected in `CHANGED`, add a note to the PR:
+## No-op exit
+
+If no source files in `CHANGED` match any page's `sourceFiles` (and no fallback
+mapping matches), exit with:
+
 ```
-⚠️ API-related change — verify StakTrakrWiki infrastructure pages are current.
-Check: health.md, fly-container.md, spot-pipeline.md as applicable.
-StakTrakrApi Claude owns these pages — flag, don't rewrite.
+Wiki update: no relevant files changed — skipping.
 ```
 
 ---
@@ -131,3 +195,18 @@ This skill is invoked after the version bump commit in Phase 3 of `/release patc
 
 > After committing the version bump, invoke the `wiki-update` skill via the Skill
 > tool as a background Task agent. Do not wait for it before proceeding to Phase 4.
+
+---
+
+## Edge Cases
+
+- **Renamed source files:** If a file was renamed in this patch, the old name in
+  `sourceFiles` won't match. The fallback mapping may catch it. After rewriting,
+  update the page's `sourceFiles` to use the new filename.
+- **New wiki page needed:** If the patch introduces a new subsystem with no
+  existing wiki page, flag it: `"New subsystem detected — consider creating a wiki
+  page for [topic]."` Do not auto-create pages.
+- **Multiple patches in flight:** Each patch branch updates its own wiki pages
+  independently. Merge conflicts in `wiki/` are resolved like any other file.
+- **Deleted source files:** If a `sourceFiles` entry no longer exists on disk,
+  flag the page for manual review rather than silently removing the reference.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -318,12 +318,11 @@ The project uses `ruleset.xml` at the project root. PMD analyzes JavaScript for 
 
 ## Documentation Policy
 
-StakTrakrWiki (`lbruton/StakTrakrWiki`) is the single source of truth for all
-architecture, operational runbooks, and pattern documentation. Do not create
-new markdown documentation in this repo (except `docs/plans/` for planning artifacts).
+The `wiki/` subfolder is the single source of truth for all
+architecture, operational runbooks, and pattern documentation.
+New documentation goes in `wiki/` (or `docs/plans/` for planning artifacts).
 
-After any commit that changes behavior, update the relevant wiki page via `gh api`.
-Use `claude-context` to search the wiki: index path `/Volumes/DATA/GitHub/StakTrakrWiki`.
+After any commit that changes behavior, update the relevant wiki page directly.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,47 +290,47 @@ Playwright test harness (`js/test-loader.js`) loads in localhost-only mode and i
 - Use `safeGetElement()` for DOM access
 - No `eval()` or `Function()` constructor
 
-## Documentation (StakTrakrWiki)
+## Documentation (Wiki)
 
-StakTrakr maintains a private wiki at `github.com/lbruton/StakTrakrWiki` as the single source of truth for the codebase. Reference it before making architectural changes. Pages are maintained by agents — do not let docs drift after meaningful patches.
+StakTrakr maintains an in-repo wiki at `wiki/` (served via Docsify) as the single source of truth for the codebase. Reference it before making architectural changes. Pages are maintained by agents — do not let docs drift after meaningful patches.
 
 ### Frontend pages (maintained by Claude Code / StakTrakr agents)
 
 | Page | Contents |
 |------|----------|
-| [Frontend Overview](https://github.com/lbruton/StakTrakrWiki/blob/main/frontend-overview.md) | File structure, 67-script load order, service worker, PWA |
-| [Data Model](https://github.com/lbruton/StakTrakrWiki/blob/main/data-model.md) | Portfolio model, storage keys, coin/entry schema |
-| [Storage Patterns](https://github.com/lbruton/StakTrakrWiki/blob/main/storage-patterns.md) | saveData/loadData wrappers, sync variants, key validation |
-| [DOM Patterns](https://github.com/lbruton/StakTrakrWiki/blob/main/dom-patterns.md) | safeGetElement, sanitizeHtml, event delegation |
-| [Cloud Sync](https://github.com/lbruton/StakTrakrWiki/blob/main/sync-cloud.md) | Cloudflare R2 backup/restore, vault encryption, sync flow |
-| [Retail Modal](https://github.com/lbruton/StakTrakrWiki/blob/main/retail-modal.md) | Coin detail modal, vendor legend, OOS detection, price carry-forward |
-| [API Consumption](https://github.com/lbruton/StakTrakrWiki/blob/main/api-consumption.md) | Spot feed, market price feed, goldback feed, health checks |
-| [Release Workflow](https://github.com/lbruton/StakTrakrWiki/blob/main/release-workflow.md) | Patch cycle, version bump, worktree pattern, ship to main |
-| [Service Worker](https://github.com/lbruton/StakTrakrWiki/blob/main/service-worker.md) | CORE_ASSETS, cache strategy, pre-commit stamp hook |
+| [Frontend Overview](wiki/frontend-overview.md) | File structure, 67-script load order, service worker, PWA |
+| [Data Model](wiki/data-model.md) | Portfolio model, storage keys, coin/entry schema |
+| [Storage Patterns](wiki/storage-patterns.md) | saveData/loadData wrappers, sync variants, key validation |
+| [DOM Patterns](wiki/dom-patterns.md) | safeGetElement, sanitizeHtml, event delegation |
+| [Cloud Sync](wiki/sync-cloud.md) | Cloudflare R2 backup/restore, vault encryption, sync flow |
+| [Retail Modal](wiki/retail-modal.md) | Coin detail modal, vendor legend, OOS detection, price carry-forward |
+| [API Consumption](wiki/api-consumption.md) | Spot feed, market price feed, goldback feed, health checks |
+| [Release Workflow](wiki/release-workflow.md) | Patch cycle, version bump, worktree pattern, ship to main |
+| [Service Worker](wiki/service-worker.md) | CORE_ASSETS, cache strategy, pre-commit stamp hook |
 
 ### Infrastructure pages (maintained by StakTrakrApi agents)
 
-Architecture, data pipelines, Fly.io, pollers, secrets — see `github.com/lbruton/StakTrakrWiki` README for full index.
+Architecture, data pipelines, Fly.io, pollers, secrets — see `wiki/README.md` for full index.
 
 ### Wiki update policy
 
 - Use `/wiki-update` after any patch that changes JS, CSS, skills, or devops files
 - Use `/wiki-audit` for background drift detection and auto-correction
-- Raw pages accessible at `raw.githubusercontent.com/lbruton/StakTrakrWiki/main/<page>.md`
+- Pages live at `wiki/*.md` in this repo
 
 ## Documentation Policy
 
-StakTrakrWiki (`lbruton/StakTrakrWiki`) is the single source of truth for all
-architecture, operational runbooks, and pattern documentation. Do not create
-new markdown documentation in this repo (except `docs/plans/` for planning artifacts).
+The `wiki/` subfolder is the single source of truth for all
+architecture, operational runbooks, and pattern documentation.
+New documentation goes in `wiki/` (or `docs/plans/` for planning artifacts).
 
-After any commit that changes behavior, update the relevant wiki page via `gh api`.
-Use `claude-context` to search the wiki: index path `/Volumes/DATA/GitHub/StakTrakrWiki`.
+After any commit that changes behavior, update the relevant wiki page directly.
+Use `claude-context` to search the wiki: index path includes `wiki/` within the StakTrakr repo.
 
 ```
 mcp__claude-context__search_code
   query: "your question about how something works"
-  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  path: /Volumes/DATA/GitHub/StakTrakr
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ Works on `file://` and HTTP. Runtime artifact: zero build step, zero install. Se
 ## Code Search Paths
 
 - `mcp__claude-context__search_code` path: `/Volumes/DATA/GitHub/StakTrakr`
-- Wiki docs path: `/Volumes/DATA/GitHub/StakTrakrWiki` — e.g. "find wiki pages about spot pipeline stale thresholds"
+- Wiki docs path: `wiki/` (in-repo) — e.g. "find wiki pages about spot pipeline stale thresholds"
 - **CGC setup**: `cd devops/cgc && docker compose up -d`
 
 ## API Infrastructure
 
 > **Separation of duties:** `StakTrakr` = frontend only. All API backend poller code, Fly.io devops, and GHA data workflows live in `lbruton/StakTrakrApi`. Do not add poller scripts, Fly.io config, or data-pipeline workflows to this repo.
 
-**Runbook:** See StakTrakrWiki for current runbooks: [`health.md`](https://github.com/lbruton/StakTrakrWiki/blob/main/health.md), [`fly-container.md`](https://github.com/lbruton/StakTrakrWiki/blob/main/fly-container.md), [`spot-pipeline.md`](https://github.com/lbruton/StakTrakrWiki/blob/main/spot-pipeline.md). (`docs/devops/api-infrastructure-runbook.md` is deprecated.)
+**Runbook:** See wiki/ for current runbooks: [`health.md`](wiki/health.md), [`fly-container.md`](wiki/fly-container.md), [`spot-pipeline.md`](wiki/spot-pipeline.md). (`docs/devops/api-infrastructure-runbook.md` is deprecated.)
 
 Three feeds served from `lbruton/StakTrakrApi` main branch via GitHub Pages at `api.staktrakr.com`:
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -288,48 +288,45 @@ Structured reasoning tool for complex multi-step analysis.
 
 Use when planning architecture, evaluating trade-offs, or breaking down complex problems before implementation.
 
-## Documentation (StakTrakrWiki)
+## Documentation (Wiki)
 
-StakTrakr maintains a private wiki at `github.com/lbruton/StakTrakrWiki` — single source of truth for the codebase architecture and patterns. Reference it before making architectural changes or when researching how a subsystem works.
+StakTrakr maintains an in-repo wiki at `wiki/` (served via Docsify) — single source of truth for the codebase architecture and patterns. Reference it before making architectural changes or when researching how a subsystem works.
 
 ### Frontend pages (maintained by Claude Code / StakTrakr agents)
 
 | Page | Topic |
 |------|-------|
-| `frontend-overview.md` | File structure, 67-script load order, service worker, PWA |
-| `data-model.md` | Portfolio model, storage keys, coin/entry schema |
-| `storage-patterns.md` | saveData/loadData wrappers, sync variants, key validation |
-| `dom-patterns.md` | safeGetElement, sanitizeHtml, event delegation |
-| `sync-cloud.md` | Cloud backup/restore, vault encryption, sync flow |
-| `retail-modal.md` | Coin detail modal, vendor legend, OOS detection, price carry-forward |
-| `api-consumption.md` | Spot feed, market price feed, goldback feed, health checks |
-| `release-workflow.md` | Patch cycle, version bump, worktree pattern, ship to main |
-| `service-worker.md` | CORE_ASSETS, cache strategy, pre-commit stamp hook |
+| `wiki/frontend-overview.md` | File structure, 67-script load order, service worker, PWA |
+| `wiki/data-model.md` | Portfolio model, storage keys, coin/entry schema |
+| `wiki/storage-patterns.md` | saveData/loadData wrappers, sync variants, key validation |
+| `wiki/dom-patterns.md` | safeGetElement, sanitizeHtml, event delegation |
+| `wiki/sync-cloud.md` | Cloud backup/restore, vault encryption, sync flow |
+| `wiki/retail-modal.md` | Coin detail modal, vendor legend, OOS detection, price carry-forward |
+| `wiki/api-consumption.md` | Spot feed, market price feed, goldback feed, health checks |
+| `wiki/release-workflow.md` | Patch cycle, version bump, worktree pattern, ship to main |
+| `wiki/service-worker.md` | CORE_ASSETS, cache strategy, pre-commit stamp hook |
 
 ### Infrastructure pages (maintained by StakTrakrApi agents)
 
-Architecture, data pipelines, Fly.io, pollers, and secrets — see the README at `github.com/lbruton/StakTrakrWiki`.
+Architecture, data pipelines, Fly.io, pollers, and secrets — see `wiki/README.md` for full index.
 
-### Fetching pages
+### Accessing pages
 
-Pages are accessible at:
-`https://raw.githubusercontent.com/lbruton/StakTrakrWiki/main/<page>.md`
-
-Use `brave-search` or `firecrawl-local` to fetch if needed. Prefer reading the raw URL directly when context permits.
+Pages live at `wiki/*.md` in this repo. Read them directly with file tools or search with `claude-context`.
 
 ## Documentation Policy
 
-StakTrakrWiki (`lbruton/StakTrakrWiki`) is the single source of truth for all
-architecture, operational runbooks, and pattern documentation. Do not create
-new markdown documentation in this repo (except `docs/plans/` for planning artifacts).
+The `wiki/` subfolder is the single source of truth for all
+architecture, operational runbooks, and pattern documentation.
+New documentation goes in `wiki/` (or `docs/plans/` for planning artifacts).
 
-After any commit that changes behavior, update the relevant wiki page via `gh api`.
-Use `claude-context` to search the wiki: index path `/Volumes/DATA/GitHub/StakTrakrWiki`.
+After any commit that changes behavior, update the relevant wiki page directly.
+Use `claude-context` to search the wiki: index path includes `wiki/` within the StakTrakr repo.
 
 ```
 mcp__claude-context__search_code
   query: "your question about how something works"
-  path: /Volumes/DATA/GitHub/StakTrakrWiki
+  path: /Volumes/DATA/GitHub/StakTrakr
 ```
 
 ---

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.18-b1772364125';
+const CACHE_NAME = 'staktrakr-v3.33.18-b1772396785';
 
 
 
@@ -157,6 +157,9 @@ self.addEventListener('fetch', (event) => {
 
   // Never cache OAuth callback — must always hit network for fresh code
   if (url.pathname.includes('oauth-callback')) return;
+
+  // Skip wiki pages — Docsify handles its own routing
+  if (url.pathname.startsWith('/wiki/')) return;
 
   // Network-first for API calls (spot prices, catalog lookups)
   if (API_HOSTS.some((host) => url.hostname === host)) {

--- a/wiki/CHANGELOG.md
+++ b/wiki/CHANGELOG.md
@@ -1,0 +1,45 @@
+---
+title: "Changelog"
+category: meta
+owner: shared
+lastUpdated: v3.33.18
+date: 2026-03-01
+sourceFiles: []
+relatedPages: []
+---
+
+# StakTrakrWiki Changelog
+
+Running log of structural wiki updates. Not a code changelog — tracks when wiki content was added, reorganized, or policy was updated.
+
+---
+
+## 2026-02-25
+
+- **STAK-335 per-state Goldback documentation** — updated for PR `StakTrakrApi#3`
+  - Rewrote [Goldback Pipeline](goldback-pipeline.md) — 8 states × 7 denominations (56 slugs), migration from legacy slugs, enabling workflow
+  - Updated [REST API Reference](rest-api-reference.md) — per-state endpoint patterns, updated coin slug list
+  - Updated [Retail Pipeline](retail-pipeline.md) — noted disabled goldback slugs add zero scrape load
+  - Updated [Turso Schema](turso-schema.md) — data volume projections for STAK-335 expansion
+- **Full API infrastructure audit** from live Fly.io container source code
+- Created [REST API Reference](rest-api-reference.md) — complete endpoint map, schemas, confidence tiers, vendor reference, HTTP server audit
+- Created [Turso Schema](turso-schema.md) — database tables, indexes, key query patterns (readLatestPerVendor, readRecentWindows, etc.), data volume estimates
+- Created [Cron Schedule](cron-schedule.md) — full timeline view showing how spot/retail/publish cycles interleave, with design rationale
+- Updated [Spot Pipeline](spot-pipeline.md) — added full architecture diagram (MetalPriceAPI → poller.py → hourly/15min/seed files), rate conversion table, backfill logic, three output file types
+- Updated [Goldback Pipeline](goldback-pipeline.md) — documented all 6 denomination slugs (G1–G50), API endpoint table, dual-path architecture (retail pipeline + denomination spot JSON)
+- Updated [Retail Pipeline](retail-pipeline.md) — corrected coin/vendor counts (17 coins × 7 vendors), added source values (firecrawl/playwright/gemini-vision/fbp), removed stale goldback cron entry, added cross-links to new pages
+- Updated [Architecture Overview](architecture-overview.md) — new page index, corrected verification date
+- Updated sidebar and README with links to 3 new pages
+- Deprecated Notion infrastructure pages; StakTrakrWiki is now the sole source of truth for all infrastructure documentation
+- Added `wiki-search` skill to StakTrakr — guides indexing and querying the wiki via `mcp__claude-context__search_code`
+- Deprecated `docs/devops/api-infrastructure-runbook.md` in StakTrakr (deprecation banner added; file retained pending wiki parity audit)
+- Added Update Policy section to README.md
+- Added Documentation Policy section to CLAUDE.md, AGENTS.md, GEMINI.md, and copilot-instructions.md
+- Updated `finishing-a-development-branch` skill with mandatory Wiki Update Gate (runs before every PR)
+- Updated `wiki-update` skill with infrastructure page mapping table
+- Added SSH Remote Management section to `home-poller.md` — Claude Code can now SSH directly via `stakpoller` user
+- Updated `home-poller.md` user from `lbruton` to `stakpoller` for SSH access
+- Verified home poller from VM console: fixed cron `30 * * * *` → `0,30 * * * *` (runs 2×/hr) across `home-poller.md`, `retail-pipeline.md`, `architecture-overview.md`
+- Fixed `retail-pipeline.md` home poller IP from `192.168.1.48` → `192.168.1.81` and POLLER_ID from `api2` → `home`
+- Added `FLYIO_TAILSCALE_IP` to `home-poller.md` env table
+- Pinned Node.js version to 22.22.0 in `home-poller.md` stack table

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,91 @@
+---
+title: "StakTrakr Wiki"
+category: meta
+owner: shared
+lastUpdated: v3.33.18
+date: 2026-03-01
+sourceFiles: []
+relatedPages: []
+---
+
+# StakTrakr Wiki
+
+Private wiki for StakTrakr. Covers the full system: API infrastructure and data pipelines (maintained by StakTrakrApi agents) and the frontend app (maintained by Claude Code / StakTrakr agents).
+
+This wiki is the **shared source of truth** between two independent Claude agent contexts:
+
+| Agent | Repo | Owns |
+|-------|------|------|
+| StakTrakrApi Claude | `lbruton/StakTrakrApi` | Poller source code, GHA workflows, data pipeline |
+| StakScraper Claude | `lbruton/stakscrapr` | Home poller env config, Ubuntu-specific setup |
+
+Both agents can read and write this wiki. When behavior diverges between Fly.io and the home poller (intentionally or by drift), it should be documented here so either agent can identify it, reconcile it, or propose it upstream.
+
+**Status:** In progress — being audited for accuracy before making public.
+
+---
+
+## Infrastructure
+
+Pages covering the API backend, data pipelines, and operational runbooks. Maintained by the **StakTrakrApi** agent context.
+
+| Page | Contents |
+|------|----------|
+| [Architecture Overview](architecture-overview.md) | System diagram, repo boundaries, data feeds |
+| [Retail Market Price Pipeline](retail-pipeline.md) | Dual-poller, Turso, providers.json, OOS detection |
+| [Fly.io Container](fly-container.md) | Services, cron, env vars, proxy config, deployment |
+| [Home Poller (LXC)](home-poller.md) | Proxmox LXC setup, cron, sync process |
+| [Spot Price Pipeline](spot-pipeline.md) | MetalPriceAPI, hourly/15min files, backfill logic |
+| [Goldback Pipeline](goldback-pipeline.md) | Denomination generation, retail pipeline integration |
+| [REST API Reference](rest-api-reference.md) | Complete endpoint map, schemas, confidence tiers |
+| [Turso Schema](turso-schema.md) | Database tables, indexes, key query patterns |
+| [Cron Schedule](cron-schedule.md) | Full timeline view, design rationale |
+| [providers.json](providers.md) | URL strategy, year-start patterns, update process |
+| [Secrets & Keys](secrets.md) | Where every secret lives, how to rotate |
+| [Health & Diagnostics](health.md) | Quick health checks, stale thresholds, diagnosis commands |
+
+---
+
+## Frontend
+
+Pages covering the StakTrakr single-page app — architecture, patterns, and workflows. Maintained by **Claude Code** in the StakTrakr repo context.
+
+| Page | Contents |
+|------|----------|
+| [Frontend Overview](frontend-overview.md) | File structure, script load order, service worker, PWA |
+| [Data Model](data-model.md) | Portfolio model, storage keys, coin/entry schema |
+| [Storage Patterns](storage-patterns.md) | saveData/loadData wrappers, sync variants, key validation |
+| [DOM Patterns](dom-patterns.md) | safeGetElement, sanitizeHtml, event delegation |
+| [Cloud Sync](sync-cloud.md) | Dropbox backup/restore, vault encryption, sync flow |
+| [Image Pipeline](image-pipeline.md) | Image IDB stores, resolution cascade, upload flow, pattern rules, rendering |
+| [Backup & Restore](backup-restore.md) | ZIP backup, encrypted vault, image vault, cloud sync coverage matrix |
+| [Retail Modal](retail-modal.md) | Coin detail modal, vendor legend, OOS detection, price carry-forward |
+| [API Consumption](api-consumption.md) | Spot feed, market price feed, goldback feed, health checks |
+| [Release Workflow](release-workflow.md) | Patch cycle, version bump, worktree pattern, ship to main |
+| [Service Worker](service-worker.md) | CORE_ASSETS, cache strategy, pre-commit stamp hook |
+
+---
+
+## Contributing
+
+- Each agent context owns its relevant section — infra pages for StakTrakrApi agents, frontend pages for Claude Code
+- Update docs in the same PR/commit as the code change when possible
+- Use `/wiki-update` in StakTrakr to sync frontend pages after a patch
+- Use `/wiki-audit` for background drift detection and auto-correction
+- Mark sections `> ⚠️ NEEDS VERIFICATION` if unsure — don't let inaccurate docs sit unmarked
+- All agents can reference pages via `raw.githubusercontent.com` URLs
+
+### Update Policy
+
+- Every code change in StakTrakr or StakTrakrApi that affects documented behavior must include a wiki update in the same PR
+- Use `claude-context` to search before writing (avoid duplication): `mcp__claude-context__search_code` with `path: /Volumes/DATA/GitHub/StakTrakrWiki`
+- If uncertain about accuracy, add `> ⚠️ NEEDS VERIFICATION` rather than omitting content
+- Add a one-line entry to `CHANGELOG.md` in this repo for each structural change
+- Re-index the wiki after major updates: `mcp__claude-context__index_codebase` with `path: /Volumes/DATA/GitHub/StakTrakrWiki` and `force: true`
+
+### Documenting drift between pollers
+
+If the home poller's `price-extract.js` diverges from StakTrakrApi's version, document it in `home-poller.md` under a **"Behavioral Differences from Fly.io"** section. Include:
+- What changed and why (env constraint, experiment, etc.)
+- Whether it should be proposed upstream to StakTrakrApi
+- Date of divergence so it can be tracked

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -1,0 +1,32 @@
+- [Home](/)
+
+- **Infrastructure**
+  - [Architecture Overview](architecture-overview.md)
+  - [REST API Reference](rest-api-reference.md)
+  - [Turso Schema](turso-schema.md)
+  - [Cron Schedule](cron-schedule.md)
+  - [Retail Pipeline](retail-pipeline.md)
+  - [Fly.io Container](fly-container.md)
+  - [Home Poller (LXC)](home-poller.md)
+  - [Spot Pipeline](spot-pipeline.md)
+  - [Goldback Pipeline](goldback-pipeline.md)
+  - [Provider Database](provider-database.md)
+  - [providers.json](providers.md)
+  - [Secrets & Keys](secrets.md)
+  - [Health & Diagnostics](health.md)
+  - [Poller Parity](poller-parity.md)
+  - [Vendor Quirks](vendor-quirks.md)
+
+- **Frontend**
+  - [Frontend Overview](frontend-overview.md)
+  - [Data Model](data-model.md)
+  - [Storage Patterns](storage-patterns.md)
+  - [DOM Patterns](dom-patterns.md)
+  - [Cloud Sync](sync-cloud.md)
+  - [Retail Modal](retail-modal.md)
+  - [API Consumption](api-consumption.md)
+  - [Release Workflow](release-workflow.md)
+  - [Service Worker](service-worker.md)
+
+- **Meta**
+  - [Changelog](CHANGELOG.md)

--- a/wiki/api-consumption.md
+++ b/wiki/api-consumption.md
@@ -1,0 +1,184 @@
+---
+title: API Consumption
+category: frontend
+owner: staktrakr
+lastUpdated: v3.32.25
+date: 2026-02-23
+sourceFiles:
+  - js/api.js
+  - js/api-health.js
+  - js/constants.js
+relatedPages:
+  - frontend-overview.md
+  - retail-modal.md
+---
+# API Consumption
+
+> **Last updated:** v3.32.25 — 2026-02-23
+> **Source files:** `js/api.js`, `js/api-health.js`, `js/constants.js`
+
+## Overview
+
+StakTrakr is a **frontend consumer only**. It pulls three data feeds from `api.staktrakr.com` (GitHub Pages, served from the `lbruton/StakTrakrApi` repo). All poller scripts, Fly.io config, and data-pipeline code live in `StakTrakrApi` — never in this repo.
+
+Requests use an automatic dual-endpoint fallback: if the primary endpoint does not respond within 5 seconds, the fetch is retried against a secondary endpoint (`api2.staktrakr.com`).
+
+---
+
+## Key Rules (read before touching this area)
+
+- **StakTrakr = consumer only.** Never add poller scripts, Fly.io config, or data-pipeline workflows to this repo. Those belong in `lbruton/StakTrakrApi`.
+- **`spot-history-YYYY.json` is a seed file**, not live data. It is a noon-UTC daily snapshot. `api-health.js` currently checks it for spot freshness, so it always shows ~10 h stale even when the poller is healthy. This is a known issue (STAK-265 follow-up).
+- **Fallback is automatic.** Do not add manual endpoint-switching logic — `_staktrakrFetch()` already handles it via `AbortController` with a 5 000 ms timeout.
+- **Stale thresholds are defined as constants** in `api-health.js` (`API_HEALTH_MARKET_STALE_MIN`, `API_HEALTH_SPOT_STALE_MIN`, `API_HEALTH_GOLDBACK_STALE_MIN`). Update those constants — never hardcode values elsewhere.
+
+---
+
+## Architecture
+
+### Endpoints
+
+| Role | Base URL |
+|---|---|
+| Primary | `https://api.staktrakr.com/data` |
+| Fallback | `https://api2.staktrakr.com/data` |
+
+Both are GitHub Pages deployments of the `lbruton/StakTrakrApi` repo. The fallback is tried automatically after a 5-second timeout or network error on the primary.
+
+### Fallback mechanism (`_staktrakrFetch`)
+
+```js
+// js/api.js — simplified
+const _staktrakrFetch = async (baseUrls, path) => {
+  for (const base of baseUrls) {
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 5000); // 5-second timeout
+    const resp = await fetch(`${base}${path}`, { mode: 'cors', signal: ctrl.signal });
+    if (resp.ok) return resp.json();
+  }
+};
+```
+
+`baseUrls` is always `[primary, fallback]`. On abort or error the loop advances to the next URL.
+
+---
+
+## Data Feeds
+
+### 1. Market prices — `manifest.json`
+
+| Property | Value |
+|---|---|
+| Path | `data/api/manifest.json` |
+| Primary URL | `https://api.staktrakr.com/data/api/manifest.json` |
+| Fallback URL | `https://api2.staktrakr.com/data/api/manifest.json` |
+| Freshness field | `generated_at` (ISO 8601 UTC) |
+| Stale threshold | 30 minutes |
+| Poller | Fly.io retail cron in `StakTrakrApi` (hourly at :00, home poller at :30) |
+
+Contains retail and market prices for all tracked metals. Consumed via `API_PROVIDERS.STAKTRAKR.parseBatchResponse()`.
+
+### 2. Hourly spot prices
+
+| Property | Value |
+|---|---|
+| Path pattern | `data/hourly/YYYY/MM/DD/HH.json` |
+| Primary base | `https://api.staktrakr.com/data/hourly` |
+| Fallback base | `https://api2.staktrakr.com/data/hourly` |
+| Freshness field | timestamp within the JSON file |
+| Stale threshold | 20 minutes |
+| Poller | `spot-poller.yml` GHA in `StakTrakrApi` (~every 15 min) |
+
+One file per UTC hour. `api.js` constructs the path for the current hour, falls back to the previous hour on a miss, then fetches backwards as needed for history. Entry `source` value: `"api-hourly"`.
+
+### 3. 15-minute spot prices
+
+| Property | Value |
+|---|---|
+| Path pattern | `data/15min/YYYY/MM/DD/HHMM.json` |
+| Primary base | `https://api.staktrakr.com/data/15min` |
+| Fallback base | `https://api2.staktrakr.com/data/15min` |
+| Freshness field | timestamp within the JSON file |
+| Stale threshold | 20 minutes |
+| Poller | `spot-poller.yml` GHA in `StakTrakrApi` (~every 15 min) |
+
+One file per 15-minute UTC slot. Used by `fetchStaktrakr15minRange()`. Entry `source` value: `"api-15min"`.
+
+### 4. Goldback spot price
+
+| Property | Value |
+|---|---|
+| Path | `data/api/goldback-spot.json` |
+| URL | `https://api.staktrakr.com/data/api/goldback-spot.json` |
+| Freshness field | `scraped_at` (ISO 8601 UTC) |
+| Stale threshold | 25 hours |
+| Poller | Fly.io goldback cron in `StakTrakrApi` (daily scrape) |
+
+Goldback is an informational feed. The Health modal shows its age but does not include it in the primary/backup verdict.
+
+---
+
+## Seed File Warning — `spot-history-YYYY.json`
+
+`spot-history-YYYY.json` files are **daily snapshots** (noon UTC), not live data. They are used to backfill historical spot charts, not to determine current freshness.
+
+**Known issue (STAK-265 follow-up):** `api-health.js` previously used this file to assess spot freshness, causing it to always appear ~10 h stale even when the hourly poller is running correctly. The health check now uses the live hourly files instead. Do not reintroduce spot-history reads into the health-check path.
+
+---
+
+## Health Checks (`api-health.js`)
+
+The Health modal (`js/api-health.js`) runs parallel checks against both endpoints and displays per-feed drift.
+
+```
+Market:  manifest.json       — stale after 30 min   (API_HEALTH_MARKET_STALE_MIN)
+Spot:    hourly/YYYY/MM/DD/HH.json — stale after 20 min   (API_HEALTH_SPOT_STALE_MIN)
+Goldback: goldback-spot.json — stale after 25 h      (API_HEALTH_GOLDBACK_STALE_MIN)
+```
+
+- Each feed shows its age (`X min ago`) and a healthy/stale badge.
+- When both endpoints are healthy, the modal reports drift between them (e.g., `api2 market 2m behind`).
+- Goldback is informational — it does not affect the overall health verdict.
+
+Timeout for health-check fetches: **5 000 ms** (`_fetchWithTimeout(url, 5000)`).
+
+---
+
+## Entry Source Labels
+
+Entries written to `spotHistory` carry a `source` field:
+
+| Source value | Description |
+|---|---|
+| `"api-hourly"` | Fetched from the hourly file feed |
+| `"api-15min"` | Fetched from the 15-minute file feed |
+| `"seed"` | Loaded from a local `spot-history-YYYY.json` seed file |
+| `"cached"` | Served from in-memory cache, not re-fetched |
+
+---
+
+## Separation of Duties
+
+| Repo | Responsibility |
+|---|---|
+| `lbruton/StakTrakr` | Frontend consumer — reads feeds, displays data |
+| `lbruton/StakTrakrApi` | Backend — Fly.io pollers, GHA workflows, data files, GitHub Pages deployment |
+
+**Never add to StakTrakr:** poller scripts, Fly.io TOML/config, `spot-poller.yml`, data pipeline workflows, or any server-side scraping logic.
+
+---
+
+## Common Mistakes
+
+- **Checking `spot-history-YYYY.json` for liveness.** It is a seed file — always stale by design.
+- **Hardcoding endpoint URLs** outside `js/constants.js`. The `hourlyBaseUrls` and `fifteenMinBaseUrls` arrays in `API_PROVIDERS.STAKTRAKR` are the single source of truth.
+- **Adding a manual retry loop.** `_staktrakrFetch()` already iterates `baseUrls`. Double-wrapping it creates redundant requests.
+- **Adding poller code to this repo.** All backend code lives in `StakTrakrApi`.
+- **Ignoring the 5-second timeout.** `AbortController` enforces it — do not use bare `fetch()` for API calls without a signal.
+
+---
+
+## Related Pages
+
+- [frontend-overview.md](frontend-overview.md) — overall architecture and file map
+- [retail-modal.md](retail-modal.md) — how manifest.json market prices are displayed

--- a/wiki/architecture-overview.md
+++ b/wiki/architecture-overview.md
@@ -1,0 +1,150 @@
+---
+title: Architecture Overview
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages: []
+---
+
+# Architecture Overview
+
+> **Last verified:** 2026-02-25 — full audit from live Fly.io container source code. Dual poller, Turso shared DB, 17 coins, 7 vendors.
+> ⚠️ **Known gaps:** Spot poller not writing to Turso. See STAK-331.
+
+---
+
+## System Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Fly.io Container (staktrakr, dfw)                          │
+│                                                             │
+│  ┌─────────────┐  ┌──────────────┐                          │
+│  │ run-local.sh│  │ run-spot.sh  │                          │
+│  │ 0 * * * *   │  │ 5,20,35,50   │                          │
+│  └──────┬──────┘  └──────┬───────┘                          │
+│         │                │ ⚠️ writes files directly          │
+│  ┌──────▼──────────────────────────────────────────────┐   │
+│  │  Self-hosted Firecrawl (port 3002)                   │   │
+│  │  Playwright Service (port 3003)                      │   │
+│  │  Redis, RabbitMQ, PostgreSQL 17                      │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                                                             │
+│  ┌──────────────┐                                           │
+│  │run-publish.sh│  8,23,38,53 * * * *                      │
+│  │api-export.js │◄── Turso (price_snapshots + goldback-g1)  │
+│  └──────┬───────┘                                           │
+│         │ force-push HEAD:api                               │
+└─────────┼───────────────────────────────────────────────────┘
+          │
+┌─────────▼───────────────────────────────────────────────────┐
+│  Home VM (Ubuntu LXC, 192.168.1.81)                         │
+│  run-home.sh  30 * * * *                                        │
+│  Firecrawl + Playwright (supervisord)                       │
+│  Dashboard (port 3010), Metrics Exporter (port 9100)        │
+│  Grafana (port 3000), Prometheus (port 9090)                │
+│                │                                             │
+│                └──► Turso (same DB, POLLER_ID=home)          │
+└─────────────────────────────────────────────────────────────┘
+
+          │
+          ▼
+  Turso (libSQL cloud)
+  price_snapshots  — retail prices (both pollers)
+  poller_runs      — run metadata (both pollers)
+  provider_failures — per-URL failure log (both pollers)
+  ⚠️ spot_prices NOT yet in Turso (pending STAK-331)
+          │
+          ▼ (via run-publish.sh)
+  StakTrakrApi  api  branch
+          │
+          │  Merge Poller Branches GHA (*/15 min)
+          ▼
+  StakTrakrApi  main  branch
+          │
+          ▼
+  GitHub Pages → api.staktrakr.com
+          │
+          ▼
+  StakTrakr frontend (Cloudflare Pages)
+```
+
+---
+
+## Repo Boundaries
+
+| Repo | Owns |
+|------|------|
+| `lbruton/StakTrakrApi` | All API backend: poller code (`devops/`), GHA workflows, data files served via GitHub Pages |
+| `lbruton/StakTrakr` | Frontend app code, Cloudflare Pages deployment, local dev tools |
+| `lbruton/stakscrapr` | Home VM full stack — identical Firecrawl+Playwright+scraper core PLUS dashboard.js, tinyproxy/Cox residential proxy, Tailscale exit node config |
+| `lbruton/StakTrakrWiki` | This wiki — shared infrastructure documentation |
+
+---
+
+## Three Data Feeds
+
+| Feed | File | Writer | Cadence | Status |
+|------|------|--------|---------|--------|
+| Market prices | `data/api/manifest.json` | Fly.io `run-local.sh` + `run-publish.sh` via Turso | `0 * * * *` | ✅ Live |
+| Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` → **direct file write** | `5,20,35,50 * * * *` | ⚠️ Not via Turso — see STAK-331 |
+| Goldback | `data/api/goldback-spot.json` | Fly.io `run-local.sh` (via `goldback-g1` in providers.json) + `api-export.js` generates denominations (G1–G50) from Turso | `0 * * * *` (same as retail) | ✅ Live |
+
+---
+
+## Branch Strategy
+
+| Branch | Purpose | Writer |
+|--------|---------|--------|
+| `api` | Live data + providers.json config | Fly.io `run-publish.sh` (force-push) |
+| `main` | Merged source of truth; served by GitHub Pages | `Merge Poller Branches` GHA workflow |
+| `api1` | (Reserved for second Fly.io poller if needed) | Not currently active |
+
+GitHub Pages is configured to serve the **`main` branch** (not `api`). The merge workflow runs every 15 minutes to pull `api` data into `main`.
+
+---
+
+## Key Infrastructure Components
+
+| Component | What it is | Where |
+|-----------|-----------|-------|
+| Fly.io `staktrakr` app | All-in-one container: Firecrawl + pollers + serve.js | cloud |
+| Turso `staktrakrapi` DB | libSQL cloud — dual-poller write-through store (retail only currently) | cloud |
+| Home VM | Secondary poller + monitoring stack (Grafana, Prometheus) | 192.168.1.81 |
+| tinyproxy | Residential HTTP proxy on home VM for Fly.io scraper traffic | 192.168.1.81:8888 |
+| MetalPriceAPI | Spot price data source | cloud |
+| Gemini API | Vision cross-validation | cloud |
+| GitHub Pages | Static JSON API host | cloud |
+
+---
+
+## Deployment Paths
+
+| Change type | Action needed |
+|-------------|--------------|
+| Poller code change | `git push origin main` + `fly deploy` from `devops/fly-poller/` |
+| providers.json URL fix | Push to `api` branch — auto-synced next cycle, no redeploy |
+| Home poller code update | curl files from `raw.githubusercontent.com/lbruton/StakTrakrApi/main/devops/fly-poller/` |
+| New Fly.io secret | `fly secrets set KEY=value --app staktrakr` |
+| GHA workflow change | Push to `main` branch — GHA reads from main |
+
+---
+
+## Open Architecture Gaps (STAK-331 — Urgent)
+
+| Gap | Impact |
+|-----|--------|
+| Spot poller writes files, not Turso | Turso not single source of truth for spot data |
+| Turso missing weeks of historical data | Backfill script needed before charts/trends are usable |
+
+---
+
+## New Pages (2026-02-25 audit)
+
+| Page | Contents |
+|------|----------|
+| [REST API Reference](rest-api-reference.md) | Complete endpoint map, schemas, confidence scoring, vendor reference |
+| [Turso Schema](turso-schema.md) | Database tables, indexes, key query patterns, data volume estimates |
+| [Cron Schedule](cron-schedule.md) | Full timeline view, design rationale, verification commands |

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -1,0 +1,278 @@
+---
+title: "Backup & Restore"
+category: frontend
+owner: staktrakr
+lastUpdated: v3.32.41
+date: 2026-02-25
+sourceFiles:
+  - js/inventory.js
+  - js/vault.js
+  - js/cloud-sync.js
+  - js/cloud-storage.js
+  - js/image-cache.js
+relatedPages:
+  - cloud-sync.md
+  - image-pipeline.md
+  - idb-stores.md
+  - vault-crypto.md
+  - constants.md
+---
+# Backup & Restore
+
+> **Last updated:** v3.32.41 — 2026-02-25
+> **Source files:** `js/inventory.js`, `js/vault.js`, `js/cloud-sync.js`, `js/cloud-storage.js`, `js/image-cache.js`
+
+## Overview
+
+StakTrakr has **4 backup/restore mechanisms**. Each covers a different slice of application data — no single mechanism backs up everything. Full recovery requires combining mechanisms (typically ZIP + vault, or vault + image vault).
+
+| Mechanism | Format | Encrypted | Trigger |
+|-----------|--------|-----------|---------|
+| ZIP Backup | `.zip` | No | Settings → "Backup All Data" button |
+| Encrypted Vault | `.stvault` | Yes (AES-256-GCM) | Settings → Vault → "Export Vault" |
+| Image Vault | `.stvault` | Yes (AES-256-GCM) | Dropbox cloud sync (auto) |
+| Cloud Sync | Dropbox | Yes (vault-wrapped) | Settings → Cloud → Sync |
+
+---
+
+## Key Rules (read before touching this area)
+
+- **Full recovery requires two steps.** Vault alone restores localStorage only. User-uploaded photo blobs live in IndexedDB (IDB) and need a ZIP restore or image vault restore separately.
+- **CDN image URLs survive a vault restore.** Numista-enriched images (`obverseImageUrl`, `reverseImageUrl`) are stored on the inventory items in localStorage, so they come back immediately with any vault or ZIP restore. Only user-uploaded blobs need IDB restore.
+- **`coinImages` IDB store is legacy — never touch it.** The schema is retained to avoid a forced migration but is never read or written. ZIP restore explicitly skips this folder.
+- **`SYNC_SCOPE_KEYS`** intentionally excludes API keys, OAuth tokens, and spot history. Cloud sync is scoped to inventory + display prefs.
+- When modifying restore logic, always verify the post-restore call sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`.
+
+---
+
+## ZIP Backup (Non-Encrypted)
+
+**Trigger:** Settings → "Backup All Data" button (`exportZipBtn`)
+**Function:** `createBackupZip()` in `js/inventory.js`
+**Output filename:** `precious_metals_backup_YYYYMMDD.zip`
+
+### Files included in the ZIP
+
+| File in ZIP | Contents | Storage restored to |
+|-------------|----------|---------------------|
+| `inventory_data.json` | Full inventory array (includes CDN URLs: `obverseImageUrl`, `reverseImageUrl`) | localStorage (`LS_KEY`) |
+| `settings.json` | Theme, currency, catalog mappings, feature flags, chip config, table settings | localStorage (multiple keys) |
+| `spot_price_history.json` | Historical spot prices | localStorage (`SPOT_HISTORY_KEY`) |
+| `item_price_history.json` | Per-item price history | Merged via `mergeItemPriceHistory()` |
+| `item_tags.json` | Item tags | localStorage |
+| `retail_prices.json` | Retail price data | localStorage |
+| `retail_price_history.json` | Retail price history | localStorage |
+| `image_metadata.json` | Numista enrichment metadata | IDB `coinMetadata` store |
+| `user_images/` | User-uploaded photo blobs (obverse/reverse per UUID) | IDB `userImages` store |
+| `user_image_manifest.json` | UUID→filename mapping (STAK-226) | Used during restore |
+| `pattern_images/` | Pattern rule image blobs | IDB `patternImages` store |
+| `inventory_export.csv` | Human-readable CSV | Not restored (report only) |
+| `inventory_report.html` | HTML report | Not restored (report only) |
+
+### What is NOT included
+
+- `coinImages` IDB store (legacy/dead — explicitly skipped)
+- API keys and Dropbox OAuth tokens
+- Cloud sync state
+
+### Restore function
+
+`restoreBackupZip(file)` in `js/inventory.js`
+
+- `coinImages/` folder explicitly skipped with debug log: `"skipping legacy coinImages folder (store deprecated)"`
+- User images use manifest-based import (`user_image_manifest.json`); falls back to filename parsing for old ZIPs that predate STAK-226
+- Post-restore sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`
+
+---
+
+## Encrypted Vault (.stvault)
+
+**Trigger:** Settings → Vault → "Export Vault"
+**Function:** `vaultEncryptToBytes()` in `js/vault.js`
+**Crypto:** AES-256-GCM, PBKDF2 (600K iterations), 56-byte header
+**Output:** `*.stvault` binary file
+
+### What is included
+
+All localStorage keys listed in `ALLOWED_STORAGE_KEYS` (~80+ keys), including:
+
+- Inventory items with CDN URLs (`obverseImageUrl`, `reverseImageUrl`)
+- API keys and Dropbox OAuth tokens
+- Spot history, theme, all settings
+
+### What is NOT included
+
+- `userImages` IDB blobs
+- `patternImages` IDB blobs
+- `coinMetadata` IDB records
+
+### Scope variants
+
+| Scope | Function | Keys included | Used by |
+|-------|----------|---------------|---------|
+| `'full'` | `vaultEncryptToBytes()` | All `ALLOWED_STORAGE_KEYS` | Manual export |
+| `'sync'` | `vaultEncryptToBytesScoped()` | `SYNC_SCOPE_KEYS` only (excludes API keys, tokens, spot history) | Cloud auto-sync |
+
+### Restore function
+
+`vaultDecryptAndRestore(fileBytes, password)` in `js/vault.js`
+
+- Decrypts and writes all scoped localStorage keys
+- Image blobs are NOT restored — requires a separate ZIP or image vault restore
+- Post-restore sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`
+
+---
+
+## Image Vault
+
+**Functions:** `collectAndHashImageVault()` → `vaultEncryptImageVault()` in `js/vault.js`
+**Crypto:** AES-256-GCM (same as regular vault)
+**Cloud path:** `/StakTrakr/staktrakr-images.stvault` (Dropbox)
+
+### What is included
+
+All `userImages` IDB records serialized as base64 blobs.
+
+**Payload shape:**
+
+```json
+{
+  "_meta": {
+    "appVersion": "3.32.41",
+    "exportTimestamp": "2026-02-25T...",
+    "imageCount": 42
+  },
+  "records": [
+    {
+      "uuid": "abc123",
+      "obverse": "<base64>",
+      "reverse": "<base64>",
+      "cachedAt": "...",
+      "size": 12345
+    }
+  ]
+}
+```
+
+**Hash tracking:** `simpleHash(uuid + ':' + size + ':' + obverse.slice(0, 32))` — detects content changes even when file size is identical.
+
+### What is NOT included
+
+- `patternImages` IDB blobs
+- `coinMetadata` IDB records
+
+### Restore function
+
+`vaultDecryptAndRestoreImages(fileBytes, password)` → `restoreImageVaultData()` in `js/vault.js`
+
+- Decodes base64 strings back to `Blob` objects
+- Writes each record to `userImages` IDB via `imageCache.importUserImageRecord()`
+
+---
+
+## Cloud Sync (Dropbox)
+
+**Functions:** `pushSyncVault()` and `pullSyncVault()` in `js/cloud-sync.js`
+**Provider:** Dropbox via OAuth token
+
+### Remote paths
+
+| File | Path | Contents |
+|------|------|----------|
+| Inventory vault | `/StakTrakr/staktrakr-sync.stvault` | Sync-scoped vault (inventory + display prefs) |
+| Image vault | `/StakTrakr/staktrakr-images.stvault` | `userImages` blobs only |
+| Metadata pointer | `/StakTrakr/staktrakr-sync.json` | `imageHash`, `itemCount`, `syncId`, `deviceId` |
+
+### Push sequence
+
+1. `vaultEncryptToBytesScoped(password)` — build sync-scope vault
+2. Upload inventory vault to Dropbox
+3. `collectAndHashImageVault()` — compute current image hash; compare vs last push
+4. If hash changed → `vaultEncryptImageVault()` → upload image vault (failure here is non-fatal)
+5. Upload metadata pointer JSON with `imageHash`, `itemCount`, `syncId`, `deviceId`
+
+### Pull sequence
+
+1. `syncSaveOverrideBackup()` — snapshot local state before overwrite (conflict detection)
+2. Download + decrypt inventory vault → `vaultDecryptAndRestore()`
+3. Check remote `imageVault` hash vs local — if differs: download + decrypt image vault → `vaultDecryptAndRestoreImages()`
+4. Post-restore sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`
+
+### Sync scope
+
+`SYNC_SCOPE_KEYS` (defined in `js/constants.js`) includes: `metalInventory`, `itemTags`, display preferences.
+
+Intentionally excludes: API keys, OAuth tokens, spot price history.
+
+### Conflict detection
+
+`syncSaveOverrideBackup()` stores a pre-pull snapshot. The UI surfaces a conflict resolution prompt if item counts diverge between the snapshot and the pulled data.
+
+---
+
+## Coverage Matrix
+
+| Data | ZIP Backup | Encrypted Vault | Image Vault | Cloud Sync |
+|------|:----------:|:---------------:|:-----------:|:----------:|
+| Inventory items | ✅ | ✅ | ❌ | ✅ (sync scope) |
+| CDN image URLs on items | ✅ (in items) | ✅ (in items) | ❌ | ✅ (in items) |
+| User-uploaded photo blobs | ✅ `user_images/` | ❌ | ✅ | ✅ conditional |
+| Pattern rule image blobs | ✅ `pattern_images/` | ❌ | ❌ | ❌ |
+| Numista metadata cache | ✅ `image_metadata.json` | ❌ | ❌ | ❌ |
+| API keys / OAuth tokens | ❌ | ✅ (full scope) | ❌ | ❌ |
+| Spot price history | ✅ | ✅ (full scope) | ❌ | ❌ |
+| Settings / theme / prefs | ✅ | ✅ | ❌ | ✅ (display prefs only) |
+| `coinImages` (legacy) | ❌ SKIPPED | ❌ | ❌ | ❌ |
+
+**Key takeaway:** Full recovery requires BOTH a ZIP backup (for IDB blobs) AND a vault (for localStorage including API keys). Cloud sync alone does not cover pattern images or Numista metadata.
+
+---
+
+## Full Recovery Playbook
+
+### Scenario A: Full restore from ZIP backup
+
+1. Settings → "Backup All Data" produces the ZIP
+2. Settings → Restore → select the `.zip` file → `restoreBackupZip(file)`
+3. Restores: localStorage keys + `userImages` + `patternImages` + `coinMetadata`
+4. Verify inventory loads and photos appear
+
+### Scenario B: Full restore from vault + image vault
+
+1. Restore encrypted vault → `vaultDecryptAndRestore(fileBytes, password)`
+   - Restores: all localStorage (inventory, settings, API keys, spot history)
+   - CDN image URLs come back immediately (stored on items)
+2. Restore image vault → `vaultDecryptAndRestoreImages(fileBytes, password)`
+   - Restores: `userImages` IDB blobs
+3. Pattern images and Numista metadata are NOT recovered via this path
+
+### Scenario C: Cloud sync pull only
+
+- Restores inventory + display prefs (sync scope)
+- CDN image URLs come back immediately
+- If remote image hash differs from local, image vault is pulled and `userImages` restored
+- Pattern images and API keys are NOT restored
+
+---
+
+## Common Mistakes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "My photos are gone after restoring vault" | Vault only restores localStorage. User-uploaded blobs live in IDB and require a separate restore. CDN URLs survive, but locally uploaded images do not. | Also restore from ZIP (`user_images/`) or from the image vault. |
+| "Pattern images disappeared after restore" | Only the ZIP backup includes `pattern_images/`. Cloud sync and the image vault do not cover this store. | Restore from ZIP backup to recover pattern images. |
+| "Numista images came back immediately after vault restore" | Expected behavior. Numista CDN URLs (`obverseImageUrl`, `reverseImageUrl`) are stored on the inventory items in localStorage, so they survive any vault restore without touching IDB. | No action needed — this is correct. |
+| "Image vault upload failed during cloud push" | Image vault upload is non-fatal — the inventory vault still succeeds. | Check Dropbox token validity. The next successful push will retry the image vault if the hash changed. |
+| "Conflict prompt appeared after cloud pull" | Item counts diverged between the pre-pull snapshot and pulled data. | Review the conflict UI and choose which version to keep. |
+
+> **Never modify the `coinImages` IDB store.** It is a legacy store retained only to avoid a forced migration. It is never read or written. ZIP restore explicitly skips `coinImages/` and logs: `"skipping legacy coinImages folder (store deprecated)"`.
+
+---
+
+## Related Pages
+
+- [cloud-sync.md](cloud-sync.md) — Dropbox OAuth setup and sync troubleshooting
+- [image-pipeline.md](image-pipeline.md) — Numista enrichment, CDN URL lifecycle, IDB stores
+- [idb-stores.md](idb-stores.md) — IndexedDB store reference (`userImages`, `patternImages`, `coinMetadata`, `coinImages`)
+- [vault-crypto.md](vault-crypto.md) — AES-256-GCM vault format, header layout, PBKDF2 parameters
+- [constants.md](constants.md) — `ALLOWED_STORAGE_KEYS`, `SYNC_SCOPE_KEYS`, `IMAGE_ZIP_MANIFEST_VERSION`

--- a/wiki/cron-schedule.md
+++ b/wiki/cron-schedule.md
@@ -1,0 +1,96 @@
+---
+title: Cron Schedule
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-26
+sourceFiles: []
+relatedPages:
+  - fly-container.md
+  - home-poller.md
+  - health.md
+---
+
+# Cron Schedule
+
+> **Last verified:** 2026-02-26 — read from live `/etc/cron.d/retail-poller` on Fly.io container
+
+---
+
+## Fly.io Container Cron
+
+Written dynamically by `docker-entrypoint.sh` at container start. `CRON_SCHEDULE` env var controls retail poller cadence (default: `0`).
+
+| Minute | Script | Purpose | Log file |
+|--------|--------|---------|----------|
+| `0` | `run-local.sh` | Retail price scrape (Firecrawl + Vision) | `/var/log/retail-poller.log` |
+| `5,20,35,50` | `run-spot.sh` | Spot price poll (MetalPriceAPI) | `/var/log/spot-poller.log` |
+| `8,23,38,53` | `run-publish.sh` | Export Turso → JSON, git push to `api` branch | `/var/log/publish.log` |
+| `15` (hourly) | `run-retry.sh` | T3 retry of failed retail SKUs with Webshare proxy | `/var/log/retail-retry.log` |
+| `0 20` (daily) | `run-fbp.sh` | FindBullionPrices gap-fill for remaining failures | `/var/log/retail-poller.log` |
+
+### Raw crontab (`/etc/cron.d/retail-poller`)
+
+```
+0 * * * * root . /etc/environment; /app/run-local.sh >> /var/log/retail-poller.log 2>&1
+5,20,35,50 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1
+8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1
+15 * * * * root . /etc/environment; /app/run-retry.sh >> /var/log/retail-retry.log 2>&1
+0 20 * * * root . /etc/environment; /app/run-fbp.sh >> /var/log/retail-poller.log 2>&1
+```
+
+---
+
+## Timeline View (one hour)
+
+```
+:00  Fly.io retail scrape (Firecrawl + Vision → Turso)
+:05  Spot poll #1 (MetalPriceAPI → hourly + 15min files)
+:08  Publisher #1 (Turso → JSON → git push api branch) ← picks up :00 retail data
+:15  T3 Retry (re-scrape failures with proxy)
+:20  Spot poll #2
+:23  Publisher #2
+:30  Home poller retail scrape (Firecrawl → Turso)
+:35  Spot poll #3
+:38  Publisher #3 ← picks up :30 home poller data
+:50  Spot poll #4
+:53  Publisher #4
+:00  ──────────────────────────────────────────────
+```
+
+**Design rationale:** The schedule was relaxed from 2-3x/hr per poller to 1x/hr per poller (as of 2026-02-26) to reduce vendor rate-limiting risk and eliminate overlap between the two pollers. With a 30-minute offset (Fly.io at `:00`, home at `:30`), fresh data still arrives every 30 minutes. The publish cycle at `:08/:23/:38/:53` picks up whichever poller ran most recently. Spot polling remains at 4x/hr (every 15 min) since it uses a paid API with its own rate limits.
+
+---
+
+## Home LXC Cron
+
+| Minute | Script | Purpose |
+|--------|--------|---------|
+| `30` | `run-home.sh` | Retail scrape (Firecrawl only, no Vision) → Turso |
+
+The home poller runs at `:30`, offset from Fly.io's `:00`. Both write to the same Turso database. `readLatestPerVendor()` merges their data at publish time. Each poller fires once per hour; with the 30-minute offset, fresh data arrives every 30 minutes.
+
+---
+
+## Verifying the Schedule
+
+```bash
+# Read live crontab from container
+fly ssh console --app staktrakr -C "cat /etc/cron.d/retail-poller"
+
+# Check CRON_SCHEDULE env var
+fly ssh console --app staktrakr -C "grep CRON_SCHEDULE /etc/environment"
+
+# Home LXC
+ssh stakpoller@192.168.1.81 "cat /etc/cron.d/retail-poller"
+```
+
+**Known issue (2026-02-25 incident):** If `CRON_SCHEDULE` is set to `*/15` instead of `0`, the Fly.io poller fires at `:00/:15/:30/:45` — colliding with the home poller at `:30`. See [health.md](health.md) incident log.
+
+---
+
+## Related Pages
+
+- [Fly.io Container](fly-container.md) — services, env vars, deployment
+- [Home Poller (LXC)](home-poller.md) — secondary poller setup
+- [Health & Diagnostics](health.md) — diagnosing cron issues

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -1,0 +1,334 @@
+---
+title: Data Model
+category: frontend
+owner: staktrakr
+lastUpdated: v3.33.18
+date: 2026-03-01
+sourceFiles:
+  - js/constants.js
+  - js/utils.js
+relatedPages:
+  - storage-patterns.md
+  - frontend-overview.md
+  - api-consumption.md
+  - retail-modal.md
+---
+# Data Model
+
+> **Last updated:** v3.33.18 — 2026-03-01
+> **Source files:** `js/constants.js`, `js/utils.js`
+
+## Overview
+
+StakTrakr tracks precious metals inventory using three value dimensions per item. All state is persisted to `localStorage` through a strict allowlist guard. There is no backend database; the browser is the source of truth.
+
+## Key Rules (read before touching this area)
+
+1. **`meltValue` is never stored.** It is always computed at render time: `meltValue = item.weight * item.qty * spotPrice`. Storing it would produce stale values.
+2. **Every localStorage key must be registered in `ALLOWED_STORAGE_KEYS`** (`js/constants.js`) before use. `saveData()` and `saveDataSync()` silently no-op on unregistered keys — no error is thrown, data is simply discarded.
+3. **`saveData` / `loadData` are the only permitted localStorage accessors.** Never call `localStorage.setItem` / `getItem` directly in application code.
+4. **`spotPrice` is runtime state, not stored state.** It is fetched from the API and exposed as `window.spotPrice` (one property per metal). It is not written to the inventory object.
+5. **`disposition` is stored on the item record.** When an item is disposed (sold/traded/lost/gifted/returned), a `disposition` object is written to the item. The `realizedGainLoss` is computed once at disposition time and stored — it is not re-derived at render.
+
+## Architecture
+
+### Portfolio Value Model
+
+| Dimension | Source | Stored? |
+|---|---|---|
+| `purchasePrice` | User entry | Yes (in item record) |
+| `meltValue` | `item.weight * item.qty * spotPrice` | **No — computed at render** |
+| `retailPrice` | Live market ask from API | No (cached separately in `retailPrices`) |
+
+`purchasePrice` is the historical cost basis — what the user actually paid. It never changes after entry.
+
+`meltValue` reflects the current intrinsic metal value and changes every time spot moves. Computing it at render time avoids stale data and keeps the stored schema simple.
+
+`retailPrice` is the current market ask for that specific product. It is fetched from the retail price API and stored in its own cache key (`retailPrices`), not inside the inventory item.
+
+### Portfolio Item Shape
+
+```js
+{
+  id:            String,   // UUID v4 — primary key
+  name:          String,   // display name, e.g. "2024 American Gold Eagle 1 oz"
+  type:          String,   // "coin" | "bar" | "round"
+  metal:         String,   // "gold" | "silver" | "platinum" | "palladium"
+  weight:        Number,   // fine troy ounces per unit
+  qty:           Number,   // integer quantity held
+  purchasePrice: Number,   // total cost basis in USD (all units combined)
+  purchaseDate:  String,   // ISO date string "YYYY-MM-DD"
+  mintmark:      String,   // optional mint or issuer label
+  tags:          String[], // arbitrary user-defined labels
+  disposition:   Object|null // disposition record (v3.33.17) — null for active items
+}
+```
+
+`weight` is always in **fine troy ounces** (the pure metal content, not the gross weight). For a 1 oz Gold Eagle, `weight = 1.0`. For a 90% silver dime, `weight ≈ 0.07234`.
+
+### Disposition Record Shape (v3.33.17 — STAK-72)
+
+When an item is disposed, a `disposition` object is written to the item record:
+
+```js
+{
+  type:             String,   // "sold" | "traded" | "lost" | "gifted" | "returned"
+  date:             String,   // ISO date string "YYYY-MM-DD"
+  amount:           Number,   // sale/trade/refund amount in USD (0 for lost/gifted)
+  currency:         String,   // always "USD" currently
+  recipient:        String,   // optional — who received the item
+  notes:            String,   // optional — free-text notes
+  realizedGainLoss: Number,   // amount - (purchasePrice * qty) — computed once at disposition
+  disposedAt:       String    // ISO timestamp — when the disposition was recorded
+}
+```
+
+**Key behaviors:**
+
+- `isDisposed(item)` (in `js/constants.js`) returns `true` if `item.disposition` is truthy.
+- Disposed items are excluded from active portfolio totals (melt value, purchase total, weight, item count). They are tracked in a separate `disposedItems` counter and `realizedGainLoss` accumulator per metal in `updateSummary()`.
+- `realizedGainLoss` is computed once at disposition time (`confirmDisposition()` in `js/inventory.js`): `amount - (item.price * item.qty)`. It is stored, not re-derived.
+- `undoDisposition(idx)` sets `item.disposition = null`, restoring the item to active inventory.
+- The filter system (`js/filters.js`) strips disposed items by default; a toggle (`#showDisposedToggle`) reveals them.
+
+### Disposition Types
+
+Defined in `DISPOSITION_TYPES` (frozen object in `js/constants.js`):
+
+| Key | Label | `requiresAmount` |
+|---|---|---|
+| `sold` | Sold | `true` |
+| `traded` | Traded | `true` |
+| `lost` | Lost | `false` |
+| `gifted` | Gifted | `false` |
+| `returned` | Returned | `true` |
+
+Types where `requiresAmount` is `false` do not require a monetary amount — the disposition modal hides the amount input for these types.
+
+### Spot Price Access
+
+```js
+// Reading spot at render time — never from a stored field:
+const spotPrice = window.spotPrice?.[item.metal] ?? 0;
+const meltValue = item.weight * item.qty * spotPrice;
+```
+
+`window.spotPrice` is populated by the spot-price fetch in `api.js` and is not written to `localStorage` under the inventory key. Individual per-metal spot values are cached under `spotGold`, `spotSilver`, `spotPlatinum`, and `spotPalladium` (see key list below).
+
+### Storage Layer
+
+**Async API (preferred for large data):**
+
+```js
+await saveData(key, value);          // js/utils.js — JSON-serialises, compresses if needed
+const data = await loadData(key, defaultValue);
+```
+
+**Sync API (used for UI preferences and non-blocking reads):**
+
+```js
+saveDataSync(key, value);
+const data = loadDataSync(key, defaultValue);
+```
+
+Both variants are exported to `window` (`window.saveDataSync`, `window.loadDataSync`). Both transparently handle LZ compression for large payloads. `loadData` / `loadDataSync` return `defaultValue` on missing or corrupt keys — they never throw to the caller.
+
+### ALLOWED_STORAGE_KEYS
+
+All keys currently registered in `js/constants.js`. Keys are grouped by domain below.
+
+**Core inventory:**
+
+| Key | Type | Description |
+|---|---|---|
+| `metalInventory` | JSON array | Primary inventory — array of item objects (includes `disposition` field per item when disposed) |
+| `inventorySerial` | Number string | Monotonic serial for change detection |
+| `catalogMap` | JSON object | Catalog metadata keyed by item ID |
+| `item-price-history` | JSON object | Per-item price history keyed by UUID |
+| `itemTags` | JSON object | Per-item tags keyed by UUID |
+
+**Spot prices:**
+
+| Key | Type | Description |
+|---|---|---|
+| `metalSpotHistory` | JSON array | Hourly spot price history |
+| `spotGold` | Number string | Cached gold spot price |
+| `spotSilver` | Number string | Cached silver spot price |
+| `spotPlatinum` | Number string | Cached platinum spot price |
+| `spotPalladium` | Number string | Cached palladium spot price |
+| `spotTrendRange` | String | Selected spot trend range |
+| `spotCompareMode` | String | Spot chart compare mode |
+| `spotTrendPeriod` | String | Trend period: "1"\|"7"\|"30"\|"90"\|"365"\|"1095" |
+
+**Retail prices:**
+
+| Key | Type | Description |
+|---|---|---|
+| `retailPrices` | JSON object | Current retail ask prices keyed by item slug |
+| `retailPriceHistory` | JSON array | Historical retail price entries |
+| `retailProviders` | JSON array | Active retail data provider list |
+| `retailIntradayData` | JSON object | Intraday retail price data |
+| `retailSyncLog` | JSON array | Retail sync event log |
+| `retailAvailability` | JSON object | Per-item availability data |
+
+**Goldback:**
+
+| Key | Type | Description |
+|---|---|---|
+| `goldback-prices` | JSON object | Current Goldback prices |
+| `goldback-price-history` | JSON array | Historical Goldback prices |
+| `goldback-enabled` | Boolean string | Goldback feature toggle |
+| `goldback-estimate-enabled` | Boolean string | Goldback estimate display toggle |
+| `goldback-estimate-modifier` | Number string | Goldback estimate adjustment modifier |
+
+**API / catalog:**
+
+| Key | Type | Description |
+|---|---|---|
+| `metalApiConfig` | JSON object | API provider credentials |
+| `metalApiCache` | JSON object | General API response cache |
+| `lastCacheRefresh` | Timestamp | Last cache refresh time |
+| `lastApiSync` | Timestamp | Last API sync time |
+| `catalog_api_config` | JSON object | Catalog API configuration |
+| `staktrakr.catalog.cache` | JSON object | Catalog item cache |
+| `staktrakr.catalog.settings` | JSON object | Catalog display settings |
+| `staktrakr.catalog.history` | JSON array | Catalog browse history |
+| `numista_response_cache` | JSON object | Numista API response cache |
+| `pcgs_response_cache` | JSON object | PCGS API response cache |
+| `autocomplete_lookup_cache` | JSON object | Autocomplete suggestion cache |
+| `autocomplete_cache_timestamp` | Timestamp | Autocomplete cache age |
+| `numistaLookupRules` | JSON array | Custom Numista search rules |
+| `numistaViewFields` | JSON object | View modal Numista field visibility |
+| `numistaOverridePersonal` | Boolean string | Numista API overrides user pattern images |
+| `enabledSeedRules` | JSON array | Enabled built-in Numista lookup rule IDs |
+| `seedImagesVer` | String | Seed images version for cache invalidation |
+
+**UI / display preferences:**
+
+| Key | Type | Description |
+|---|---|---|
+| `appTheme` | String | UI theme name |
+| `displayCurrency` | String | Display currency code (e.g. "USD") |
+| `exchangeRates` | JSON object | Cached exchange rates |
+| `appTimeZone` | String | "auto" \| "UTC" \| IANA zone |
+| `settingsItemsPerPage` | Number string | Table rows per page |
+| `cardViewStyle` | String | "A"\|"B"\|"C" — card display variant |
+| `desktopCardView` | Boolean string | Desktop card view toggle |
+| `defaultSortColumn` | Number string | Default table sort column index |
+| `defaultSortDir` | String | "asc"\|"desc" — default sort direction |
+| `metalOrderConfig` | JSON array | Metal order/visibility configuration |
+| `layoutVisibility` | JSON object | Legacy section visibility (migrated to `layoutSectionConfig`) |
+| `layoutSectionConfig` | JSON array | Ordered section config `[{ id, label, enabled }]` |
+| `viewModalSectionConfig` | JSON array | Ordered view modal section config |
+| `tableImagesEnabled` | Boolean string | Show thumbnail images in table rows |
+| `tableImageSides` | String | "both"\|"obverse"\|"reverse" — table image sides |
+| `headerThemeBtnVisible` | Boolean string | Header theme button visibility |
+| `headerCurrencyBtnVisible` | Boolean string | Header currency button visibility |
+| `headerTrendBtnVisible` | Boolean string | Header trend button visibility |
+| `headerSyncBtnVisible` | Boolean string | Header sync button visibility |
+| `headerMarketBtnVisible` | Boolean string | Header market button visibility |
+| `chipMinCount` | Number string | Minimum item count for chip display |
+| `chipCustomGroups` | JSON array | Custom chip grouping definitions |
+| `chipBlacklist` | JSON array | Hidden chip values |
+| `inlineChipConfig` | JSON object | Inline chip display configuration |
+| `chipSortOrder` | String | Chip sort order preference |
+| `apiProviderOrder` | JSON array | API provider display order |
+| `providerPriority` | JSON object | API provider priority map |
+| `filterChipCategoryConfig` | JSON object | Filter chip category configuration |
+
+**Version / app state:**
+
+| Key | Type | Description |
+|---|---|---|
+| `currentAppVersion` | String | Installed app version string |
+| `ackVersion` | String | Last acknowledged version for changelog |
+| `ackDismissed` | Boolean string | Dismissal state for acknowledgement banner |
+| `featureFlags` | JSON object | Feature flag overrides |
+| `lastVersionCheck` | Timestamp | Last remote version check time |
+| `latestRemoteVersion` | String | Cached latest remote version string |
+| `latestRemoteUrl` | String | Cached latest remote release URL |
+| `changeLog` | JSON array | Cached changelog entries |
+| `staktrakr.debug` | Boolean string | Debug mode toggle |
+| `stackrtrackr.debug` | Boolean string | Legacy debug key (typo alias kept for compatibility) |
+
+**Image storage (added v3.32.27):**
+
+| Key | Constant | Type | Description |
+|---|---|---|---|
+| `storagePersistGranted` | `STORAGE_PERSIST_GRANTED_KEY` | Boolean string | `"true"`/`"false"` — whether the browser has granted persistent storage via `navigator.storage.persist()` |
+
+**Cloud sync:**
+
+| Key | Type | Description |
+|---|---|---|
+| `cloud_token_dropbox` | JSON | Dropbox OAuth token data |
+| `cloud_token_pcloud` | JSON | pCloud OAuth token data |
+| `cloud_token_box` | JSON | Box OAuth token data |
+| `cloud_last_backup` | JSON | `{ provider, timestamp }` last backup info |
+| `cloud_kraken_seen` | Boolean string | Easter egg seen flag |
+| `staktrakr_oauth_result` | JSON | Transient OAuth callback relay (cleared after read) |
+| `cloud_activity_log` | JSON | Cloud sync activity log entries |
+| `cloud_sync_enabled` | Boolean string | Master auto-sync toggle |
+| `cloud_sync_last_push` | JSON | `{ syncId, timestamp, rev, itemCount }` |
+| `cloud_sync_last_pull` | JSON | `{ syncId, timestamp, rev }` |
+| `cloud_sync_device_id` | UUID string | Stable per-device identifier |
+| `cloud_sync_cursor` | String | Dropbox rev string for change detection |
+| `cloud_sync_override_backup` | JSON | Pre-pull local snapshot |
+| `cloud_vault_idle_timeout` | Number string | Vault idle lock timeout in minutes |
+| `cloud_vault_password` | String | Vault password for persistent unlock |
+| `cloud_dropbox_account_id` | String | Dropbox account_id for key derivation |
+| `cloud_sync_mode` | String | DEPRECATED — kept for migration only |
+| `manifestPruningThreshold` | Number string | Days to keep manifest entries before pruning (STAK-184 diff/merge architecture) |
+
+**One-time migrations:**
+
+| Key | Type | Description |
+|---|---|---|
+| `ff_migration_fuzzy_autocomplete` | Flag | Fuzzy autocomplete migration (v3.26.01) |
+| `migration_hourlySource` | Flag | Re-tag StakTrakr hourly entries |
+| `migration_seedHistoryMerge` | Flag | Backfill full historical seed data (v3.32.01) |
+
+### Feature Flags (added to FEATURE_FLAGS in v3.33.06)
+
+Three new feature flags were added to `js/constants.js` for the Market Page Redesign:
+
+| Flag | Default | Description |
+|---|---|---|
+| `MARKET_LIST_VIEW` | `false` | Gates the new full-width market card layout with search, sort, inline 7-day trend charts, spike detection, vendor price chips, computed stats, and card click-to-expand |
+| `MARKET_DASHBOARD_ITEMS` | `false` | Gates goldback and dashboard items in the market list |
+| `MARKET_AUTO_RETAIL` | `false` | Auto-update inventory retail prices from linked market data |
+
+All three use `urlOverride: true` (enable via `?market_list_view=true` etc.) and `userToggle: true` (Settings UI toggle). Phase: `"beta"`.
+
+## Common Mistakes
+
+**Storing `meltValue` in the item record.**
+Never do this. Spot moves constantly; a stored `meltValue` is wrong the moment spot changes. Always derive it at render: `item.weight * item.qty * window.spotPrice[item.metal]`.
+
+**Adding a new localStorage key without registering it.**
+`saveData` and `saveDataSync` check the key against `ALLOWED_STORAGE_KEYS` and silently discard writes if the key is missing. There is no error. The symptom is settings that appear to save but reset on reload. Fix: add the key to the array in `js/constants.js` first.
+
+**Calling `localStorage.setItem` / `getItem` directly.**
+Only `saveData` / `saveDataSync` and `loadData` / `loadDataSync` are permitted. Direct calls bypass compression, bypass the allowlist guard, and are not portable to future storage backends.
+
+**Assuming `loadData` returns the same type as written.**
+`loadData` returns the `defaultValue` argument (default: `[]`) when the key is absent or parse fails. Always pass an explicit default that matches the expected type (e.g., pass `{}` for objects, `[]` for arrays, `null` for nullable scalars).
+
+**Reading spot from the item record.**
+There is no `spotPrice` field on the item. Always read from `window.spotPrice[item.metal]` or the per-metal keys (`spotGold`, `spotSilver`, etc.) via `loadDataSync`.
+
+**Hardcoding a storage quota.**
+Do not use a fixed byte limit like `50 * 1024 * 1024`. As of v3.32.27, quota is derived dynamically from `navigator.storage.estimate()` in `js/image-cache.js`. Use the runtime estimate so the limit scales with the device's actual available storage.
+
+**Re-computing `realizedGainLoss` at render time.**
+`realizedGainLoss` is calculated once at disposition time (`amount - purchasePrice * qty`) and stored in `item.disposition.realizedGainLoss`. Do not re-derive it — the stored value is the authoritative figure. To update it, the user must undo the disposition and re-dispose.
+
+**Filtering without checking `disposition`.**
+Active portfolio calculations (totals, weight, melt value) must skip disposed items. The `updateSummary()` function in `js/inventory.js` uses `isDisposed(item)` to partition items into active vs. disposed buckets. If you add a new summary calculation, ensure disposed items are excluded from the active totals and their `realizedGainLoss` is accumulated separately.
+
+## Related Pages
+
+- [storage-patterns.md](storage-patterns.md) — `saveData` / `loadData` usage patterns, compression, and the allowlist guard implementation
+- [frontend-overview.md](frontend-overview.md) — module load order, `index.html` script sequence, and `sw.js` asset list
+- [api-consumption.md](api-consumption.md) — spot price fetch, retail price feed, and how `window.spotPrice` is populated
+- [retail-modal.md](retail-modal.md) — retail view modal and market list view architecture

--- a/wiki/dom-patterns.md
+++ b/wiki/dom-patterns.md
@@ -1,0 +1,161 @@
+---
+title: DOM Patterns
+category: frontend
+owner: staktrakr
+lastUpdated: v3.32.25
+date: 2026-02-23
+sourceFiles:
+  - js/utils.js
+  - js/init.js
+  - js/about.js
+relatedPages:
+  - frontend-overview.md
+  - storage-patterns.md
+---
+# DOM Patterns
+
+> **Last updated:** v3.32.25 — 2026-02-23
+> **Source files:** `js/utils.js`, `js/init.js`, `js/about.js`
+
+## Overview
+
+StakTrakr enforces two strict DOM safety rules:
+
+1. All element lookups must go through `safeGetElement()` — never raw `document.getElementById()` except in two designated boot files.
+2. All user-controlled content written to `innerHTML` must pass through `sanitizeHtml()` first to prevent XSS.
+
+These rules exist because the app runs on `file://` (no server-side sanitization) and handles user-entered text that is later rendered as HTML. Violations are a recurring source of both runtime null-reference crashes and security bugs.
+
+---
+
+## Key Rules (read before touching this area)
+
+- **Use `safeGetElement(id)`** for every DOM lookup in application code.
+- **Raw `document.getElementById()` is only allowed in `js/about.js` and `js/init.js`** — these are the two boot files that run before the `safeGetElement` wrapper is available.
+- **Always call `sanitizeHtml(str)` before assigning user-supplied text to `innerHTML`.**
+- Never assign an unescaped user string directly to `innerHTML`, even for "display-only" fields.
+
+---
+
+## Architecture
+
+### `safeGetElement(id, required?)` — defined in `js/init.js`
+
+```js
+function safeGetElement(id, required = false) {
+  const element = document.getElementById(id);
+  if (!element && required) {
+    console.warn(`Required element '${id}' not found in DOM`);
+  }
+  return element || createDummyElement();
+}
+```
+
+**What it does when the element is not found:** returns a `createDummyElement()` object — a plain object with no-op stubs for all common DOM properties (`textContent`, `innerHTML`, `style`, `value`, `addEventListener`, etc.). This means callers never receive `null` and do not need to null-check before setting `.textContent` or attaching listeners. If `required = true` is passed, a `console.warn` is emitted so missing elements are visible in the DevTools console during development.
+
+**Why this matters:** Raw `document.getElementById()` returns `null` when an element is absent. Any subsequent property access on `null` throws a TypeError and can crash the entire initialization chain. `safeGetElement` eliminates that failure mode.
+
+---
+
+### `sanitizeHtml(str)` — defined in `js/utils.js`
+
+```js
+const sanitizeHtml = (text) => {
+  if (!text) return "";
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+```
+
+**What it does:** HTML-encodes the five characters that are meaningful inside HTML (`&`, `<`, `>`, `"`, `'`). The result is safe to interpolate directly into an `innerHTML` assignment or template literal — it renders as visible text, never as markup or script.
+
+**When to use it:** Any time the string being inserted originated from user input (item names, notes, imported CSV fields, custom labels, etc.).
+
+---
+
+## Common Mistakes
+
+### Mistake 1 — Raw `getElementById` in application code
+
+```js
+// WRONG — returns null if element is missing, crashes on .textContent
+const el = document.getElementById('spotPrice');
+el.textContent = price;
+```
+
+```js
+// RIGHT — returns a dummy element if missing, no crash
+const el = safeGetElement('spotPrice');
+el.textContent = price;
+```
+
+---
+
+### Mistake 2 — `innerHTML` with unsanitized user content
+
+```js
+// WRONG — XSS: a crafted item name like <script>alert(1)</script> executes
+row.innerHTML = `<td>${item.name}</td>`;
+```
+
+```js
+// RIGHT — encoded, renders as visible text only
+row.innerHTML = `<td>${sanitizeHtml(item.name)}</td>`;
+```
+
+---
+
+### Mistake 3 — Using `safeGetElement` in `about.js` or `init.js` before it is defined
+
+`safeGetElement` is defined inside `js/init.js`. The `DOMContentLoaded` handler in `init.js` and the top-level code in `about.js` both run as part of early boot, before the function is reliably available to all callers in those two files. This is why those two files are the **only** permitted users of raw `document.getElementById()`.
+
+```js
+// ALLOWED — inside js/about.js or js/init.js only
+const el = document.getElementById('aboutVersion');
+```
+
+```js
+// WRONG — do not use raw getElementById anywhere else
+const el = document.getElementById('settingsPanel'); // in settings.js — use safeGetElement instead
+```
+
+---
+
+### Mistake 4 — Skipping sanitization for "non-dangerous" fields
+
+```js
+// WRONG — item notes are user input; even "safe-looking" strings can contain angle brackets
+modal.innerHTML = `<p>${item.notes}</p>`;
+```
+
+```js
+// RIGHT — sanitize regardless of expected content
+modal.innerHTML = `<p>${sanitizeHtml(item.notes)}</p>`;
+```
+
+---
+
+### Mistake 5 — Sanitizing developer-controlled template strings
+
+`sanitizeHtml` is for **user-supplied content only**. Do not wrap static developer-written HTML strings — that double-encodes intentional markup.
+
+```js
+// WRONG — sanitizing a static layout string; produces &lt;span&gt; in the DOM
+el.innerHTML = sanitizeHtml(`<span class="badge">Active</span>`);
+```
+
+```js
+// RIGHT — static markup from the developer does not need sanitizing
+el.innerHTML = `<span class="badge">Active</span>`;
+```
+
+---
+
+## Related Pages
+
+- [frontend-overview.md](frontend-overview.md) — overall JS architecture and file load order
+- [storage-patterns.md](storage-patterns.md) — `saveData()` / `loadData()` and `ALLOWED_STORAGE_KEYS`

--- a/wiki/fly-container.md
+++ b/wiki/fly-container.md
@@ -1,0 +1,201 @@
+---
+title: Fly.io Container
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages: []
+---
+
+# Fly.io Container
+
+> **Last verified:** 2026-02-25 — app `staktrakr`, region `dfw`, 4GB RAM / 4 shared CPUs
+
+---
+
+## Overview
+
+Single Fly.io app (`staktrakr`) that runs all retail polling, spot price polling, and an HTTP API proxy. Everything is managed by **supervisord** inside one container.
+
+As of 2026-02-24, outbound scraping traffic is routed through a residential home VM via Tailscale exit node rather than a third-party proxy service.
+
+Goldback pricing was migrated from a standalone daily scraper (`run-goldback.sh`) to the standard retail pipeline in Feb 2026 — it is now scraped as the `goldback-g1` coin via `providers.json`, once per hour alongside all other coins. See [goldback-pipeline.md](goldback-pipeline.md).
+
+---
+
+## App Config
+
+| Key | Value |
+|-----|-------|
+| App name | `staktrakr` |
+| Region | `dfw` (fly.toml says `iad` but deployed to `dfw`) |
+| Memory | 4096 MB |
+| CPUs | 4 shared |
+| Volume | `staktrakr_data` mounted at `/data` |
+| HTTP port | 8080 (proxied by Fly, force HTTPS) |
+
+**Persistent volume** (`/data`) holds the cloned `StakTrakrApi` repo at `/data/staktrakr-api-export` and Tailscale state at `/data/tailscale/tailscaled.state`.
+
+---
+
+## Services (supervisord)
+
+| Service | Command | Priority | Notes |
+|---------|---------|----------|-------|
+| `redis` | `redis-server` on `127.0.0.1:6379` | 10 | Firecrawl queue backing |
+| `rabbitmq` | `rabbitmq-server` | 10 | Firecrawl job queue |
+| `postgres` | PostgreSQL 17 on `localhost:5432` | 10 | Firecrawl NUQ state |
+| `playwright-service` | Node.js on port 3003 | 15 | Playwright CDP; `BLOCK_MEDIA=True`; no proxy |
+| `firecrawl-api` | Node.js on port 3002 | 20 | Firecrawl HTTP API |
+| `firecrawl-worker` | Node.js queue worker | 20 | Processes scrape jobs |
+| `firecrawl-extract-worker` | Node.js extract worker | 20 | LLM extraction jobs |
+| `cron` | `cron -f` | 30 | Runs all poller cron jobs |
+| `http-server` | `node /app/serve.js` on port 8080 | 30 | Proxy/health endpoint |
+
+---
+
+## Cron Schedule
+
+Written dynamically by `docker-entrypoint.sh` at container start. `CRON_SCHEDULE` env var controls the retail poller cadence.
+
+| Schedule | Script | Log |
+|----------|--------|-----|
+| `0 * * * *` (default) | `/app/run-local.sh` | `/var/log/retail-poller.log` |
+| `5,20,35,50 * * * *` | `/app/run-spot.sh` | `/var/log/spot-poller.log` |
+| `8,23,38,53 * * * *` | `/app/run-publish.sh` | `/var/log/publish.log` |
+| `15 * * * *` | `/app/run-retry.sh` | `/var/log/retail-retry.log` |
+| `0 20 * * *` | `/app/run-fbp.sh` | `/var/log/retail-poller.log` |
+
+> **Staggered dual-poller cadence.** Fly.io runs at `:00`, home poller at `:30` — fresh data every 30 minutes. The `CRON_SCHEDULE` env var in `docker-entrypoint.sh` defaults to `0`. Override with a Fly secret only if needed. Goldback is scraped as part of the regular retail cycle (via `goldback-g1` coin in `providers.json`) — there is no separate goldback cron.
+
+---
+
+## 4-Tier Scraper Fallback
+
+As of 2026-02-24, the retail poller uses a fully automated 4-tier fallback to recover from scraping failures without data gaps.
+
+| Tier | Method | When | Status |
+|------|--------|------|--------|
+| T1 | **Tailscale exit node** (`100.112.198.50`) | Normal — residential IP every cycle | Configured (inactive — tailscaled not in supervisord) |
+| T2 | **Fly.io datacenter IP** | Tailscale socket absent — automatic via socket-check in `run-local.sh` | Live (current active egress) |
+| T3 | **Webshare proxy + `:15` cron retry** | ≥1 SKU still failed after T1/T2 | Live |
+| T4 | **Turso last-known-good price** | T3 also failed for a vendor | Live |
+
+### T1 → T2: automatic per-cycle egress selection
+
+`run-local.sh` pings the exit node before each run:
+
+```bash
+if tailscale ping -c 1 --timeout=3s 100.112.198.50 &>/dev/null; then
+  tailscale set --exit-node=100.112.198.50   # residential IP
+else
+  tailscale set --exit-node=                 # fall back to Fly datacenter IP
+fi
+```
+
+### T3: automated proxy retry at `:15`
+
+After the retail scrape, `price-extract.js` writes `/tmp/retail-failures.json` listing any SKUs that failed both the main scrape and the FBP backfill. `run-retry.sh` fires at `:15` each hour:
+
+- **No-op** if `/tmp/retail-failures.json` is absent — zero overhead on clean runs
+- Re-scrapes only the failed coin slugs with `PROXY_DISABLED=""` (Webshare enabled for Playwright fallback)
+- Clears the queue file on exit regardless of outcome (via `trap`) — T4 covers any remainder
+
+Webshare credentials are in Fly secrets (`WEBSHARE_PROXY_USER`, `WEBSHARE_PROXY_PASS`). The main scrape sets `PROXY_DISABLED=1`; T3 explicitly unsets it — no `fly deploy` needed to activate proxy.
+
+Log: `/var/log/retail-retry.log`
+
+If `WEBSHARE_PROXY_USER` is not set, T3 logs a warning and runs unproxied — T4 still covers gaps.
+
+### T4: Turso last-known-good fill
+
+At the `:23` publish run, `api-export.js` checks any vendor slot with `price === null` (but not known OOS). If `getLastKnownPrice()` finds a prior in-stock row in Turso, the manifest entry is filled with:
+
+```json
+{
+  "price": 34.21,
+  "source": "turso_last_known",
+  "stale": true,
+  "stale_since": "2026-02-24T14:00:00Z",
+  "inStock": true
+}
+```
+
+The `stale` flag is available for future frontend UI use. Vendor is kept in the manifest rather than omitted.
+
+---
+
+## Environment Variables
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
+| `POLLER_ID` | `fly.toml` (hardcoded `api`) | Written to Turso rows to identify this poller |
+| `API_EXPORT_DIR` / `DATA_REPO_PATH` | `fly.toml` (`/data/staktrakr-api-export`) | Working copy of StakTrakrApi repo |
+| `FIRECRAWL_BASE_URL` | `fly.toml` (`http://localhost:3002`) | Self-hosted Firecrawl endpoint |
+| `BROWSER_MODE` | `fly.toml` (`local`) | Playwright launch mode |
+| `PLAYWRIGHT_LAUNCH` | `fly.toml` (`1`) | Enable local Chromium for fallback |
+| `PROXY_DISABLED` | `fly.toml` (`1`) | Disables Webshare proxy in `price-extract.js` |
+| `TS_EXIT_NODE` | `fly.toml` (`100.112.198.50`) | Tailscale exit node IP (home VM) |
+| `GITHUB_TOKEN` | Fly secret | Push to `api` branch via run-publish.sh |
+| `TURSO_DATABASE_URL` | Fly secret | Turso libSQL cloud |
+| `TURSO_AUTH_TOKEN` | Fly secret | Turso auth |
+| `GEMINI_API_KEY` | Fly secret | Vision pipeline (Gemini) |
+| `METAL_PRICE_API_KEY` | Fly secret | Spot price API (MetalPriceAPI) |
+| `TS_AUTHKEY` | Fly secret | Tailscale reusable ephemeral auth key (also in Infisical as `FLY_TAILSCALE_AUTHKEY`) |
+| `WEBSHARE_PROXY_USER` | Fly secret | Webshare credentials — retained but inactive |
+| `WEBSHARE_PROXY_PASS` | Fly secret | Webshare credentials — retained but inactive |
+| `CRON_SCHEDULE` | Fly secret (optional) | Override retail poller cron; default `0` |
+
+---
+
+## Deployment
+
+```bash
+# From repo root
+cd devops/fly-poller
+fly deploy
+
+# After deploy, verify services
+fly ssh console --app staktrakr -C "supervisorctl status"
+
+# Watch logs
+fly logs --app staktrakr
+fly logs --app staktrakr | grep -E 'retail|publish|spot|goldback|ERROR|exit node'
+
+# Manually trigger a run
+fly ssh console --app staktrakr -C "/app/run-local.sh"
+
+# Verify Tailscale connectivity
+fly ssh console --app staktrakr -C "tailscale status"
+
+# Verify egress IP (should show home residential IP when exit node active)
+fly ssh console --app staktrakr -C "curl -s https://ifconfig.me"
+```
+
+**Code changes** require `fly deploy`. **Provider URL changes** do not — pollers read from Turso on each run. Use the [dashboard](home-poller.md) at `http://192.168.1.81:3010/providers` or `provider-db.js` CRUD functions. See [Provider Database](provider-database.md).
+
+---
+
+## Volume and Git Repo
+
+The persistent volume at `/data/staktrakr-api-export` is a clone of `StakTrakrApi`. It is seeded on first run by `run-local.sh` (if missing `.git`). After that it persists across deploys.
+
+`run-publish.sh` commits from this directory and force-pushes `HEAD:api`. This is the **sole Git writer** for the `api` branch data files.
+
+Tailscale state lives at `/data/tailscale/tailscaled.state` — also on the persistent volume, so node identity survives redeploys without re-registering in the Tailscale admin console.
+
+---
+
+## Common Issues
+
+| Symptom | Check |
+|---------|-------|
+| Services not running | `fly ssh console --app staktrakr -C "supervisorctl status"` |
+| OOM / container crash | Concurrent `api-export.js` runs — verify `run-local.sh` does NOT call `api-export.js` |
+| Exit node not routing | `tailscale status` in container; check `stacktrckr-home` is Connected in Tailscale admin |
+| Volume not mounted | `fly volumes list --app staktrakr`; verify `staktrakr_data` exists |
+| Git push rejected in publish | Run `git fetch origin api && git rebase origin/api` inside the volume |
+| Tailscale SSH lockout | Exit node iptables can block Fly internal SSH — remove `--exit-node` from `tailscale-up` and redeploy |
+| T3 not firing | Check `/var/log/retail-retry.log`; verify `WEBSHARE_PROXY_USER` is set as a Fly secret |
+| Stale prices in manifest | Expected T4 behavior when T3 also fails — `stale: true` in manifest, `source: turso_last_known` |

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -1,0 +1,190 @@
+---
+title: Frontend Overview
+category: frontend
+owner: staktrakr
+lastUpdated: v3.33.18
+date: 2026-03-01
+sourceFiles:
+  - index.html
+  - js/constants.js
+  - sw.js
+  - js/file-protocol-fix.js
+relatedPages:
+  - data-model.md
+  - storage-patterns.md
+  - dom-patterns.md
+  - service-worker.md
+  - release-workflow.md
+  - retail-modal.md
+---
+# Frontend Overview
+
+> **Last updated:** v3.33.18 — 2026-03-01
+> **Source files:** `index.html`, `js/constants.js`, `sw.js`, `js/file-protocol-fix.js`
+
+## Overview
+
+StakTrakr is a single-page precious metals inventory tracker built with pure HTML and vanilla JavaScript — zero build step, zero install, zero dependencies. It works on both `file://` and HTTP without any configuration changes. All application state persists in `localStorage`; there is no server, no database, and no backend beyond a static API feed.
+
+## Key Rules (read before touching this area)
+
+- **New JS files must be registered in TWO places:** add a `<script>` tag to `index.html` in strict load order AND add the path to `CORE_ASSETS` in `sw.js`. Missing either means the file never loads or the service worker silently skips it on offline fetch.
+- **Never use `document.getElementById()` directly** (except in `about.js` and `init.js` startup code) — always use `safeGetElement(id)`.
+- **Never write to `localStorage` directly** — always use `saveData()` / `loadData()` from `js/utils.js`.
+- **All localStorage keys must be declared** in `ALLOWED_STORAGE_KEYS` in `js/constants.js`.
+- **Always call `sanitizeHtml()`** before assigning user content to `innerHTML`.
+- The `sw.js` `CACHE_NAME` is auto-stamped by the `devops/hooks/stamp-sw-cache.sh` pre-commit hook — do not edit it manually.
+- Script load order in `index.html` is strict; dependencies must appear before dependents. There are currently **70 `<script>` tags** in `index.html`.
+- **Feature-flagged views must respect both code paths.** When a feature flag like `MARKET_LIST_VIEW` gates an alternative rendering path, the original grid view must remain fully functional when the flag is off. Always restore the original DOM state (headers, class names) in the default path.
+
+## Architecture
+
+### Runtime model
+
+```
+index.html  (single page, all UI panels)
+  └── 70 <script> tags (strict load order)
+        ├── js/file-protocol-fix.js   — detects file:// vs HTTP, patches fetch
+        ├── js/constants.js           — APP_VERSION, all constants, ALLOWED_STORAGE_KEYS
+        ├── js/state.js               — shared mutable state
+        ├── js/utils.js               — saveData(), loadData(), safeGetElement()
+        ├── ... (feature modules)
+        └── js/init.js                — bootstraps the app after all scripts load
+```
+
+### Versioning
+
+`APP_VERSION` in `js/constants.js` follows `BRANCH.RELEASE.PATCH` format (e.g. `3.33.17`).
+Optional state suffix: `a` = alpha, `b` = beta, `rc` = release candidate.
+Run `/release patch` after every meaningful committed change — one change, one patch tag.
+
+### Feature flags (FEATURE_FLAGS in js/constants.js)
+
+Feature flags gate beta/experimental UI paths. Each flag has:
+
+| Property | Type | Description |
+|---|---|---|
+| `enabled` | boolean | Default state (most beta flags default `false`) |
+| `urlOverride` | boolean | If `true`, `?flag_name=true` in the URL enables it |
+| `userToggle` | boolean | If `true`, the user can toggle it in Settings |
+| `description` | string | Human-readable description |
+| `phase` | string | `"beta"` / `"stable"` / `"deprecated"` |
+
+Active feature flags as of v3.33.06:
+
+| Flag | Default | Description |
+|---|---|---|
+| `MARKET_LIST_VIEW` | `false` | New full-width market card layout with search, sort, and inline 7-day trend charts |
+| `MARKET_DASHBOARD_ITEMS` | `false` | Show goldback and dashboard items in the market list |
+| `MARKET_AUTO_RETAIL` | `false` | Auto-update inventory retail prices from linked market data |
+
+### Key globals exposed on `window`
+
+| Global | Source file | Purpose |
+|---|---|---|
+| `APP_VERSION` | `js/constants.js` | Current version string |
+| `saveData(key, value)` | `js/utils.js` | Write to localStorage (validated key) |
+| `loadData(key)` | `js/utils.js` | Read from localStorage |
+| `safeGetElement(id)` | `js/utils.js` | Safe `getElementById` wrapper |
+| `retailPrices` | `js/retail-pricing.js` | Latest retail price map |
+| `retailAvailability` | `js/retail-pricing.js` | Availability flags per item |
+| `spotPrice` | `js/spot-price.js` | Current spot price object |
+| `STORAGE_PERSIST_GRANTED_KEY` | `js/constants.js` | localStorage key for storage persistence grant flag |
+| `IMAGE_ZIP_MANIFEST_VERSION` | `js/constants.js` | Version string for image ZIP export manifest format (currently `'1.0'`) |
+| `_renderMarketListView` | `js/retail.js` | Re-render market list view (added v3.33.06) |
+| `_buildMarketListCard` | `js/retail.js` | Build a single market list card (added v3.33.06) |
+| `_getFilteredSortedSlugs` | `js/retail.js` | Filter + sort slugs for market list (added v3.33.06) |
+| `DISPOSITION_TYPES` | `js/constants.js` | Frozen map of disposition types (`sold`, `traded`, `lost`, `gifted`, `returned`) with labels and amount requirements |
+| `isDisposed(item)` | `js/constants.js` | Helper predicate — returns `true` if an item has a `disposition` record |
+| `SYNC_MANIFEST_PATH` | `js/constants.js` | Dropbox path for encrypted change manifest (`/StakTrakr/sync/staktrakr-sync.stmanifest`) |
+| `SYNC_MANIFEST_PATH_LEGACY` | `js/constants.js` | Legacy Dropbox path for change manifest (flat root) |
+
+### Key subsystems
+
+| Subsystem | Entry point(s) | Notes |
+|---|---|---|
+| Inventory | `js/inventory.js`, `js/items.js` | CRUD for precious metals holdings |
+| Disposition (v3.33.17) | `js/inventory.js`, `js/constants.js` | Realized gains/losses workflow — dispose items as sold/traded/lost/gifted/returned; undo disposition; portfolio summary breakdown |
+| Retail pricing | `js/retail-pricing.js`, `js/api.js` | Polls `api.staktrakr.com/data/api/manifest.json` |
+| Market list view | `js/retail.js` | Full-width card layout with search/sort/charts (feature-flagged, v3.33.06) |
+| Spot prices | `js/spot-price.js`, `js/spot-history.js` | Polls hourly and 15-min feeds from `api.staktrakr.com` |
+| Cloud sync | `js/cloud-sync.js`, `js/cloud-settings.js` | Backup/restore via encrypted cloud vault |
+| Diff/Merge | `js/diff-engine.js`, `js/diff-modal.js` | Change-set diffing and interactive merge review UI (STAK-184) |
+| Catalog | `js/catalog.js`, `js/seed-images.js` | Coin/bar catalog with image cache |
+| Image cache | `js/image-cache.js` | Per-item user photo storage; dynamic quota; byte tracking per store |
+| Service worker | `sw.js` | Offline support, PWA installability, cache versioning |
+
+### `file://` protocol support
+
+`js/file-protocol-fix.js` detects whether the app is running under `file://` and patches `fetch` calls accordingly so that API polling and local JSON reads work in both environments.
+
+### Portfolio value model
+
+```
+meltValue  = weight x qty x spotPrice
+```
+
+Three price columns tracked per holding: **Purchase Price**, **Melt Value**, **Retail Price**.
+
+### Market section dual-header layout (v3.33.06)
+
+The Market Prices section in `index.html` now has **two mutually exclusive headers**:
+
+- `#marketListHeader` — shown when `MARKET_LIST_VIEW` feature flag is active. Contains search bar, sort dropdown, Expand All button, and a dedicated sync button/timestamp.
+- `#marketGridHeader` — the original grid header. Shown when the feature flag is off.
+
+`renderRetailCards()` in `js/retail.js` checks the feature flag at entry and either delegates to `_renderMarketListView()` or falls through to the original grid renderer. The grid path explicitly hides `#marketListHeader` and removes `.market-list-mode` from the grid container to ensure a clean state.
+
+### Disposition workflow (v3.33.17 — STAK-72)
+
+Items can be marked as disposed via a modal form (`#dispositionModal` in `index.html`). Disposition types are defined in `DISPOSITION_TYPES` in `js/constants.js`:
+
+| Type | Label | Requires Amount |
+|---|---|---|
+| `sold` | Sold | Yes |
+| `traded` | Traded | Yes |
+| `lost` | Lost | No |
+| `gifted` | Gifted | No |
+| `returned` | Returned | Yes |
+
+**Realized gain/loss** is computed at disposition time: `amount - (purchasePrice * qty)`. The result is stored in `item.disposition.realizedGainLoss`.
+
+**Visual indicators:** Disposed items show a colored badge (`.disposition-badge--{type}`) in both table rows and card views. Disposed table rows receive `.disposed-row` (opacity + strikethrough); disposed cards receive `.disposed-card`. Badge colors are theme-aware (light and dark variants in `css/styles.css`).
+
+**Filter toggle:** A "Show disposed" toggle (`#showDisposedToggle`) in the filter bar controls whether disposed items appear in the inventory list. When unchecked (default), `js/filters.js` strips items with a `disposition` property.
+
+**Portfolio summary:** Each metal's summary card and the "All" summary card include a disposed-items breakdown with realized G/L when disposed items exist (`#disposedWrap{Metal}`, `#disposedWrapAll`).
+
+**Undo:** `undoDisposition(idx)` restores a disposed item to active inventory after user confirmation, clearing the `disposition` property and logging the change.
+
+**CSV export:** Four disposition columns are appended to the export: Disposition Type, Disposition Date, Disposition Amount, Realized G/L.
+
+### Storage gauge (v3.32.27)
+
+The Settings storage section now renders a **split storage gauge** with two independently tracked bars:
+
+- **Your Photos** — bytes used by user-uploaded images (tracked via `js/image-cache.js`)
+- **Numista Cache** — bytes used by Numista API response cache
+
+A persistence status line (`#gaugePersistLine`) shows whether the browser has granted persistent storage. The persistence request is triggered by `js/settings.js` and the grant is recorded under `storagePersistGranted` in localStorage. Quota is computed dynamically from the `navigator.storage.estimate()` API rather than the previous hardcoded 50 MB cap.
+
+## Common Mistakes
+
+- Adding a new JS file to `index.html` but forgetting `sw.js` CORE_ASSETS (or vice versa) — the app works in dev but breaks for users with a cached service worker.
+- Calling `document.getElementById()` outside of `about.js` / `init.js` — the safe wrapper provides error logging and avoids silent null-ref failures.
+- Writing directly to `localStorage` instead of `saveData()` — bypasses key validation and breaks the data audit trail.
+- Editing `sw.js` `CACHE_NAME` manually — the pre-commit hook will overwrite it; always let the hook stamp the value.
+- Placing a new `<script>` tag in the wrong position in `index.html` — scripts that reference globals from later files will throw at load time.
+- Assuming `spot-history-YYYY.json` is live data — it is a seed file (noon UTC daily snapshot) and will always appear ~10 h stale in health checks.
+- Hardcoding a storage quota (e.g. `50 * 1024 * 1024`) — quota is now derived dynamically from `navigator.storage.estimate()` in `js/image-cache.js`.
+- Forgetting to restore the default header/class state in the non-flagged code path when a feature flag gates an alternative UI. Both `#marketListHeader` visibility and `.market-list-mode` must be explicitly reset in `renderRetailCards` when the flag is off.
+- Storing `meltValue` or `realizedGainLoss` at render time — `meltValue` is always computed from current spot; `realizedGainLoss` is computed once at disposition time and stored in the `disposition` object, not re-derived.
+
+## Related Pages
+
+- [Data Model](data-model.md)
+- [Storage Patterns](storage-patterns.md)
+- [DOM Patterns](dom-patterns.md)
+- [Service Worker](service-worker.md)
+- [Release Workflow](release-workflow.md)
+- [Retail View Modal](retail-modal.md)

--- a/wiki/goldback-pipeline.md
+++ b/wiki/goldback-pipeline.md
@@ -1,0 +1,194 @@
+---
+title: Goldback Pipeline
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages:
+  - rest-api-reference.md
+  - retail-pipeline.md
+  - turso-schema.md
+  - providers.md
+---
+
+# Goldback Pipeline
+
+> **Last verified:** 2026-02-25 — audited from live Fly.io container + PR `StakTrakrApi#3` (STAK-335 per-state scaffolding).
+> **56 per-state slugs** (8 states × 7 denominations) + **6 deprecated legacy slugs**.
+
+---
+
+## Overview
+
+Goldback pricing flows through **two paths**:
+
+1. **Retail pipeline** — Per-state Goldback coins (`goldback-{state}-g{denom}`) are tracked in `providers.json`, scraped from vendor product pages via `run-local.sh` cron → Turso → `api-export.js` → per-coin JSON endpoints.
+
+2. **Denomination spot JSON** — `api-export.js` generates `data/api/goldback-spot.json` with denomination prices computed from the G1 vendor rate (`G1 × multiplier`).
+
+There is **no separate goldback cron** — the legacy `run-goldback.sh` / `goldback-scraper.js` are not wired into any cron schedule.
+
+---
+
+## States
+
+8 states currently issue Goldbacks. Each state has 7 denominations in `providers.json`:
+
+| State | Slug prefix | Notes |
+|-------|-------------|-------|
+| Utah | `goldback-utah-` | First issuer (2019) |
+| Nevada | `goldback-nevada-` | |
+| Wyoming | `goldback-wyoming-` | |
+| New Hampshire | `goldback-new-hampshire-` | |
+| South Dakota | `goldback-south-dakota-` | |
+| Arizona | `goldback-arizona-` | |
+| Oklahoma | `goldback-oklahoma-` | |
+| Washington DC | `goldback-dc-` | |
+
+---
+
+## Denominations
+
+7 denominations per state:
+
+| Slug suffix | Denomination | Gold content |
+|-------------|-------------|-------------|
+| `ghalf` | ½ Goldback | 1/2000 oz |
+| `g1` | 1 Goldback | 1/1000 oz |
+| `g2` | 2 Goldback | 1/500 oz |
+| `g5` | 5 Goldback | 1/200 oz |
+| `g10` | 10 Goldback | 1/100 oz |
+| `g25` | 25 Goldback | 1/40 oz |
+| `g50` | 50 Goldback | 1/20 oz |
+
+**Full slug format:** `goldback-{state}-g{denom}` — e.g., `goldback-oklahoma-g1`, `goldback-utah-ghalf`, `goldback-dc-g50`
+
+---
+
+## Migration from Legacy Slugs (STAK-335)
+
+The original `goldback-g{N}` slugs silently mixed states across vendors (APMEX→Wyoming, Hero→Utah, SD→Arizona, JM→Nevada). PR `StakTrakrApi#3` replaces them with per-state slugs.
+
+### Deprecated slugs (kept for backward compat)
+
+| Legacy slug | Status | Notes |
+|-------------|--------|-------|
+| `goldback-g1` | `deprecated: true` | Exchange rate scraping still runs on this slug |
+| `goldback-g2` | `deprecated: true` | |
+| `goldback-g5` | `deprecated: true` | |
+| `goldback-g10` | `deprecated: true` | |
+| `goldback-g25` | `deprecated: true` | |
+| `goldback-g50` | `deprecated: true` | |
+
+**Exchange rate scraping** stays on deprecated slugs only — 6 hits/cycle, not 62. The deprecated slugs feed `goldback-spot.json` denomination generation.
+
+**Frontend migration:** The frontend currently references `goldback-g{N}` endpoints. These continue to work until the frontend is updated to use per-state slugs.
+
+---
+
+## Enabling a State/Vendor
+
+All 56 per-state slugs start with `url: null` and `enabled: false`. To enable a vendor for a state denomination:
+
+1. Find the slug in `providers.json` (e.g., `goldback-oklahoma-g1`)
+2. Set the vendor's `url` to the product page URL
+3. Set `enabled: true`
+
+Changes auto-sync next cycle — no redeploy needed.
+
+---
+
+## providers.json Structure
+
+**56 per-state entries** (all disabled initially) + **6 deprecated legacy entries**.
+
+- **Metal:** `goldback`, **Weight:** varies by denomination
+- Listed in `SLOW_PROVIDERS` — JS-rendered pages, uses `waitFor: 6000`
+- Price range validation: `$5–$25` per G1 (via `METAL_PRICE_RANGE_PER_OZ` in `price-extract.js`)
+
+Vendors that previously mixed states under the old slugs:
+
+| Vendor | State they were actually scraping |
+|--------|-----------------------------------|
+| `apmex` | Wyoming |
+| `herobullion` | Utah |
+| `sdbullion` | Arizona |
+| `jmbullion` | Nevada |
+| `goldback` (official rate) | N/A — exchange rate, not state-specific |
+
+---
+
+## Denomination Spot JSON (api-export.js)
+
+At publish time (`8,23,38,53 * * * *`), `api-export.js` reads the latest `goldback-g1` (deprecated slug) rows from Turso via `readLatestPerVendor()` and writes `data/api/goldback-spot.json`:
+
+```json
+{
+  "date": "2026-02-25",
+  "scraped_at": "2026-02-25T19:08:01.756Z",
+  "g1_usd": 10.43,
+  "denominations": {
+    "g1": 10.43,
+    "g5": 52.15,
+    "g10": 104.30,
+    "g25": 260.75,
+    "g50": 521.50
+  },
+  "source": "goldback.com",
+  "confidence": "high"
+}
+```
+
+All denomination prices are computed as `G1 × multiplier`, rounded to 2 decimal places.
+
+---
+
+## API Endpoints
+
+### Legacy (still active via deprecated slugs)
+
+| Endpoint | Description | Updated |
+|----------|-------------|---------|
+| `data/api/goldback-spot.json` | G1 USD rate + denomination multipliers | Every 15 min |
+| `data/api/goldback-g1/latest.json` | Legacy G1 mixed-state vendor prices | Every 15 min |
+| `data/api/goldback-g{N}/latest.json` | Legacy denomination endpoints (deprecated) | Every 15 min |
+| `data/goldback-YYYY.json` | Rolling annual history log (legacy scraper) | Not active |
+
+### Per-State (new — populated as vendors are enabled)
+
+| Endpoint Pattern | Example | Description |
+|------------------|---------|-------------|
+| `data/api/goldback-{state}-g{denom}/latest.json` | `goldback-oklahoma-g1/latest.json` | Per-vendor prices for a state+denomination |
+| `data/api/goldback-{state}-g{denom}/history-7d.json` | `goldback-utah-g5/history-7d.json` | Daily aggregates, last 7 days |
+| `data/api/goldback-{state}-g{denom}/history-30d.json` | `goldback-dc-g50/history-30d.json` | Daily aggregates, last 30 days |
+
+**Note:** Per-state endpoints only populate once a vendor URL is enabled in `providers.json`. Until then, they return empty/no data.
+
+See [rest-api-reference.md](rest-api-reference.md) for full endpoint schemas.
+
+---
+
+## Legacy Files (do not use)
+
+`run-goldback.sh` and `goldback-scraper.js` exist on the container but are **not wired into any cron**. The daily goldback cron was removed from `docker-entrypoint.sh` in commit `21db95d`. The standalone `goldback-scraper.js` scraped `goldback.com/exchange-rate/` via Firecrawl and wrote directly to `goldback-spot.json` and `goldback-YYYY.json` — this is now handled by the retail pipeline + `api-export.js`.
+
+---
+
+## Diagnosing Issues
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `goldback-spot.json` > 25h stale | `goldback-g1` scrape failing or goldback.com down | Check `fly logs --app staktrakr \| grep goldback` |
+| G1 price null in manifest | Firecrawl timeout on JS-rendered page | goldback.com is in `SLOW_PROVIDERS` — verify `waitFor` is sufficient |
+| Denomination prices wrong | G1 base rate incorrect | Check Turso `goldback-g1` rows; compare to goldback.com/exchange-rate/ |
+| Per-denomination retail prices differ from computed spot | Normal — retail vendor prices ≠ official exchange rate | `goldback-spot.json` uses vendor G1 rate × multiplier; individual `goldback-gN` endpoints track actual retail prices |
+
+---
+
+## Related Pages
+
+- [REST API Reference](rest-api-reference.md) — full goldback endpoint schemas
+- [Retail Pipeline](retail-pipeline.md) — how goldback coins flow through the scrape pipeline
+- [Turso Schema](turso-schema.md) — database tables
+- [providers.json](providers.md) — goldback vendor URLs

--- a/wiki/health.md
+++ b/wiki/health.md
@@ -1,0 +1,191 @@
+---
+title: "Health & Diagnostics"
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages: []
+---
+
+# Health & Diagnostics
+
+> **Last verified:** 2026-02-25
+
+---
+
+## Quick Health Check
+
+```python
+python3 << 'EOF'
+import urllib.request, json, re
+from datetime import datetime, timezone, timedelta
+
+def age_min(ts):
+    ts = ts.strip()
+    if not re.search(r'[zZ]$|[+-]\d{2}:?\d{2}$', ts):
+        ts = ts.replace(' ', 'T') + 'Z'
+    return (datetime.now(timezone.utc) - datetime.fromisoformat(ts.replace('Z','+00:00'))).total_seconds()/60
+
+def fetch(url):
+    with urllib.request.urlopen(url, timeout=10) as r: return json.load(r)
+
+print(f"API Health — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}\n")
+try:
+    d = fetch('https://api.staktrakr.com/data/api/manifest.json')
+    age = age_min(d['generated_at'])
+    print(f"Market   {'✅' if age<=30 else '⚠️'}  {age:.0f}m ago  ({len(d.get('coins',[]))} coins)")
+except Exception as e: print(f"Market   ❌  {e}")
+try:
+    now = datetime.now(timezone.utc)
+    def url(dt): return f"https://api.staktrakr.com/data/hourly/{dt.year}/{dt.month:02d}/{dt.day:02d}/{dt.hour:02d}.json"
+    try: d = fetch(url(now))
+    except: d = fetch(url(now - timedelta(hours=1)))
+    age = age_min(d[-1]['timestamp'])
+    print(f"Spot     {'✅' if age<=75 else '⚠️'}  {age:.0f}m ago")
+except Exception as e: print(f"Spot     ❌  {e}")
+try:
+    d = fetch('https://api.staktrakr.com/data/api/goldback-spot.json')
+    age = age_min(d['scraped_at'])
+    print(f"Goldback {'✅' if age<=1500 else '⚠️'}  {age/60:.1f}h ago  (${d.get('g1_usd')} G1)")
+except Exception as e: print(f"Goldback ❌  {e}")
+EOF
+```
+
+---
+
+## Stale Thresholds
+
+| Feed | Stale at | Critical at |
+|------|----------|-------------|
+| Market prices (`manifest.json`) | 30 min | 4 hours |
+| Spot prices (hourly file) | 75 min | 3 hours |
+| Goldback | 25 hours | 48 hours |
+
+---
+
+## Container Status
+
+```bash
+# Fly.io machine and service status
+fly status --app staktrakr
+fly ssh console --app staktrakr -C "supervisorctl status"
+
+# Logs (all services)
+fly logs --app staktrakr
+
+# Filter by pipeline
+fly logs --app staktrakr | grep -E 'retail|publish|spot|goldback|ERROR|WARN'
+
+# Log files inside container
+fly ssh console --app staktrakr -C "tail -50 /var/log/retail-poller.log"
+fly ssh console --app staktrakr -C "tail -50 /var/log/publish.log"
+fly ssh console --app staktrakr -C "tail -50 /var/log/spot-poller.log"
+fly ssh console --app staktrakr -C "tail -20 /var/log/goldback-poller.log"
+```
+
+---
+
+## GitHub Actions Status
+
+```bash
+# Merge Poller Branches (runs */15)
+gh run list --repo lbruton/StakTrakrApi --workflow "Merge Poller Branches" --limit 5
+
+# Spot poller (retired — manual trigger only)
+gh run list --repo lbruton/StakTrakrApi --workflow "spot-poller.yml" --limit 5
+```
+
+---
+
+## Turso Database
+
+Check for recent rows from both pollers:
+
+```bash
+# If turso CLI is installed
+turso db shell staktrakrapi \
+  "SELECT poller_id, COUNT(*) as rows, MAX(scraped_at) as latest
+   FROM price_snapshots
+   WHERE scraped_at > datetime('now', '-2 hours')
+   GROUP BY poller_id;"
+```
+
+Expected: rows from both `api` (Fly.io) and `home` (LXC) pollers within the last 2 hours.
+
+---
+
+## Diagnosing by Symptom
+
+| Symptom | Likely cause | Action |
+|---------|-------------|--------|
+| `manifest.json` > 30 min stale | `run-local.sh` missed cycle or `run-publish.sh` not running | `fly logs --app staktrakr \| grep retail` |
+| `manifest.json` > 4h stale | Container down | `fly status --app staktrakr` |
+| Spot hourly > 75 min stale | `METAL_PRICE_API_KEY` expired or quota exceeded | Check MetalPriceAPI dashboard |
+| Goldback > 25h stale | `run-goldback.sh` failed | `fly logs --app staktrakr \| grep goldback` |
+| Only 1–2 vendors per coin | Home or Fly poller down, or OOS | Check both pollers; verify Turso has recent rows |
+| Vendor missing multiple cycles | URL changed or bot-blocked | Update vendor URL via [dashboard](home-poller.md) at `192.168.1.81:3010/providers` or `provider-db.js` — see [Provider Database](provider-database.md) |
+| OOM on Fly.io | Concurrent api-export.js invocations | Verify `run-local.sh` does NOT call `api-export.js` |
+| Monument Metals missing at year-start | Random-year SKU on pre-order | Switch to year-specific SKU in providers.json |
+| JMBullion presale coins show OOS | Pre-order pattern matching | Verify `PREORDER_TOLERANT_PROVIDERS` includes `jmbullion` |
+| Merge workflow failing | Branch conflict or jq parse error | Check GHA run logs; verify `api` branch has valid JSON |
+| Both pollers firing at same time | `CRON_SCHEDULE` set to `*/15` instead of `0` | `fly ssh console -C "head -1 /etc/cron.d/retail-poller"` — must show `0` |
+| `api-export.js` import crash | `db.js` missing export after refactor | `fly ssh console -C "sh -c 'tail -5 /var/log/publish.log'"` — look for `SyntaxError` |
+
+---
+
+## Manual Triggers
+
+```bash
+# Force a retail scrape cycle
+fly ssh console --app staktrakr -C "/app/run-local.sh"
+
+# Force a publish cycle
+fly ssh console --app staktrakr -C "/app/run-publish.sh"
+
+# Force a spot poll
+fly ssh console --app staktrakr -C "/app/run-spot.sh"
+
+# Force a goldback scrape
+fly ssh console --app staktrakr -C "/app/run-goldback.sh"
+
+# Home poller (SSH to LXC)
+ssh stakpoller@192.168.1.81 "bash /opt/poller/run-home.sh"
+```
+
+---
+
+## Lockfile Issues
+
+If a script was killed mid-run, its lockfile may remain:
+
+```bash
+# Fly.io
+fly ssh console --app staktrakr -C "rm -f /tmp/retail-poller.lock /tmp/retail-publish.lock /tmp/goldback-poller.lock"
+
+# Home LXC
+ssh stakpoller@192.168.1.81 "rm -f /tmp/retail-poller.lock"
+```
+
+---
+
+## Incident Log
+
+### 2026-02-25: Publish pipeline down + cron collision (4h outage)
+
+**Impact:** API JSON files stopped updating for ~4 hours. Market prices 50+ min stale. Both pollers colliding on same schedule.
+
+**Root cause:** The `retail-poller -> fly-poller` rename (commit `4e23633`) introduced two regressions:
+
+1. **`db.js` missing `readLatestPerVendor` export** -- `api-export.js` imports this function to merge data from both pollers into vendor maps. Without it, `run-publish.sh` crashed on every cycle with `SyntaxError: The requested module './db.js' does not provide an export named 'readLatestPerVendor'`. No new JSON was written to the `api` branch.
+
+2. **`docker-entrypoint.sh` defaulted `CRON_SCHEDULE` to `*/15`** instead of `15,45` (the schedule at the time). This fired the Fly.io retail poller at `:00/:15/:30/:45` instead of just `:15/:45`, colliding with the home poller at `:00/:30`. Both pollers wrote to the same Turso `window_start` simultaneously, and the `:15/:45` windows were empty. (Note: schedule has since been relaxed to `0` / `30` — see [cron-schedule.md](cron-schedule.md).)
+
+3. **`db.js` also missing `startRunLog`/`finishRunLog`** -- `price-extract.js` imports these for Turso run logging. The scraper crashed before executing any scrape logic. (Home poller was unaffected -- separate codebase.)
+
+**Fix:** Commit `c80442f` on StakTrakrApi main:
+- Added `readLatestPerVendor()` to `db.js` (latest non-failed row per vendor within lookback window)
+- Changed `CRON_SCHEDULE` default from `*/15` to `15,45` (later relaxed to `0` in 2026-02-26)
+- Three deploys total to restore full pipeline
+
+**Lesson:** After any `git mv` refactor that touches the Fly.io deploy path, verify all ES module imports resolve on the deployed container before moving on. The `SyntaxError` is fatal at parse time -- nothing runs.

--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -1,0 +1,320 @@
+---
+title: Home Poller (Ubuntu VM)
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages: []
+---
+
+# Home Poller (Ubuntu VM)
+
+> **Last verified:** 2026-02-25 — Ubuntu 24.04.3 LTS LXC at 192.168.1.81, user `stakpoller`. Verified from VM console.
+
+---
+
+## Overview
+
+A secondary retail poller running on an Ubuntu Server LXC container. Runs at `:30` past every hour (once per hour). The Fly.io poller runs at `:00` — with the 30-minute offset, fresh data arrives every 30 minutes.
+
+Both pollers write to the **same Turso database**. `run-publish.sh` on Fly.io merges their data using `readLatestPerVendor()`. The home poller never touches Git.
+
+As of 2026-02-25, this VM also hosts the full monitoring stack: dashboard, Grafana, Prometheus, and a Prometheus metrics exporter.
+
+---
+
+## SSH Remote Management
+
+As of 2026-02-25, Claude Code on the Mac can SSH directly into this VM — no need for a separate Claude agent running in the VM's terminal.
+
+| Alias | Network | Host | Latency |
+|-------|---------|------|---------|
+| `homepoller` | LAN | 192.168.1.81 | ~0.5ms |
+| `homepoller-ts` | Tailscale | 100.112.198.50 | ~36ms |
+
+**User:** `stakpoller` — has `NOPASSWD: ALL` sudo via `/etc/sudoers.d/stakpoller`.
+
+**Key:** `~/.ssh/stakpoller_ed25519` (on Mac) — sourced from Infisical prod environment.
+
+**Usage:** Always use `-T` flag for non-interactive commands:
+
+```bash
+ssh -T homepoller 'sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf status'
+ssh -T homepoller 'tail -50 /var/log/retail-poller.log'
+```
+
+See `homepoller-ssh` skill in the StakTrakr repo for full diagnostic commands and common tasks.
+
+---
+
+## Specs
+
+| Property | Value |
+|----------|-------|
+| Host | Ubuntu Server LXC (Proxmox) |
+| IP | 192.168.1.81 |
+| OS | Ubuntu 24.04 |
+| User | `stakpoller` (SSH) / `lbruton` (Proxmox console) |
+| Install path | `/opt/poller/` |
+| Config repo | `github.com/lbruton/stakscrapr` (Claude config, CLAUDE.md) |
+| Poller source | `github.com/lbruton/StakTrakrApi` → `devops/fly-poller/` (source of truth) |
+| Log | `/var/log/retail-poller.log` |
+| Cron | `30 * * * *` (`:30` every hour, runs as `root`) |
+
+---
+
+## Stack
+
+| Component | How it runs | Port |
+|-----------|-------------|------|
+| Redis | systemd (`redis-server`) | localhost:6379 |
+| RabbitMQ | systemd (`rabbitmq-server`) | localhost:5672 |
+| Playwright Service | supervisord | localhost:3003 |
+| Firecrawl API | supervisord | localhost:3002 |
+| Firecrawl Worker | supervisord | — |
+| Dashboard | supervisord (`dashboard`) | 0.0.0.0:3010 |
+| Metrics Exporter | supervisord (`metrics-exporter`) | 0.0.0.0:9100 |
+| Grafana | systemd (`grafana-server`) | 0.0.0.0:3000 |
+| Prometheus | systemd (`prometheus`) | 0.0.0.0:9090 |
+| Tailscale | systemd (`tailscaled`) | tailscale0 |
+| tinyproxy | systemd (`tinyproxy`) | 0.0.0.0:8888 |
+| Cron | systemd (`cron`) | — |
+| Node.js 22.22.0 | system | — |
+| Playwright + Chromium | npm package (local) | — |
+
+Supervisord config: `/etc/supervisor/conf.d/staktrakr.conf`
+
+---
+
+## Dashboard & Monitoring
+
+### Dashboard (`http://192.168.1.81:3010`)
+
+Node.js HTTP server (`/opt/poller/dashboard.js`) showing:
+- System stats (CPU, memory, network, uptime)
+- Service health (supervisord + systemd)
+- Fly.io container health (Tailscale + HTTP ping, `/tmp/flyio-health.json`)
+- All poller runs from Turso (`poller_runs` table — home + Fly.io)
+- Home poller log tail (last 300 lines)
+- **`/providers`** — Provider URL editor (inline CRUD against Turso — see [Provider Database](provider-database.md))
+- **`/failures`** — Failure queue (URLs with 3+ failures in last 10 days from Turso)
+
+### Grafana (`http://192.168.1.81:3000`)
+
+Grafana OSS 12.4.0, default login `admin/admin`. Three provisioned dashboards in `StakTrakr` folder:
+- **StakTrakr — System** — CPU load, memory, network rate, uptime, service health grid
+- **StakTrakr — Poller Runs** — capture rate over time, failures per run, duration, home vs Fly.io
+- **StakTrakr — Failure Queue** — failing provider count, per-provider breakdown
+
+Datasource: Prometheus at `http://localhost:9090`. Provisioning files at `/etc/grafana/provisioning/`.
+
+### Prometheus (`http://192.168.1.81:9090`)
+
+Scrapes `localhost:9100` (metrics exporter) every 15s. Config: `/etc/prometheus/prometheus.yml`.
+
+### Metrics Exporter (`http://192.168.1.81:9100/metrics`)
+
+`/opt/poller/metrics-exporter.js` — Prometheus text format. Exposes:
+- System: `poller_uptime_seconds`, `poller_cpu_load1/5/15`, `poller_mem_used_pct`, `poller_net_rx/tx_bytes`
+- Services: `poller_service_up{service, manager}` for all supervisord + systemd services
+- Turso: `poller_turso_up`, last-run stats per poller, provider failure counts
+
+---
+
+## Residential Proxy (tinyproxy)
+
+As of 2026-02-24, this VM runs **tinyproxy** as an HTTP proxy for the Fly.io container, routing its scraper traffic through the home residential IP.
+
+| Property | Value |
+|----------|-------|
+| Proxy URL | `http://100.112.198.50:8888` |
+| Accepts connections from | Tailscale IPs only (100.112.198.50, 100.90.171.110) |
+| Residential egress IP | `98.184.142.225` |
+| Config | `/etc/tinyproxy/tinyproxy.conf` |
+| `DisableViaHeader` | Yes (no proxy fingerprint) |
+
+The Fly.io container sets `PROXY_SERVER=http://100.112.198.50:8888` and routes scraper traffic through it. The home VM exits as a residential IP — retail bullion dealers don't block residential IPs.
+
+**Previous approach (deprecated):** Tailscale exit node — `sudo tailscale set --advertise-exit-node=true`. This was replaced by tinyproxy in Feb 2026 for better reliability and selective routing.
+
+### Tailscale mesh
+
+| Node | Tailscale IP |
+|------|-------------|
+| Home VM (`stacktrckr`) | 100.112.198.50 |
+| Fly.io container (`staktrakr-fly`) | 100.90.171.110 |
+
+IPv4/IPv6 forwarding enabled via `/etc/sysctl.d/99-tailscale.conf`.
+
+---
+
+## Fly.io Health Check
+
+`/opt/poller/check-flyio.sh` runs every 5 min via `/etc/cron.d/flyio-health`. Checks:
+- Tailscale ping to `100.90.171.110`
+- HTTP GET to `https://api2.staktrakr.com/data/retail/providers.json`
+
+Writes `/tmp/flyio-health.json` — dashboard reads this for the Fly.io status card.
+
+---
+
+## Browser / Playwright Setup
+
+The home poller runs Playwright with **local Chromium** — no Docker, no Browserless, no Playwright Service microservice.
+
+| Property | Home Poller | Fly.io Container |
+|----------|-------------|------------------|
+| `BROWSER_MODE` | `local` | `local` |
+| Playwright package | `playwright` (full, from npm) | `playwright-core` (connects to service) |
+| Chromium source | Playwright-managed (`npx playwright install chromium`) | Playwright Service image (port 3003) |
+| Browser path | `/usr/local/share/playwright/` + `/root/.cache/ms-playwright/` | `/usr/local/share/playwright/` (copied from Docker stage) |
+| System deps | Ubuntu apt packages (pre-installed) | Dockerfile `apt-get install` |
+
+### Updating Playwright / Chromium
+
+```bash
+cd /opt/poller && sudo npm install playwright && sudo npx playwright install --with-deps chromium
+```
+
+> **Drift risk:** When the Fly.io Dockerfile pins a new Playwright version, the home poller will not automatically follow. Run the update command above after any `fly deploy` that bumps the Playwright version. Check with: `ssh -T homepoller 'node -e "import(\"playwright\").then(p=>console.log(p.chromium.name(),\"—\",p.chromium.executablePath()))"'`
+
+---
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `/opt/poller/` | Poller scripts, JS source, package.json |
+| `/opt/poller/dashboard.js` | Dashboard + provider editor + failure queue |
+| `/opt/poller/metrics-exporter.js` | Prometheus metrics exporter |
+| `/opt/poller/.env` | Secrets (Turso creds, POLLER_ID) — **never commit** |
+| `/opt/poller/data/retail/providers.json` | Dealer URLs — local fallback copy (primary source is Turso) |
+| `/opt/poller/docs/plans/` | Implementation plan docs |
+| `/opt/firecrawl/` | Firecrawl API + worker binaries |
+| `/opt/playwright-service/` | Playwright microservice |
+| `/usr/local/share/playwright/` | Chromium for Playwright |
+| `/etc/supervisor/conf.d/staktrakr.conf` | Supervisord config |
+| `/etc/cron.d/retail-poller` | Cron schedule |
+| `/etc/cron.d/flyio-health` | Fly.io health check cron (every 5 min) |
+| `/etc/tinyproxy/tinyproxy.conf` | tinyproxy config |
+| `/etc/grafana/provisioning/` | Grafana datasource + dashboard provisioning |
+| `/etc/prometheus/prometheus.yml` | Prometheus scrape config |
+| `/var/log/retail-poller.log` | Poller output (written by root) |
+| `/var/log/supervisor/` | Firecrawl/Playwright/dashboard/metrics service logs |
+| `/tmp/flyio-health.json` | Fly.io health check result (read by dashboard) |
+
+---
+
+## Environment (`.env`)
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `TURSO_DATABASE_URL` | Yes | Turso/libSQL connection string |
+| `TURSO_AUTH_TOKEN` | Yes | From Infisical `dev` env |
+| `POLLER_ID` | Yes | Set to `home` |
+| `DATA_DIR` | Yes | `/opt/poller/data` |
+| `FIRECRAWL_BASE_URL` | Yes | `http://localhost:3002` |
+| `FLYIO_TAILSCALE_IP` | Yes | `100.90.171.110` — used by `check-flyio.sh` |
+| `GEMINI_API_KEY` | No | Enables vision pipeline (`capture.js` + `extract-vision.js`) |
+| `PLAYWRIGHT_BROWSERS_PATH` | No | Default `/usr/local/share/playwright` — override if browsers installed elsewhere |
+| `COINS` | No | Restrict to specific coins for testing |
+| `DRY_RUN` | No | Set to `1` to skip DB writes |
+
+---
+
+## run-home.sh
+
+1. Lockfile guard at `/tmp/retail-poller.lock` — skips if previous run still active
+2. Loads `.env` from script directory
+3. Providers loaded from **Turso** (file sync removed — STAK-348)
+4. Runs `price-extract.js` — writes retail prices + run logs + failure logs to Turso
+
+The vision pipeline (`capture.js` → `extract-vision.js`) runs on the home poller when `GEMINI_API_KEY` is set in `.env`. It uses `BROWSER_MODE=local` with Playwright's bundled Chromium.
+
+---
+
+## Common Tasks
+
+### Check service health
+
+```bash
+sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf status
+systemctl status redis-server rabbitmq-server cron tailscaled tinyproxy grafana-server prometheus
+```
+
+### Test a single coin
+
+```bash
+COINS=ase bash /opt/poller/run-home.sh
+```
+
+### View recent logs
+
+```bash
+tail -100 /var/log/retail-poller.log
+tail -50 /var/log/supervisor/firecrawl-api.log
+sudo tail -20 /var/log/supervisor/metrics-exporter.log
+```
+
+### Restart Firecrawl stack
+
+```bash
+sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf restart all
+```
+
+### Manual run after reboot or stale lock
+
+```bash
+sudo rm -f /tmp/retail-poller.lock
+bash /opt/poller/run-home.sh
+```
+
+### Fix log file permissions
+
+```bash
+sudo touch /var/log/retail-poller.log
+sudo chmod 666 /var/log/retail-poller.log
+```
+
+---
+
+## Updating Poller Code
+
+```bash
+BASE=https://raw.githubusercontent.com/lbruton/StakTrakrApi/main/devops/fly-poller
+for f in price-extract.js capture.js db.js turso-client.js provider-db.js merge-prices.js api-export.js \
+          export-providers-json.js serve.js vision-patch.js extract-vision.js import-from-log.js \
+          goldback-scraper.js run-home.sh run-fbp.sh run-spot.sh run-publish.sh run-goldback.sh \
+          monitor-oos.sh package.json; do
+  curl -sf "$BASE/$f" -o "/opt/poller/$f" || echo "WARN: $f not found upstream"
+done
+npm install
+```
+
+## Updating Firecrawl/Playwright Binaries
+
+```bash
+sudo docker run --rm ghcr.io/firecrawl/firecrawl:latest tar -cf - -C / app | sudo tar -xf - -C /opt/ && sudo mv /opt/app /opt/firecrawl
+sudo docker run --rm ghcr.io/firecrawl/playwright-service:latest tar -cf - -C /usr/src app | sudo tar -xf - -C /opt/ && sudo mv /opt/app /opt/playwright-service
+sudo /usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf restart all
+```
+
+---
+
+## Diagnosing Issues
+
+| Symptom | Check |
+|---------|-------|
+| No rows from home poller in Turso | Cron running? Log shows errors? Turso auth valid? |
+| Firecrawl/Playwright not responding | `supervisorctl status` — restart if needed |
+| Turso provider load fails | Check Turso creds in `.env`; falls back to local `providers.json` automatically |
+| Lockfile stuck after reboot | `sudo rm -f /tmp/retail-poller.lock` |
+| Log file missing/unreadable | `sudo touch /var/log/retail-poller.log && sudo chmod 666 /var/log/retail-poller.log` |
+| Dashboard not loading | `supervisorctl status dashboard` — restart; check `/var/log/supervisor/dashboard.log` |
+| Grafana not loading | `systemctl status grafana-server` |
+| Metrics exporter returning no supervisord services | Verify `/usr/bin/supervisorctl -c /etc/supervisor/supervisord.conf status` works as root |
+| Fly.io scraper traffic not through residential IP | Check `tinyproxy` running; verify `PROXY_SERVER` set on Fly.io |
+| `ERR_MODULE_NOT_FOUND: playwright` | `npm install playwright && npx playwright install --with-deps chromium` in `/opt/poller/` |
+| jmbullion returns fractional weights | Provider URL/selector issue — not a scraper bug |
+| monumentmetals shows PRE-ORDER | FBP backfill usually covers it |

--- a/wiki/image-pipeline.md
+++ b/wiki/image-pipeline.md
@@ -1,0 +1,185 @@
+---
+title: "Image Pipeline"
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.32.42
+date: 2026-02-25
+sourceFiles: []
+relatedPages:
+  - health.md
+  - spot-pipeline.md
+  - fly-container.md
+---
+
+# Image Pipeline
+
+> **Last updated:** v3.32.42 — 2026-02-25
+> **Source files:** `js/image-cache.js`, `js/image-processor.js`, `js/events.js`, `js/viewModal.js`, `js/inventory.js`, `js/card-view.js`, `js/bulk-image-cache.js`, `js/image-cache-modal.js`
+
+## Overview
+
+StakTrakr stores item images entirely client-side using IndexedDB (database `StakTrakrImages`, version 3). There is no server-side image storage. Each item can have an obverse and a reverse image, sourced from three tiers: user uploads, pattern rule images, and Numista CDN URLs. The resolution cascade resolves each side independently.
+
+The pipeline was significantly refactored in v3.32.41 (STAK-339): the legacy `coinImages` IDB store was removed, and image resolution became per-side rather than per-item.
+
+---
+
+## Key Rules (read before touching this area)
+
+- **Never** call `document.getElementById` for image elements — always use `safeGetElement()`.
+- **Never** write directly to the `userImages` IDB store — always go through `imageCache.cacheUserImage()`.
+- **Do not** assume obverse is always populated — v3.32.41 allows reverse-only records.
+- `resolveImageForItem()` is the legacy item-level function — use `resolveImageUrlForItem(item, side)` for per-side resolution.
+- Always revoke object URLs after use or you will leak memory.
+- Call `renderTable()` after any IDB write or thumbnails will not update.
+
+---
+
+## IDB Storage Architecture
+
+Database: **`StakTrakrImages`**, version **3**
+
+| Store | Key | Value shape | Status |
+|---|---|---|---|
+| `userImages` | `uuid` (item UUID) | `{ uuid, obverse: Blob, reverse: Blob, cachedAt, size, sharedImageId }` | ACTIVE |
+| `patternImages` | `ruleId` | `{ ruleId, obverse: Blob, reverse: Blob }` | ACTIVE |
+| `coinMetadata` | `catalogId` (Numista N#) | Numista enrichment data | ACTIVE |
+| `coinImages` | `catalogId` | Legacy cached CDN blobs | LEGACY — schema retained, never read or written (removed in STAK-339, v3.32.41) |
+
+The `coinImages` store still exists in the schema to avoid migration complexity, but no code reads from or writes to it. Do not add new code that touches it.
+
+---
+
+## Image Resolution Cascade
+
+Each side (obverse and reverse) is resolved **independently** using:
+
+```
+imageCache.resolveImageUrlForItem(item, side)   // side = 'obverse' | 'reverse'
+```
+
+Located in `js/image-cache.js`. Resolution order per side:
+
+| Priority | Source | Detail |
+|---|---|---|
+| 1 | User upload | `userImages[uuid][side]` — blob stored in IDB |
+| 2 | Pattern rule image | `patternImages[ruleId][side]` — shared blob for all matching items |
+| 3 | Numista CDN URL | `item.obverseImageUrl` / `item.reverseImageUrl` — string URL on inventory item |
+| 4 | Placeholder | Empty slot — no image shown |
+
+**Important:** Because resolution is per-side, uploading only an obverse leaves the reverse on its own cascade step (pattern or CDN). There is no requirement for both sides to come from the same source.
+
+Prior to v3.32.41 this was a single item-level resolution that returned one source for both sides. The old function `resolveImageForItem()` still exists for backward compatibility but should not be used in new code.
+
+---
+
+## Upload Flow
+
+1. **File selection** — User picks an image file in the edit form (obverse or reverse slot).
+2. **Resize/compress** — `js/image-processor.js` resizes and compresses the file to a JPEG blob. No raw uploads are stored.
+3. **Pending blob** — The compressed blob is held in memory as `_pendingObverseBlob` or `_pendingReverseBlob` inside `js/events.js`. Nothing is written to IDB yet.
+4. **Form save** — On save, `saveUserImageForItem(uuid)` in `js/events.js`:
+   - Reads any existing IDB record for this UUID so the other side is preserved (partial upload keeps the untouched side).
+   - Calls `imageCache.cacheUserImage(uuid, obvBlob, revBlob)` — either blob argument may be `null`; v3.32.41 accepts reverse-only records.
+   - Calls `renderTable()` to refresh displayed thumbnails immediately.
+5. **IDB write** — `cacheUserImage()` writes the merged record to `userImages`.
+
+```
+User selects file
+  → image-processor.js (resize/compress → JPEG blob)
+  → _pendingObverseBlob / _pendingReverseBlob (events.js in-memory)
+  → form save triggers saveUserImageForItem(uuid)
+      → reads existing IDB record (preserve untouched side)
+      → imageCache.cacheUserImage(uuid, obvBlob, revBlob)
+          → writes to userImages IDB store
+      → renderTable()
+```
+
+**Deletion** is also handled in `js/events.js`. Deleting a side calls `imageCache.deleteUserImageSide(uuid, side)`, which merges a null blob into the existing record and writes back. If both sides become null the record is removed entirely.
+
+---
+
+## Pattern Rules
+
+Pattern rules let a single image cover many items that share a name pattern.
+
+- Defined in **Settings → Images → Pattern Rules**.
+- Each rule matches by item name keywords or regex and carries a `seedImageId`.
+- `NumistaLookup.matchQuery(item.name)` returns the first matching rule for an item name.
+- Pattern images are stored in `patternImages` IDB by `ruleId` — one blob record shared across all matching items.
+- User uploads **always override pattern** on a per-side basis: uploading an obverse replaces the pattern obverse for that item, while the pattern reverse still shows for that item's reverse slot.
+- Items have an `ignorePatternImages` flag for opting out at the item level. The UI for this flag is hidden in v3.32.41 but the data field is preserved for future per-slot control.
+- Pattern rule UI wiring lives in `js/settings-listeners.js`.
+- **Pattern rule promotion (`imagePatternToggle`)** reads from the existing per-item `userImages` IDB record when no pending blobs are in memory — this supports two-session workflows (upload → save → re-open → promote). After promotion the per-item `userImages` record is deleted so the item falls through to the shared pattern image on future resolution.
+
+---
+
+## Numista CDN URLs
+
+- Stored as plain strings directly on inventory items: `item.obverseImageUrl` and `item.reverseImageUrl`.
+- Populated when the user assigns a Numista result via the N# picker, or during a bulk Numista import.
+- Refreshed only on an explicit Numista API action — not on every page load.
+- No IDB blob is stored for CDN images; the string URL is used directly in `<img src>`.
+- Serve as cascade step 3 — used when no user upload or pattern image exists for that side.
+- CDN URL writeback was fixed in v3.32.39 (STAK-333).
+
+---
+
+## Rendering (Table / Card / View Modal)
+
+### Table thumbnails
+
+`js/inventory.js` → `_loadThumbImage(item, side)`
+
+- Calls `resolveImageUrlForItem(item, side)` for each side.
+- Creates an object URL from any returned blob.
+- Caller is responsible for revoking object URLs after the thumbnail is no longer displayed.
+- `renderTable()` must be called after any IDB write for thumbnails to update.
+
+### Card thumbnails
+
+`js/card-view.js` → `_loadCardImage(item, side)`
+
+- Same pattern as table thumbnails.
+- Object URLs created per card, revoked when the card is removed from DOM.
+
+### View modal
+
+`js/viewModal.js` → `loadViewImages(item, container)`
+
+- Calls `resolveImageUrlForItem(item, 'obverse')` and `resolveImageUrlForItem(item, 'reverse')` independently.
+- Falls back to CDN URLs on the item (`item.obverseImageUrl` / `item.reverseImageUrl`) if both sides return null from IDB (defensive fallback, cascade should already have returned these).
+- Object URLs are tracked in `_viewModalObjectUrls` array and revoked on modal close to prevent memory leaks.
+
+---
+
+## Common Mistakes
+
+| Mistake | Correct approach |
+|---|---|
+| `document.getElementById('img-el')` | `safeGetElement('img-el')` |
+| Direct IDB write to `userImages` | `imageCache.cacheUserImage(uuid, obvBlob, revBlob)` |
+| Assuming obverse is always set | Always null-check both sides; reverse-only records are valid since v3.32.41 |
+| Using `resolveImageForItem()` (legacy) | Use `resolveImageUrlForItem(item, side)` |
+| Not revoking object URLs | Track URL in array and call `URL.revokeObjectURL()` when done |
+| IDB write without `renderTable()` | Always call `renderTable()` after writes so thumbnails refresh |
+| Touching `coinImages` IDB store | Store is legacy — do not add code that reads or writes it |
+
+---
+
+## Version History
+
+| Version | Ticket | Change |
+|---|---|---|
+| v3.32.42 | — | Pattern rule promotion reads from existing per-item `userImages` IDB when no pending blobs are in memory; per-item record deleted after promotion (two-session workflow fix) |
+| v3.32.41 | STAK-339 | Removed `coinImages` layer; per-side cascade; `cacheUserImage` accepts reverse-only records; `ignorePatternImages` UI hidden, field preserved |
+| v3.32.40 | STAK-337 | Fixed race condition in `cacheImages` re-render |
+| v3.32.39 | STAK-333 | Fixed CDN URL writeback; added per-item pattern opt-out flag (`ignorePatternImages`) |
+
+---
+
+## Related Pages
+
+- [health.md](health.md) — API and poller health checks
+- [spot-pipeline.md](spot-pipeline.md) — Spot price data pipeline
+- [fly-container.md](fly-container.md) — Fly.io container management

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>StakTrakr Wiki</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
+  <style>
+    :root {
+      --base-font-size: 15px;
+      --theme-color: #c9a84c;
+      --sidebar-width: 260px;
+      --sidebar-background: #1a1a2e;
+      --sidebar-nav-link-color--active: #c9a84c;
+      --sidebar-name-color: #c9a84c;
+      --sidebar-name-font-weight: 700;
+      --link-color: #c9a84c;
+      --link-color--hover: #e6c65a;
+    }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'StakTrakr Wiki',
+      repo: '',
+      basePath: '/wiki/',
+      loadSidebar: true,
+      subMaxLevel: 2,
+      auto2top: true,
+      search: {
+        placeholder: 'Search wiki...',
+        noData: 'No results.',
+        paths: 'auto'
+      },
+      pagination: {
+        previousText: 'Previous',
+        nextText: 'Next',
+        crossChapter: true
+      }
+    };
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify-front-matter/dist/docsify-front-matter.min.js"></script>
+</body>
+</html>

--- a/wiki/poller-parity.md
+++ b/wiki/poller-parity.md
@@ -1,0 +1,460 @@
+---
+title: "Poller Parity — Fly.io vs Home Poller"
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-26
+sourceFiles: []
+relatedPages: []
+---
+
+# Poller Parity — Fly.io vs Home Poller
+
+> **Last verified:** 2026-02-26 — all 5 core JS files have identical MD5 hashes across both pollers. Both read from the same Turso database.
+
+---
+
+## Goal
+
+Both pollers should produce identical scrape results for the same coin/vendor target, offset only by their cron schedule (Fly.io at `:00`, home at `:30`). Any configuration drift between them is a bug.
+
+---
+
+## Infrastructure Comparison
+
+| Property | Fly.io Container | Home Poller (Ubuntu VM) |
+|----------|-----------------|------------------------|
+| **POLLER_ID** | `api` | `home` |
+| **OS** | Debian Bookworm (node:20-slim) | Ubuntu 24.04 LTS |
+| **Node.js** | 20.x (Docker base image) | 22.22.0 (system) |
+| **Install path** | `/app/` | `/opt/poller/` |
+| **BROWSER_MODE** | `local` | `local` |
+| **PLAYWRIGHT_LAUNCH** | `1` | `1` |
+| **PLAYWRIGHT_BROWSERS_PATH** | `/usr/local/share/playwright` | `/usr/local/share/playwright` |
+| **Playwright package** | `playwright-core` (connects to Playwright Service) | `playwright` (full, bundled Chromium) |
+| **Chromium source** | Playwright Service Docker stage (port 3003) | `npx playwright install chromium` (local) |
+| **Firecrawl** | Self-hosted in-container (port 3002) | Self-hosted via supervisord (port 3002) |
+| **FIRECRAWL_BASE_URL** | `http://localhost:3002` | `http://localhost:3002` |
+| **Redis** | In-container | systemd |
+| **RabbitMQ** | In-container | systemd |
+| **Proxy (HOME_PROXY_URL_2)** | `""` (empty — not used) | Not set |
+| **Cron schedule** | `:00` every hour | `:30` every hour |
+| **Vision pipeline** | Yes (GEMINI_API_KEY set) | Yes (if GEMINI_API_KEY set in .env) |
+| **Run script** | `run-local.sh` | `run-home.sh` |
+| **Git push** | Yes (`run-publish.sh` at `:08/:23/:38/:53`) | No (Turso only) |
+| **Tailscale** | Client (connects to home exit node) | Server (advertises exit node) |
+| **Dashboard** | None | Port 3010 |
+| **Monitoring** | None | Grafana (3000), Prometheus (9090), Metrics (9100) |
+
+### Known Drift Points
+
+| Issue | Impact | Resolution |
+|-------|--------|------------|
+| Node 20 (Fly) vs Node 22 (Home) | Minimal — ESM and all APIs are compatible | Pin home to Node 20 or accept minor runtime differences |
+| `playwright-core` (Fly) vs `playwright` (Home) | Fly uses Playwright Service on port 3003; home launches Chromium directly | Both produce equivalent Chromium sessions — same browser version is key |
+| Chromium version drift | Fly rebuilds from `ghcr.io/firecrawl/playwright-service:latest`; home updates via `npx playwright install` | After `fly deploy`, run `npx playwright install chromium` on home poller |
+| HOME_PROXY_URL_2 empty on Fly | Fly Playwright never tries tinyproxy hop; home poller also lacks it (not in .env) | Currently equivalent — neither uses it |
+
+---
+
+## Shared Source Files (verified identical)
+
+All 5 core JS files have **matching MD5 hashes** between the repo (`StakTrakrApi/devops/fly-poller/`) and the home poller (`/opt/poller/`):
+
+| File | Purpose | Hash |
+|------|---------|------|
+| `price-extract.js` | Firecrawl + Playwright scraper | `aa5422f0...` |
+| `capture.js` | Vision screenshot pipeline | `49b3587e...` |
+| `provider-db.js` | Turso provider CRUD + bulk ops + coverage stats | *(updated 2026-02-26 — re-hash after next deploy)* |
+| `db.js` | Turso write operations | `1fc71a0b...` |
+| `turso-client.js` | Turso connection + schema | `2d01c8c7...` |
+
+Both pollers read from the **same Turso database** — provider configuration, URLs, and enabled flags are always in sync.
+
+---
+
+## Full File Inventory Diff
+
+### JS Files
+
+| File | Repo | Home | Status |
+|------|------|------|--------|
+| `api-export.js` | Y | Y | **Identical** |
+| `capture.js` | Y | Y | **Identical** |
+| `db.js` | Y | Y | **Identical** |
+| `export-providers-json.js` | Y | Y | **Identical** |
+| `extract-vision.js` | Y | Y | **Identical** |
+| `goldback-scraper.js` | Y | Y | **Identical** |
+| `import-from-log.js` | Y | Y | **Identical** |
+| `merge-prices.js` | Y | Y | **Identical** |
+| `price-extract.js` | Y | Y | **Identical** |
+| `provider-db.js` | Y | Y | **Identical** |
+| `serve.js` | Y | Y | **Identical** |
+| `turso-client.js` | Y | Y | **Identical** |
+| `vision-patch.js` | Y | Y | **Identical** |
+| `dashboard.js` | — | Y | Home-only (admin UI, port 3010) |
+| `metrics-exporter.js` | — | Y | Home-only (Prometheus metrics, port 9100) |
+| `migrate-providers.js` | Y | — | Repo-only (one-time STAK-348 migration) |
+
+### Shell Scripts
+
+| File | Repo | Home | Status |
+|------|------|------|--------|
+| `run-local.sh` | Y | Y | **DRIFT** (see below) |
+| `run-home.sh` | — | Y | Home-only (home poller entry point) |
+| `run-goldback.sh` | Y | Y | **Identical** |
+| `run-spot.sh` | Y | Y | **Identical** |
+| `run-publish.sh` | Y | Y | **DRIFT** (see below) |
+| `run-retry.sh` | Y | — | Repo-only (T3 retry — Fly.io only) |
+| `run-fbp.sh` | — | Y | Home-only (FBP backfill) |
+
+### run-local.sh Drift
+
+The **home poller copy** has diverged from the repo. Key differences:
+
+| Area | Repo (Fly.io) | Home Poller |
+|------|---------------|-------------|
+| Tailscale egress | Block near line 39 (after providers log) | Block near line 19 (before providers) |
+| T3 failure queue | Yes — logs failure count + systemic warning | No — removed |
+| Vision pipeline gate | `GEMINI_API_KEY` only | `GEMINI_API_KEY` + `BROWSERLESS_URL` |
+| Vision BROWSER_MODE | `local` | `browserless` |
+| Post-scrape | "run-publish.sh will push on next cycle" | Runs `api-export.js` + `git add` inline |
+
+> **Impact:** The home poller does NOT use `run-local.sh` — it uses `run-home.sh` instead. This drift is cosmetic (the file exists on the home poller from a previous sync but is unused). **Verify with:** `grep run-local /etc/cron.d/retail-poller` on the home poller.
+
+### run-publish.sh Drift
+
+| Area | Repo (Fly.io) | Home Poller |
+|------|---------------|-------------|
+| Lockfile guard | Yes (`/tmp/retail-publish.lock`) | No |
+| Runs `api-export.js` | Yes (exports Turso → JSON) | No |
+| Runs `export-providers-json.js` | Yes (Turso → providers.json) | No |
+
+> **Impact:** `run-publish.sh` is Fly.io only (pushes to Git). The home poller copy is stale — it should not be called from any home poller cron.
+
+---
+
+## Firecrawl & Playwright Config Diff
+
+### Playwright Service (supervisord)
+
+| Config | Fly.io | Home Poller |
+|--------|--------|-------------|
+| Command | `node /opt/playwright-service/dist/api.js` | `node /opt/playwright-service/dist/api.js` |
+| Port | 3003 | 3003 |
+| `PLAYWRIGHT_BROWSERS_PATH` | `/usr/local/share/playwright` | `/usr/local/share/playwright` |
+| `PROXY_SERVER` | `http://p.webshare.io:80` | **Not set** |
+| `PROXY_USERNAME` / `PROXY_PASSWORD` | Webshare creds (from Fly secrets) | **Not set** |
+| `BLOCK_MEDIA` | `True` | **Not set** |
+| `HOME_PROXY_URL_2` | From env (empty string) | **Not set** |
+| Chromium version | `chromium-1208` (from Docker stage) | `chromium-1208` (from `npx playwright install`) |
+| Log output | `/dev/stdout` (Docker) | `/var/log/supervisor/playwright-service.log` |
+
+> **Key difference:** Fly.io Playwright Service has Webshare proxy config and `BLOCK_MEDIA=True`. Home poller Playwright Service has neither. This means Firecrawl on Fly.io can route through a proxy when scraping via the Playwright microservice, but the home poller cannot. However, `price-extract.js` Playwright fallback (Phase 2) handles its own proxy chain independently of the Playwright Service.
+
+### Firecrawl API (supervisord)
+
+| Config | Fly.io | Home Poller |
+|--------|--------|-------------|
+| Command | `node /opt/firecrawl/dist/src/index.js` | `node /opt/firecrawl/dist/src/index.js` |
+| Port | 3002 | 3002 |
+| `REDIS_URL` | `redis://localhost:6379` | `redis://localhost:6379` |
+| `PLAYWRIGHT_MICROSERVICE_URL` | `http://localhost:3003/scrape` | `http://localhost:3003/scrape` |
+| `NUQ_RABBITMQ_URL` | `amqp://localhost:5672` | **Not set** |
+| `POSTGRES_*` | Full PostgreSQL config | **Not set** |
+| `USE_DB_AUTHENTICATION` | `false` | `false` |
+| Firecrawl source | Docker stage `ghcr.io/firecrawl/firecrawl:latest` | Extracted from Docker image to `/opt/firecrawl/` |
+
+> **Key difference:** Fly.io has NUQ (RabbitMQ + PostgreSQL) for Firecrawl's internal job queue. Home poller lacks these env vars — Firecrawl worker falls back to in-memory or Redis-only mode. This should not affect scrape results but may impact error recovery on the home poller.
+
+### Firecrawl Worker
+
+| Config | Fly.io | Home Poller |
+|--------|--------|-------------|
+| `NUQ_RABBITMQ_URL` | `amqp://localhost:5672` | **Not set** |
+| `NUQ_DATABASE_URL` | `postgresql://postgres:firecrawl@localhost:5432/postgres` | `postgresql://postgres:firecrawl@localhost:5432/postgres` |
+| `POSTGRES_*` | Full config | **Not set** |
+| Extract worker | Yes (`firecrawl-extract-worker`) | **No** (not in supervisord) |
+
+> **Key difference:** Home poller is missing the `firecrawl-extract-worker` process entirely, and lacks RabbitMQ URL in the worker config. The extract worker handles LLM-based extraction — not used by the retail poller, but its absence could cause Firecrawl to log warnings.
+
+### package.json
+
+| Dependency | Fly.io (repo) | Home Poller |
+|------------|---------------|-------------|
+| `playwright` | `^1.49.0` | `^1.58.2` |
+| `playwright-core` | `^1.49.0` | `^1.49.0` |
+
+> **Drift:** Home poller has `playwright@^1.58.2` (installed today) while repo pins `^1.49.0`. The `playwright` package is only used for `BROWSER_MODE=local` Chromium launch — the actual browser binary (`chromium-1208`) is the same version on both. Update the repo `package.json` to match: `"playwright": "^1.58.2"`.
+
+### Chromium Browser
+
+| Property | Fly.io | Home Poller |
+|----------|--------|-------------|
+| Version | `chromium-1208` | `chromium-1208` |
+| Path | `/usr/local/share/playwright/chromium-1208` | `/usr/local/share/playwright/chromium-1208` + `/root/.cache/ms-playwright/chromium-1208` |
+| Source | Copied from `ghcr.io/firecrawl/playwright-service:latest` Docker stage | `npx playwright install chromium` |
+| Headless shell | `chromium_headless_shell-1208` | `chromium_headless_shell-1208` |
+| FFmpeg | `ffmpeg-1011` | `ffmpeg-1011` |
+
+> Both pollers are running the same Chromium build (v1208). Parity confirmed.
+
+---
+
+## Hardcoded Per-Vendor Rules (price-extract.js)
+
+These are **NOT in Turso** — they are hardcoded Sets and Maps in `price-extract.js`. Both pollers execute the same code, so these are identical. Listed here for the complete picture.
+
+### PLAYWRIGHT_ONLY_PROVIDERS (skip Firecrawl entirely)
+
+| Vendor | Reason | Line |
+|--------|--------|------|
+| `jmbullion` | Firecrawl ignores `waitFor` — product table renders as "Loading..." — fractional_weight fires on nav links | 430 |
+| `bullionexchanges` | Cloudflare bot detection redirects to homepage — markdown is a single banner image | 430 |
+
+> **Note:** Both vendors are currently `enabled: false` in Turso for all coins, so this Set has no runtime effect.
+
+### SLOW_PROVIDERS (extra wait time in Firecrawl + Playwright)
+
+| Vendor | Firecrawl `waitFor` | Playwright extra wait | Reason | Line |
+|--------|--------------------|-----------------------|--------|------|
+| `jmbullion` | 6000ms | 8000ms | Next.js/React — price tables take ~5s | 422 |
+| `herobullion` | 6000ms | 8000ms | React app — needs render time | 422 |
+| `monumentmetals` | 6000ms | 8000ms | React Native Web SPA — router mounts at ~6s | 422 |
+| `summitmetals` | 6000ms | 8000ms | Shopify SPA — JS render delay | 422 |
+| `bullionexchanges` | 6000ms | 8000ms | React/Magento SPA — pricing grid at ~6-8s | 422 |
+
+### PREORDER_TOLERANT_PROVIDERS (skip pre-order OOS detection)
+
+| Vendor | Effect | Line |
+|--------|--------|------|
+| `jmbullion` | "Pre-Order" items treated as in-stock (they show purchasable prices) | 132 |
+
+### FRACTIONAL_EXEMPT_PROVIDERS (skip fractional weight OOS check)
+
+| Vendor | Reason | Line |
+|--------|--------|------|
+| `jmbullion` | Mega-menu always lists "1/2 oz Gold Eagle" etc. — causes false fractional_weight detection | 438 |
+
+### MARKDOWN_CUTOFF_PATTERNS (trim page tail)
+
+| Vendor | Patterns removed | Line |
+|--------|-----------------|------|
+| `sdbullion` | "Add on Items", "Customers Also Purchased" (markdown + HTML) | 134-142 |
+| `jmbullion` | "Similar Products You May Like" (carousel with fractional coin prices) | 146-149 |
+
+### MARKDOWN_HEADER_SKIP_PATTERNS (strip header/nav)
+
+| Vendor | What's stripped | Line |
+|--------|----------------|------|
+| `jmbullion` | Spot price ticker in nav (e.g., "Gold Ask $5,120.96") — stripped by matching timestamp pattern | 155-159 |
+
+### Firecrawl Config Overrides
+
+| Vendor | `onlyMainContent` | `waitFor` | Line |
+|--------|-------------------|-----------|------|
+| `jmbullion` | `false` (disabled — React pages return empty with it on) | 6000ms | 449, 453 |
+| All SLOW_PROVIDERS | default (`true`) | 6000ms | 453 |
+| All others | `true` | none | 449 |
+
+### Price Extraction Strategy (extractPrice)
+
+| Vendor | Strategy order | Line |
+|--------|---------------|------|
+| `summitmetals` | `regularPricePrices()` → `tablePrices()` | 362 |
+| `jmbullion` | `firstTableRowFirstPrice()` → `jmPriceFromProseTable()` → `asLowAsPrices()` | 370 |
+| All others | `firstTableRowFirstPrice()` → `firstInRangePriceProse()` → `asLowAsPrices()` | 398 |
+
+### Metal Price Ranges (per oz, for range validation)
+
+| Metal | Min | Max | Line |
+|-------|-----|-----|------|
+| silver | $40 | $200 | 104 |
+| gold | $1,500 | $15,000 | 105 |
+| platinum | $500 | $6,000 | 106 |
+| palladium | $300 | $6,000 | 107 |
+| goldback | $5 | $25 | 108 |
+
+---
+
+## Hardcoded Per-Vendor Rules (capture.js)
+
+### PROVIDER_PAGE_LOAD_WAIT (vision capture)
+
+| Vendor | Wait (ms) | Default | Line |
+|--------|-----------|---------|------|
+| `jmbullion` | 10000 | 4000 | 53 |
+| `monumentmetals` | 7000 | 4000 | 54 |
+| `bullionexchanges` | 8000 | 4000 | 55 |
+| `herobullion` | 6000 | 4000 | 56 |
+| All others | 4000 (PAGE_LOAD_WAIT) | — | 45 |
+
+### COINS allowlist (capture.js env default)
+
+```
+ase, age, ape, buffalo, maple-silver, maple-gold, britannia-silver,
+krugerrand-silver, krugerrand-gold, generic-silver-round, generic-silver-bar-10oz
+```
+
+### PROVIDERS allowlist (capture.js env default)
+
+```
+apmex, sdbullion, jmbullion, monumentmetals, herobullion, bullionexchanges, summitmetals
+```
+
+> **Note:** `capture.js` uses both the Turso `enabled` flag AND this PROVIDERS allowlist as a double gate. A vendor must be in both to be captured.
+
+---
+
+## Active Coin/Vendor Matrix
+
+15 coins with at least one enabled vendor. 5 active vendors. 48 enabled targets total.
+
+Disabled vendors (jmbullion, bullionexchanges, sdbullion for gold) are omitted.
+
+### Silver Coins (1 oz)
+
+| Coin | APMEX | SD Bullion | Monument | Hero | Summit |
+|------|-------|------------|----------|------|--------|
+| **ase** (American Silver Eagle) | [Y](https://www.apmex.com/product/23331/1-oz-american-silver-eagle-coin-bu-random-year) | [Y](https://sdbullion.com/1-oz-american-silver-eagle-coins-random-year) | [Y](https://monumentmetals.com/1-oz-american-silver-eagle-bu-dates-our-choice.html) | [Y](https://www.herobullion.com/american-silver-eagle-1-oz-coin/) | [Y](https://summitmetals.com/products/1-oz-american-silver-eagle) |
+| **maple-silver** (Silver Maple Leaf) | [Y](https://www.apmex.com/product/1090/1-oz-canadian-silver-maple-leaf-coin-bu-random-year) | [Y](https://sdbullion.com/canadian-silver-maple-leaf-coin-random-year) | [Y](https://monumentmetals.com/2026-canada-silver-maple-leaf.html) | [Y](https://www.herobullion.com/canadian-silver-maple-1-oz-coin/) | — |
+| **britannia-silver** (Silver Britannia) | [Y](https://www.apmex.com/product/53532/great-britain-1-oz-silver-britannia-bu-random-year) | [Y](https://sdbullion.com/1-oz-britannia-silver-coin-random-year) | [Y](https://monumentmetals.com/doc-silver-britannia.html) | [Y](https://www.herobullion.com/1-oz-british-silver-britannia-coin/) | — |
+| **krugerrand-silver** (Silver Krugerrand) | [Y](https://www.apmex.com/product/206258/south-africa-1-oz-silver-krugerrand-random) | [Y](https://sdbullion.com/south-african-silver-krugerrand-coin-random-year) | [Y](https://monumentmetals.com/2026-south-africa-1-oz-silver-krugerrand-bu.html) | [Y](https://www.herobullion.com/1-oz-south-african-silver-krugerrand/) | — |
+| **generic-silver-round** (Generic Silver Round) | [Y](https://www.apmex.com/product/23/1-oz-silver-round-secondary-market) | [Y](https://sdbullion.com/1-oz-silver-rounds-new) | [Y](https://monumentmetals.com/elemetal-1oz-silver-round.html) | [Y](https://www.herobullion.com/1-oz-silver-round-any-mint-any-condition/) | — |
+
+### Silver Bars (10 oz)
+
+| Coin | APMEX | SD Bullion | Monument | Hero | Summit |
+|------|-------|------------|----------|------|--------|
+| **generic-silver-bar-10oz** | [Y](https://www.apmex.com/product/21/10-oz-silver-bar-secondary-market) | [Y](https://sdbullion.com/10-oz-sd-bullion-proclaim-liberty-silver-bar) | [Y](https://monumentmetals.com/10oz-elemetal-silver-bar.html) | [Y](https://www.herobullion.com/10-oz-silver-bar-any-mint-any-condition/) | — |
+
+### Gold Coins (1 oz)
+
+| Coin | APMEX | SD Bullion | Monument | Hero | Summit |
+|------|-------|------------|----------|------|--------|
+| **age** (American Gold Eagle) | [Y](https://www.apmex.com/product/1/1-oz-american-gold-eagle-coin-bu-random-year) | — | — | [Y](https://www.herobullion.com/american-gold-eagle-1-oz-coin/) | — |
+| **buffalo** (Gold Buffalo) | [Y](https://www.apmex.com/product/39598/1-oz-gold-buffalo-bu-random-year) | [Y](https://sdbullion.com/1-oz-american-gold-buffalo-coin-random-year) | [Y](https://monumentmetals.com/random-date-1oz-gold-buffalo.html) | [Y](https://www.herobullion.com/american-gold-buffalo-1-oz-coin/) | — |
+| **maple-gold** (Gold Maple Leaf) | [Y](https://www.apmex.com/product/9/canada-1-oz-gold-maple-leaf-9999-fine-bu-random-year) | [Y](https://sdbullion.com/1-oz-canadian-gold-maple-leaf-coin-random-year) | [Y](https://monumentmetals.com/random-date-1oz-gold-maple.html) | [Y](https://www.herobullion.com/canadian-gold-maple-1-oz-coin/) | — |
+| **krugerrand-gold** (Gold Krugerrand) | [Y](https://www.apmex.com/product/62/south-african-1-oz-gold-krugerrand-coin-bu-random-year) | [Y](https://sdbullion.com/1-oz-south-african-gold-krugerrand-coin-random-year) | [Y](https://monumentmetals.com/random-date-1oz-gold-krugerrand.html) | [Y](https://www.herobullion.com/south-african-gold-krugerrand-1-oz-coin/) | — |
+
+### Platinum Coins (1 oz)
+
+| Coin | APMEX | SD Bullion | Monument | Hero | Summit |
+|------|-------|------------|----------|------|--------|
+| **ape** (American Platinum Eagle) | [Y](https://www.apmex.com/product/52/1-oz-american-platinum-eagle-coin-bu-random-year-1997-2023) | [Y](https://sdbullion.com/1-oz-platinum-american-eagle-coin-random-dates) | [Y](https://monumentmetals.com/random-date-1oz-platinum-eagle.html) | [Y](https://www.herobullion.com/american-platinum-eagle-1-oz-coin/) | — |
+
+### Goldback Notes
+
+| Coin | Weight | APMEX | Hero | Summit |
+|------|--------|-------|------|--------|
+| **goldback-oklahoma-g1** | 1 oz | [Y](https://www.apmex.com/product/314866/1-oklahoma-goldback-aurum-gold-foil-note-24k) | [Y](https://www.herobullion.com/1-oklahoma-goldback-aurum-gold-note/) | — |
+| **goldback-utah-g50** | 50 oz | — | [Y](https://www.herobullion.com/50-utah-goldback-aurum-gold-note/) | — |
+| **goldback-wyoming-g5** | 5 oz | Y (no URL) | — | — |
+| **goldback-wyoming-g50** | 50 oz | [Y](https://www.apmex.com/product/255963/50-wyoming-goldback-aurum-gold-foil-note-24k) | — | — |
+
+> **Issue:** `goldback-wyoming-g5` for APMEX has an empty URL — this target is enabled but will always fail.
+
+---
+
+## Disabled Vendors (in Turso for all coins)
+
+| Vendor | Reason disabled | Hardcoded rules still present |
+|--------|----------------|-------------------------------|
+| `jmbullion` | Firecrawl unreliable (PLAYWRIGHT_ONLY); frequent OOS false positives | Yes — extraction strategy, cutoff patterns, header skip, fractional exempt, preorder tolerant |
+| `bullionexchanges` | Cloudflare bot detection defeats both Firecrawl and Playwright | Yes — PLAYWRIGHT_ONLY, SLOW_PROVIDERS |
+| `sdbullion` (gold coins only) | Disabled for gold — enabled for silver/platinum | Yes — cutoff patterns |
+
+---
+
+## Scraper Flow Per Target
+
+```
+For each enabled coin/vendor target:
+  1. Is vendor in PLAYWRIGHT_ONLY_PROVIDERS?
+     YES → skip to step 4
+     NO  → step 2
+
+  2. Phase 1: Firecrawl
+     - POST to localhost:3002/v1/scrape
+     - onlyMainContent: true (false for jmbullion)
+     - waitFor: 6000ms if SLOW_PROVIDERS, else none
+     - Retry up to 2x on failure
+     - preprocessMarkdown() strips header/nav + tail sections
+     - detectStockStatus() checks OOS patterns
+     - extractPrice() tries per-vendor strategy
+     - If price found → done
+     - If OOS → done (no Playwright retry)
+     - If no price + in stock → step 4
+
+  3. Jitter 2-8s between targets
+
+  4. Phase 2: Playwright (if Firecrawl failed or skipped)
+     - Launch Chromium (PLAYWRIGHT_LAUNCH=1)
+     - Block images/fonts/styles/media
+     - Wait networkidle + 8s extra for SLOW_PROVIDERS
+     - Proxy chain: direct → HOME_PROXY_URL_2 → PROXY_HTTP (on 403/geo-block)
+     - Same preprocessMarkdown + detectStockStatus + extractPrice
+
+  5. Record to Turso: price_snapshots + provider_failures (if failed)
+```
+
+---
+
+## Keeping Pollers in Sync
+
+### After any code change to `devops/fly-poller/`
+
+1. **Fly.io:** `cd devops/fly-poller && fly deploy`
+2. **Home poller:** Run the update script from [home-poller.md](home-poller.md#updating-poller-code)
+3. **Verify hashes:**
+   ```bash
+   # Repo
+   md5 -q devops/fly-poller/{price-extract,capture,provider-db,db,turso-client}.js
+   # Home poller
+   ssh -T homepoller 'md5sum /opt/poller/{price-extract,capture,provider-db,db,turso-client}.js'
+   ```
+
+### After `fly deploy` bumps Playwright version
+
+```bash
+ssh -T homepoller 'cd /opt/poller && sudo npm install playwright && sudo npx playwright install --with-deps chromium'
+```
+
+### Provider changes (URLs, enabled flags)
+
+No deploy needed — both pollers read from Turso on every run. Use the dashboard at `http://192.168.1.81:3010/providers`.
+
+---
+
+## Parity Checklist
+
+Run this after any deploy to verify both pollers are equivalent:
+
+```bash
+# 1. File hashes match
+REPO=devops/fly-poller
+for f in price-extract.js capture.js provider-db.js db.js turso-client.js run-home.sh; do
+  LOCAL=$(md5 -q "$REPO/$f" 2>/dev/null)
+  REMOTE=$(ssh -T homepoller "md5sum /opt/poller/$f 2>/dev/null" | awk '{print $1}')
+  STATUS=$([[ "$LOCAL" == "$REMOTE" ]] && echo "OK" || echo "DRIFT")
+  echo "$STATUS  $f  local=$LOCAL  remote=$REMOTE"
+done
+
+# 2. Both can reach Turso
+ssh -T homepoller 'cd /opt/poller && set -a && source .env && set +a && node -e "
+import { createTursoClient } from \"./turso-client.js\";
+const c = createTursoClient();
+const r = await c.execute(\"SELECT COUNT(*) as n FROM provider_vendors WHERE enabled = 1\");
+console.log(\"Home poller: \" + r.rows[0].n + \" enabled vendors\");
+"'
+fly ssh console --app staktrakr -C "cd /app && node -e \"
+import { createTursoClient } from './turso-client.js';
+const c = createTursoClient();
+const r = await c.execute('SELECT COUNT(*) as n FROM provider_vendors WHERE enabled = 1');
+console.log('Fly.io: ' + r.rows[0].n + ' enabled vendors');
+\""
+
+# 3. Playwright version match
+ssh -T homepoller 'node -e "import(\"playwright\").then(p=>console.log(\"Home:\",p.chromium.name()))"'
+fly ssh console --app staktrakr -C "node -e \"import('playwright-core').then(p=>console.log('Fly:',p.chromium.name()))\""
+```

--- a/wiki/provider-database.md
+++ b/wiki/provider-database.md
@@ -1,0 +1,274 @@
+---
+title: Provider Database (Turso)
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-26
+sourceFiles: []
+relatedPages:
+  - turso-schema.md
+  - providers.md
+  - fly-container.md
+  - home-poller.md
+  - health.md
+---
+
+# Provider Database (Turso)
+
+> **Last verified:** 2026-02-26 — bulk vendor operations + goldback cleanup deployed, coverage stats added
+
+---
+
+## Overview
+
+Provider data (which vendors to scrape, URLs, coin metadata) is stored in **Turso** as the single source of truth. Prior to 2026-02-25, this data lived in a static `providers.json` file on the `api` branch — pollers curled it before each run, and the home dashboard wrote edits back to the file. This caused race conditions when multiple writers edited the file simultaneously.
+
+The shared query module `provider-db.js` provides all read/write operations. All consumers — Fly.io poller scripts, home poller, dashboard, and the publish pipeline — import from this module.
+
+**Current stats:** 73 coins (silver, gold, goldback, platinum), 377 vendors.
+
+---
+
+## Schema
+
+### `provider_coins`
+
+```sql
+CREATE TABLE IF NOT EXISTS provider_coins (
+  slug       TEXT PRIMARY KEY,
+  metal      TEXT NOT NULL,        -- "gold", "silver", "platinum"
+  name       TEXT NOT NULL,        -- "American Silver Eagle"
+  weight_oz  REAL NOT NULL,        -- troy ounces (e.g. 1, 10)
+  fbp_url    TEXT,                 -- FindBullionPrices URL (legacy, nullable)
+  notes      TEXT,                 -- free-form notes
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+### `provider_vendors`
+
+```sql
+CREATE TABLE IF NOT EXISTS provider_vendors (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  coin_slug  TEXT NOT NULL REFERENCES provider_coins(slug),
+  vendor_id  TEXT NOT NULL,        -- "jmbullion", "apmex", etc.
+  vendor_name TEXT,                -- display name
+  url        TEXT,                 -- scrape URL (null = disabled/no URL)
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  selector   TEXT,                 -- CSS selector override (nullable)
+  hints      TEXT,                 -- JSON hints for scraper (nullable)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(coin_slug, vendor_id)
+);
+```
+
+### `provider_failures`
+
+```sql
+CREATE TABLE IF NOT EXISTS provider_failures (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  coin_slug  TEXT NOT NULL,
+  vendor_id  TEXT NOT NULL,
+  url        TEXT,
+  error      TEXT,
+  failed_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+Added in STAK-349. Populated by `recordFailure()` in `db.js` — called from `price-extract.js` whenever a scrape returns no price for an in-stock vendor.
+
+### Indexes
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_pv_coin ON provider_vendors(coin_slug);
+CREATE INDEX IF NOT EXISTS idx_pv_vendor ON provider_vendors(vendor_id);
+CREATE INDEX IF NOT EXISTS idx_pv_enabled ON provider_vendors(enabled);
+CREATE INDEX IF NOT EXISTS idx_pf_coin_vendor ON provider_failures(coin_slug, vendor_id);
+CREATE INDEX IF NOT EXISTS idx_pf_failed_at ON provider_failures(failed_at);
+```
+
+---
+
+## provider-db.js API
+
+Shared module at `StakTrakrApi/devops/fly-poller/provider-db.js`. All functions take a Turso `client` as the first argument.
+
+| Function | Description |
+|----------|-------------|
+| `initProviderSchema(client)` | Idempotent DDL — creates both tables and indexes |
+| `getProviders(client)` | Returns `{ coins: { [slug]: { metal, name, weight_oz, providers: [...] } } }` — matches `providers.json` shape |
+| `getProvidersByCoin(client, coinSlug)` | Vendors for a single coin |
+| `getAllCoins(client)` | Coin list without vendor detail |
+| `upsertCoin(client, coin)` | Insert or update a coin row |
+| `upsertVendor(client, vendor)` | Insert or update a vendor row |
+| `toggleVendor(client, coinSlug, vendorId, enabled)` | Enable/disable a vendor |
+| `updateVendorUrl(client, coinSlug, vendorId, url)` | Change a vendor's scrape URL |
+| `deleteCoin(client, slug)` | Delete coin + all its vendors (batch) |
+| `deleteVendor(client, coinSlug, vendorId)` | Delete a single vendor row |
+| `updateVendorFields(client, coinSlug, vendorId, { selector, hints })` | Update selector/hints metadata |
+| `getVendorScrapeStatus(client)` | Latest scrape result per vendor (window function query) |
+| `getFailureStats(client)` | Vendors with 3+ failures in last 10 days |
+| `getRunStats(client)` | Poller run aggregates (last 24h) |
+| `batchToggleVendor(client, { vendorId, metal, enabled })` | Toggle all vendors of a vendor ID + metal type. Returns `{ rowsAffected }` |
+| `batchDeleteVendor(client, { vendorId, metal })` | Delete all vendor entries for a vendor ID + metal type. Returns `{ rowsAffected }` |
+| `batchToggleVendorByCoins(client, { vendorId, coinSlugs, enabled })` | Toggle vendor across specific coin slugs. Returns `{ rowsAffected }` |
+| `getVendorSummary(client)` | Grouped counts by vendor ID and metal. Returns `{ [vendorId]: { total, enabled, disabled, byMetal: { [metal]: { total, enabled, disabled } } } }` |
+| `getCoverageStats(client, hours?)` | Hourly coverage — how many enabled pairs had a successful price. Returns `{ totalEnabled, hours: [{ hour, covered, pct }] }` |
+| `getMissingItems(client)` | Enabled pairs with no successful price this hour. Returns `[{ coinSlug, coinName, metal, vendor, url }]` |
+| `exportProvidersJson(client)` | Returns JSON string matching `providers.json` format |
+| `loadProvidersFromFile(dataDir)` | File fallback — reads `{dataDir}/retail/providers.json` |
+| `loadProviders(client, dataDir)` | Turso-first with file fallback; logs which path taken |
+
+---
+
+## Sync Between Pollers
+
+`provider-db.js` is shared between Fly.io (`StakTrakrApi/devops/fly-poller/`) and the home poller (`/opt/poller/`). The home poller copy may contain **extra functions** (e.g. `getCoverageStats`, `getMissingItems`) that `dashboard.js` imports but that haven't been committed to StakTrakrApi yet.
+
+**Safe sync procedure:**
+
+1. Edit `provider-db.js` in `StakTrakrApi/devops/fly-poller/` (source of truth)
+2. Diff before overwriting: `ssh homepoller 'cat /opt/poller/provider-db.js' | diff - devops/fly-poller/provider-db.js`
+3. SCP: `scp devops/fly-poller/provider-db.js homepoller:/opt/poller/provider-db.js`
+4. Restart dashboard: `ssh homepoller 'sudo pkill -f "node.*dashboard"; sudo bash -c "cd /opt/poller && nohup node dashboard.js >> dashboard.log 2>&1 &"'`
+5. Verify: `ssh homepoller 'curl -sf http://localhost:3010/ > /dev/null && echo OK'`
+
+**Never blindly overwrite** the home poller's copy — always diff first to avoid breaking dashboard imports.
+
+The canonical sync tool is `devops/home-scraper/sync-from-fly.sh --apply` which handles all shared files.
+
+---
+
+## Data Flow
+
+```
+Dashboard (CRUD)  ──→  Turso provider tables  ←── migrate-providers.js (one-time import)
+                            │
+                            ├──→ price-extract.js (reads providers for scraping)
+                            ├──→ capture.js (reads providers for vision pipeline)
+                            ├──→ api-export.js (reads providers for manifest generation)
+                            │
+                            └──→ run-publish.sh → exportProvidersJson() → providers.json on api branch
+```
+
+`providers.json` on the `api` branch is now **auto-generated** from Turso every publish cycle. It serves as a read-only snapshot for backward compatibility. Direct edits to the file will be overwritten.
+
+---
+
+## Dashboard CRUD
+
+The home poller dashboard at `http://192.168.1.81:3010/providers` provides full CRUD against the Turso provider tables. Rebuilt in STAK-349 (2026-02-26).
+
+### Layout
+
+- **Stats bar** — total coins, total vendors, enabled vendors, poller run stats (last 24h)
+- **Search/filter** — client-side filter by coin name, metal, or vendor name
+- **Collapsible accordion** — each coin is a collapsible section (73 coins, collapsed by default)
+- **Per-vendor scrape status** — green/red dots showing latest scrape result from `price_snapshots`
+
+### Operations
+
+| Action | Trigger | Backend |
+|--------|---------|---------|
+| Add coin | Modal form | `upsertCoin()` |
+| Edit coin | Inline fields | `upsertCoin()` |
+| Delete coin | Button + confirm dialog | `deleteCoin()` (cascades vendors) |
+| Add vendor | Modal form | `upsertVendor()` |
+| Edit vendor URL | Blur-to-save on input | `updateVendorUrl()` |
+| Edit selector/hints | Save button per vendor | `updateVendorFields()` |
+| Toggle vendor | Checkbox click | `toggleVendor()` |
+| Delete vendor | Button + confirm dialog | `deleteVendor()` |
+| Export JSON | Button | `exportProvidersJson()` |
+
+All writes are individual Turso calls — no batch "Save All" button. Changes take effect on the next poller cycle.
+
+### Bulk Operations
+
+The providers page includes a **bulk action bar** (visible when filtering by metal type). Select a vendor from the dropdown and apply Enable All / Disable All / Remove All across all items of that metal.
+
+| Action | Endpoint | Backend |
+|--------|----------|---------|
+| Enable all vendor items for a metal | `POST /providers/bulk-toggle` | `batchToggleVendor()` |
+| Disable all vendor items for a metal | `POST /providers/bulk-toggle` | `batchToggleVendor()` |
+| Remove all vendor items for a metal | `POST /providers/bulk-delete` | `batchDeleteVendor()` |
+| Get vendor summary counts | `GET /providers/vendor-summary` | `getVendorSummary()` |
+
+Confirmation modal shows the affected item count before executing. Added 2026-02-26 (goldback-vendor-cleanup + bulk-vendor-management-ui specs).
+
+### Coverage Stats
+
+The main dashboard shows hourly coverage cards and a missing items table:
+
+- **Coverage cards** — latest hour coverage %, 12-hour average, spark bars
+- **Missing Items table** — enabled vendor-coin pairs with no successful price this hour, with Diagnose and Browserbase action buttons
+
+Powered by `getCoverageStats()` and `getMissingItems()` in `provider-db.js`.
+
+### Failure Queue
+
+A dedicated page at `/failures` shows vendors with repeated scrape failures:
+
+- Aggregated from `provider_failures` table (3+ failures in last 10 days)
+- Shows coin name, vendor ID, failure count, last error, and scrape URL
+- Links back to the vendor's entry in `/providers` for editing
+
+### Read-only fallback
+
+If Turso is unreachable, the dashboard renders in read-only mode with a warning banner. Data is loaded from the local `providers.json` file via `loadProvidersFromFile()`.
+
+---
+
+## Fallback Strategy
+
+All poller scripts use `loadProviders(client, dataDir)` which:
+
+1. Tries `getProviders(client)` from Turso
+2. On failure, falls back to `loadProvidersFromFile(dataDir)` — reads the local `providers.json`
+3. Logs which path was taken (Turso vs file fallback)
+
+The local `providers.json` files are kept on both pollers as a safety net but are no longer the primary data source.
+
+---
+
+## Migration
+
+**One-time migration script:** `migrate-providers.js`
+
+```bash
+# Dry run (safe)
+TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... DATA_DIR=data \
+  node devops/fly-poller/migrate-providers.js --dry-run --production
+
+# Execute
+TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... DATA_DIR=data \
+  node devops/fly-poller/migrate-providers.js --production
+```
+
+- `--production` required when Turso URL is not localhost
+- `--dry-run` prints what would be inserted without writing
+- Uses `INSERT OR REPLACE` — fully idempotent
+- Migrated 2026-02-25: 11 coins, 67 vendors, verified round-trip fidelity
+
+---
+
+## Rollback
+
+If Turso provider tables need to be abandoned:
+
+1. All poller scripts automatically fall back to `loadProvidersFromFile()` if Turso is unreachable
+2. Restore `curl` lines in `run-local.sh` and `run-home.sh` (see git history pre-STAK-348)
+3. Remove `exportProvidersJson()` call from `run-publish.sh`
+4. Edit `providers.json` on the `api` branch directly (old workflow)
+
+---
+
+## Related Pages
+
+- [Turso Schema](turso-schema.md) — all Turso tables including `price_snapshots`
+- [providers.json](providers.md) — file format reference (now auto-generated)
+- [Fly.io Container](fly-container.md) — deployment and environment
+- [Home Poller](home-poller.md) — dashboard and secondary poller
+- [Health & Diagnostics](health.md) — monitoring and troubleshooting

--- a/wiki/providers.md
+++ b/wiki/providers.md
@@ -1,0 +1,160 @@
+---
+title: "providers.json"
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-24
+sourceFiles: []
+relatedPages: []
+---
+
+# providers.json
+
+> **Last verified:** 2026-02-24 — 15 URL corrections applied 2026-02-23, year-start SKU patterns documented
+
+---
+
+## Overview
+
+> **As of 2026-02-25 (STAK-348):** Provider data is now stored in **Turso** as the single source of truth. `providers.json` on the `api` branch is **auto-generated** from Turso by `run-publish.sh` every 15 minutes via `exportProvidersJson()`. Direct edits to the file will be overwritten. To change provider URLs, use the [dashboard](home-poller.md) at `http://192.168.1.81:3010/providers` or the `provider-db.js` API. See [Provider Database](provider-database.md) for details.
+
+`providers.json` lives on the **`api` branch** at `data/retail/providers.json`. It defines:
+- Which vendors to scrape for each coin
+- The URL for each vendor/coin combination
+- Coin weights (for price-per-oz normalization)
+
+Pollers read provider data from **Turso** (with file fallback). The file on the `api` branch is a generated snapshot for backward compatibility.
+
+---
+
+## Location
+
+```
+StakTrakrApi repo, api branch:
+  data/retail/providers.json
+```
+
+Raw URL:
+```
+https://raw.githubusercontent.com/lbruton/StakTrakrApi/api/data/retail/providers.json
+```
+
+---
+
+## Structure
+
+```json
+{
+  "last_updated": "2026-02-24",
+  "notes": "...",
+  "coins": {
+    "ase": {
+      "name": "American Silver Eagle",
+      "weight_oz": 1,
+      "providers": [
+        {
+          "id": "jmbullion",
+          "name": "JM Bullion",
+          "urls": [
+            "https://www.jmbullion.com/2026-1-oz-american-silver-eagle-coin/",
+            "https://www.jmbullion.com/american-silver-eagle-varied-year/"
+          ]
+        },
+        {
+          "id": "apmex",
+          "name": "APMEX",
+          "url": "https://www.apmex.com/..."
+        }
+      ]
+    }
+  }
+}
+```
+
+### `urls` vs `url`
+
+Providers support two forms:
+
+| Field | Type | Behavior |
+|-------|------|----------|
+| `url` | string | Single URL — backward compatible, treated as a 1-element list |
+| `urls` | array | Multi-URL fallback list — scraper tries each in order |
+
+**Never set both on the same entry.** Use `urls` when a provider has year-specific SKUs that may go OOS; use `url` for stable random-year SKUs.
+
+The scraper (since 2026-02-23) tries all `urls` via Firecrawl first, then falls back to Playwright on the last URL only if the entire Firecrawl chain fails. On OOS or parse failure at URL[i], it jitters and tries URL[i+1]. A price found at any URL stops the loop immediately.
+
+---
+
+## URL Strategy
+
+### Prefer random-year / dates-our-choice SKUs
+
+When a vendor offers a "dates our choice" or "random year" SKU, prefer it over a specific year. These SKUs stay stable year-over-year and typically represent the best price.
+
+### Year-start exception: Monument Metals
+
+Monument Metals maintains **parallel SKUs** for each coin:
+- `random-date-*.html` — random year, best price when bulk stock available
+- `2026-*.html` — current year, in stock from January
+
+**At year-start (Jan–Mar):**
+- Random-year SKUs go to pre-order while year-specific is the only in-stock option
+- Switch to year-specific SKUs until bulk random-year stock arrives (typically March–April)
+
+**Known year-start pattern (verified 2026-02-23):**
+
+| Coin | Year-start URL | Status |
+|------|---------------|--------|
+| `ase` | `2026-american-silver-eagle.html` | Year-specific (random was pre-order) |
+| `age` | `2026-american-1-oz-gold-eagle-bu.html` | Year-specific (random was pre-order) |
+| `maple-gold` | `2026-1oz-gold-maple.html` | Year-specific (random was pre-order) |
+| `krugerrand-silver` | `south-africa-1-oz-silver-krugerrand-bu-random-date.html` | Random-date (2026 was pre-order — opposite) |
+
+> Check Monument Metals in late March/April to see if random-year SKUs are back in stock.
+
+---
+
+## JMBullion Pre-Order / Presale
+
+JMBullion marks some coins as "Presale" or "Pre-Order" at year-start but still shows live purchasable prices. These coins should NOT be treated as out of stock.
+
+`price-extract.js` has `PREORDER_TOLERANT_PROVIDERS = Set(["jmbullion"])` which skips the `pre-?order` OOS pattern for JMBullion only.
+
+Affected coins at year-start:
+- `buffalo`
+- `maple-silver`
+- `maple-gold`
+- `krugerrand-silver`
+
+---
+
+## Out-of-Stock vs. Genuinely Unavailable
+
+Not all vendors carry all coins. Some vendor/coin pairs may have correct URLs but genuinely no stock:
+- `ape/bullionexchanges` — correct URL, OOS at some periods
+- `ape/herobullion` — correct URL, OOS at some periods
+- `britannia-silver/bullionexchanges` — correct URL, OOS at some periods
+
+These return `null` price with `in_stock: false`. Leave the URL as-is; prices will return when vendors restock.
+
+---
+
+## Updating Providers
+
+> **Preferred (post-STAK-348):** Use the dashboard at `http://192.168.1.81:3010/providers` for URL edits, or the `provider-db.js` CRUD functions. Changes are written to Turso and take effect on the next scrape cycle. `run-publish.sh` regenerates `providers.json` on the `api` branch automatically.
+
+**Legacy method (pre-STAK-348, no longer recommended):**
+
+1. Edit `data/retail/providers.json` on the `api` branch directly
+2. Push to `api` branch
+3. File will be overwritten on the next publish cycle by Turso export
+
+---
+
+## URL Corrections History
+
+| Date | Changes |
+|------|---------|
+| 2026-02-23 | 15 URL corrections: JMBullion ASE dead redirect fixed; Monument Metals 6 coins switched to year-specific; Hero Bullion 10oz bar switched to Engelhard SKU |
+| 2026-02-23 | JMBullion ASE and Silver Maple Leaf converted from single `url` to `urls` fallback array (2026 → 2025 → 2024 → varied-year) |

--- a/wiki/release-workflow.md
+++ b/wiki/release-workflow.md
@@ -1,0 +1,252 @@
+---
+title: Release Workflow
+category: frontend
+owner: staktrakr
+lastUpdated: v3.32.24
+date: 2026-02-23
+sourceFiles:
+  - .claude/skills/release/SKILL.md
+  - devops/version-lock-protocol.md
+relatedPages:
+  - service-worker.md
+  - frontend-overview.md
+---
+# Release Workflow
+
+> **Last updated:** v3.32.24 — 2026-02-23
+> **Source files:** `.claude/skills/release/SKILL.md`, `devops/version-lock-protocol.md`
+
+## Overview
+
+StakTrakr uses a structured patch versioning workflow. Every meaningful change — bug fix, UX tweak, or feature addition — gets its own version bump, its own worktree, and its own PR to `dev`. This keeps the commit graph clean and gives every release a set of breadcrumb tags that can be reconstructed into a precise changelog.
+
+The two commands that drive this workflow are:
+
+- **`/release patch`** — claims the next version, isolates work in a worktree, bumps 7 files, commits, and opens a draft PR to `dev`
+- **`/ship`** (Phase 4.5 of the release skill) — explicit `dev → main` release using version tags as the changelog source; never runs automatically
+
+---
+
+## Key Rules (read before touching this area)
+
+- **One meaningful change = one patch tag = one worktree.** Never batch unrelated changes under a single version bump.
+- **Always sync before starting.** `git fetch origin && git pull origin dev` is a hard gate — do not skip. A worktree created from a stale HEAD produces PRs that conflict with or silently drop remote commits.
+- **Never push directly to `dev` or `main`.** Both branches are protected with Codacy quality gates. All changes must go through PRs.
+- **Claim the version lock before any code.** The version number is the first thing decided, not the last.
+- **`/ship` is always explicit.** The `dev → main` PR is created only when you say "ready to ship" — never automatically at the end of a patch cycle.
+
+---
+
+## Architecture
+
+### Version Format
+
+Defined in `js/constants.js` as `APP_VERSION`:
+
+```
+BRANCH.RELEASE.PATCH
+  3  .  32  .  24
+```
+
+- `BRANCH` — major branch (rarely changes)
+- `RELEASE` — bumped when shipping a batch to `main` via `/release release`
+- `PATCH` — bumped after every meaningful committed change via `/release patch`
+
+Current value as of this writing: `3.32.24`
+
+---
+
+### Version Lock (`devops/version.lock`)
+
+The lock prevents two concurrent agents from claiming the same version number. It is the first thing written and the last thing deleted.
+
+**Lock file format** (`devops/version.lock` — gitignored):
+
+```json
+{
+  "locked": "3.32.25",
+  "locked_by": "claude-sonnet / STAK-XX feature name",
+  "locked_at": "2026-02-23T19:00:00Z",
+  "expires_at": "2026-02-23T19:30:00Z"
+}
+```
+
+- TTL is 30 minutes. Any agent may take over an expired lock (and must log the takeover in mem0).
+- If the lock is held and not expired, stop and report to the user — do not proceed.
+
+---
+
+### Worktrees (`.claude/worktrees/`)
+
+Each patch gets an isolated filesystem via `git worktree`. All file edits, version bumps, and commits happen inside the worktree — not in the main `dev` working tree.
+
+```bash
+# Created automatically by /release patch after the lock is written
+git worktree add .claude/worktrees/patch-3.32.25 -b patch/3.32.25
+```
+
+Worktrees are stored at `.claude/worktrees/patch-VERSION/` and are gitignored.
+
+---
+
+### 7 Files Bumped per Patch
+
+Every `/release patch` run touches exactly these files:
+
+| # | File | What changes |
+|---|------|--------------|
+| 1 | `js/constants.js` | `APP_VERSION` string |
+| 2 | `sw.js` | `CACHE_NAME` — auto-stamped by pre-commit hook (`devops/hooks/stamp-sw-cache.sh`); no manual edit needed |
+| 3 | `CHANGELOG.md` | New version section with bullets |
+| 4 | `docs/announcements.md` | Prepend one-line entry to What's New; trim to 3–5 entries |
+| 5 | `js/about.js` | `getEmbeddedWhatsNew()` and `getEmbeddedRoadmap()` — must mirror `announcements.md` exactly |
+| 6 | `version.json` | `version` + `releaseDate` fields |
+| 7 | wiki (via `wiki-update` skill) | `release-workflow.md` and related pages updated as part of the wiki system |
+
+`announcements.md` and `js/about.js` (files 4 and 5) **must stay in sync** — HTTP users read the former via `fetch()`; `file://` users fall back to the latter.
+
+---
+
+## `/start-patch` — Session Start
+
+Before running `/release patch`, use `/start-patch` to orient the session:
+
+1. Fetches open Linear issues for the StakTrakr team, ranked by priority
+2. Presents the list to the user
+3. User picks the issue to work on
+4. Hands off to `/release patch` with the selected issue as context
+
+This ensures every patch has a Linear issue anchor before any code is written.
+
+---
+
+## `/release patch` — Full Flow
+
+### Phase 0: Remote Sync Gate (hard gate)
+
+```bash
+git fetch origin
+git rev-list HEAD..origin/dev --count
+```
+
+If the count is greater than 0: **STOP.** Pull first, then restart.
+
+```bash
+git pull origin dev
+```
+
+### Phase 0a: Version Lock Check
+
+```bash
+cat devops/version.lock 2>/dev/null || echo "UNLOCKED"
+```
+
+- Locked and not expired → stop, report to user
+- Locked but expired (>30 min) → take over, log takeover in mem0
+- Unlocked → proceed: compute `next_version = APP_VERSION + 1 (PATCH)`, write lock, create worktree
+
+### Phase 1: Implement + Version Bump
+
+All work happens inside `.claude/worktrees/patch-VERSION/`. The skill bumps all 7 files, then presents a release plan for user confirmation before writing anything.
+
+### Phase 2: Verify
+
+Grep for the new version string in all 7 files. Confirm `announcements.md` has 3–5 What's New entries, `about.js` mirrors it exactly, and `version.json` has today's date.
+
+### Phase 3: Commit
+
+```bash
+git add js/constants.js sw.js CHANGELOG.md docs/announcements.md js/about.js version.json
+git commit -m "vNEW_VERSION — TITLE"
+```
+
+Commit message format: `vNEW_VERSION — TITLE` (em dash, not hyphen). Include `STAK-XX` references if applicable.
+
+### Phase 4: Push + Draft PR to `dev`
+
+```bash
+git push origin patch/VERSION
+gh pr create --base dev --head patch/VERSION --draft --label "codacy-review" \
+  --title "vNEW_VERSION — brief description" \
+  --body "..."
+```
+
+Cloudflare Pages generates a preview URL for every PR branch. QA the preview before merging.
+
+> PR always targets `dev`, never `main`.
+
+### Post-Merge Cleanup
+
+After the PR merges to `dev`:
+
+```bash
+# Tag the patch on dev (breadcrumb for changelog reconstruction)
+git fetch origin dev
+git tag vNEW_VERSION origin/dev
+git push origin vNEW_VERSION
+
+# Remove the worktree
+git worktree remove .claude/worktrees/patch-VERSION --force
+
+# Delete local and remote branches
+git branch -d patch/VERSION
+git push origin --delete patch/VERSION
+
+# Release the version lock
+rm -f devops/version.lock
+```
+
+Note: this tag lands on `dev`, not `main`. It is NOT a GitHub Release — it appears only in the Tags tab. The actual GitHub Release is created in Phase 5 after the `dev → main` merge.
+
+---
+
+## `/ship` — Batched `dev → main` Release (Phase 4.5)
+
+Run only when the user explicitly says "ready to ship", "release", or "merge to main". Never runs automatically.
+
+### What it does
+
+1. Audits `dev` — lists all commits and version tags not yet on `main`
+2. Fetches Linear issue titles for all referenced `STAK-###` identifiers
+3. Creates the `dev → main` PR with a comprehensive title and changelog sourced from the version tags
+4. Marks the PR ready: `gh pr ready [number]`
+5. Runs `/pr-resolve` to clear all Codacy and Copilot review threads
+6. After merge: creates the GitHub Release targeting `main` (Phase 5) — **mandatory**
+
+### Why version tags are the changelog source
+
+Each patch tag (`v3.32.24`) is a breadcrumb. By collecting all tags on `dev` that haven't merged to `main` yet, the skill assembles an accurate changelog without relying on commit message wording. This is more reliable than reading raw commit messages, which may be terse or out of order.
+
+### Phase 5: GitHub Release (mandatory post-merge)
+
+```bash
+git fetch origin main
+gh release create vNEW_VERSION \
+  --target main \
+  --title "vNEW_VERSION — TITLE" \
+  --latest \
+  --notes "..."
+```
+
+Without this step, the GitHub Releases page shows a stale version and the "Latest" badge is wrong. `version.json`'s `releaseUrl` points to `/releases/latest`, which resolves to the most recent GitHub Release — so this must be created for the URL to resolve correctly.
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Correct behavior |
+|---------|-------------|-----------------|
+| Skipping the remote sync gate | Worktree is created from a stale HEAD; PR silently drops remote commits | Always run `git pull origin dev` before `/release patch` |
+| Batching multiple features under one patch | Version history becomes ambiguous; changelog is harder to reconstruct | One meaningful change = one patch |
+| Pushing directly to `dev` or `main` | Blocked by branch protection; Codacy gate will reject | Always use a PR |
+| Creating a `dev → main` PR automatically | Ships code before QA | Phase 4.5 only runs when user explicitly requests it |
+| Skipping Phase 5 (GitHub Release) | `version.json` `releaseUrl` resolves to stale release; "Latest" badge is wrong | Always create the GitHub Release after `dev → main` merge |
+| Editing `announcements.md` without updating `about.js` | HTTP users and `file://` users see different What's New content | Keep both files in sync at all times |
+| Forgetting to delete `version.lock` after cleanup | Next agent sees a stale lock and stops unnecessarily | `rm -f devops/version.lock` is part of cleanup |
+
+---
+
+## Related Pages
+
+- [Service Worker](service-worker.md) — `sw.js` cache name auto-stamp, CORE_ASSETS maintenance
+- [Frontend Overview](frontend-overview.md) — file load order, `index.html` script block, `js/constants.js` role

--- a/wiki/rest-api-reference.md
+++ b/wiki/rest-api-reference.md
@@ -1,0 +1,295 @@
+---
+title: REST API Reference
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages:
+  - architecture-overview.md
+  - retail-pipeline.md
+  - spot-pipeline.md
+  - goldback-pipeline.md
+  - api-consumption.md
+  - turso-schema.md
+---
+
+# REST API Reference
+
+> **Last verified:** 2026-02-25 — audited from live Fly.io container source code
+> **Base URL:** `https://api.staktrakr.com`
+> **Fallback URL:** `https://api2.staktrakr.com`
+
+---
+
+## Overview
+
+All endpoints are static JSON files served via GitHub Pages from the `api` branch of `lbruton/StakTrakrApi`. There is no dynamic server — `serve.js` on Fly.io port 8080 is a redundancy proxy serving the same files.
+
+**Update cadence:** Every 15 minutes via `run-publish.sh` (cron `8,23,38,53 * * * *`).
+
+---
+
+## Global Endpoints
+
+| Endpoint | Description | Updated |
+|----------|-------------|---------|
+| `data/api/manifest.json` | Index: coin list, latest window, endpoint templates | Every 15 min |
+| `data/api/latest.json` | All coins' current median/lowest prices | Every 15 min |
+| `data/api/providers.json` | Vendor → product URL mapping per coin (auto-generated from Turso — see [Provider Database](provider-database.md)) | Every 15 min |
+| `data/api/goldback-spot.json` | Goldback G1 rate + denomination multipliers | Every 15 min |
+
+### manifest.json Schema
+
+```json
+{
+  "generated_at": "2026-02-25T19:08:01.756Z",
+  "latest_window": "2026-02-25T19:00:00Z",
+  "window_count": 96,
+  "coin_count": 17,
+  "coins": ["age", "ape", "ase", "..."],
+  "endpoints": {
+    "latest": "api/latest.json",
+    "slug_latest": "api/{slug}/latest.json",
+    "history_7d": "api/{slug}/history-7d.json",
+    "history_30d": "api/{slug}/history-30d.json",
+    "providers": "api/providers.json"
+  }
+}
+```
+
+### latest.json Schema
+
+```json
+{
+  "window_start": "2026-02-25T19:00:00Z",
+  "generated_at": "2026-02-25T19:08:01.756Z",
+  "coin_count": 17,
+  "coins": {
+    "ase": {
+      "window_start": "2026-02-25T19:00:00Z",
+      "median_price": 36.42,
+      "lowest_price": 35.19,
+      "vendor_count": 7
+    }
+  }
+}
+```
+
+### goldback-spot.json Schema
+
+```json
+{
+  "date": "2026-02-25",
+  "scraped_at": "2026-02-25T19:08:01.756Z",
+  "g1_usd": 10.43,
+  "denominations": {
+    "g1": 10.43,
+    "g5": 52.15,
+    "g10": 104.30,
+    "g25": 260.75,
+    "g50": 521.50
+  },
+  "source": "goldback.com",
+  "confidence": "high"
+}
+```
+
+---
+
+## Per-Coin Endpoints
+
+**17 bullion coins + 56 per-state Goldback slugs + 6 deprecated Goldback slugs** as of 2026-02-25 (STAK-335). Per-state Goldback endpoints populate only when vendors are enabled in `providers.json`. Each coin has three endpoint files:
+
+| Endpoint Pattern | Description | Updated |
+|------------------|-------------|---------|
+| `data/api/{slug}/latest.json` | Per-vendor prices, confidence, availability, 24h time series (96 windows) | Every 15 min |
+| `data/api/{slug}/history-7d.json` | Daily aggregates, last 7 days | Every 15 min |
+| `data/api/{slug}/history-30d.json` | Daily aggregates, last 30 days | Every 15 min |
+
+### Coin Slugs
+
+**Silver (1 oz):** `ase`, `maple-silver`, `britannia-silver`, `krugerrand-silver`, `generic-silver-round`
+**Silver (10 oz):** `generic-silver-bar-10oz`
+**Gold (1 oz):** `age`, `ape`, `buffalo`, `maple-gold`, `krugerrand-gold`
+**Goldback (deprecated — backward compat):** `goldback-g1`, `goldback-g2`, `goldback-g5`, `goldback-g10`, `goldback-g25`, `goldback-g50`
+**Goldback (per-state — STAK-335):** `goldback-{state}-g{denom}` where state is one of `utah`, `nevada`, `wyoming`, `new-hampshire`, `south-dakota`, `arizona`, `oklahoma`, `dc` and denom is `ghalf`, `g1`, `g2`, `g5`, `g10`, `g25`, `g50` (56 slugs total). See [goldback-pipeline.md](goldback-pipeline.md) for the full matrix.
+
+### Per-Coin latest.json Schema
+
+```json
+{
+  "slug": "ase",
+  "window_start": "2026-02-25T19:00:00Z",
+  "median_price": 36.42,
+  "lowest_price": 35.19,
+  "vendors": {
+    "jmbullion": {
+      "price": 35.19,
+      "confidence": 99,
+      "source": "firecrawl+vision",
+      "inStock": true
+    },
+    "apmex": {
+      "price": 36.99,
+      "confidence": 80,
+      "source": "firecrawl",
+      "inStock": true
+    }
+  },
+  "availability_by_site": {
+    "jmbullion": true,
+    "apmex": true
+  },
+  "last_known_price_by_site": {},
+  "last_available_date_by_site": {},
+  "windows_24h": [
+    {
+      "window": "2026-02-24T19:15:00Z",
+      "median": 36.50,
+      "low": 35.20,
+      "vendors": { "jmbullion": 35.20, "apmex": 37.01 }
+    }
+  ]
+}
+```
+
+**Vendor source values:**
+
+| Source | Meaning |
+|--------|---------|
+| `firecrawl+vision` | Both Firecrawl and Gemini Vision agreed (≤3% diff) — 99 confidence |
+| `firecrawl` | Firecrawl text extraction only |
+| `vision` | Gemini Vision screenshot extraction only |
+| `turso_last_known` | T4 fallback — most recent in-stock price from Turso history (includes `stale: true`) |
+
+**Confidence tiers:**
+
+| Range | Meaning |
+|-------|---------|
+| 90–99 | Firecrawl + Vision cross-validated |
+| 60–89 | Single source, agrees with median |
+| 30–59 | Single source, moderate deviation |
+| 0–29 | Outlier or disagreement |
+
+---
+
+## Spot Price Endpoints
+
+| Endpoint Pattern | Description | Updated |
+|------------------|-------------|---------|
+| `data/hourly/YYYY/MM/DD/HH.json` | Hourly spot prices (4 metals) — overwritten each poll | Every 15 min |
+| `data/15min/YYYY/MM/DD/HHMM.json` | Immutable 15-min spot snapshots | Per poll (immutable) |
+| `data/spot-history-YYYY.json` | Annual daily spot history (noon UTC seed) | Once daily |
+
+### Hourly File Schema
+
+```json
+[
+  {
+    "spot": 2945.12,
+    "metal": "Gold",
+    "source": "hourly",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-25 19:05:00"
+  },
+  {
+    "spot": 33.41,
+    "metal": "Silver",
+    "source": "hourly",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-25 19:05:00"
+  }
+]
+```
+
+**Metals:** Gold (XAU), Silver (XAG), Platinum (XPT), Palladium (XPD)
+**Data source:** MetalPriceAPI (`metalpriceapi.com`)
+**Rate conversion:** `1 / rate` = USD per troy oz (API returns units-of-metal-per-USD)
+
+---
+
+## Goldback-Specific Endpoints
+
+### Global
+
+| Endpoint | Description | Updated |
+|----------|-------------|---------|
+| `data/api/goldback-spot.json` | G1 USD rate + all denomination multipliers | Every 15 min (from Turso) |
+| `data/goldback-YYYY.json` | Rolling annual history log (newest first) | Daily (legacy scraper) |
+
+### Legacy (deprecated — backward compat)
+
+| Endpoint | Description | Updated |
+|----------|-------------|---------|
+| `data/api/goldback-g1/latest.json` | Mixed-state G1 vendor prices | Every 15 min |
+| `data/api/goldback-g{N}/latest.json` | Mixed-state denomination prices | Every 15 min |
+
+### Per-State (STAK-335 — populates as vendors are enabled)
+
+| Endpoint Pattern | Example | Description |
+|------------------|---------|-------------|
+| `data/api/goldback-{state}-g{denom}/latest.json` | `goldback-oklahoma-g1/latest.json` | Per-vendor prices for a specific state + denomination |
+| `data/api/goldback-{state}-g{denom}/history-7d.json` | `goldback-utah-ghalf/history-7d.json` | 7-day daily aggregates |
+| `data/api/goldback-{state}-g{denom}/history-30d.json` | `goldback-dc-g50/history-30d.json` | 30-day daily aggregates |
+
+**8 states × 7 denominations = 56 per-state slugs**, each with 3 endpoint files = **168 potential endpoint files** (only populated when vendors are enabled).
+
+**Note:** `goldback-spot.json` denominations are computed from the deprecated `goldback-g1` vendor rate (`G1 × multiplier`). Per-state endpoints track actual retail vendor prices for physical Goldback notes from specific states — these may differ from the computed denomination prices and from each other across states.
+
+---
+
+## Vendor Reference
+
+7 primary vendors tracked across all bullion coins:
+
+| Vendor ID | Name | Notes |
+|-----------|------|-------|
+| `jmbullion` | JM Bullion | JS-heavy (Next.js), 10s render wait |
+| `apmex` | APMEX | Standard extraction |
+| `sdbullion` | SD Bullion | Standard extraction |
+| `monumentmetals` | Monument Metals | React Native Web SPA, 7s render wait |
+| `herobullion` | Hero Bullion | 6s render wait |
+| `bullionexchanges` | Bullion Exchanges | React/Magento SPA, 8s render wait |
+| `summitmetals` | Summit Metals | ASE only |
+
+Goldback-specific vendors: `goldback` (official exchange rate)
+
+---
+
+## HTTP Server Details
+
+`serve.js` runs on Fly.io port 8080 as a redundancy endpoint:
+
+- **CORS:** `Access-Control-Allow-Origin: *`
+- **Cache:** `Cache-Control: public, max-age=300` (5 minutes)
+- **Methods:** GET and OPTIONS only
+- **Security:** Directory traversal (`..`) rejected
+- **Content types:** `.json` → `application/json`, `.db` → `application/x-sqlite3`
+
+---
+
+## Best Practices Audit
+
+**Strengths:**
+- Static file serving — zero dynamic attack surface
+- Proper CORS configuration with preflight handling
+- Cache-Control headers appropriate for 15-min update cycle
+- Turso as single source of truth for retail data
+- Dual-source verification (Firecrawl + Vision) with confidence scoring
+
+**Recommendations:**
+1. Add `/_health` endpoint returning `{"status":"ok","generated_at":"..."}` for Fly.io health checks
+2. Add `Last-Modified` header from `stat.mtime` for conditional caching (`If-Modified-Since`)
+3. Consider adding `schema_version` to `manifest.json` for client-side breaking change detection
+
+---
+
+## Related Pages
+
+- [Architecture Overview](architecture-overview.md) — system diagram, repo boundaries
+- [Retail Pipeline](retail-pipeline.md) — scraping, Turso, confidence scoring
+- [Spot Pipeline](spot-pipeline.md) — MetalPriceAPI, hourly files
+- [Goldback Pipeline](goldback-pipeline.md) — denomination generation, legacy scraper
+- [API Consumption](api-consumption.md) — frontend fetch patterns and fallback
+- [Turso Schema](turso-schema.md) — database tables and indexes

--- a/wiki/retail-modal.md
+++ b/wiki/retail-modal.md
@@ -1,0 +1,476 @@
+---
+title: "Retail View Modal & Market List View"
+category: frontend
+owner: staktrakr
+lastUpdated: v3.33.06
+date: 2026-02-27
+sourceFiles:
+  - js/retail-view-modal.js
+  - js/retail.js
+  - css/styles.css
+relatedPages:
+  - api-consumption.md
+  - frontend-overview.md
+  - data-model.md
+---
+# Retail View Modal & Market List View
+
+> **Last updated:** v3.33.06 — 2026-02-27
+> **Source files:** `js/retail-view-modal.js`, `js/retail.js`, `css/styles.css`
+
+## Overview
+
+The retail subsystem has two presentation modes for market pricing:
+
+1. **Grid view** (default) — the original card-per-coin layout rendered by `renderRetailCards()`.
+2. **Market list view** (v3.33.06, feature-flagged) — a full-width single-row card layout with inline 7-day trend charts, spike detection, vendor price chips, computed stats (MED/LOW/AVG), card click-to-expand, and search/sort. Activated by `?market_list_view=true` or via the `MARKET_LIST_VIEW` feature flag in Settings.
+
+The **Retail View Modal** is a per-coin detail panel that opens when a user clicks a coin card in the Grid view. It contains two tabs:
+
+- **24h Chart** (default on open) — a Chart.js line chart of vendor prices over the past 24 hours, plus a "Recent windows" table beneath it.
+- **Price History** — a daily candlestick-style chart and 30-day history table showing average vendor prices per day.
+
+As of v3.32.25 the modal also forward-fills vendor prices across gap windows and shows out-of-stock (OOS) vendors as clickable links in the vendor legend.
+
+## Key Rules (read before touching this area)
+
+- **Never call `document.getElementById()` directly.** Use `safeGetElement(id)` for all DOM lookups.
+- **Do not access `localStorage` directly.** Retail data is read/written through `saveData()`/`loadData()` from `js/utils.js`. Specific retail helpers (`saveRetailPrices`, `saveRetailIntradayData`, etc.) are exported by `retail.js`.
+- `_buildIntradayChart` always calls `_buildIntradayTable` at the end. Do not call both independently.
+- `_buildVendorLegend` is called both on modal open and after the async background refresh completes. It must be idempotent — it clears the container on every call.
+- The Chart.js intraday chart instance is stored in the module-level `_retailViewIntradayChart` variable. Always destroy the old instance before creating a new one or you will leak canvas contexts.
+- `_forwardFillVendors` must always return `[]` on empty input. Never mutate the input `bucketed` array; return a new array with decorated window objects.
+- **Market list view Chart.js instances** are tracked in `_marketChartInstances` (a `Map<slug, Chart>`). They are lazily created when a card's `<details>` opens and destroyed when it closes or when the list re-renders. Failing to destroy before clearing the grid DOM causes "Canvas is already in use" errors.
+
+## Architecture
+
+### Data flow (Retail View Modal)
+
+```
+retailIntradayData[slug].windows_24h   (raw 15-min windows from API)
+         |
+         v
+  _bucketWindows(windows)              -> bucketed[]  (30-min slots, up to 48)
+         |
+         v
+  _forwardFillVendors(bucketed)        -> filled[]    (gaps filled, _carriedVendors set on each window)
+         |
+         +-->  _buildIntradayChart()   -> Chart.js line chart; tooltip prefixes carried values with "~"
+         +-->  _buildIntradayTable()   -> Recent windows table; carried cells shown as "~$XX.XX" muted italic
+```
+
+The vendor legend is built separately from `retailPrices` (current snapshot), not from intraday windows.
+
+### Data flow (Market List View — v3.33.06)
+
+```
+renderRetailCards()
+  |-- isFeatureEnabled("MARKET_LIST_VIEW") ? --> _renderMarketListView()
+  |-- else --> original grid renderer
+  
+_renderMarketListView()
+  |-- _getFilteredSortedSlugs(query, sortKey)   -> filtered + sorted slug list
+  |-- for each slug: _buildMarketListCard(slug, meta, priceData, historyData)
+  |      |-- image column (glass orb placeholder, metal-tinted)
+  |      |-- info column (name, weight, metal badge, GB daily price)
+  |      |-- stats column (MED / LOW / AVG computed from live vendors or history fallback)
+  |      |-- trend badge (7-day direction + percentage from _computeRetailTrend)
+  |      |-- vendor row (sorted chips: medal ranks, vendor link, price, confidence %)
+  |      +-- <details> chart (lazy-loaded on expand)
+  |             |-- _filterHistorySpikes(entries, vendorIds) -> spike-filtered price matrix
+  |             |-- _interpolateGaps(data, preEstimated) -> smooth lines with dashed interpolated segments
+  |             +-- Chart.js line chart stored in _marketChartInstances Map
+  |
+  +-- market footer (disclaimer + sponsor badge)
+```
+
+### Spike Detection (`_filterHistorySpikes`) — v3.33.06
+
+Two-pass anomaly filter applied to daily history vendor prices before charting:
+
+**Pass 1 — Temporal spike:** For each vendor, if neighbors at t-1 and t+1 are stable (within `RETAIL_SPIKE_NEIGHBOR_TOLERANCE`, default 5%) but price at t deviates beyond the tolerance, it is nulled.
+
+**Pass 2 — Cross-vendor median:** For each day with 3+ in-stock vendors, any vendor price deviating >40% (`RETAIL_ANOMALY_THRESHOLD`) from the median is nulled. If all vendors would be flagged, none are (prevents false consensus collapse).
+
+OOS carry-forward prices are tracked in a parallel `estimated[]` array and are exempt from spike detection (they are synthetic, not scraped).
+
+### Gap Interpolation (`_interpolateGaps`) — v3.33.06
+
+After spike filtering, null gaps in vendor price arrays are linearly interpolated between the nearest non-null neighbors. Leading/trailing nulls are not extrapolated. Interpolated points are rendered as:
+
+- Dashed line segments (via Chart.js `segment.borderDash` callback)
+- Dimmed point color (50% alpha)
+- Tooltip prefix `~$XX.XX (est.)`
+
+A vendor is excluded from the chart entirely if it has fewer than 2 real (non-estimated) data points.
+
+### Module-level state
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `_retailViewModalChart` | `Chart \| null` | Daily history Chart.js instance |
+| `_retailViewIntradayChart` | `Chart \| null` | 24h intraday Chart.js instance |
+| `_intradayRowCount` | `number` | Number of rows shown in Recent windows table (default 24) |
+| `_marketChartInstances` | `Map<string, Chart>` | Market list view per-card Chart.js instances (v3.33.06) |
+| `_marketSearchTimer` | `number \| null` | Debounce timer for search input (v3.33.06) |
+
+### Globals consumed from `retail.js`
+
+| Global | Declared in | Purpose |
+|---|---|---|
+| `retailPrices` | `retail.js` | Current price snapshot (`{ prices: { [slug]: { vendors, median_price, lowest_price } } }`) |
+| `retailAvailability` | `retail.js` | Per-slug per-vendor availability flags (`{ [slug]: { [vendorId]: false } }` when OOS) |
+| `retailLastKnownPrices` | `retail.js` | Last-seen price per vendor per slug, used for OOS legend display |
+| `retailLastAvailableDates` | `retail.js` | ISO date string of last availability per vendor per slug |
+| `retailProviders` | `retail.js` | Per-slug per-vendor deep-link URLs (overrides `RETAIL_VENDOR_URLS` when present) |
+| `retailPriceHistory` | `retail.js` | Per-slug daily history array (used by market list charts) |
+| `RETAIL_VENDOR_NAMES` | `retail.js` | `{ [vendorId]: displayName }` — canonical vendor list and display order |
+| `RETAIL_VENDOR_COLORS` | `retail.js` | `{ [vendorId]: hexColor }` — brand colors for chart lines and legend swatches |
+| `RETAIL_VENDOR_URLS` | `retail.js` | `{ [vendorId]: url }` — fallback homepage URLs when `retailProviders` has no slug-level override |
+| `RETAIL_COIN_META` | `retail.js` | `{ [slug]: { name, weight, metal } }` — metadata for each tracked product |
+| `RETAIL_SLUGS` | `retail.js` | Ordered array of all tracked product slugs |
+
+### Vendor roster (as of v3.33.06)
+
+Vendor colors were brightened in v3.33.06 for better contrast on dark backgrounds.
+
+| ID | Display name | Color |
+|---|---|---|
+| `apmex` | APMEX | `#60a5fa` bright blue |
+| `monumentmetals` | Monument | `#c4b5fd` bright violet |
+| `sdbullion` | SDB | `#34d399` bright emerald |
+| `jmbullion` | JM | `#fbbf24` bright amber |
+| `herobullion` | Hero | `#f87171` red |
+| `bullionexchanges` | BullionX | `#f472b6` bright pink |
+| `summitmetals` | Summit | `#22d3ee` bright cyan |
+
+### Vendor chip layout (Market List View)
+
+Each vendor in a market list card is rendered as a `.vendor-chip` element containing:
+
+| Element | Class | Description |
+|---|---|---|
+| Medal rank | `.vendor-medal .vendor-medal--{1,2,3}` | "1st", "2nd", "3rd" for top-3 in-stock high-confidence vendors sorted by price |
+| Vendor link | `.vendor-name` | Colored label, clickable to open vendor page in popup |
+| Price | `.vendor-price` | Formatted price, or "OOS" for out-of-stock |
+| Confidence | `.vendor-confidence` | Scraper confidence percentage (only shown for in-stock) |
+
+Vendors are sorted: in-stock high-confidence (>=60) by price ascending, then in-stock low-confidence, then OOS. Low-confidence chips get `.low-conf` class (dimmed price). OOS chips get `.oos` class (strikethrough name and price).
+
+### Search and sort
+
+`_getFilteredSortedSlugs(query, sortKey)` filters `RETAIL_SLUGS` by:
+- Item name (case-insensitive substring)
+- Metal type
+- Vendor name (checks active vendors for the slug)
+
+Sort keys: `name` (alphabetical), `metal` (then name), `price-low` (lowest_price ascending), `price-high` (lowest_price descending), `trend` (7-day trend percentage descending).
+
+Search is debounced at 150ms via `_onMarketSearch`. Sort triggers an immediate re-render via `_onMarketSort`.
+
+---
+
+## Function Reference (Retail View Modal)
+
+### `_bucketWindows(windows)`
+
+Groups raw 15-min API windows into 30-min aligned slots (HH:00 and HH:30 boundaries).
+
+**Input:** `windows` — the `windows_24h` array from `retailIntradayData[slug]`.
+
+**Output:** A new sorted array of up to 48 window objects, oldest first. Each object has its `window` field overwritten to the ISO slot key (e.g. `2026-02-23T14:30:00.000Z`) and an extra `_originalWindow` field preserving the raw timestamp.
+
+**Algorithm:**
+1. For each raw window, round its UTC timestamp down to the nearest 30-min boundary.
+2. For each slot, keep only the most recent raw window (compared by `_originalWindow`).
+3. Return the de-duplicated entries sorted chronologically.
+
+**Edge cases:**
+- Returns `[]` on null, undefined, or empty input.
+- Windows with a missing or unparseable `window` field are silently skipped.
+
+---
+
+### `_forwardFillVendors(bucketed)` *(added v3.32.25)*
+
+Fills vendor price gaps across consecutive windows so the chart never shows a false "vendor dropped out" dip when a vendor simply had no poll for a slot.
+
+**Input:** `bucketed` — the output of `_bucketWindows`.
+
+**Output:** A new array (never mutates input). Each window object is a shallow copy; windows with carried prices have a `_carriedVendors: Set<vendorId>` property listing which vendor values were forward-filled from an earlier window.
+
+**Algorithm:**
+1. Iterate windows in chronological order, maintaining a `lastSeen` map of `vendorId -> price`.
+2. For each window, for each vendor in `RETAIL_VENDOR_NAMES`:
+   - If the window has a real price for that vendor, update `lastSeen[vendorId]`.
+   - If the window is missing a price but `lastSeen[vendorId]` exists, copy it in and add the vendor to the window's `_carriedVendors` set.
+3. Return the decorated array.
+
+**Edge cases:**
+- Returns `[]` on empty input — no iteration attempted.
+- Only vendors present in `RETAIL_VENDOR_NAMES` are considered.
+- A vendor that has never appeared in any window is never forward-filled (no `lastSeen` entry).
+
+---
+
+### `_buildIntradayChart(slug)`
+
+Renders the Chart.js 24h line chart and delegates to `_buildIntradayTable`.
+
+**Steps:**
+1. Reads `retailIntradayData[slug].windows_24h`.
+2. Calls `_bucketWindows` then `_forwardFillVendors` to produce the filled window array.
+3. Shows "no data" placeholder if fewer than 2 windows are available.
+4. Destroys any existing `_retailViewIntradayChart` instance before creating a new one.
+5. Builds one dataset per active vendor (vendors with at least one non-null price in the filled windows), using `RETAIL_VENDOR_NAMES` to determine order and `RETAIL_VENDOR_COLORS` for line colors.
+6. Falls back to Median + Low datasets when no per-vendor data exists (pre-vendor-format windows).
+7. Attaches a `_carriedIndices: Set<number>` to each dataset — the bucket indices whose value was forward-filled.
+8. Tooltip `label` callback: if `ctx.raw` is null (guard required — `ctx.raw` can be null on `spanGaps: true` datasets), returns nothing; if the index is in `_carriedIndices`, prefixes with `~` (e.g. `~$32.15`); otherwise formats normally.
+9. Calls `_buildIntradayTable(slug, filled)` at the end.
+
+**Chart options:**
+- `spanGaps: true` — lines bridge over null entries.
+- Legend hidden when vendor-mode is active (each vendor is already color-coded).
+- X-axis ticks: HH:00 labels rendered at full opacity/size; HH:30 labels at reduced opacity and smaller font.
+
+---
+
+### `_buildIntradayTable(slug, bucketed)`
+
+Renders the "Recent windows" table beneath the 24h chart.
+
+**Signature:** `_buildIntradayTable(slug, bucketed?)` — `bucketed` is optional. If omitted the function re-buckets from `retailIntradayData[slug]` (used by the row-count dropdown's `onchange` handler).
+
+**Column logic:**
+- When per-vendor data is present: one column per active vendor using `RETAIL_VENDOR_NAMES` display names.
+- Fallback: "Median" and "Low" columns.
+
+**Cell rendering — three branches:**
+
+| Condition | Output |
+|---|---|
+| Value is `null` (vendor had no data in this slot and nothing to carry) | `--` (em dash, no styling) |
+| Value was forward-filled (`_carriedVendors` contains this vendor) | `~$XX.XX` muted italic, no trend glyph |
+| Value is fresh | `$XX.XX upward/downward arrow` with `text-success` / `text-danger` class |
+
+Trend glyphs compare each row to the row immediately below it (the next older window, since the table is displayed newest-first). Carried values never show a trend glyph because the price movement is artificially flat.
+
+**Row count:** Slices to the `_intradayRowCount` most recent windows (default 24, controlled by a dropdown in the modal).
+
+---
+
+### `_buildVendorLegend(slug)`
+
+Renders the colored vendor legend above the price-history chart showing current prices.
+
+**Behavior:**
+- Clears the `#retailViewVendorLegend` container on every call.
+- `hasAny` check: at least one vendor in `RETAIL_VENDOR_NAMES` must have a non-null `price` in `retailPrices.prices[slug].vendors`. If no vendors pass this check, the function returns early (no legend rendered).
+- Iterates all `RETAIL_VENDOR_NAMES` keys in declaration order.
+
+**Per-vendor item:**
+- Skips vendors with `price == null` in the current snapshot **unless** they appear in `retailAvailability[slug][v] === false` (OOS) — OOS vendors are always shown.
+- OOS item treatment: `opacity: 0.5`, price wrapped in `<del>`, "OOS" badge appended, item is still a clickable `<a>` element.
+- In-stock with price: rendered as an `<a>` if a URL is available (checking `retailProviders[slug][vendorId]` first, then `RETAIL_VENDOR_URLS[vendorId]`); otherwise a plain `<span>`.
+- Click handler opens vendor URL in a named popup window (`retail_vendor_{vendorId}`) with fixed dimensions; falls back to `_blank` if the popup is blocked.
+
+**Structure per item:**
+```
+<a class="retail-legend-item">
+  <span class="retail-legend-swatch" style="background: {color}"></span>
+  <span class="retail-legend-name"   style="color: {color}">{displayName}</span>
+  <span class="retail-legend-price">${price}</span>
+</a>
+```
+
+---
+
+### `openRetailViewModal(slug)`
+
+Entry point — called from retail card click handlers.
+
+**Sequence:**
+1. Reads `RETAIL_COIN_META[slug]` for coin name, weight, and metal type.
+2. Populates modal title and subtitle.
+3. Removes any stale staleness banner from a previous open.
+4. Calls `_buildVendorLegend(slug)`.
+5. Populates the 30-day history table from `getRetailHistoryForSlug(slug)`.
+6. Builds the daily history Chart.js chart (per-vendor lines; gaps for OOS entries via `spanGaps: false`).
+7. Calls `_buildIntradayChart(slug)` (which internally calls `_buildIntradayTable`).
+8. Wires the row-count `<select>` dropdown.
+9. Defaults to the "intraday" (24h) tab.
+10. Opens the modal via `openModalById("retailViewModal")`.
+11. Fires an async `Promise.all` to fetch fresh `latest.json` and `history-30d.json` from the API; on success, updates `retailIntradayData`, `retailPrices`, and `retailPriceHistory`, then rebuilds the chart and legend. On total failure, inserts a staleness warning banner.
+
+### `closeRetailViewModal()`
+
+Destroys both Chart.js instances and calls `closeModalById("retailViewModal")`.
+
+### `_switchRetailViewTab(tab)`
+
+Toggles between `"history"` and `"intraday"` tabs by toggling `display` and the Bootstrap `active` class on the tab buttons.
+
+---
+
+## Function Reference (Market List View — v3.33.06)
+
+### `_renderMarketListView()`
+
+Main renderer for the market list view. Called when `MARKET_LIST_VIEW` flag is enabled.
+
+**Sequence:**
+1. Shows `#marketListHeader`, hides `#marketGridHeader`.
+2. Updates sync timestamp in `#retailLastSyncList` with relative time ("5 min ago").
+3. Adds `.market-list-mode` to the grid container (switches CSS from grid to flex column).
+4. Destroys all active `_marketChartInstances` and clears the grid DOM.
+5. If sync in progress, renders skeleton cards. If no data, shows empty state.
+6. Calls `_getFilteredSortedSlugs()` with current search/sort values.
+7. For each slug, builds and appends a card via `_buildMarketListCard()`.
+8. Appends a market footer with disclaimer text and sponsor badge.
+
+### `_buildMarketListCard(slug, meta, priceData, historyData)`
+
+Builds a single full-width row card. Returns an `HTMLElement`.
+
+**Card structure (CSS grid: `100px 1fr auto auto`):**
+
+| Column | Content |
+|---|---|
+| Image | `.market-card-image-col` with glass orb placeholder, metal-tinted radial gradient |
+| Info | `.market-card-info` — name, weight + metal badge, optional GB Daily price |
+| Stats | `.market-card-stats-col` — MED/LOW/AVG computed from vendor prices or history fallback |
+| Trend | `.market-card-trend` — directional arrow + percentage, color-coded up/down/flat |
+
+Below the main row: vendor chips (`.market-card-vendors`, spans columns 2-4) and a collapsible `<details>` chart (spans full width).
+
+**Card click behavior:** Clicking anywhere on the card body (except vendor chips, links, and the `<summary>` toggle) opens/closes the `<details>` chart element.
+
+### `_filterHistorySpikes(entries, vendorIds)`
+
+Two-pass anomaly filter for daily history vendor prices (see Architecture section above).
+
+**Returns:** `{ prices: Object<vendorId, Array<number|null>>, estimated: Object<vendorId, boolean[]> }`
+
+### `_interpolateGaps(data, preEstimated)`
+
+Linear interpolation for null gaps in a price array.
+
+**Returns:** `{ filled: Array<number|null>, interp: boolean[] }`
+
+### `_initMarketCardChart(slug, detailsEl)`
+
+Creates a Chart.js line chart inside a market card's `<details>` block.
+
+**Steps:**
+1. Guards: `Chart` defined, not already instantiated, canvas exists, 2+ history entries.
+2. Takes last 7 entries from `retailPriceHistory[slug]`.
+3. Identifies active vendors.
+4. Applies `_filterHistorySpikes` then `_interpolateGaps` per vendor.
+5. Excludes vendors with fewer than 2 real data points.
+6. Falls back to "Avg Median" line if no per-vendor data.
+7. Stores instance in `_marketChartInstances`.
+
+### `_getFilteredSortedSlugs(query, sortKey)`
+
+See Search and Sort section above.
+
+### `_initMarketListViewListeners()`
+
+Called once during `initRetailPrices()`. Wires:
+- Search input `input` event -> `_onMarketSearch` (150ms debounce)
+- Sort select `change` event -> `_onMarketSort`
+- Sync button `click` -> `syncRetailPrices()`
+- Expand All button `click` -> toggles all `<details>` open/closed
+
+---
+
+## Window Exports
+
+Only a subset of functions are exported to `window` for use by inline HTML handlers:
+
+```js
+// Retail View Modal
+window.openRetailViewModal   // called from retail card buttons
+window.closeRetailViewModal  // called from modal close button
+window._switchRetailViewTab  // called from tab button onclick
+window._bucketWindows        // exported for console/smoke-test inspection
+window._buildIntradayTable   // exported for row-count dropdown onchange
+
+// Market List View (added v3.33.06)
+window._renderMarketListView   // re-render the market list
+window._buildMarketListCard    // build a single card (debugging/testing)
+window._getFilteredSortedSlugs // filter+sort inspection
+```
+
+`_forwardFillVendors`, `_buildIntradayChart`, and `_buildVendorLegend` are module-private.
+`_filterHistorySpikes`, `_interpolateGaps`, `_initMarketCardChart`, `_onMarketSearch`, `_onMarketSort`, and `_initMarketListViewListeners` are module-private.
+
+---
+
+## CSS Architecture (Market List View — v3.33.06)
+
+All market list view styles are in `css/styles.css` under the `/* Market List View (STAK-369) */` section.
+
+**Key classes:**
+
+| Class | Element | Notes |
+|---|---|---|
+| `.market-list-mode` | `#retailCardsGrid` | Switches grid to flex column layout |
+| `.market-list-card` | Card container | CSS grid `100px 1fr auto auto` with metal-colored left border |
+| `.market-list-card.metal-{metal}` | Card | Sets `--metal-color` CSS variable |
+| `.market-card-image-col` | Image column | Spans 2 rows, has metal-tinted radial gradient overlay |
+| `.market-card-no-image` | Glass orb | Radial gradient + inset shadows, `.bar-shape` variant for goldback |
+| `.market-card-vendors` | Vendor row | Spans columns 2-4, flex wrap |
+| `.vendor-chip` | Vendor element | Contains medal, name link, price, confidence |
+| `.vendor-medal--{1,2,3}` | Medal badge | Gold/silver/bronze color scheme |
+| `.market-card-trend.{up,down,flat}` | Trend badge | Green/red/muted with background tint |
+| `.market-card-chart` | Details element | Full-width collapsible, 200px chart height |
+| `.market-footer` | Footer | Disclaimer + sponsor badge |
+
+**Responsive breakpoints:**
+- `<=1024px`: Image column shrinks to 80px, trend badge hidden
+- `<=767px`: Image column shrinks to 70px, card switches to 2-column grid, vendor row spans full width, search/controls stack vertically
+
+---
+
+## Common Mistakes
+
+### Calling `_buildIntradayChart` and `_buildIntradayTable` separately
+
+`_buildIntradayChart` always calls `_buildIntradayTable` at the end with the same `bucketed` array. If you call both independently you will build the table twice and the second call will re-bucket from scratch, potentially producing stale data.
+
+### Forgetting the null guard on `ctx.raw` in tooltip callbacks
+
+Chart.js passes `ctx.raw = null` for gap points when `spanGaps: true`. Calling `Number(null).toFixed(2)` produces `"0.00"`, not an error — but it silently shows wrong data. Always guard: `if (ctx.raw == null) return;`.
+
+### Mutating the `bucketed` input in `_forwardFillVendors`
+
+`_bucketWindows` returns window objects that are re-used across chart and table builds. Mutating them in `_forwardFillVendors` would corrupt the source data for subsequent calls. Always shallow-copy each window before adding `_carriedVendors`.
+
+### Adding a new vendor without updating all three vendor maps
+
+`RETAIL_VENDOR_NAMES`, `RETAIL_VENDOR_COLORS`, and `RETAIL_VENDOR_URLS` must all be updated together in `retail.js`. A vendor missing from `RETAIL_VENDOR_NAMES` will never appear in the chart, table, or legend — the other two maps are irrelevant without the name entry.
+
+### OOS legend items disappearing after a `retailPrices` refresh
+
+`_buildVendorLegend` currently reads current prices from `retailPrices.prices[slug].vendors`. OOS vendors have `price == null` in that snapshot. The `hasAny` guard checks `RETAIL_VENDOR_NAMES` keys against live prices — if all vendors are OOS, `hasAny` is false and the legend is suppressed entirely. If OOS vendors must always be shown, check `retailAvailability` in the `hasAny` guard as well.
+
+### Not destroying the old Chart.js instance before creating a new one
+
+Both `_retailViewModalChart` and `_retailViewIntradayChart` must be explicitly destroyed before reassignment. Skipping this leaks canvas rendering contexts and causes "Canvas is already in use" console warnings on subsequent modal opens.
+
+### Not clearing `_marketChartInstances` before re-rendering the market list (v3.33.06)
+
+`_renderMarketListView` destroys all chart instances and clears the map before clearing the grid DOM. If you add a code path that clears the grid without destroying the chart instances first, the canvas elements are removed from the DOM but Chart.js retains references — subsequent card opens will fail to initialize because `_marketChartInstances.has(slug)` returns `true` for a destroyed chart.
+
+### Applying spike detection to estimated/OOS data points (v3.33.06)
+
+`_filterHistorySpikes` intentionally skips estimated points (OOS carry-forward) during temporal spike detection. If you modify the filter to include estimated points, OOS carry-forward prices — which are intentionally flat — will create false negatives in the neighbor stability check and allow real spikes to pass through.
+
+---
+
+## Related Pages
+
+- [api-consumption.md](api-consumption.md) — how `retail.js` fetches `latest.json` and `history-30d.json` from `api.staktrakr.com`
+- [frontend-overview.md](frontend-overview.md) — script load order, `window` global conventions, feature flags, and `safeGetElement` usage
+- [data-model.md](data-model.md) — feature flag definitions in `FEATURE_FLAGS`

--- a/wiki/retail-pipeline.md
+++ b/wiki/retail-pipeline.md
@@ -1,0 +1,251 @@
+---
+title: Retail Market Price Pipeline
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages:
+  - rest-api-reference.md
+  - turso-schema.md
+  - cron-schedule.md
+  - goldback-pipeline.md
+  - spot-pipeline.md
+  - providers.md
+---
+
+# Retail Market Price Pipeline
+
+> **Last verified:** 2026-02-25 — dual-poller architecture, Turso shared DB, readLatestPerVendor() merge logic
+
+---
+
+## Overview
+
+The retail pipeline scrapes coin dealer prices from **7 vendors × 17 bullion coins** every cycle, writes to a shared Turso database, then exports to REST JSON and pushes to GitHub Pages.
+
+**Goldback expansion (STAK-335):** 56 per-state Goldback slugs are scaffolded in `providers.json` but start disabled (`url: null`). They add zero scrape load until vendor URLs are populated. See [goldback-pipeline.md](goldback-pipeline.md) for the full state × denomination matrix.
+
+Two independent pollers write to the **same Turso database**. A single publisher script on Fly.io merges their data using latest-per-vendor logic and pushes to the `api` branch.
+
+---
+
+## Dual-Poller Architecture
+
+| Poller | Location | Cron | Script | POLLER_ID |
+|--------|----------|------|--------|-----------|
+| **Fly.io** (primary) | `staktrakr` app, `dfw` region | `0 * * * *` | `run-local.sh` | `api` |
+| **Home LXC** (secondary) | Proxmox Ubuntu @ 192.168.1.81 | `30 * * * *` (1×/hr) | `run-home.sh` | `home` |
+
+**Why two pollers?**
+- Redundancy — if Fly.io misses a cycle, home poller fills the gap within 30 min (hourly offset)
+- Both write to the same Turso DB; `run-publish.sh` merges via `readLatestPerVendor()` — most recent row per vendor within last 2h wins
+- No branch conflicts — the home poller never pushes to Git, only writes to Turso
+
+---
+
+## Script Responsibilities
+
+### Scrape scripts (`run-local.sh` / `run-home.sh`)
+
+1. Sync `providers.json` from `api` branch via curl
+2. `price-extract.js` — scrape dealers, write results to Turso `price_snapshots`
+3. `capture.js` — screenshots via Playwright (Fly.io only)
+4. `extract-vision.js` — Gemini Vision cross-validation (Fly.io only, requires `GEMINI_API_KEY`)
+5. **Done** — does NOT touch Git
+
+### `run-publish.sh` (Fly.io only, every 15 min: `8,23,38,53 * * * *`)
+
+1. Lockfile guard (`/tmp/retail-publish.lock`) — skips if previous run still active
+2. `api-export.js` — reads Turso via `readLatestPerVendor()`, builds `data/api/` JSON
+3. `git add data/` + commit if changed
+4. Force-push `HEAD:api` to `StakTrakrApi` `api` branch
+
+> **Single writer, no merge conflicts.** Force-push is intentional — Fly.io is the sole Git writer for the `api` branch data files.
+
+---
+
+## Data Flow
+
+```
+Fly.io run-local.sh  ──┐
+(0 * * * *)            ├──► Turso (price_snapshots) ──► api-export.js ──► data/api/ JSON
+Home LXC run-home.sh ──┘    readLatestPerVendor()        (run-publish.sh, 8,23,38,53)
+(30 * * * *)
+                                                              │
+                                                              ▼
+                                                   StakTrakrApi api branch
+                                                              │
+                                               Merge Poller Branches GHA
+                                                              │
+                                                        main branch
+                                                              │
+                                                    GitHub Pages → api.staktrakr.com
+```
+
+---
+
+## Turso Database
+
+**Table:** `price_snapshots`
+
+| Column | Description |
+|--------|-------------|
+| `scraped_at` | ISO 8601 UTC timestamp of scrape |
+| `window_start` | 15-min window bucket (legacy, kept for compatibility) |
+| `coin_slug` | e.g. `ase`, `age`, `maple-silver` |
+| `vendor` | Provider ID, e.g. `jmbullion`, `apmex` |
+| `price` | Scraped price (null if OOS or failed) |
+| `source` | `firecrawl`, `playwright`, `gemini-vision`, or `fbp` |
+| `in_stock` | false if OOS patterns matched |
+| `is_failed` | true if scrape threw an error |
+
+### `readLatestPerVendor()` — the dual-poller merge function
+
+`api-export.js` uses `readLatestPerVendor(db, coinSlug, lookbackHours=2)` which returns the **most recent row per vendor** within the last 2 hours. This means both pollers' data shows up regardless of which time window they ran in.
+
+---
+
+## providers.json
+
+Lives on the **`api` branch** at `data/retail/providers.json`. Both pollers curl this before each run — URL corrections take effect next cycle with **no redeploy needed**.
+
+### URL strategy
+
+Prefer random-year / dates-our-choice SKUs when in stock. At year-start, Monument Metals random-year SKUs go pre-order while year-specific (e.g. `2026-american-silver-eagle.html`) are in stock — switch to year-specific until bulk stock arrives.
+
+See [providers.md](providers.md) for full details.
+
+---
+
+## Multi-URL Fallback (`price-extract.js`)
+
+Since 2026-02-23, each provider entry can specify a `urls` array instead of a single `url`. The scraper tries each URL in sequence using a two-phase strategy:
+
+**Phase 1 — Firecrawl chain (all URLs):**
+
+| Event at URL[i] | Action |
+|-----------------|--------|
+| OOS detected | Log ⚠, jitter, try URL[i+1] |
+| Price not found (page loaded) | Log ?, jitter, try URL[i+1] |
+| Firecrawl error | Log ✗, jitter, try URL[i+1] |
+| Price found | Log ✓, break — skip remaining URLs |
+
+**Phase 2 — Playwright (last resort, once):**
+Only runs after the full Firecrawl chain is exhausted with no price. Uses `finalUrl` (the last URL tried). If Playwright also fails, result is recorded as `price_not_found` or `out_of_stock`.
+
+Single-`url` entries are backward compatible — treated as a 1-element `urls` list.
+
+---
+
+## OOS Detection (`price-extract.js`)
+
+`detectStockStatus(markdown, weightOz, providerId)` checks scraped text for out-of-stock signals before price extraction.
+
+**Global patterns:** `out of stock`, `sold out`, `currently unavailable`, `notify me when available`, `email when in stock`, `temporarily out of stock`, `back order`, `pre-order`/`preorder`, `notify me`
+
+**Per-provider exceptions:**
+
+`PREORDER_TOLERANT_PROVIDERS = Set(["jmbullion"])`
+
+JMBullion marks some coins as Presale/Pre-Order but still shows live purchasable prices. The `pre-?order` pattern is skipped for `jmbullion`. Affected coins at year-start: `buffalo`, `maple-silver`, `maple-gold`, `krugerrand-silver`.
+
+---
+
+## Tiered Scraper Fallback (T1–T4)
+
+As of 2026-02-24, the retail pipeline has four automatic recovery layers for scrape failures:
+
+| Tier | Method | Trigger | How |
+|------|--------|---------|-----|
+| T1 | Tailscale residential IP | If `tailscaled` socket present | `run-local.sh` socket-checks before each cycle — gracefully skipped if Tailscale not running |
+| T2 | Fly.io datacenter IP | Tailscale unreachable | Automatic fallback in same ping-check |
+| T3 | Webshare proxy + cron retry | SKUs still failed after T1/T2 | `run-retry.sh` fires at `:15`; re-scrapes failed slugs only |
+| T4 | Turso last-known-good | T3 also fails for a vendor | `api-export.js` fills from `price_snapshots` at publish time |
+
+### Failure signal: `/tmp/retail-failures.json`
+
+`price-extract.js` writes this file after each run listing SKUs that failed **both** the main scrape and the FBP backfill. `run-retry.sh` reads it at `:15` and clears it on exit.
+
+- If the file is absent → `:15` cron is a no-op
+- If ≥80% of targets are in the file → `run-local.sh` logs `[WARN] SYSTEMIC` for monitoring
+
+### T4 manifest output
+
+When T4 fills a vendor slot, the manifest entry includes extra fields the frontend can use:
+
+```json
+"herobullion": {
+  "price": 34.21,
+  "source": "turso_last_known",
+  "stale": true,
+  "stale_since": "2026-02-24T14:00:00Z",
+  "inStock": true
+}
+```
+
+---
+
+## Vision Pipeline (Fly.io only)
+
+Requires `GEMINI_API_KEY`. Non-fatal — failure is logged and scrape continues.
+
+1. **`capture.js`** — Playwright screenshots each dealer page. Dismisses popups/modals (Escape + common close selectors) before screenshot.
+2. **`extract-vision.js`** — Sends screenshots to Gemini Vision. Extracts price from image, compares against Firecrawl price.
+
+| Scenario | Confidence |
+|----------|-----------|
+| Firecrawl + Vision agree (≤3% diff) | 99 |
+| Vision only (Firecrawl null) | ~70 |
+| Firecrawl + Vision disagree (>3% diff) | ≤70, scaled by divergence |
+| Firecrawl only, no Vision | `scoreVendorPrice()` vs 30-day median |
+
+---
+
+## Common Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Vendor missing prices multiple cycles | URL changed, OOS, or bot-blocked | Add backup URLs via `urls` array in providers.json — auto-synced next cycle, no redeploy |
+| Only 1-2 vendors per coin | Poller down or Turso connectivity | Check `fly logs` and home LXC cron; verify Turso has recent rows |
+| JMBullion presale coins show OOS | `pre-?order` matching before provider check | Verify `PREORDER_TOLERANT_PROVIDERS` includes `jmbullion` in price-extract.js |
+| OOM on Fly.io | Concurrent api-export.js invocations | Verify run-local.sh does NOT call api-export.js; run-publish.sh has lockfile |
+| Monument Metals missing at year-start | Random-year SKUs on pre-order | Switch to year-specific SKU in providers.json |
+| Vendor price marked `stale: true` in manifest | T3 proxy retry also failed — T4 filled from last known Turso row | Check `/var/log/retail-retry.log`; top up Webshare quota if over limit |
+| `[WARN] SYSTEMIC` in retail-poller.log | ≥80% of SKUs failed — likely Fly.io IP blocked | Check egress IP (`curl ifconfig.me` in container); Webshare T3 will retry at `:15` |
+
+---
+
+## Deployment Notes
+
+- **Code changes** — `git push origin main` then `fly deploy` from `devops/fly-poller/`
+- **providers.json URL fixes** — push to `api` branch; auto-synced next cycle, no redeploy
+- **Home LXC code update** — curl changed files from `raw.githubusercontent.com/lbruton/StakTrakrApi/main/devops/fly-poller/`
+- **After deploy** — `fly logs --app staktrakr | grep -E 'retail|publish|ERROR'`
+
+---
+
+## Cron Schedule Summary (Fly.io)
+
+| Script | Cron | Purpose |
+|--------|------|---------|
+| `run-local.sh` | `0 * * * *` | Retail scrape (hourly) |
+| `run-spot.sh` | `5,20,35,50 * * * *` | Spot price scrape |
+| `run-publish.sh` | `8,23,38,53 * * * *` | Export Turso → JSON, push to `api` branch |
+| `run-retry.sh` | `15 * * * *` | T3 proxy retry of failed SKUs |
+| `run-fbp.sh` | `0 20 * * *` | FBP gap-fill for remaining failures |
+
+**Note:** `run-goldback.sh` is no longer in the cron schedule — goldback is scraped via the standard retail pipeline. Legacy `goldback-g{N}` slugs are deprecated; per-state slugs (`goldback-{state}-g{denom}`) are the new standard. See [goldback-pipeline.md](goldback-pipeline.md).
+
+See [cron-schedule.md](cron-schedule.md) for the full timeline view and design rationale.
+
+---
+
+## Related Pages
+
+- [REST API Reference](rest-api-reference.md) — complete endpoint map and schemas
+- [Turso Schema](turso-schema.md) — database tables, indexes, and key queries
+- [Cron Schedule](cron-schedule.md) — full timeline view with rationale
+- [Goldback Pipeline](goldback-pipeline.md) — denomination generation
+- [Spot Pipeline](spot-pipeline.md) — MetalPriceAPI polling
+- [providers.json](providers.md) — vendor URL configuration

--- a/wiki/secrets.md
+++ b/wiki/secrets.md
@@ -1,0 +1,110 @@
+---
+title: "Secrets & Keys"
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-24
+sourceFiles: []
+relatedPages: []
+---
+
+# Secrets & Keys
+
+> **Last verified:** 2026-02-24
+> ⚠️ This page lists WHERE secrets live, not their values. Never commit secret values.
+
+---
+
+## Secret Stores
+
+| Store | Used by |
+|-------|---------|
+| **Fly.io secrets** (`fly secrets`) | Fly.io container — all runtime secrets |
+| **Infisical** (`stak-trakr-94m4`, env: `dev`) | Local development, agent contexts |
+| **Home LXC `.env`** (`/opt/poller/.env`) | Home poller — local file, not in any repo |
+
+---
+
+## Fly.io Secrets
+
+Set with `fly secrets set KEY=VALUE --app staktrakr`.
+
+| Secret | Purpose | Notes |
+|--------|---------|-------|
+| `GITHUB_TOKEN` | Push to `api` branch from `run-publish.sh` | Needs `contents: write` on `StakTrakrApi` |
+| `TURSO_DATABASE_URL` | Turso libSQL cloud DB | `libsql://staktrakrapi-lbruton.aws-us-east-2.turso.io` |
+| `TURSO_AUTH_TOKEN` | Turso auth | Rotate in Turso dashboard |
+| `GEMINI_API_KEY` | Vision pipeline (Gemini API) | Google AI Studio |
+| `METAL_PRICE_API_KEY` | Spot price API | MetalPriceAPI dashboard |
+| `WEBSHARE_PROXY_USER` | Playwright service proxy | Webshare dashboard |
+| `WEBSHARE_PROXY_PASS` | Playwright service proxy | Webshare dashboard |
+| `CRON_SCHEDULE` | Override retail poller cron frequency | Currently set to `0` (once per hour at :00) |
+
+---
+
+## Infisical (Local Dev)
+
+- **Project:** StakTrakr
+- **Project ID:** `319a1db5-207d-49d0-a61d-3f3e6b440ded`
+- **Slug:** `stak-trakr-94m4`
+- **Environment:** `dev` (production env is empty — all secrets in `dev`)
+
+Contains all secrets mirrored from Fly.io plus additional dev-only keys. Access via MCP (`mcp__infisical__*`) or `infisical` CLI.
+
+---
+
+## Home LXC `.env`
+
+File at `/opt/poller/.env` on the LXC container (192.168.1.81). Contains:
+
+```
+TURSO_DATABASE_URL=libsql://staktrakrapi-lbruton.aws-us-east-2.turso.io
+TURSO_AUTH_TOKEN=<token>
+POLLER_ID=home
+DATA_DIR=/opt/poller/data
+```
+
+This file is not in any repo. Copy from `.env.example` and fill in manually.
+
+---
+
+## Rotating Secrets
+
+### GitHub Token
+1. Generate new PAT at github.com → Settings → Developer settings
+2. Required scope: `contents: write` on `lbruton/StakTrakrApi`
+3. `fly secrets set GITHUB_TOKEN=<new-token> --app staktrakr`
+4. Update Infisical dev env
+
+### Turso Auth Token
+1. Turso dashboard → Database → `staktrakrapi` → Create token
+2. `fly secrets set TURSO_AUTH_TOKEN=<new-token> --app staktrakr`
+3. Update Infisical dev env
+4. Update home LXC `.env`
+
+### MetalPriceAPI Key
+1. MetalPriceAPI dashboard → API Keys
+2. `fly secrets set METAL_PRICE_API_KEY=<new-key> --app staktrakr`
+3. Update Infisical dev env
+
+### Webshare Proxy
+1. Webshare dashboard → Proxy users
+2. `fly secrets set WEBSHARE_PROXY_USER=<user> WEBSHARE_PROXY_PASS=<pass> --app staktrakr`
+3. Update Infisical dev env
+
+### Gemini API Key
+1. Google AI Studio → API Keys
+2. `fly secrets set GEMINI_API_KEY=<new-key> --app staktrakr`
+3. Update Infisical dev env
+
+---
+
+## Verifying Secrets Are Set
+
+```bash
+# List Fly secrets (names only, not values)
+fly secrets list --app staktrakr
+
+# Verify a specific secret is accessible inside container
+fly ssh console --app staktrakr -C "printenv TURSO_DATABASE_URL"
+```

--- a/wiki/service-worker.md
+++ b/wiki/service-worker.md
@@ -1,0 +1,198 @@
+---
+title: Service Worker
+category: frontend
+owner: staktrakr
+lastUpdated: v3.33.18
+date: 2026-03-01
+sourceFiles:
+  - sw.js
+  - devops/hooks/stamp-sw-cache.sh
+relatedPages:
+  - frontend-overview.md
+  - release-workflow.md
+---
+# Service Worker
+
+> **Last updated:** v3.33.18 — 2026-03-01
+> **Source files:** `sw.js`, `devops/hooks/stamp-sw-cache.sh`
+
+## Overview
+
+StakTrakr uses a vanilla Service Worker (`sw.js`) to cache all application assets for offline use. On every version bump (patch or higher), the pre-commit hook auto-stamps a new `CACHE_NAME` into `sw.js`, forcing users' browsers to fetch a fresh copy of all assets. No manual edits to `CACHE_NAME` are ever required or permitted.
+
+---
+
+## Key Rules (read before touching this area)
+
+1. **Never edit `CACHE_NAME` by hand.** It is written by the pre-commit hook on every commit that touches a cached asset. Manual edits are overwritten immediately.
+2. **When adding a new JS file**, update **both** `index.html` (script tag, in load order) **and** `CORE_ASSETS` in `sw.js`. Missing either causes a stale-serve bug.
+3. **New JS files also require an entry in `sw.js` CORE_ASSETS** — this is listed in `CLAUDE.md` as a mandatory step.
+4. Keep `CORE_ASSETS` in the same logical order as the `<script>` tags in `index.html`.
+
+---
+
+## Architecture
+
+### CACHE_NAME format
+
+```
+staktrakr-v{APP_VERSION}-b{EPOCH}
+```
+
+Example from current source:
+
+```js
+const CACHE_NAME = 'staktrakr-v3.33.18-b1772346419';
+```
+
+- `APP_VERSION` — read from `js/constants.js` at commit time (e.g. `3.33.18`)
+- `EPOCH` — Unix timestamp in seconds at commit time, making every build unique
+- When the name changes, the browser treats it as a new cache bucket and re-fetches all assets
+
+### Cache strategy
+
+- **CORE_ASSETS** — cache-first (installed during the `install` event via `cache.addAll()`)
+- **API hosts** — network-first (live spot/price feeds must never be served stale)
+- **Everything else** — network-first with cache fallback
+
+### Pre-commit hook: `devops/hooks/stamp-sw-cache.sh`
+
+The hook is symlinked from `.git/hooks/pre-commit`. It runs automatically on every `git commit`.
+
+**What it does, step by step:**
+
+1. Checks whether any staged file matches one of the cached path patterns: `css/`, `js/`, `index.html`, `data/`, `images/`, `manifest.json`, or `sw.js` itself.
+2. If no cached asset is staged, exits immediately (no-op).
+3. Reads `APP_VERSION` from `js/constants.js` using `grep` + `sed` (macOS-compatible — no `grep -P`).
+4. Captures the current Unix epoch with `date +%s`.
+5. Computes `NEW_CACHE = staktrakr-v{APP_VERSION}-b{EPOCH}`.
+6. Compares against the current `CACHE_NAME` in `sw.js`; if already equal, exits (idempotent).
+7. Rewrites the `CACHE_NAME` line in `sw.js` using `sed` (with BSD/GNU dual-path for macOS vs Linux).
+8. Runs `git add sw.js` to re-stage the updated file so the rewrite is included in the commit.
+9. Prints `[stamp-sw-cache] CACHE_NAME updated: staktrakr-v...` to stdout.
+
+**Install the hook (one-time, already done in this repo):**
+
+```bash
+ln -sf ../../devops/hooks/stamp-sw-cache.sh .git/hooks/pre-commit
+```
+
+---
+
+## CORE_ASSETS
+
+The full pre-cache list as of v3.33.18 (76 entries). This list **must be kept in sync** with the `<script>` load order in `index.html`.
+
+```js
+const CORE_ASSETS = [
+  './',
+  './css/styles.css',
+  './js/file-protocol-fix.js',
+  './js/debug-log.js',
+  './js/constants.js',
+  './js/field-meta.js',
+  './js/state.js',
+  './js/utils.js',
+  './js/dialogs.js',
+  './js/image-cache.js',
+  './js/image-processor.js',
+  './js/bulk-image-cache.js',
+  './js/image-cache-modal.js',
+  './js/fuzzy-search.js',
+  './js/autocomplete.js',
+  './js/numista-lookup.js',
+  './js/seed-images.js',
+  './js/versionCheck.js',
+  './js/changeLog.js',
+  './js/diff-engine.js',
+  './js/diff-modal.js',
+  './js/charts.js',
+  './js/theme.js',
+  './js/search.js',
+  './js/chip-grouping.js',
+  './js/tags.js',
+  './js/filters.js',
+  './js/sorting.js',
+  './js/pagination.js',
+  './js/detailsModal.js',
+  './js/viewModal.js',
+  './js/debugModal.js',
+  './js/numista-modal.js',
+  './js/spot.js',
+  './js/card-view.js',
+  './js/seed-data.js',
+  './js/priceHistory.js',
+  './js/spotLookup.js',
+  './js/goldback.js',
+  './js/retail.js',
+  './js/retail-view-modal.js',
+  './js/api.js',
+  './js/catalog-api.js',
+  './js/pcgs-api.js',
+  './js/catalog-providers.js',
+  './js/catalog-manager.js',
+  './js/inventory.js',
+  './js/vault.js',
+  './js/cloud-storage.js',
+  './js/cloud-sync.js',
+  './privacy.html',
+  './js/about.js',
+  './js/api-health.js',
+  './js/faq.js',
+  './js/customMapping.js',
+  './js/settings.js',
+  './js/settings-listeners.js',
+  './js/bulkEdit.js',
+  './js/clone-picker.js',
+  './js/events.js',
+  './js/init.js',
+  './data/spot-history-bundle.js',
+  './data/spot-history-2025.json',
+  './data/spot-history-2026.json',
+  './images/safe-favicon.svg',
+  './images/staktrakr-logo.svg',
+  './images/icon-192.png',
+  './images/icon-512.png',
+  './manifest.json',
+  './vendor/papaparse.min.js',
+  './vendor/jspdf.umd.min.js',
+  './vendor/jspdf.plugin.autotable.min.js',
+  './vendor/chart.min.js',
+  './vendor/chartjs-plugin-datalabels.min.js',
+  './vendor/jszip.min.js',
+  './vendor/forge.min.js',
+];
+```
+
+Note: `spot-history-2026.json` (and future yearly files) must be added to `CORE_ASSETS` at the start of each new year alongside the `spot-history-bundle.js` seed.
+
+---
+
+## Cache Busting
+
+Every patch bump triggers `stamp-sw-cache.sh`, producing a new `CACHE_NAME`. When a user's browser fetches the new `sw.js`, it sees an unknown cache name, opens a fresh cache bucket, and re-downloads all `CORE_ASSETS`. The old cache bucket is deleted in the `activate` event.
+
+This means:
+
+- Users always get the latest JS/CSS within one page load of a new deploy.
+- No manual cache-clearing is required by the user.
+- Offline mode still works immediately after the fresh install completes.
+
+---
+
+## Common Mistakes
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| Added JS file to `index.html` but not `CORE_ASSETS` | Service worker serves the old (missing) version of the file offline; bug disappears on hard refresh | Add the `./js/your-file.js` entry to `CORE_ASSETS` in `sw.js` |
+| Edited `CACHE_NAME` manually | Pre-commit hook overwrites it on the next commit | Do not edit — the hook owns this line |
+| Hook not symlinked after a fresh clone | `CACHE_NAME` never updates; users cache stale assets forever | Run `ln -sf ../../devops/hooks/stamp-sw-cache.sh .git/hooks/pre-commit` |
+| Added a vendor file to `vendor/` but not `CORE_ASSETS` | Vendor script missing in offline mode | Add `./vendor/your-lib.min.js` to the bottom of `CORE_ASSETS` |
+| `CORE_ASSETS` out of order vs `index.html` | No runtime error, but makes auditing the list harder | Keep entries in `<script>` load order |
+
+---
+
+## Related Pages
+
+- [frontend-overview.md](frontend-overview.md) — full JS file list and load order
+- [release-workflow.md](release-workflow.md) — patch versioning and the pre-commit hook pipeline

--- a/wiki/spot-pipeline.md
+++ b/wiki/spot-pipeline.md
@@ -1,0 +1,209 @@
+---
+title: Spot Price Pipeline
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages: []
+---
+
+# Spot Price Pipeline
+
+> **Last verified:** 2026-02-25 — audited from live Fly.io container `poller.py` and `update-seed-data.py`
+> ⚠️ **ARCHITECTURE GAP:** Spot poller still writes to files, not Turso — See STAK-331
+
+---
+
+## Overview
+
+Spot prices (gold, silver, platinum, palladium in USD/oz) are polled **4× per hour** (every 15 minutes) from MetalPriceAPI and written as JSON files to the persistent volume. Published to the `api` branch by `run-publish.sh`.
+
+**Writer:** `run-spot.sh` cron inside the Fly.io container
+**Cadence:** `5,20,35,50 * * * *` (4×/hr, offset from retail at `:00`)
+**Stale threshold:** 75 minutes
+
+---
+
+## ⚠️ Known Architecture Gap (STAK-331)
+
+The spot price poller (`poller.py`) is **not yet writing to Turso**. It writes directly to JSON files on the Fly.io persistent volume.
+
+**Expected architecture:** `poller.py` → Turso `spot_prices` table → `api-export.js` reads Turso → JSON files
+**Actual state:** `poller.py` → JSON files directly (Turso bypassed entirely for spot data)
+
+---
+
+## Architecture
+
+```
+MetalPriceAPI.com
+  /v1/latest?base=USD&currencies=XAU,XAG,XPT,XPD
+         │
+         │  HTTP GET (Python requests)
+         │  API key: METAL_PRICE_API_KEY (Fly secret)
+         ▼
+┌──────────────────────────────┐
+│  spot-poller/poller.py       │
+│  (--once mode via cron)      │
+│                              │
+│  1. backfill_recent_hours()  │
+│     └─ Scan last 24h for     │
+│        missing hourly files  │
+│     └─ Use /timeframe to fill│
+│                              │
+│  2. poll_once()              │
+│     └─ fetch /latest         │
+│     └─ Invert rates:         │
+│        1/XAU = $/oz gold     │
+│        1/XAG = $/oz silver   │
+│        1/XPT = $/oz platinum │
+│        1/XPD = $/oz palladium│
+└───────────┬──────────────────┘
+            │
+    ┌───────┼────────────────────────┐
+    │       │                        │
+    ▼       ▼                        ▼
+ Hourly    15-min                 Daily Seed
+ file      snapshot               (at noon EST / 17:00 UTC)
+    │       │                        │
+    ▼       ▼                        ▼
+data/hourly/     data/15min/        data/spot-history-{YYYY}.json
+YYYY/MM/DD/      YYYY/MM/DD/
+HH.json          HHMM.json
+            │
+            ▼ (via run-publish.sh at 8,23,38,53)
+   api branch → GitHub Pages → api.staktrakr.com
+```
+
+---
+
+## Data Source
+
+**MetalPriceAPI** (`metalpriceapi.com`) — requires `METAL_PRICE_API_KEY` Fly secret.
+
+**Endpoints used:**
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/v1/latest` | Current spot prices (each poll) |
+| `/v1/timeframe` | Historical backfill (gap recovery) |
+
+**Rate conversion:** API returns rates as "units of metal per 1 USD". Inversion gives USD/oz:
+
+| Symbol | Metal | Calculation |
+|--------|-------|-------------|
+| `XAU` | Gold | `1 / rate` = USD per troy oz |
+| `XAG` | Silver | `1 / rate` = USD per troy oz |
+| `XPT` | Platinum | `1 / rate` = USD per troy oz |
+| `XPD` | Palladium | `1 / rate` = USD per troy oz |
+
+---
+
+## Output Files
+
+Each poll writes **three** types of files:
+
+### Hourly (`data/hourly/YYYY/MM/DD/HH.json`)
+
+Overwritten each poll — always has the latest reading for that hour. The frontend fetches this for live spot prices.
+
+```
+data/hourly/2026/02/25/19.json
+```
+
+### 15-Minute (`data/15min/YYYY/MM/DD/HHMM.json`)
+
+**Immutable** — each poll creates its own file. Never overwritten. Used for fine-grained historical analysis.
+
+```
+data/15min/2026/02/25/1905.json
+data/15min/2026/02/25/1920.json
+data/15min/2026/02/25/1935.json
+data/15min/2026/02/25/1950.json
+```
+
+### Daily Seed (`data/spot-history-YYYY.json`)
+
+Written **once per day** at noon EST (17:00 UTC). Contains one entry per day per metal. Used for long-term historical charts.
+
+**Warning:** This is a **seed file**, not live data. Do not use it for freshness checks.
+
+---
+
+## Backfill Logic
+
+`poller.py` runs `backfill_recent_hours()` before each poll (in `--once` mode). It:
+
+1. Scans the last 24 hours for missing hourly files
+2. Calls `/v1/timeframe` to fetch historical rates for missing dates
+3. Writes the missing hourly files
+
+This ensures no gaps from missed cron cycles, container restarts, or deploys.
+
+---
+
+## run-spot.sh
+
+Thin wrapper that calls `poller.py --once`:
+
+```bash
+DATA_DIR="/data/staktrakr-api-export/data" \
+  METAL_PRICE_API_KEY="$METAL_PRICE_API_KEY" \
+  python3 /app/spot-poller/poller.py --once
+```
+
+Requires:
+- Volume mounted at `/data/staktrakr-api-export`
+- `METAL_PRICE_API_KEY` env var set
+
+---
+
+## GHA Workflow (Retired)
+
+`.github/workflows/spot-poller.yml` is **retired** as of 2026-02-23. Spot polling moved to the Fly.io container cron to reduce complexity and avoid GHA minute usage.
+
+The workflow file is kept for emergency manual triggering only.
+
+---
+
+## Diagnosing Issues
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Hourly file > 75 min stale | `METAL_PRICE_API_KEY` expired or quota exceeded | Check MetalPriceAPI dashboard; rotate key in Fly secrets |
+| Hourly file missing entirely | run-spot.sh not running | `fly logs --app staktrakr \| grep spot` |
+| Stale data after deploy | New deploy wiped cron schedule? | `fly ssh console -C "crontab -l"` to verify |
+
+```bash
+# Check recent spot poll logs
+fly logs --app staktrakr | grep spot
+
+# Manual trigger
+fly ssh console --app staktrakr -C "/app/run-spot.sh"
+
+# Verify output
+curl https://api.staktrakr.com/data/hourly/$(date -u +%Y/%m/%d/%H).json | jq .[-1]
+```
+
+---
+
+## Health Check
+
+```python
+import urllib.request, json
+from datetime import datetime, timezone, timedelta
+
+def fetch(url):
+    with urllib.request.urlopen(url, timeout=10) as r: return json.load(r)
+
+now = datetime.now(timezone.utc)
+def url(dt): return f"https://api.staktrakr.com/data/hourly/{dt.year}/{dt.month:02d}/{dt.day:02d}/{dt.hour:02d}.json"
+try:
+    d = fetch(url(now))
+except:
+    d = fetch(url(now - timedelta(hours=1)))
+ts = d[-1]['timestamp']
+age_min = (datetime.now(timezone.utc) - datetime.fromisoformat(ts.replace('Z','+00:00'))).total_seconds()/60
+print(f"Spot: {'✅' if age_min <= 75 else '⚠️'} {age_min:.0f}m ago")
+```

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -1,0 +1,290 @@
+---
+title: Storage Patterns
+category: frontend
+owner: staktrakr
+lastUpdated: v3.32.23
+date: 2026-02-23
+sourceFiles:
+  - js/utils.js
+  - js/constants.js
+relatedPages:
+  - data-model.md
+  - dom-patterns.md
+---
+# Storage Patterns
+
+> **Last updated:** v3.32.23 — 2026-02-23
+> **Source files:** `js/utils.js`, `js/constants.js`
+
+## Overview
+
+StakTrakr persists all application state in `localStorage`. Direct calls to
+`localStorage.setItem` / `localStorage.getItem` are **forbidden**. All reads
+and writes must go through the wrapper functions `saveData` / `loadData` (async)
+or `saveDataSync` / `loadDataSync` (sync), defined in `js/utils.js`.
+
+The wrappers exist for three reasons:
+
+1. **Allowlist enforcement** — `cleanupStorage()` iterates every key in
+   `localStorage` and deletes anything not listed in `ALLOWED_STORAGE_KEYS`
+   (`js/constants.js`). A key that bypasses the wrappers still lives in
+   `localStorage`, but it will be silently wiped the next time `cleanupStorage`
+   runs.
+2. **Transparent compression** — Large values (inventory, history) are
+   automatically compressed with LZ-string via `__compressIfNeeded` on write and
+   decompressed via `__decompressIfNeeded` on read. Bypassing the wrappers
+   breaks this transparently.
+3. **Consistent error handling** — Parse errors and quota-exceeded errors are
+   caught in one place; callers always receive the `defaultValue` rather than an
+   uncaught exception.
+
+---
+
+## Key Rules (read before touching this area)
+
+- **Never** call `localStorage.setItem()` or `localStorage.getItem()` directly.
+- **Never** introduce a new storage key without first adding it to
+  `ALLOWED_STORAGE_KEYS` in `js/constants.js`.
+- New keys written outside the allowlist will be deleted by `cleanupStorage()`.
+- Prefer `saveData` / `loadData` (async) for new code. Use `saveDataSync` /
+  `loadDataSync` only where the call site cannot be made async.
+
+---
+
+## Architecture
+
+### `saveData(key, value)` — async
+
+```js
+const saveData = async (key, data) => {
+  try {
+    const raw = JSON.stringify(data);
+    const out = __compressIfNeeded(raw);
+    localStorage.setItem(key, out);
+  } catch(e) {
+    console.error('saveData failed', e);
+  }
+};
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `key` | `string` | Must be present in `ALLOWED_STORAGE_KEYS`. |
+| `data` | `any` | Any JSON-serialisable value. |
+
+**Returns:** `Promise<void>`. Errors are caught internally; no rejection is
+propagated to the caller. A `console.error` is emitted on failure (e.g.
+`QuotaExceededError`).
+
+If `key` is **not** in `ALLOWED_STORAGE_KEYS`, the write still succeeds at the
+`localStorage` level — there is no runtime guard inside `saveData` itself. The
+key is removed the next time `cleanupStorage()` runs (called during startup and
+after imports). Always add the key to the allowlist first.
+
+---
+
+### `loadData(key, defaultValue)` — async
+
+```js
+const loadData = async (key, defaultValue = []) => {
+  try {
+    const raw = localStorage.getItem(key);
+    if(raw == null) return defaultValue;
+    const str = __decompressIfNeeded(raw);
+    return JSON.parse(str);
+  } catch(e) {
+    console.warn(`loadData failed for ${key}, returning default:`, e);
+    return defaultValue;
+  }
+};
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `key` | `string` | — | Storage key to read. |
+| `defaultValue` | `any` | `[]` | Returned when the key is missing or parsing fails. |
+
+**Returns:** `Promise<any>`. Never rejects. If the key is absent (`null`) the
+`defaultValue` is returned. If the stored string is corrupt or decompression
+fails, `defaultValue` is returned and a `console.warn` is emitted.
+
+Note: the default for `defaultValue` is an **empty array** (`[]`). For keys
+that hold objects, booleans, or strings, always pass an explicit default to
+avoid type surprises:
+
+```js
+// Correct — explicit default for a non-array value
+const theme = await loadData(THEME_KEY, 'light');
+
+// Risky — returns [] when key is absent, not null/undefined
+const theme = await loadData(THEME_KEY);
+```
+
+---
+
+### `saveDataSync(key, data)` — sync
+
+```js
+const saveDataSync = (key, data) => {
+  try {
+    const raw = JSON.stringify(data);
+    const out = __compressIfNeeded(raw);
+    localStorage.setItem(key, out);
+  } catch(e) {
+    console.error('saveDataSync failed', e);
+    throw e;  // re-throws, unlike the async version
+  }
+};
+```
+
+Identical behavior to `saveData` except it is synchronous and **re-throws** on
+error. Use only at call sites that cannot be made async (e.g., `beforeunload`
+handlers, initialisation code that runs before the event loop is established).
+
+---
+
+### `loadDataSync(key, defaultValue)` — sync
+
+```js
+const loadDataSync = (key, defaultValue = []) => {
+  try {
+    const raw = localStorage.getItem(key);
+    if(raw == null) return defaultValue;
+    const str = __decompressIfNeeded(raw);
+    return JSON.parse(str);
+  } catch(e) {
+    return defaultValue;
+  }
+};
+```
+
+Synchronous equivalent of `loadData`. Same `defaultValue = []` caveat applies.
+Errors are swallowed silently (no `console.warn`).
+
+---
+
+### `cleanupStorage()` — the allowlist enforcer
+
+```js
+const cleanupStorage = () => {
+  if (typeof localStorage === 'undefined') return;
+  const allowed = new Set(ALLOWED_STORAGE_KEYS);
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i);
+    if (!allowed.has(key)) {
+      localStorage.removeItem(key);
+    }
+  }
+};
+```
+
+Called automatically during app startup. Any key not present in
+`ALLOWED_STORAGE_KEYS` is permanently deleted. This is the primary mechanism
+that enforces the allowlist contract.
+
+---
+
+### `ALLOWED_STORAGE_KEYS` — the allowlist
+
+Defined in `js/constants.js`. Contains every key StakTrakr is permitted to
+store. Mix of constant references (e.g. `LS_KEY`, `THEME_KEY`) and raw string
+literals for legacy or one-off keys. As of v3.32.23 the list contains ~70+
+entries covering inventory, spot prices, retail prices, UI preferences, cloud
+sync, feature flags, and one-time migration markers.
+
+---
+
+## How to Add a New Storage Key
+
+1. **Define a constant** in `js/constants.js` (preferred) or use a raw string
+   for simple one-off flags:
+
+   ```js
+   // js/constants.js
+   const MY_NEW_SETTING_KEY = 'myNewSetting';
+   ```
+
+2. **Add it to `ALLOWED_STORAGE_KEYS`** in the same file, with a comment
+   describing the type and purpose:
+
+   ```js
+   const ALLOWED_STORAGE_KEYS = [
+     // ... existing keys ...
+     MY_NEW_SETTING_KEY, // string: description of what this stores
+   ];
+   ```
+
+3. **Expose the constant** if it needs to be accessed from other files:
+
+   ```js
+   // bottom of constants.js, inside the window assignment block
+   window.MY_NEW_SETTING_KEY = MY_NEW_SETTING_KEY;
+   ```
+
+4. **Use the wrappers** in your feature code:
+
+   ```js
+   // Write
+   await saveData(MY_NEW_SETTING_KEY, value);
+
+   // Read
+   const value = await loadData(MY_NEW_SETTING_KEY, 'default');
+   ```
+
+Do **not** use the key anywhere before step 2 is complete — `cleanupStorage()`
+will delete it on next startup.
+
+---
+
+## Migration Pattern — Renaming a Key
+
+When a key must be renamed (e.g. to fix a typo or consolidate settings):
+
+```js
+// 1. Read the old value
+const oldValue = await loadData('oldKeyName', null);
+
+// 2. If present, migrate to the new key
+if (oldValue !== null) {
+  await saveData(NEW_KEY, oldValue);
+  localStorage.removeItem('oldKeyName'); // direct remove is OK for cleanup
+}
+
+// 3. Keep 'oldKeyName' in ALLOWED_STORAGE_KEYS until after the migration
+//    flag is confirmed written, then remove it in the next release.
+```
+
+Also add a one-time migration flag so the migration runs only once:
+
+```js
+const MIGRATION_FLAG = 'migration_myKeyRename';
+// add to ALLOWED_STORAGE_KEYS
+
+if (!loadDataSync(MIGRATION_FLAG, false)) {
+  // ... migration logic ...
+  saveDataSync(MIGRATION_FLAG, true);
+}
+```
+
+Existing migration flags in the codebase follow the `migration_` prefix
+convention (e.g. `migration_hourlySource`, `migration_seedHistoryMerge`).
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| `localStorage.setItem('myKey', JSON.stringify(val))` | Bypasses compression; key deleted by `cleanupStorage` if not in allowlist | Use `saveData` / `saveDataSync` |
+| `JSON.parse(localStorage.getItem('myKey'))` | Bypasses decompression; crashes on compressed values | Use `loadData` / `loadDataSync` |
+| Omitting explicit `defaultValue` for non-array keys | Caller receives `[]` instead of `null` / `false` / `''` | Always pass the correct default |
+| Writing a new key before adding it to `ALLOWED_STORAGE_KEYS` | Value is silently deleted on next `cleanupStorage` run | Add to allowlist first |
+| Using `saveDataSync` in async code paths | Works but loses the `console.error`-only behaviour — sync version re-throws | Prefer `saveData` for async code |
+| Hardcoding a key string in two places | Key name drift and allowlist mismatches | Define a constant in `constants.js`, reference the constant everywhere |
+
+---
+
+## Related Pages
+
+- [data-model.md](data-model.md) — shape of the inventory objects stored under `LS_KEY`
+- [dom-patterns.md](dom-patterns.md) — `safeGetElement` and other DOM access rules

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -1,0 +1,298 @@
+---
+title: Cloud Sync
+category: frontend
+owner: staktrakr
+lastUpdated: v3.32.41
+date: 2026-02-25
+sourceFiles:
+  - js/cloud-sync.js
+  - js/cloud-storage.js
+relatedPages:
+  - data-model.md
+  - storage-patterns.md
+  - image-pipeline.md
+  - backup-restore.md
+---
+# Cloud Sync
+
+> **Last updated:** v3.32.41 — 2026-02-25
+> **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
+
+---
+
+## Overview
+
+StakTrakr supports Dropbox-based cloud sync that automatically pushes an encrypted vault snapshot whenever inventory changes, and polls for remote updates on other devices.
+
+Two files live in Dropbox under `/StakTrakr/`:
+
+| File | Purpose |
+|---|---|
+| `staktrakr-sync.stvault` | Full encrypted inventory snapshot |
+| `staktrakr-sync.json` | Lightweight metadata pointer, polled for change detection |
+
+The poller compares the remote `staktrakr-sync.json` revision against the last-seen cursor. When it detects a change it calls `handleRemoteChange()`, which decides between a clean pull or a conflict modal.
+
+---
+
+## Key Rules (read before touching this area)
+
+1. **Never bypass `getSyncPasswordSilent()`** — do not add your own `localStorage.getItem('cloud_vault_password')` reads inline. All key derivation logic (Simple mode migration, Unified mode construction) is encapsulated there.
+2. **All `pushSyncVault()` and `pullSyncVault()` call sites must have `.catch()` handlers** — bare calls cause silent unhandled rejections on token failures. This was the root cause of the v3.32.24 regression.
+3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before opening any modal. If you add new pull paths, replicate this cancel guard.
+4. **Do not duplicate `getSyncPassword()` logic** — the fast-path check at the top of that function delegates to `getSyncPasswordSilent()`, which handles both modes. Adding a second localStorage read before it breaks Simple-mode migration.
+
+---
+
+## Architecture
+
+### Two Sync Modes
+
+#### Simple Mode
+
+The encryption key is derived entirely from the Dropbox account ID (`cloud_dropbox_account_id` in localStorage). No password is ever prompted on any device.
+
+Key construction: `STAKTRAKR_SIMPLE_SALT + ':' + accountId`
+
+- `STAKTRAKR_SIMPLE_SALT` is a fixed hex string baked into `js/cloud-sync.js`.
+- `cloud_sync_mode` is set to `'simple'` in localStorage.
+- Any device that authenticates with the same Dropbox account can decrypt transparently.
+- **Trade-off:** anyone with the Dropbox OAuth token can also derive the key.
+
+#### Secure Mode (Unified Mode)
+
+The encryption key combines a user-chosen vault password **and** the Dropbox account ID:
+
+Key construction: `vaultPassword + ':' + accountId`
+
+- Stored separately: `cloud_vault_password` and `cloud_dropbox_account_id`.
+- `getSyncPasswordSilent()` returns `null` on a new device until the user enters the password at least once.
+- After first entry, the password is cached in `cloud_vault_password` (localStorage) so subsequent page loads are silent.
+- Zero-knowledge: Dropbox access alone is insufficient to decrypt the vault.
+
+### `getSyncPassword()`
+
+```
+getSyncPassword()
+  └─ getSyncPasswordSilent()   ← always checked first (fast-path)
+       ├─ Unified mode: vaultPw + ':' + accountId  (both present)
+       ├─ Simple migration: SALT + ':' + accountId  (cloud_sync_mode === 'simple')
+       └─ null → fall through to interactive prompt modal
+```
+
+- **Never call `localStorage.getItem('cloud_vault_password')` directly** at a call site — `getSyncPasswordSilent()` handles both modes and the migration edge case.
+- If the silent path returns a key, `getSyncPassword()` resolves immediately without opening any modal.
+- The interactive modal sets the password in localStorage and fires `pushSyncVault()` 100 ms later on confirm.
+
+### `pushSyncVault()`
+
+1. Guards: `syncIsEnabled()`, token present, no push already in-flight, `getSyncPasswordSilent()` returns a key.
+2. Encrypts the sync-scoped inventory with `vaultEncryptToBytesScoped()` (falls back to `vaultEncryptToBytes()`).
+3. Uploads the encrypted bytes to `/StakTrakr/staktrakr-sync.stvault` (overwrite mode).
+4. Writes the metadata pointer to `/StakTrakr/staktrakr-sync.json`.
+5. Persists the push meta (timestamp, syncId, itemCount) via `syncSetLastPush()`.
+6. Handles 429 rate-limit with exponential backoff (caps at 5 minutes).
+
+**All call sites must have `.catch()` handlers.** Example:
+
+```js
+pushSyncVault().catch(function (err) {
+  debugLog('[CloudSync] pushSyncVault failed:', err);
+});
+```
+
+### `pullSyncVault()`
+
+1. Tries `getSyncPasswordSilent()` first; falls back to interactive `getSyncPassword()` if null.
+2. Calls `syncSaveOverrideBackup()` (snapshots current localStorage state before overwriting).
+3. Downloads `staktrakr-sync.stvault` from Dropbox.
+4. Decrypts and restores via `vaultDecryptAndRestore()`.
+5. Persists pull meta via `syncSetLastPull()`.
+
+**All call sites must have `.catch()` handlers.**
+
+### `handleRemoteChange()`
+
+Called by the poller when `staktrakr-sync.json` has a new revision.
+
+```
+handleRemoteChange(remoteMeta)
+  ├─ If password prompt is active → defer (return, retry next poll)
+  ├─ scheduleSyncPush.cancel()           ← CRITICAL: cancels any queued push
+  ├─ syncHasLocalChanges()?
+  │    No  → showSyncUpdateModal() → pullSyncVault()
+  │    Yes → showSyncConflictModal()
+  │             ├─ Keep Mine  → pushSyncVault()
+  │             └─ Keep Theirs → pullSyncVault().catch(...)
+```
+
+**The `scheduleSyncPush.cancel()` call is mandatory.** Without it:
+1. User triggers local change → debounced push is queued (2 s delay).
+2. Poller detects remote change → conflict modal opens.
+3. Debounced push fires while modal is open → overwrites remote vault with stale local data.
+4. User clicks "Keep Theirs" → pulls back their own just-pushed stale data.
+5. Remote device's changes are silently discarded.
+
+---
+
+## Image Vault Sync
+
+Cloud sync uploads a **separate encrypted image vault** (`staktrakr-images.stvault`) alongside the inventory vault. This vault carries user-uploaded coin images between devices.
+
+### Files in Dropbox
+
+| File | Purpose |
+|---|---|
+| `staktrakr-sync.stvault` | Encrypted inventory snapshot |
+| `staktrakr-images.stvault` | Encrypted image vault (user images only) |
+| `staktrakr-sync.json` | Metadata pointer (includes `imageVault.hash` field) |
+
+### Upload Behavior
+
+- Triggered as part of `pushSyncVault()` when image data is present.
+- Only uploads if the image hash has changed since the last push.
+- **Hash formula:** `simpleHash(uuid + size + first32bytes_of_obverse)` for each `userImages` IDB record — a lightweight fingerprint that avoids re-uploading unchanged blobs.
+- **Does NOT include `patternImages`** — pattern images are built-in assets served from the app bundle, not user data.
+
+### Contents
+
+The image vault contains serialized `userImages` IDB records, with base64-encoded blob data. It is encrypted with the same key as the inventory vault (derived via `getSyncPasswordSilent()`).
+
+### Pull Behavior
+
+- On `pullSyncVault()`, the remote `staktrakr-sync.json` is checked for an `imageVault.hash` field.
+- If the remote hash differs from the locally stored image hash, the image vault is downloaded and decrypted.
+- If the hashes match, the download is skipped (no unnecessary traffic).
+
+### Non-Fatal Design
+
+Image vault upload and download failures are **non-fatal**. If the image vault push or pull throws, inventory sync continues normally. The error is logged but does not block the sync flow or show an error to the user.
+
+### Key Functions (`js/vault.js`)
+
+| Function | Purpose |
+|---|---|
+| `collectAndHashImageVault()` | Reads `userImages` from IDB, serializes records, computes hash |
+| `vaultEncryptImageVault()` | Encrypts the serialized image data to bytes |
+| `vaultDecryptAndRestoreImages()` | Decrypts downloaded bytes and writes records back to `userImages` IDB |
+
+---
+
+## Vault Overwrite Race (fixed v3.32.24)
+
+**Symptom:** On two-device setups, choosing "Keep Remote" in the conflict modal silently discarded the remote device's changes.
+
+**Root cause:** On page load, `initSyncModule()` builds `scheduleSyncPush` as a debounced wrapper around `pushSyncVault` with a `SYNC_PUSH_DEBOUNCE` delay (2000 ms). If the poller detected a remote change within that 2-second window, the debounced push fired during or after the conflict modal, overwriting the remote vault before the pull could complete.
+
+**Fix (v3.32.24):** `handleRemoteChange()` now calls `scheduleSyncPush.cancel()` as its first substantive action — before any modal is shown.
+
+**Both devices must be on v3.32.24+** for the race to be fully closed. A v3.32.23 device will still exhibit the bug on its own debounced push, even if the other device has been updated.
+
+---
+
+## Conflict Resolution
+
+**Default: remote wins** (when the user accepts the update modal with no local changes).
+
+When both sides have unsaved changes, the conflict modal shows:
+
+| Side | Info displayed |
+|---|---|
+| Local | Item count, last-push timestamp, app version |
+| Remote | Item count, timestamp, app version, device ID |
+
+Choices:
+- **Keep Mine** → `pushSyncVault()` (overwrites remote with local)
+- **Keep Theirs** → `pullSyncVault(remoteMeta).catch(...)` (overwrites local with remote)
+
+The override backup (`syncSaveOverrideBackup`) is always written before any pull, enabling the "Restore Override Backup" button in the sync history section.
+
+---
+
+## Debounced Push
+
+`scheduleSyncPush` is a debounced wrapper built in `initSyncModule()`:
+
+```
+SYNC_PUSH_DEBOUNCE = 2000 ms
+```
+
+Any inventory change fires `scheduleSyncPush()`. If another change arrives within 2 seconds, the timer resets. The actual `pushSyncVault()` only fires after 2 seconds of quiet.
+
+If the `debounce` utility is not available at init time, a plain `setTimeout` fallback is used (no deduplication in that case).
+
+---
+
+## `changeLog` IIFE Parse Failures
+
+`changeLog` is initialized as an IIFE in `js/state.js` that reads from localStorage on page load. Prior to v3.32.24, a JSON parse failure (malformed stored value) would silently return `[]` with no indication of data loss.
+
+**Since v3.32.24:** parse failures emit `console.warn('[state] changeLog parse failed — resetting to []. Error:', e)` so they are visible in DevTools.
+
+---
+
+## localStorage Keys
+
+| Key | Purpose |
+|---|---|
+| `cloud_vault_password` | User vault password (Secure mode) |
+| `cloud_dropbox_account_id` | Dropbox account ID (used in key derivation for both modes) |
+| `cloud_sync_mode` | `'simple'` — deprecated, kept for migration only, will be removed after v3.33 |
+| `cloud_sync_enabled` | `'true'` when sync is active |
+| `cloud_sync_device_id` | Stable per-device UUID |
+| `cloud_sync_last_push` | JSON: last push metadata (syncId, timestamp, itemCount) |
+| `cloud_sync_last_pull` | JSON: last pull metadata |
+| `cloud_sync_cursor` | Last-seen remote revision (change detection) |
+| `cloud_sync_override_backup` | Snapshot of localStorage taken before a pull overwrites data |
+
+---
+
+## Common Mistakes
+
+### Adding a raw localStorage read for the vault password
+
+```js
+// WRONG — breaks Simple-mode migration
+var pw = localStorage.getItem('cloud_vault_password');
+
+// CORRECT — handles all modes and migration
+var pw = getSyncPasswordSilent();
+```
+
+### Bare push/pull calls without `.catch()`
+
+```js
+// WRONG — silent unhandled rejection if token is missing
+pullSyncVault(remoteMeta);
+
+// CORRECT
+pullSyncVault(remoteMeta).catch(function (err) {
+  debugLog('[CloudSync] pull failed:', err);
+});
+```
+
+### Adding a new pull path without cancelling the debounced push
+
+```js
+// WRONG — vault overwrite race
+async function myNewPullPath(remoteMeta) {
+  await pullSyncVault(remoteMeta);
+}
+
+// CORRECT
+async function myNewPullPath(remoteMeta) {
+  if (typeof scheduleSyncPush === 'function' && typeof scheduleSyncPush.cancel === 'function') {
+    scheduleSyncPush.cancel();
+  }
+  await pullSyncVault(remoteMeta);
+}
+```
+
+---
+
+## Related Pages
+
+- `data-model.md` — inventory structure and field definitions
+- `storage-patterns.md` — `saveData()` / `loadData()` patterns, `ALLOWED_STORAGE_KEYS`
+- `image-pipeline.md` — Image IDB stores, resolution cascade, upload flow
+- `backup-restore.md` — ZIP backup, encrypted vault, image vault, cloud sync coverage matrix

--- a/wiki/turso-schema.md
+++ b/wiki/turso-schema.md
@@ -1,0 +1,232 @@
+---
+title: Turso Database Schema
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-02-25
+sourceFiles: []
+relatedPages:
+  - provider-database.md
+  - retail-pipeline.md
+  - rest-api-reference.md
+  - architecture-overview.md
+  - spot-pipeline.md
+---
+
+# Turso Database Schema
+
+> **Last verified:** 2026-02-25 — audited from live Fly.io container `turso-client.js` and `db.js`
+> **Database:** `staktrakrapi` on Turso (libSQL cloud)
+> **Client library:** `@libsql/client`
+
+---
+
+## Overview
+
+Turso is the **single source of truth** for retail price data. Both pollers (Fly.io and Home LXC) write to the same database. `api-export.js` reads from Turso at publish time and generates static JSON files.
+
+**Note:** Spot prices (MetalPriceAPI) are NOT in Turso — they write directly to hourly JSON files. See [spot-pipeline.md](spot-pipeline.md) and STAK-331.
+
+---
+
+## Tables
+
+### `price_snapshots`
+
+Primary data table. One row per scrape attempt per coin per vendor.
+
+```sql
+CREATE TABLE IF NOT EXISTS price_snapshots (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  scraped_at   TEXT NOT NULL,       -- ISO 8601 UTC timestamp of scrape
+  window_start TEXT NOT NULL,       -- 15-min floor bucket (e.g. "2026-02-25T14:15:00Z")
+  coin_slug    TEXT NOT NULL,       -- e.g. "ase", "age", "goldback-g1"
+  vendor       TEXT NOT NULL,       -- e.g. "jmbullion", "apmex", "goldback"
+  price        REAL,                -- USD price (null if scrape failed or OOS)
+  source       TEXT NOT NULL,       -- "firecrawl", "playwright", "gemini-vision", "fbp"
+  confidence   INTEGER,             -- 0-100 confidence score (set by merge/export)
+  is_failed    INTEGER NOT NULL DEFAULT 0,  -- 1 if scrape threw an error
+  in_stock     INTEGER NOT NULL DEFAULT 1   -- 0 if OOS detected
+);
+```
+
+**Indexes:**
+
+```sql
+CREATE INDEX idx_coin_window ON price_snapshots(coin_slug, window_start);
+CREATE INDEX idx_window ON price_snapshots(window_start);
+CREATE INDEX idx_coin_date ON price_snapshots(coin_slug, substr(window_start, 1, 10));
+CREATE INDEX idx_coin_vendor_stock ON price_snapshots(coin_slug, vendor, in_stock, scraped_at DESC);
+```
+
+**Source values:**
+
+| Source | Writer | Description |
+|--------|--------|-------------|
+| `firecrawl` | `price-extract.js` | Firecrawl markdown → regex price extraction |
+| `playwright` | `price-extract.js` | Playwright DOM fallback (when Firecrawl fails) |
+| `gemini-vision` | `extract-vision.js` | Gemini 2.5 Flash screenshot analysis |
+| `fbp` | `price-extract.js` (PATCH_GAPS mode) | FindBullionPrices gap-fill scrape |
+
+**Window start calculation:**
+
+```javascript
+// 15-minute floor: 14:22:45 → "2026-02-20T14:15:00Z"
+function windowFloor(ts = new Date()) {
+  const d = new Date(ts);
+  d.setUTCMinutes(Math.floor(d.getUTCMinutes() / 15) * 15, 0, 0);
+  return d.toISOString().replace(".000Z", "Z");
+}
+```
+
+---
+
+### `poller_runs`
+
+One row per scrape run. Written by each poller instance for monitoring and diagnostics.
+
+```sql
+CREATE TABLE IF NOT EXISTS poller_runs (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id       TEXT NOT NULL UNIQUE, -- "{pollerId}-{startedAt}" (deduped)
+  poller_id    TEXT NOT NULL,        -- "api" (Fly.io) or "home" (LXC)
+  started_at   TEXT NOT NULL,        -- ISO 8601 UTC
+  finished_at  TEXT,                 -- ISO 8601 UTC (null while running)
+  status       TEXT NOT NULL DEFAULT 'running', -- "running", "ok", "error"
+  total        INTEGER,              -- total SKUs attempted
+  captured     INTEGER,              -- successful price extractions
+  failures     INTEGER,              -- failed extractions
+  fbp_filled   INTEGER,              -- gaps filled by FBP fallback
+  error        TEXT                  -- error message if status = "error"
+);
+```
+
+**Index:**
+
+```sql
+CREATE INDEX idx_runs_poller_started ON poller_runs(poller_id, started_at DESC);
+```
+
+---
+
+## Key Query Patterns
+
+### `readLatestPerVendor(db, coinSlug, lookbackHours=2)`
+
+The dual-poller merge function. Returns the **most recent non-failed row per vendor** within the lookback window. This is how data from both pollers (Fly.io at `:15/:45` and Home at `:00/:30`) gets merged into a single vendor map at export time.
+
+```sql
+SELECT ps.*
+FROM price_snapshots ps
+INNER JOIN (
+  SELECT vendor, MAX(scraped_at) AS max_scraped
+  FROM price_snapshots
+  WHERE coin_slug = ? AND scraped_at >= ? AND is_failed = 0 AND price IS NOT NULL
+  GROUP BY vendor
+) latest ON ps.vendor = latest.vendor AND ps.scraped_at = latest.max_scraped
+WHERE ps.coin_slug = ? AND ps.is_failed = 0 AND ps.price IS NOT NULL
+```
+
+### `readRecentWindows(db, coinSlug, windowCount=96)`
+
+Returns raw rows for the last 96 windows (24 hours of 15-min windows). Used by `api-export.js` to build the `windows_24h` time series in per-coin `latest.json`.
+
+### `readDailyAggregates(db, coinSlug, days=30)`
+
+Returns daily per-vendor aggregates grouped by date. Used for `history-7d.json` and `history-30d.json`.
+
+### `getLastKnownPrice(db, coinSlug, vendorId)`
+
+Returns the most recent in-stock price for a coin+vendor. Used by T4 fallback in `api-export.js` when current scrape has no data.
+
+---
+
+## Data Volume Estimates
+
+**Current (pre-STAK-335):**
+- **11 coins × 7 vendors × 4 polls/hour × 24 hours** ≈ 7,392 rows/day (Fly.io poller)
+- **11 coins × 7 vendors × 2 polls/hour × 24 hours** ≈ 3,696 rows/day (Home poller)
+- **6 goldback slugs × 4 vendors × 4 polls/hour × 24 hours** ≈ 2,304 rows/day
+- **Total:** ~13,000–15,000 rows/day across both pollers
+
+**After STAK-335 (all per-state Goldback vendors enabled):**
+- **56 goldback slugs × N vendors × 4 polls/hour × 24 hours** — volume scales with number of enabled vendors per slug
+- Worst case (all 56 slugs × 7 vendors): +37,632 rows/day from Fly.io alone
+- **Likely reality:** Most per-state slugs will have 1–3 vendors initially, growing incrementally
+- Disabled slugs (`url: null`) add **zero** scrape load and **zero** Turso rows
+- **30-day window for api-export:** ~400,000–450,000 rows queried at export time
+
+---
+
+## Connection Details
+
+```javascript
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL,     // libsql://staktrakrapi-...turso.io
+  authToken: process.env.TURSO_AUTH_TOKEN,  // Fly secret
+});
+```
+
+Both `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` are Fly.io secrets. The Home LXC has its own copy in `/opt/poller/.env`. See [secrets.md](secrets.md).
+
+---
+
+## Provider Tables (STAK-348)
+
+Added 2026-02-25. Provider configuration data (which vendors to scrape, URLs, coin metadata) — previously stored in `providers.json`.
+
+### `provider_coins`
+
+```sql
+CREATE TABLE IF NOT EXISTS provider_coins (
+  slug       TEXT PRIMARY KEY,
+  metal      TEXT NOT NULL,
+  name       TEXT NOT NULL,
+  weight_oz  REAL NOT NULL,
+  fbp_url    TEXT,
+  notes      TEXT,
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+### `provider_vendors`
+
+```sql
+CREATE TABLE IF NOT EXISTS provider_vendors (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  coin_slug  TEXT NOT NULL REFERENCES provider_coins(slug),
+  vendor_id  TEXT NOT NULL,
+  vendor_name TEXT,
+  url        TEXT,
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  selector   TEXT,
+  hints      TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(coin_slug, vendor_id)
+);
+```
+
+**Indexes:**
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_pv_coin ON provider_vendors(coin_slug);
+CREATE INDEX IF NOT EXISTS idx_pv_vendor ON provider_vendors(vendor_id);
+CREATE INDEX IF NOT EXISTS idx_pv_enabled ON provider_vendors(enabled);
+```
+
+See [Provider Database](provider-database.md) for the full `provider-db.js` API and CRUD details.
+
+---
+
+## Related Pages
+
+- [Provider Database](provider-database.md) — provider CRUD, migration, dashboard
+- [Retail Pipeline](retail-pipeline.md) — how data flows into Turso
+- [REST API Reference](rest-api-reference.md) — how data flows out of Turso to JSON
+- [Architecture Overview](architecture-overview.md) — system-level view
+- [Spot Pipeline](spot-pipeline.md) — NOT yet in Turso (STAK-331)

--- a/wiki/vendor-quirks.md
+++ b/wiki/vendor-quirks.md
@@ -1,0 +1,235 @@
+---
+title: "Vendor Scraping Quirks"
+category: infrastructure
+owner: staktrakr-api
+lastUpdated: v3.33.18
+date: 2026-03-01
+sourceFiles: []
+relatedPages: []
+---
+
+# Vendor Scraping Quirks
+
+Per-vendor scraping behavior, known issues, and workarounds. This is the runbook for diagnosing price extraction failures — check here first before modifying `price-extract.js`.
+
+> **Linear**: STAK-348 — planned sprint to move all vendor-specific config into the dashboard (editable per-vendor `hints` JSON).
+
+---
+
+## APMEX
+
+| Property | Value |
+|----------|-------|
+| Site tech | Server-rendered HTML |
+| Firecrawl | Works reliably, no `waitFor` needed |
+| Playwright fallback | Rarely needed |
+| Price format | Markdown pipe table (Check/Wire \| Crypto \| Card columns) |
+| Extraction | `firstTableRowFirstPrice()` — 1-unit ACH price from first data row |
+| Known issues | None — most reliable vendor |
+
+**OOS detection**: Standard patterns work. No false positives observed.
+
+---
+
+## JM Bullion
+
+| Property | Value |
+|----------|-------|
+| Site tech | Next.js / React SPA |
+| Firecrawl | Requires `waitFor: 8000` (in `SLOW_PROVIDERS`) |
+| Playwright fallback | Raw `chromium.launch()` gets **403 Forbidden** (bot detection) |
+| Price format | Mix of pipe tables (silver) and prose tables (gold) |
+| Extraction | `firstTableRowFirstPrice()` → `jmPriceFromProseTable()` → `asLowAsPrices()` |
+| Sets | `SLOW_PROVIDERS`, `FRACTIONAL_EXEMPT_PROVIDERS` |
+
+**Critical quirks:**
+
+1. **Bot detection on headless Chromium**: JMBullion returns HTTP 403 to raw Playwright. The Firecrawl Playwright Service (port 3003) has stealth patches that bypass this. Always use Firecrawl Phase 1, never skip to raw Playwright.
+
+2. **Fractional nav links**: Mega-menu always includes "1/2 oz Gold Eagle", "1/4 oz Gold Eagle" links regardless of product page. Must be in `FRACTIONAL_EXEMPT_PROVIDERS` or fractional_weight detection fires on nav text.
+
+3. **Prose pricing table (gold pages)**: Gold product pages render pricing as plain text, not markdown pipe tables:
+   ```
+   (e)Check/Wire
+   1-9
+   $5,446.39
+   ```
+   Handled by `jmPriceFromProseTable()`. Silver pages use standard pipe tables.
+
+4. **`onlyMainContent: false`**: JMBullion's React shell returns empty markdown with `onlyMainContent: true`. Disabled specifically for this vendor (line 448).
+
+5. **Preorder tolerance**: In `PREORDER_TOLERANT_PROVIDERS` — JMBullion marks some items as "Pre-Order" with valid purchasable prices. The `pre-?order` OOS pattern is skipped for this vendor.
+
+**If JMBullion starts failing**: Check that Firecrawl Phase 1 is running (not skipped by `PLAYWRIGHT_ONLY_PROVIDERS`). Check that `waitFor` is >= 8000ms. Check Playwright Service health: `curl http://localhost:3003/health`.
+
+---
+
+## Bullion Exchanges
+
+| Property | Value |
+|----------|-------|
+| Site tech | React / Magento SPA + Cloudflare |
+| Firecrawl | Requires `waitFor: 8000` (in `SLOW_PROVIDERS`) |
+| Playwright fallback | Raw `chromium.launch()` gets **Cloudflare challenge** (403) |
+| Price format | Prose (no pipe tables) — "As Low As $X.XX Over Spot" |
+| Extraction | `firstTableRowFirstPrice()` → `firstInRangePriceProse()` → `asLowAsPrices()` |
+| Sets | `SLOW_PROVIDERS`, `FRACTIONAL_EXEMPT_PROVIDERS` |
+
+**Critical quirks:**
+
+1. **Cloudflare bot detection**: Like JMBullion, raw headless Chromium is blocked. Must go through Firecrawl (which uses the Playwright Service with stealth). Never skip Firecrawl Phase 1.
+
+2. **SPA rendering**: Without `waitFor`, Firecrawl returns only a banner image (~40 bytes of markdown). Needs 6-8 seconds for React to mount and render pricing grid.
+
+3. **Fractional related products**: Product pages include a "Related Products" carousel with fractional variants ("1/2 oz Platinum American Eagle"). Must be in `FRACTIONAL_EXEMPT_PROVIDERS`.
+
+4. **Price format**: No pipe tables. Prices appear as prose: `$96.37` inline. Extracted by `firstInRangePriceProse()` — returns first dollar amount in the metal's expected range.
+
+5. **Legitimate OOS items**: Some items genuinely go out of stock (e.g., 1oz Platinum American Eagle as of 2026-02). Shows "Out Of Stock" + "NOTIFY ME" button. This is real, not a false positive.
+
+**If Bullion Exchanges starts failing**: Check Firecrawl Phase 1 is running. Check `waitFor >= 8000`. Verify Cloudflare isn't blocking the Playwright Service IP (check `curl http://localhost:3003/health`).
+
+---
+
+## Monument Metals
+
+| Property | Value |
+|----------|-------|
+| Site tech | Full SPA (React Native Web / Magento) |
+| Firecrawl | Requires `waitFor: 8000` (in `SLOW_PROVIDERS`) |
+| Playwright fallback | Works on Fly.io (via proxy chain), **blocked on home poller** without proxy |
+| Price format | "As Low As $X.XX" — no pricing table |
+| Extraction | `firstTableRowFirstPrice()` → `firstInRangePriceProse()` → `asLowAsPrices()` |
+| Sets | `SLOW_PROVIDERS` |
+
+**Critical quirks:**
+
+1. **False OOS from review text**: Customer reviews on product pages contain casual "notify me" text (e.g., "notify me when you ship"). The broad `/notify\s+me/i` OOS pattern matched this — **removed in 2026-02-26 fix**. The specific `/notify me when available/i` pattern (line 122) still catches real "Notify Me When Available" buttons.
+
+2. **SPA mount delay**: React Native Web router doesn't mount until ~6-8 seconds. Without `waitFor`, Firecrawl gets the shell (nav bar, spot tickers) but no product content.
+
+3. **Proxy dependency for Playwright**: On Fly.io, direct Playwright gets 403. Falls back through proxy chain (`HOME_PROXY_URL_2` → Webshare). On home poller, raw Playwright also gets 403 with no proxy chain to fall back on. Fix: use Firecrawl Phase 1 (which routes through Playwright Service with stealth).
+
+4. **"As Low As" is bulk pricing**: Monument shows "As Low As" for 500+ unit purchases. The real 1-unit price is in a pipe table (`1-24` row, `eCheck/Wire` column). Extraction uses table-first strategy (updated 2026-02-21).
+
+---
+
+## Hero Bullion
+
+| Property | Value |
+|----------|-------|
+| Site tech | Next.js / React |
+| Firecrawl | Requires `waitFor: 8000` (in `SLOW_PROVIDERS`) |
+| Playwright fallback | Generally works |
+| Price format | Markdown pipe table |
+| Extraction | Standard table-first |
+| Sets | `SLOW_PROVIDERS` |
+
+**Known issues:**
+
+1. **Occasional OOS**: Some items (e.g., `ape` — American Platinum Eagle) go legitimately OOS. Verify via Chrome DevTools before investigating code.
+
+2. **Slow render**: Like JMBullion, needs 5-6s for price table to populate.
+
+---
+
+## SD Bullion
+
+| Property | Value |
+|----------|-------|
+| Site tech | Server-rendered with some JS |
+| Firecrawl | Works reliably |
+| Playwright fallback | Rarely needed |
+| Price format | Markdown pipe table |
+| Extraction | Standard table-first |
+
+**Known issues:**
+
+1. **Markdown cutoff needed**: Page includes "Add on Items" and "Customers Also Purchased" sections with prices from other products. `MARKDOWN_CUTOFF_PATTERNS` truncates markdown before these sections to prevent cross-contamination.
+
+---
+
+## Summit Metals
+
+| Property | Value |
+|----------|-------|
+| Site tech | Shopify |
+| Firecrawl | Requires `waitFor: 8000` (in `SLOW_PROVIDERS`) |
+| Price format | "Regular price $XX.XX" / "Sale price $XX.XX" |
+| Extraction | `regularPricePrices()` → `tablePrices()` |
+| Sets | `SLOW_PROVIDERS` |
+
+**Known issues:**
+
+1. **Shopify price format**: Uses "Regular price" / "Sale price" labels instead of tables or "As Low As". Dedicated `regularPricePrices()` extractor handles this.
+
+---
+
+## Goldback (goldback.com)
+
+| Property | Value |
+|----------|-------|
+| Site tech | Custom (exchange rate page) |
+| Firecrawl | Works but price is on a shared exchange-rate page |
+| Price format | Exchange rate table — not standard product page |
+| Extraction | Separate pipeline (`goldback-pipeline`) |
+
+**Known issues:**
+
+1. **Single URL for all denominations**: All goldback coins (G1, G2, G5, G10, G25, G50) use the same URL (`/exchange-rate/`). Price extraction must parse the correct denomination row.
+
+2. **Separate pipeline**: Goldback prices are handled by the dedicated goldback pipeline, not the retail poller. Failures here are separate from the main failure queue.
+
+---
+
+## Debugging Playbook
+
+### Vendor shows `price_not_found`
+
+1. **Check the URL**: Open it in Chrome DevTools — is the product actually there? Does it show a price?
+2. **Check Firecrawl output**: `curl -s http://localhost:3002/v1/scrape -H 'Content-Type: application/json' -d '{"url":"<URL>","formats":["markdown"],"waitFor":8000}'` — is the markdown complete or truncated?
+3. **Check price range**: Is the price within `METAL_PRICE_RANGE_PER_OZ[metal] * weight_oz`?
+   - Silver: $40–$200/oz
+   - Gold: $1,500–$15,000/oz
+   - Platinum: $500–$6,000/oz
+4. **Check extraction strategy**: Which `extractPrice()` path does this vendor take? Table-first, prose, or "As Low As"?
+
+### Vendor shows OOS but page is in stock
+
+1. **Check `OUT_OF_STOCK_PATTERNS`**: Which pattern matched? Run the page markdown through each regex.
+2. **Check review/footer text**: Customer reviews and footer text can contain OOS keywords casually.
+3. **Check `PREORDER_TOLERANT_PROVIDERS`**: Is "Pre-Order" being treated as OOS for a vendor that sells preorders?
+
+### Playwright Phase 2 gets 403
+
+1. **Check if Firecrawl Phase 1 ran**: Is the vendor in `PLAYWRIGHT_ONLY_PROVIDERS`? It shouldn't be — all vendors should go through Firecrawl first.
+2. **Check Playwright Service**: `curl http://localhost:3003/health` — the Playwright Service has stealth; raw `chromium.launch()` does not.
+3. **Check proxy chain**: `WEBSHARE_PROXY_USER` set? `HOME_PROXY_URL_2` set? Both empty = no fallback.
+
+### Total count drops unexpectedly
+
+1. **Check provider database**: `SELECT count(*) FROM provider_vendors WHERE enabled=1` — did someone disable items?
+2. **Check dashboard Failure Queue**: Items with 3+ failures get flagged.
+3. **Check for container restarts**: `fly logs --app staktrakr | grep -i restart` — Fly.io may have restarted.
+
+---
+
+## Configuration Reference
+
+| Set | Purpose | Current members |
+|-----|---------|-----------------|
+| `SLOW_PROVIDERS` | `waitFor: 8000` for Firecrawl | jmbullion, herobullion, monumentmetals, summitmetals, bullionexchanges |
+| `PLAYWRIGHT_ONLY_PROVIDERS` | Skip Firecrawl Phase 1 | **Empty** (as of 2026-02-26) |
+| `PREORDER_TOLERANT_PROVIDERS` | Skip `pre-?order` OOS pattern | jmbullion |
+| `FRACTIONAL_EXEMPT_PROVIDERS` | Skip fractional weight check | jmbullion, bullionexchanges |
+| `MARKDOWN_CUTOFF_PATTERNS` | Truncate markdown before noise | sdbullion, jmbullion |
+| `MARKDOWN_HEADER_SKIP_PATTERNS` | Skip misleading headers | jmbullion |
+
+## Incident Log
+
+| Date | Issue | Root cause | Fix |
+|------|-------|-----------|-----|
+| 2026-02-26 | Monument Metals all OOS on home | `/notify\s+me/i` matched review text | Removed broad pattern; specific `/notify me when available/i` suffices |
+| 2026-02-26 | JMBullion/BE `price_not_found` on home | `PLAYWRIGHT_ONLY_PROVIDERS` skipped Firecrawl → raw Playwright 403'd | Emptied set; all vendors use Firecrawl Phase 1 now |
+| 2026-02-26 | Home poller 11/47 failures | Combination of above two issues | Both fixes deployed |
+| 2026-02-26 | API poller orphaned at 22:10 | Process crash (600ms+ latency spike) | Self-recovered on next cron |


### PR DESCRIPTION
## Summary

- Migrates all 29 wiki pages from the separate `StakTrakrWiki` repo into `wiki/` subfolder
- Adds Docsify for web-browsable rendering at `staktrakr.pages.dev/wiki/`
- Adds YAML frontmatter to every page for automated change detection
- Adds `sw.js` `/wiki/` path exclusion so service worker doesn't hijack Docsify routes
- Rewrites 4 project-level wiki skills for in-repo operations (no cross-repo PRs)
- Updates all instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, copilot-instructions.md)

## What changed

| Area | Files | Description |
|------|-------|-------------|
| Wiki content | 29 `.md` files + `index.html` + `.nojekyll` | Full wiki migrated with YAML frontmatter |
| Service worker | `sw.js` | Added `/wiki/` path exclusion |
| Skills | 4 `SKILL.md` files | Rewritten for in-repo wiki |
| Instructions | CLAUDE.md, AGENTS.md, GEMINI.md, copilot-instructions.md | Updated wiki references |

## YAML frontmatter schema

```yaml
---
title: Page Title
category: frontend | infrastructure | meta
owner: staktrakr | staktrakr-api | shared
lastUpdated: v3.33.18
date: 2026-03-01
sourceFiles:
  - js/constants.js
relatedPages:
  - data-model.md
---
```

## Also created (not in this PR)

- 3 user-level universal wiki skills: `wiki-update`, `wiki-search`, `wiki-init`
- Updated global `~/.claude/CLAUDE.md` (removed StakTrakrWiki references)

## Test plan

- [ ] Verify `staktrakr.pages.dev/wiki/` loads Docsify with dark theme + gold accent
- [ ] Verify all sidebar links resolve correctly
- [ ] Verify Docsify search works across all pages
- [ ] Verify YAML frontmatter is NOT visible in rendered pages (stripped by plugin)
- [ ] Verify main app at `staktrakr.pages.dev` still works (sw.js exclusion)
- [ ] Run `/wiki-audit` to validate frontmatter and content accuracy

Closes STAK-390

🤖 Generated with [Claude Code](https://claude.com/claude-code)