### PR TITLE
docs: update goldback cron from daily to hourly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Three feeds served from `lbruton/StakTrakrApi` main branch via GitHub Pages at `
 |---|---|---|---|---|
 | Market prices | `data/api/manifest.json` | Fly.io retail cron (StakTrakrApi) | 30 min | `generated_at` within 30 min |
 | Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` cron (StakTrakrApi) | 75 min | Last hourly file within 75 min |
-| Goldback | `data/api/goldback-spot.json` | Fly.io goldback cron (StakTrakrApi) | 25h | `scraped_at` within 25h |
+| Goldback | `data/api/goldback-spot.json` | Fly.io `run-goldback.sh` hourly :01 (StakTrakrApi) | 25h | `scraped_at` within 25h |
 
 **Critical:** `spot-history-YYYY.json` is a **seed file** (noon UTC daily), NOT live data. `api-health.js` currently checks it for spot freshness — always shows ~10h stale even when poller is healthy. Open bug (STAK-265 follow-up).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Works on `file://` and HTTP. Runtime artifact: zero build step, zero install. Se
 
 **Runbook:** See wiki/ for current runbooks: [`health.md`](wiki/health.md), [`fly-container.md`](wiki/fly-container.md), [`spot-pipeline.md`](wiki/spot-pipeline.md). (`docs/devops/api-infrastructure-runbook.md` is deprecated.)
 
-Three feeds served from `lbruton/StakTrakrApi` main branch via GitHub Pages at `api.staktrakr.com`:
+Three feeds served from `lbruton/StakTrakrApi` **api branch** via GitHub Pages at `api.staktrakr.com`:
 
 | Feed | File | Poller | Stale threshold | Healthy check |
 |---|---|---|---|---|

--- a/wiki/api-consumption.md
+++ b/wiki/api-consumption.md
@@ -112,7 +112,7 @@ One file per 15-minute UTC slot. Used by `fetchStaktrakr15minRange()`. Entry `so
 | URL | `https://api.staktrakr.com/data/api/goldback-spot.json` |
 | Freshness field | `scraped_at` (ISO 8601 UTC) |
 | Stale threshold | 25 hours |
-| Poller | Fly.io goldback cron in `StakTrakrApi` (daily scrape) |
+| Poller | Fly.io `run-goldback.sh` cron in `StakTrakrApi` (hourly :01, skips if today's price exists) |
 
 Goldback is an informational feed. The Health modal shows its age but does not include it in the primary/backup verdict.
 

--- a/wiki/goldback-pipeline.md
+++ b/wiki/goldback-pipeline.md
@@ -27,7 +27,7 @@ Goldback pricing flows through **two paths**:
 
 2. **Denomination spot JSON** — `api-export.js` generates `data/api/goldback-spot.json` with denomination prices computed from the G1 vendor rate (`G1 × multiplier`).
 
-There is **no separate goldback cron** — the legacy `run-goldback.sh` / `goldback-scraper.js` are not wired into any cron schedule.
+A separate **goldback cron** (`run-goldback.sh`) runs hourly at :01 to scrape the official G1 exchange rate from `goldback.com/exchange-rates/` via Firecrawl. It writes `goldback-spot.json` and `goldback-YYYY.json`, then skips subsequent runs if today's price is already captured.
 
 ---
 
@@ -169,9 +169,9 @@ See [rest-api-reference.md](rest-api-reference.md) for full endpoint schemas.
 
 ---
 
-## Legacy Files (do not use)
+## Standalone Goldback Scraper (hourly cron)
 
-`run-goldback.sh` and `goldback-scraper.js` exist on the container but are **not wired into any cron**. The daily goldback cron was removed from `docker-entrypoint.sh` in commit `21db95d`. The standalone `goldback-scraper.js` scraped `goldback.com/exchange-rate/` via Firecrawl and wrote directly to `goldback-spot.json` and `goldback-YYYY.json` — this is now handled by the retail pipeline + `api-export.js`.
+`run-goldback.sh` and `goldback-scraper.js` are active on the container, running hourly at :01 via cron. The script scrapes `goldback.com/exchange-rates/` via Firecrawl and writes directly to `goldback-spot.json` and `goldback-YYYY.json`. An early-exit check skips the Firecrawl scrape if today's price already exists. The retail pipeline also scrapes per-state goldback vendor prices independently.
 
 ---
 

--- a/wiki/goldback-pipeline.md
+++ b/wiki/goldback-pipeline.md
@@ -25,7 +25,7 @@ Goldback pricing flows through **two paths**:
 
 1. **Retail pipeline** — Per-state Goldback coins (`goldback-{state}-g{denom}`) are tracked in `providers.json`, scraped from vendor product pages via `run-local.sh` cron → Turso → `api-export.js` → per-coin JSON endpoints.
 
-2. **Denomination spot JSON** — `api-export.js` generates `data/api/goldback-spot.json` with denomination prices computed from the G1 vendor rate (`G1 × multiplier`).
+2. **Denomination spot JSON** — `goldback-scraper.js` (invoked by `run-goldback.sh`) scrapes the official G1 rate from `goldback.com/exchange-rates/` and writes `data/api/goldback-spot.json` with the G1 USD price and denomination multipliers. `api-export.js` does not write this file.
 
 A separate **goldback cron** (`run-goldback.sh`) runs hourly at :01 to scrape the official G1 exchange rate from `goldback.com/exchange-rates/` via Firecrawl. It writes `goldback-spot.json` and `goldback-YYYY.json`, then skips subsequent runs if today's price is already captured.
 
@@ -181,7 +181,7 @@ See [rest-api-reference.md](rest-api-reference.md) for full endpoint schemas.
 |---------|-------------|-----|
 | `goldback-spot.json` > 25h stale | `goldback-g1` scrape failing or goldback.com down | Check `fly logs --app staktrakr \| grep goldback` |
 | G1 price null in manifest | Firecrawl timeout on JS-rendered page | goldback.com is in `SLOW_PROVIDERS` — verify `waitFor` is sufficient |
-| Denomination prices wrong | G1 base rate incorrect | Check Turso `goldback-g1` rows; compare to goldback.com/exchange-rate/ |
+| Denomination prices wrong | G1 base rate incorrect | Check Turso `goldback-g1` rows; compare to goldback.com/exchange-rates/ |
 | Per-denomination retail prices differ from computed spot | Normal — retail vendor prices ≠ official exchange rate | `goldback-spot.json` uses vendor G1 rate × multiplier; individual `goldback-gN` endpoints track actual retail prices |
 
 ---

--- a/wiki/rest-api-reference.md
+++ b/wiki/rest-api-reference.md
@@ -216,7 +216,7 @@ All endpoints are static JSON files served via GitHub Pages from the `api` branc
 | Endpoint | Description | Updated |
 |----------|-------------|---------|
 | `data/api/goldback-spot.json` | G1 USD rate + all denomination multipliers | Every 15 min (from Turso) |
-| `data/goldback-YYYY.json` | Rolling annual history log (newest first) | Daily (legacy scraper) |
+| `data/goldback-YYYY.json` | Rolling annual history log (newest first) | Hourly :01 (skips if today's entry exists) |
 
 ### Legacy (deprecated — backward compat)
 

--- a/wiki/rest-api-reference.md
+++ b/wiki/rest-api-reference.md
@@ -215,7 +215,7 @@ All endpoints are static JSON files served via GitHub Pages from the `api` branc
 
 | Endpoint | Description | Updated |
 |----------|-------------|---------|
-| `data/api/goldback-spot.json` | G1 USD rate + all denomination multipliers | Every 15 min (from Turso) |
+| `data/api/goldback-spot.json` | G1 USD rate + all denomination multipliers | Hourly :01 (skips if today's entry exists) |
 | `data/goldback-YYYY.json` | Rolling annual history log (newest first) | Hourly :01 (skips if today's entry exists) |
 
 ### Legacy (deprecated — backward compat)


### PR DESCRIPTION
## Summary

- Updated CLAUDE.md and 4 wiki pages to reflect goldback cron change from daily 17:01 UTC to hourly :01 with early-exit
- Fixed incorrect wiki claims that goldback cron was removed — it is active and running
- Pages updated: `CLAUDE.md`, `wiki/fly-container.md`, `wiki/goldback-pipeline.md`, `wiki/api-consumption.md`, `wiki/rest-api-reference.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)