### PR TITLE
fix: nightwatch workflow — id-token + allowed_tools

### DIFF
--- a/.github/workflows/wiki-nightwatch.yml
+++ b/.github/workflows/wiki-nightwatch.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   nightwatch:
@@ -142,4 +143,4 @@ jobs:
             - Make minimal corrections — fix the specific claim, don't refactor.
             - Always include file:line evidence in the PR body.
             - Draft PRs only — human reviews before merge.
-          allowed_tools: "Read,Grep,Glob,Edit,Write,Bash(git config:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status),Bash(gh pr create:*),Bash(wc *),Bash(grep -c:*),Bash(date *)"
+          claude_args: '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(git config:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status),Bash(gh pr create:*),Bash(wc *),Bash(grep -c:*),Bash(date *)"'


### PR DESCRIPTION
## Summary

- Added `id-token: write` permission (required for OAuth OIDC token flow)
- Moved `allowed_tools` from invalid `with:` input to `claude_args: '--allowed-tools ...'` (v1 action format)

First run failed with: `Could not fetch an OIDC token` + `Unexpected input 'allowed_tools'`

## Test plan

- [ ] Merge → trigger `workflow_dispatch` → verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)