### PR TITLE
Update nightwatch log with wiki inaccuracy

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 5,
+  "nextIndex": 6,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -27,6 +27,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "MARKET_LIST_VIEW feature flag default listed as false but is enabled: true in js/constants.js:1317; description also diverged",
+      "verified": []
+    },
+    {
+      "date": "2026-03-01",
+      "page": "release-workflow.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "Wiki claims lock format is {\"locked\": ...}, but devops/version-lock-protocol.md shows it is an array of claims: {\"claims\": [ ... ]}.",
       "verified": []
     }
   ]


### PR DESCRIPTION
Updated the wiki `.nightwatch-log.json` to report an inaccuracy found in `release-workflow.md` regarding the JSON format of the `devops/version.lock` file. Incrementally updated `nextIndex` to progress the wiki page rotation.

---
*PR created automatically by Jules for task [9308770565048167167](https://jules.google.com/task/9308770565048167167) started by @lbruton*