### PR TITLE
📝 Scribe: Remove unused migration_seedHistoryMerge storage key

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -764,7 +764,6 @@ const ALLOWED_STORAGE_KEYS = [
   LATEST_REMOTE_URL_KEY,      // string: cached latest remote release URL (STACK-67)
   "ff_migration_fuzzy_autocomplete", // one-time migration flag (v3.26.01)
   "migration_hourlySource",          // one-time migration flag: re-tag StakTrakr hourly entries
-  "migration_seedHistoryMerge",      // one-time migration flag: backfill full historical seed data (v3.32.01)
   "numistaLookupRules",              // custom Numista search lookup rules (JSON array)
   "numistaViewFields",               // view modal Numista field visibility config (JSON object)
   TIMEZONE_KEY,                        // string: "auto" | "UTC" | IANA zone (STACK-63)


### PR DESCRIPTION
💡 **What:** Scribe is safely removing an unused storage key, `migration_seedHistoryMerge`, from `ALLOWED_STORAGE_KEYS` inside `js/constants.js`.

🔍 **Evidence:**
```bash
$ grep -rn "migration_seedHistoryMerge" .
./js/constants.js:767:  "migration_seedHistoryMerge",      // one-time migration flag: backfill full historical seed data (v3.32.01)
```

📁 **Files changed:**
- `js/constants.js`

✅ **Verified:**
- Confirmed zero remaining references after removal.
- Requested explicit user confirmation prior to removal because the key name included the protected word "History", per boundaries instructions.

---
*PR created automatically by Jules for task [15919107862099437851](https://jules.google.com/task/15919107862099437851) started by @lbruton*