### PR TITLE
docs(wiki): fix ~85 inaccuracies across 27 pages (STAK-392)

### DIFF
--- a/wiki/CHANGELOG.md
+++ b/wiki/CHANGELOG.md
@@ -2,13 +2,13 @@
 title: "Changelog"
 category: meta
 owner: shared
-lastUpdated: v3.33.18
+lastUpdated: v3.33.19
 date: 2026-03-01
 sourceFiles: []
 relatedPages: []
 ---
 
-# StakTrakrWiki Changelog
+# Wiki Changelog
 
 Running log of structural wiki updates. Not a code changelog — tracks when wiki content was added, reorganized, or policy was updated.
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -16,8 +16,10 @@ This wiki is the **shared source of truth** between two independent Claude agent
 
 | Agent | Repo | Owns |
 |-------|------|------|
-| StakTrakrApi Claude | `lbruton/StakTrakrApi` | Poller source code, GHA workflows, data pipeline |
-| StakScraper Claude | `lbruton/stakscrapr` | Home poller env config, Ubuntu-specific setup |
+| StakTrakrApi Claude | `lbruton/StakTrakrApi` | Poller source code, GHA workflows, data pipeline, home poller setup (`devops/home-scraper/`) |
+| StakTrakr Claude Code | `lbruton/StakTrakr` | Frontend app, service worker, wiki maintenance |
+
+> **Note:** Home poller environment config and setup scripts (`setup-lxc.sh`, `run-home.sh`) are committed in `StakTrakrApi/devops/home-scraper/`. The legacy `lbruton/stakscrapr` repo is no longer the canonical source.
 
 Both agents can read and write this wiki. When behavior diverges between Fly.io and the home poller (intentionally or by drift), it should be documented here so either agent can identify it, reconcile it, or propose it upstream.
 
@@ -42,7 +44,10 @@ Pages covering the API backend, data pipelines, and operational runbooks. Mainta
 | [Cron Schedule](cron-schedule.md) | Full timeline view, design rationale |
 | [providers.json](providers.md) | URL strategy, year-start patterns, update process |
 | [Secrets & Keys](secrets.md) | Where every secret lives, how to rotate |
+| [Provider Database](provider-database.md) | Turso provider tables, vendor management, coverage stats |
 | [Health & Diagnostics](health.md) | Quick health checks, stale thresholds, diagnosis commands |
+| [Poller Parity](poller-parity.md) | Fly vs home poller comparison, schedule differences, drift tracking |
+| [Vendor Quirks](vendor-quirks.md) | Per-vendor scraping workarounds, selector overrides, known issues |
 
 ---
 
@@ -78,10 +83,10 @@ Pages covering the StakTrakr single-page app — architecture, patterns, and wor
 ### Update Policy
 
 - Every code change in StakTrakr or StakTrakrApi that affects documented behavior must include a wiki update in the same PR
-- Use `claude-context` to search before writing (avoid duplication): `mcp__claude-context__search_code` with `path: /Volumes/DATA/GitHub/StakTrakrWiki`
+- Use `claude-context` to search before writing (avoid duplication): `mcp__claude-context__search_code` with `path: /Volumes/DATA/GitHub/StakTrakr/wiki`
 - If uncertain about accuracy, add `> ⚠️ NEEDS VERIFICATION` rather than omitting content
 - Add a one-line entry to `CHANGELOG.md` in this repo for each structural change
-- Re-index the wiki after major updates: `mcp__claude-context__index_codebase` with `path: /Volumes/DATA/GitHub/StakTrakrWiki` and `force: true`
+- Re-index the wiki after major updates: `mcp__claude-context__index_codebase` with `path: /Volumes/DATA/GitHub/StakTrakr/wiki` and `force: true`
 
 ### Documenting drift between pollers
 

--- a/wiki/_sidebar.md
+++ b/wiki/_sidebar.md
@@ -23,6 +23,8 @@
   - [Storage Patterns](storage-patterns.md)
   - [DOM Patterns](dom-patterns.md)
   - [Cloud Sync](sync-cloud.md)
+  - [Image Pipeline](image-pipeline.md)
+  - [Backup & Restore](backup-restore.md)
   - [Retail Modal](retail-modal.md)
   - [API Consumption](api-consumption.md)
   - [Release Workflow](release-workflow.md)

--- a/wiki/api-consumption.md
+++ b/wiki/api-consumption.md
@@ -2,8 +2,8 @@
 title: API Consumption
 category: frontend
 owner: staktrakr
-lastUpdated: v3.32.25
-date: 2026-02-23
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles:
   - js/api.js
   - js/api-health.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # API Consumption
 
-> **Last updated:** v3.32.25 — 2026-02-23
+> **Last updated:** v3.33.19 — 2026-03-01
 > **Source files:** `js/api.js`, `js/api-health.js`, `js/constants.js`
 
 ## Overview
@@ -28,7 +28,7 @@ Requests use an automatic dual-endpoint fallback: if the primary endpoint does n
 ## Key Rules (read before touching this area)
 
 - **StakTrakr = consumer only.** Never add poller scripts, Fly.io config, or data-pipeline workflows to this repo. Those belong in `lbruton/StakTrakrApi`.
-- **`spot-history-YYYY.json` is a seed file**, not live data. It is a noon-UTC daily snapshot. `api-health.js` currently checks it for spot freshness, so it always shows ~10 h stale even when the poller is healthy. This is a known issue (STAK-265 follow-up).
+- **`spot-history-YYYY.json` is a seed file**, not live data. It is a noon-UTC daily snapshot used for historical chart backfill. A previous version of `api-health.js` checked this file for spot freshness, which always showed ~10 h stale even when the poller was healthy (STAK-265). This was fixed — `api-health.js` now reads the live hourly feed files (`data/hourly/YYYY/MM/DD/HH.json`) for spot freshness.
 - **Fallback is automatic.** Do not add manual endpoint-switching logic — `_staktrakrFetch()` already handles it via `AbortController` with a 5 000 ms timeout.
 - **Stale thresholds are defined as constants** in `api-health.js` (`API_HEALTH_MARKET_STALE_MIN`, `API_HEALTH_SPOT_STALE_MIN`, `API_HEALTH_GOLDBACK_STALE_MIN`). Update those constants — never hardcode values elsewhere.
 
@@ -76,7 +76,7 @@ const _staktrakrFetch = async (baseUrls, path) => {
 | Stale threshold | 30 minutes |
 | Poller | Fly.io retail cron in `StakTrakrApi` (hourly at :00, home poller at :30) |
 
-Contains retail and market prices for all tracked metals. Consumed via `API_PROVIDERS.STAKTRAKR.parseBatchResponse()`.
+Contains retail and market prices for all tracked metals. Consumed by the retail sync pipeline (`retail.js`) and the health check module (`api-health.js`). Note: `API_PROVIDERS.STAKTRAKR.parseBatchResponse()` is for parsing spot batch payloads from hourly/15-minute feeds, not the retail manifest.
 
 ### 2. Hourly spot prices
 

--- a/wiki/architecture-overview.md
+++ b/wiki/architecture-overview.md
@@ -75,7 +75,7 @@ relatedPages: []
 | `lbruton/StakTrakrApi` | All API backend: poller code (`devops/`), GHA workflows, data files served via GitHub Pages |
 | `lbruton/StakTrakr` | Frontend app code, Cloudflare Pages deployment, local dev tools |
 | `lbruton/stakscrapr` | Home VM full stack — identical Firecrawl+Playwright+scraper core PLUS dashboard.js, tinyproxy/Cox residential proxy, Tailscale exit node config |
-| `lbruton/StakTrakrWiki` | This wiki — shared infrastructure documentation |
+| `StakTrakr/wiki/` | This wiki — in-repo Docsify documentation (shared infrastructure + frontend) |
 
 ---
 

--- a/wiki/architecture-overview.md
+++ b/wiki/architecture-overview.md
@@ -2,7 +2,7 @@
 title: Architecture Overview
 category: infrastructure
 owner: staktrakr-api
-lastUpdated: v3.33.18
+lastUpdated: v3.33.19
 date: 2026-02-25
 sourceFiles: []
 relatedPages: []
@@ -10,8 +10,7 @@ relatedPages: []
 
 # Architecture Overview
 
-> **Last verified:** 2026-02-25 — full audit from live Fly.io container source code. Dual poller, Turso shared DB, 17 coins, 7 vendors.
-> ⚠️ **Known gaps:** Spot poller not writing to Turso. See STAK-331.
+> **Last verified:** 2026-03-01 — full audit from live Fly.io container source code. Dual poller, Turso shared DB, 11 coins, 7 vendors.
 
 ---
 
@@ -23,9 +22,9 @@ relatedPages: []
 │                                                             │
 │  ┌─────────────┐  ┌──────────────┐                          │
 │  │ run-local.sh│  │ run-spot.sh  │                          │
-│  │ 0 * * * *   │  │ 5,20,35,50   │                          │
+│  │ 15,45 * * * │  │ 0,30 * * * * │                          │
 │  └──────┬──────┘  └──────┬───────┘                          │
-│         │                │ ⚠️ writes files directly          │
+│         │                │ → Turso spot_prices + JSON files  │
 │  ┌──────▼──────────────────────────────────────────────┐   │
 │  │  Self-hosted Firecrawl (port 3002)                   │   │
 │  │  Playwright Service (port 3003)                      │   │
@@ -34,7 +33,7 @@ relatedPages: []
 │                                                             │
 │  ┌──────────────┐                                           │
 │  │run-publish.sh│  8,23,38,53 * * * *                      │
-│  │api-export.js │◄── Turso (price_snapshots + goldback-g1)  │
+│  │api-export.js │◄── Turso (price_snapshots + spot_prices)  │
 │  └──────┬───────┘                                           │
 │         │ force-push HEAD:api                               │
 └─────────┼───────────────────────────────────────────────────┘
@@ -53,16 +52,12 @@ relatedPages: []
           ▼
   Turso (libSQL cloud)
   price_snapshots  — retail prices (both pollers)
+  spot_prices      — spot prices (Fly.io spot poller)
   poller_runs      — run metadata (both pollers)
   provider_failures — per-URL failure log (both pollers)
-  ⚠️ spot_prices NOT yet in Turso (pending STAK-331)
           │
           ▼ (via run-publish.sh)
   StakTrakrApi  api  branch
-          │
-          │  Merge Poller Branches GHA (*/15 min)
-          ▼
-  StakTrakrApi  main  branch
           │
           ▼
   GitHub Pages → api.staktrakr.com
@@ -88,9 +83,9 @@ relatedPages: []
 
 | Feed | File | Writer | Cadence | Status |
 |------|------|--------|---------|--------|
-| Market prices | `data/api/manifest.json` | Fly.io `run-local.sh` + `run-publish.sh` via Turso | `0 * * * *` | ✅ Live |
-| Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` → **direct file write** | `5,20,35,50 * * * *` | ⚠️ Not via Turso — see STAK-331 |
-| Goldback | `data/api/goldback-spot.json` | Fly.io `run-local.sh` (via `goldback-g1` in providers.json) + `api-export.js` generates denominations (G1–G50) from Turso | `0 * * * *` (same as retail) | ✅ Live |
+| Market prices | `data/api/manifest.json` | Fly.io `run-local.sh` + `run-publish.sh` via Turso | `15,45 * * * *` | ✅ Live |
+| Spot prices | `data/hourly/YYYY/MM/DD/HH.json` | Fly.io `run-spot.sh` → `spot-extract.js` → Turso `spot_prices` + JSON files | `0,30 * * * *` | ✅ Live |
+| Goldback | `data/api/goldback-spot.json` | Fly.io `run-goldback.sh` → `goldback-scraper.js` → direct commit to `api` branch | `1 * * * *` (hourly, skips if today's rate captured) | ✅ Live |
 
 ---
 
@@ -98,11 +93,11 @@ relatedPages: []
 
 | Branch | Purpose | Writer |
 |--------|---------|--------|
-| `api` | Live data + providers.json config | Fly.io `run-publish.sh` (force-push) |
-| `main` | Merged source of truth; served by GitHub Pages | `Merge Poller Branches` GHA workflow |
+| `api` | Live data + providers.json config; served by GitHub Pages | Fly.io `run-publish.sh` (force-push) |
+| `main` | Devops code, poller source, GHA workflows | Manual pushes + PRs |
 | `api1` | (Reserved for second Fly.io poller if needed) | Not currently active |
 
-GitHub Pages is configured to serve the **`main` branch** (not `api`). The merge workflow runs every 15 minutes to pull `api` data into `main`.
+GitHub Pages is configured to serve the **`api` branch**. The `Merge Poller Branches` GHA workflow is retired/manual-only.
 
 ---
 
@@ -111,7 +106,7 @@ GitHub Pages is configured to serve the **`main` branch** (not `api`). The merge
 | Component | What it is | Where |
 |-----------|-----------|-------|
 | Fly.io `staktrakr` app | All-in-one container: Firecrawl + pollers + serve.js | cloud |
-| Turso `staktrakrapi` DB | libSQL cloud — dual-poller write-through store (retail only currently) | cloud |
+| Turso `staktrakrapi` DB | libSQL cloud — dual-poller write-through store (retail + spot) | cloud |
 | Home VM | Secondary poller + monitoring stack (Grafana, Prometheus) | 192.168.1.81 |
 | tinyproxy | Residential HTTP proxy on home VM for Fly.io scraper traffic | 192.168.1.81:8888 |
 | MetalPriceAPI | Spot price data source | cloud |
@@ -125,19 +120,18 @@ GitHub Pages is configured to serve the **`main` branch** (not `api`). The merge
 | Change type | Action needed |
 |-------------|--------------|
 | Poller code change | `git push origin main` + `fly deploy` from `devops/fly-poller/` |
-| providers.json URL fix | Push to `api` branch — auto-synced next cycle, no redeploy |
+| Provider URL fix | Update directly in Turso via `provider-db.js` or the dashboard — auto-synced next cycle, no redeploy |
 | Home poller code update | curl files from `raw.githubusercontent.com/lbruton/StakTrakrApi/main/devops/fly-poller/` |
 | New Fly.io secret | `fly secrets set KEY=value --app staktrakr` |
 | GHA workflow change | Push to `main` branch — GHA reads from main |
 
 ---
 
-## Open Architecture Gaps (STAK-331 — Urgent)
+## Resolved Architecture Gaps
 
-| Gap | Impact |
-|-----|--------|
-| Spot poller writes files, not Turso | Turso not single source of truth for spot data |
-| Turso missing weeks of historical data | Backfill script needed before charts/trends are usable |
+| Gap | Resolution |
+|-----|------------|
+| ~~Spot poller writes files, not Turso~~ (STAK-331) | Resolved — `spot-extract.js` now writes to Turso `spot_prices` table and JSON files |
 
 ---
 

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -26,7 +26,7 @@ StakTrakr tracks precious metals inventory using three value dimensions per item
 
 1. **`meltValue` is never stored.** It is always computed at render time: `meltValue = weightOz * item.qty * spotPrice * purity` (where `weightOz` converts Goldback `gb` units via `weight * GB_TO_OZT`, and `purity` defaults to `1.0`). Storing it would produce stale values.
 2. **Every localStorage key must be registered in `ALLOWED_STORAGE_KEYS`** (`js/constants.js`) before use. `ALLOWED_STORAGE_KEYS` is a cleanup/restore allowlist enforced by `cleanupStorage()` at startup — it is not a write-time guard inside `saveData()` or `saveDataSync()`. Unregistered keys are silently deleted on the next app startup.
-3. **`saveData` / `loadData` are the only permitted localStorage accessors.** Never call `localStorage.setItem` / `getItem` directly in application code.
+3. **`saveData` / `loadData` are the standard localStorage accessors for JSON-serialized data.** Raw `localStorage.getItem` / `setItem` is intentional for plain scalar string preferences (e.g., `cloud_kraken_seen`, `CLOUD_VAULT_IDLE_TIMEOUT_KEY`) where async JSON serialization is inappropriate.
 4. **`spotPrices` is runtime state, not stored state.** It is fetched from the API and held in the `spotPrices` variable (defined in `js/state.js`, one property per metal). It is not written to the inventory object.
 5. **`disposition` is stored on the item record.** When an item is disposed (sold/traded/lost/gifted/returned), a `disposition` object is written to the item. The `realizedGainLoss` is computed once at disposition time and stored — it is not re-derived at render.
 

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -2,7 +2,7 @@
 title: Data Model
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.18
+lastUpdated: v3.33.19
 date: 2026-03-01
 sourceFiles:
   - js/constants.js
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Data Model
 
-> **Last updated:** v3.33.18 — 2026-03-01
+> **Last updated:** v3.33.19 — 2026-03-01
 > **Source files:** `js/constants.js`, `js/utils.js`
 
 ## Overview
@@ -24,10 +24,10 @@ StakTrakr tracks precious metals inventory using three value dimensions per item
 
 ## Key Rules (read before touching this area)
 
-1. **`meltValue` is never stored.** It is always computed at render time: `meltValue = item.weight * item.qty * spotPrice`. Storing it would produce stale values.
-2. **Every localStorage key must be registered in `ALLOWED_STORAGE_KEYS`** (`js/constants.js`) before use. `saveData()` and `saveDataSync()` silently no-op on unregistered keys — no error is thrown, data is simply discarded.
+1. **`meltValue` is never stored.** It is always computed at render time: `meltValue = weightOz * item.qty * spotPrice * purity` (where `weightOz` converts Goldback `gb` units via `weight * GB_TO_OZT`, and `purity` defaults to `1.0`). Storing it would produce stale values.
+2. **Every localStorage key must be registered in `ALLOWED_STORAGE_KEYS`** (`js/constants.js`) before use. `ALLOWED_STORAGE_KEYS` is a cleanup/restore allowlist enforced by `cleanupStorage()` at startup — it is not a write-time guard inside `saveData()` or `saveDataSync()`. Unregistered keys are silently deleted on the next app startup.
 3. **`saveData` / `loadData` are the only permitted localStorage accessors.** Never call `localStorage.setItem` / `getItem` directly in application code.
-4. **`spotPrice` is runtime state, not stored state.** It is fetched from the API and exposed as `window.spotPrice` (one property per metal). It is not written to the inventory object.
+4. **`spotPrices` is runtime state, not stored state.** It is fetched from the API and held in the `spotPrices` variable (defined in `js/state.js`, one property per metal). It is not written to the inventory object.
 5. **`disposition` is stored on the item record.** When an item is disposed (sold/traded/lost/gifted/returned), a `disposition` object is written to the item. The `realizedGainLoss` is computed once at disposition time and stored — it is not re-derived at render.
 
 ## Architecture
@@ -37,7 +37,7 @@ StakTrakr tracks precious metals inventory using three value dimensions per item
 | Dimension | Source | Stored? |
 |---|---|---|
 | `purchasePrice` | User entry | Yes (in item record) |
-| `meltValue` | `item.weight * item.qty * spotPrice` | **No — computed at render** |
+| `meltValue` | `weightOz * item.qty * spotPrice * purity` | **No — computed at render** |
 | `retailPrice` | Live market ask from API | No (cached separately in `retailPrices`) |
 
 `purchasePrice` is the historical cost basis — what the user actually paid. It never changes after entry.
@@ -50,19 +50,22 @@ StakTrakr tracks precious metals inventory using three value dimensions per item
 
 ```js
 {
-  id:            String,   // UUID v4 — primary key
+  uuid:          String,   // UUID v4 — primary key
   name:          String,   // display name, e.g. "2024 American Gold Eagle 1 oz"
   type:          String,   // "coin" | "bar" | "round"
   metal:         String,   // "gold" | "silver" | "platinum" | "palladium"
-  weight:        Number,   // fine troy ounces per unit
+  weight:        Number,   // fine troy ounces per unit (or Goldback denomination when weightUnit is 'gb')
+  weightUnit:    String,   // "oz" (default) | "gb" (Goldback denomination)
+  purity:        Number,   // metal purity factor (default 1.0)
   qty:           Number,   // integer quantity held
-  purchasePrice: Number,   // total cost basis in USD (all units combined)
+  price:         Number,   // total cost basis in USD (all units combined)
   purchaseDate:  String,   // ISO date string "YYYY-MM-DD"
   mintmark:      String,   // optional mint or issuer label
-  tags:          String[], // arbitrary user-defined labels
   disposition:   Object|null // disposition record (v3.33.17) — null for active items
 }
 ```
+
+> **Note:** Per-item tags are stored separately under the `itemTags` localStorage key (keyed by UUID), not on the inventory item object itself.
 
 `weight` is always in **fine troy ounces** (the pure metal content, not the gross weight). For a 1 oz Gold Eagle, `weight = 1.0`. For a 90% silver dime, `weight ≈ 0.07234`.
 
@@ -109,11 +112,11 @@ Types where `requiresAmount` is `false` do not require a monetary amount — the
 
 ```js
 // Reading spot at render time — never from a stored field:
-const spotPrice = window.spotPrice?.[item.metal] ?? 0;
-const meltValue = item.weight * item.qty * spotPrice;
+const spot = spotPrices?.[item.metal] ?? 0;
+const meltValue = computeMeltValue(item, spot);
 ```
 
-`window.spotPrice` is populated by the spot-price fetch in `api.js` and is not written to `localStorage` under the inventory key. Individual per-metal spot values are cached under `spotGold`, `spotSilver`, `spotPlatinum`, and `spotPalladium` (see key list below).
+`spotPrices` is defined in `js/state.js` and populated by the spot-price fetch in `js/api.js`. It is not written to `localStorage` under the inventory key. Individual per-metal spot values are cached under `spotGold`, `spotSilver`, `spotPlatinum`, and `spotPalladium` (see key list below).
 
 ### Storage Layer
 
@@ -170,6 +173,8 @@ All keys currently registered in `js/constants.js`. Keys are grouped by domain b
 | `retailIntradayData` | JSON object | Intraday retail price data |
 | `retailSyncLog` | JSON array | Retail sync event log |
 | `retailAvailability` | JSON object | Per-item availability data |
+| `retailManifestGeneratedAt` | String | ISO timestamp — cached market manifest `generated_at` |
+| `retailManifestSlugs` | JSON array | Cached manifest coin slug list |
 
 **Goldback:**
 
@@ -202,6 +207,7 @@ All keys currently registered in `js/constants.js`. Keys are grouped by domain b
 | `numistaOverridePersonal` | Boolean string | Numista API overrides user pattern images |
 | `enabledSeedRules` | JSON array | Enabled built-in Numista lookup rule IDs |
 | `seedImagesVer` | String | Seed images version for cache invalidation |
+| `numista_tags_auto` | Boolean string | Auto-tag items from Numista data |
 
 **UI / display preferences:**
 
@@ -227,6 +233,14 @@ All keys currently registered in `js/constants.js`. Keys are grouped by domain b
 | `headerTrendBtnVisible` | Boolean string | Header trend button visibility |
 | `headerSyncBtnVisible` | Boolean string | Header sync button visibility |
 | `headerMarketBtnVisible` | Boolean string | Header market button visibility |
+| `headerVaultBtnVisible` | Boolean string | Header vault button visibility |
+| `headerRestoreBtnVisible` | Boolean string | Header restore button visibility |
+| `headerCloudSyncBtnVisible` | Boolean string | Header cloud sync button visibility |
+| `headerBtnShowText` | Boolean string | Show text labels under header icons |
+| `headerBtnOrder` | JSON array | Header button card order (STAK-320) |
+| `headerAboutBtnVisible` | Boolean string | About button visibility (STAK-320) |
+| `showRealizedGainLoss` | Boolean string | Show realized G/L in summary cards (STAK-72) |
+| `tagBlacklist` | JSON array | Tags excluded from auto-tagging |
 | `chipMinCount` | Number string | Minimum item count for chip display |
 | `chipCustomGroups` | JSON array | Custom chip grouping definitions |
 | `chipBlacklist` | JSON array | Hidden chip values |
@@ -278,7 +292,9 @@ All keys currently registered in `js/constants.js`. Keys are grouped by domain b
 | `cloud_vault_password` | String | Vault password for persistent unlock |
 | `cloud_dropbox_account_id` | String | Dropbox account_id for key derivation |
 | `cloud_sync_mode` | String | DEPRECATED — kept for migration only |
-| `manifestPruningThreshold` | Number string | Days to keep manifest entries before pruning (STAK-184 diff/merge architecture) |
+| `cloud_sync_migrated` | String | Cloud folder migration flag — `"v2"` indicates flat-to-subfolder migration complete |
+| `cloud_backup_history_depth` | String | Max cloud backups to retain (`"3"`, `"5"`, `"10"`, or `"20"`) |
+| `manifestPruningThreshold` | Number string | Max sync cycles retained in manifest before pruning older entries (STAK-184 diff/merge architecture) |
 
 **One-time migrations:**
 
@@ -290,32 +306,32 @@ All keys currently registered in `js/constants.js`. Keys are grouped by domain b
 
 ### Feature Flags (added to FEATURE_FLAGS in v3.33.06)
 
-Three new feature flags were added to `js/constants.js` for the Market Page Redesign:
+Three market-related feature flags were added to `js/constants.js` for the Market Page Redesign:
 
 | Flag | Default | Description |
 |---|---|---|
-| `MARKET_LIST_VIEW` | `false` | Gates the new full-width market card layout with search, sort, inline 7-day trend charts, spike detection, vendor price chips, computed stats, and card click-to-expand |
+| `MARKET_LIST_VIEW` | `true` | Gates the new full-width market card layout with search, sort, inline 7-day trend charts, spike detection, vendor price chips, computed stats, and card click-to-expand |
 | `MARKET_DASHBOARD_ITEMS` | `false` | Gates goldback and dashboard items in the market list |
 | `MARKET_AUTO_RETAIL` | `false` | Auto-update inventory retail prices from linked market data |
 
-All three use `urlOverride: true` (enable via `?market_list_view=true` etc.) and `userToggle: true` (Settings UI toggle). Phase: `"beta"`.
+All three use `urlOverride: true` (enable via `?market_list_view=true` etc.) and `userToggle: true` (Settings UI toggle). Phase: `"beta"`. See [frontend-overview.md](frontend-overview.md) for the complete feature flags table (10 flags total).
 
 ## Common Mistakes
 
 **Storing `meltValue` in the item record.**
-Never do this. Spot moves constantly; a stored `meltValue` is wrong the moment spot changes. Always derive it at render: `item.weight * item.qty * window.spotPrice[item.metal]`.
+Never do this. Spot moves constantly; a stored `meltValue` is wrong the moment spot changes. Always derive it at render via `computeMeltValue(item, spotPrices[item.metal])`.
 
 **Adding a new localStorage key without registering it.**
-`saveData` and `saveDataSync` check the key against `ALLOWED_STORAGE_KEYS` and silently discard writes if the key is missing. There is no error. The symptom is settings that appear to save but reset on reload. Fix: add the key to the array in `js/constants.js` first.
+`ALLOWED_STORAGE_KEYS` is enforced by `cleanupStorage()` at startup — not by `saveData`/`saveDataSync` at write time. The write succeeds, but the key is silently deleted on the next startup. The symptom is settings that appear to save but reset on reload. Fix: add the key to the array in `js/constants.js` first.
 
 **Calling `localStorage.setItem` / `getItem` directly.**
-Only `saveData` / `saveDataSync` and `loadData` / `loadDataSync` are permitted. Direct calls bypass compression, bypass the allowlist guard, and are not portable to future storage backends.
+Only `saveData` / `saveDataSync` and `loadData` / `loadDataSync` are permitted for structured JSON app data. Direct calls bypass compression and are not portable to future storage backends. (`cleanupStorage()` enforces the allowlist separately at startup.)
 
 **Assuming `loadData` returns the same type as written.**
 `loadData` returns the `defaultValue` argument (default: `[]`) when the key is absent or parse fails. Always pass an explicit default that matches the expected type (e.g., pass `{}` for objects, `[]` for arrays, `null` for nullable scalars).
 
 **Reading spot from the item record.**
-There is no `spotPrice` field on the item. Always read from `window.spotPrice[item.metal]` or the per-metal keys (`spotGold`, `spotSilver`, etc.) via `loadDataSync`.
+There is no `spotPrice` field on the item. Always read from `spotPrices[item.metal]` (defined in `js/state.js`) or the per-metal keys (`spotGold`, `spotSilver`, etc.) via `loadDataSync`.
 
 **Hardcoding a storage quota.**
 Do not use a fixed byte limit like `50 * 1024 * 1024`. As of v3.32.27, quota is derived dynamically from `navigator.storage.estimate()` in `js/image-cache.js`. Use the runtime estimate so the limit scales with the device's actual available storage.
@@ -330,5 +346,5 @@ Active portfolio calculations (totals, weight, melt value) must skip disposed it
 
 - [storage-patterns.md](storage-patterns.md) — `saveData` / `loadData` usage patterns, compression, and the allowlist guard implementation
 - [frontend-overview.md](frontend-overview.md) — module load order, `index.html` script sequence, and `sw.js` asset list
-- [api-consumption.md](api-consumption.md) — spot price fetch, retail price feed, and how `window.spotPrice` is populated
+- [api-consumption.md](api-consumption.md) — spot price fetch, retail price feed, and how `spotPrices` is populated
 - [retail-modal.md](retail-modal.md) — retail view modal and market list view architecture

--- a/wiki/dom-patterns.md
+++ b/wiki/dom-patterns.md
@@ -31,7 +31,7 @@ These rules exist because the app runs on `file://` (no server-side sanitization
 ## Key Rules (read before touching this area)
 
 - **Prefer `safeGetElement(id)`** for DOM lookups in application code.
-- **Raw `document.getElementById()` is expected in `js/about.js` and `js/init.js`** (boot files that run before the wrapper is reliably available) and also exists in pre-init and legacy paths such as `js/card-view.js` and `js/inventory.js`.
+- **Raw `document.getElementById()` is expected in `js/about.js`** (runs before `init.js` loads, so `safeGetElement` is not yet defined) and also exists in pre-init and legacy paths such as `js/card-view.js` and `js/inventory.js`. Note: `js/init.js` defines `safeGetElement` at line 31, so code within `init.js` itself CAN use it after that point.
 - **Always call `sanitizeHtml(str)` before assigning user-supplied text to `innerHTML`.**
 - Never assign an unescaped user string directly to `innerHTML`, even for "display-only" fields.
 
@@ -109,12 +109,12 @@ row.innerHTML = `<td>${sanitizeHtml(item.name)}</td>`;
 
 ---
 
-### Mistake 3 — Using `safeGetElement` in `about.js` or `init.js` before it is defined
+### Mistake 3 — Using `safeGetElement` in `about.js` before it is defined
 
-`safeGetElement` is defined inside `js/init.js`. The `DOMContentLoaded` handler in `init.js` and the top-level code in `about.js` both run as part of early boot, before the function is reliably available to all callers in those two files. This is why those files use raw `document.getElementById()`. Some other files (e.g., `card-view.js`, `inventory.js`) also use raw lookups in pre-init or legacy paths — these are acceptable but new code should prefer `safeGetElement`.
+`safeGetElement` is defined at `js/init.js:31`. Code in `js/about.js` runs before `init.js` loads in the script order, so `safeGetElement` is not yet available — `about.js` must use raw `document.getElementById()`. Code within `init.js` itself CAN use `safeGetElement` after line 31. Some other files (e.g., `card-view.js`, `inventory.js`) also use raw lookups in pre-init or legacy paths — these are acceptable but new code should prefer `safeGetElement`.
 
 ```js
-// EXPECTED — inside js/about.js, js/init.js, or legacy paths
+// EXPECTED — inside js/about.js (loads before init.js defines safeGetElement)
 const el = document.getElementById('aboutVersion');
 ```
 

--- a/wiki/dom-patterns.md
+++ b/wiki/dom-patterns.md
@@ -2,8 +2,8 @@
 title: DOM Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.32.25
-date: 2026-02-23
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles:
   - js/utils.js
   - js/init.js
@@ -14,14 +14,14 @@ relatedPages:
 ---
 # DOM Patterns
 
-> **Last updated:** v3.32.25 — 2026-02-23
+> **Last updated:** v3.33.19 — 2026-03-01
 > **Source files:** `js/utils.js`, `js/init.js`, `js/about.js`
 
 ## Overview
 
 StakTrakr enforces two strict DOM safety rules:
 
-1. All element lookups must go through `safeGetElement()` — never raw `document.getElementById()` except in two designated boot files.
+1. Element lookups should go through `safeGetElement()` as the preferred pattern. Raw `document.getElementById()` is acceptable in designated boot files (`about.js`, `init.js`) and exists in some pre-init and legacy paths (e.g., `card-view.js`, `inventory.js`).
 2. All user-controlled content written to `innerHTML` must pass through `sanitizeHtml()` first to prevent XSS.
 
 These rules exist because the app runs on `file://` (no server-side sanitization) and handles user-entered text that is later rendered as HTML. Violations are a recurring source of both runtime null-reference crashes and security bugs.
@@ -30,8 +30,8 @@ These rules exist because the app runs on `file://` (no server-side sanitization
 
 ## Key Rules (read before touching this area)
 
-- **Use `safeGetElement(id)`** for every DOM lookup in application code.
-- **Raw `document.getElementById()` is only allowed in `js/about.js` and `js/init.js`** — these are the two boot files that run before the `safeGetElement` wrapper is available.
+- **Prefer `safeGetElement(id)`** for DOM lookups in application code.
+- **Raw `document.getElementById()` is expected in `js/about.js` and `js/init.js`** (boot files that run before the wrapper is reliably available) and also exists in pre-init and legacy paths such as `js/card-view.js` and `js/inventory.js`.
 - **Always call `sanitizeHtml(str)` before assigning user-supplied text to `innerHTML`.**
 - Never assign an unescaped user string directly to `innerHTML`, even for "display-only" fields.
 
@@ -111,16 +111,16 @@ row.innerHTML = `<td>${sanitizeHtml(item.name)}</td>`;
 
 ### Mistake 3 — Using `safeGetElement` in `about.js` or `init.js` before it is defined
 
-`safeGetElement` is defined inside `js/init.js`. The `DOMContentLoaded` handler in `init.js` and the top-level code in `about.js` both run as part of early boot, before the function is reliably available to all callers in those two files. This is why those two files are the **only** permitted users of raw `document.getElementById()`.
+`safeGetElement` is defined inside `js/init.js`. The `DOMContentLoaded` handler in `init.js` and the top-level code in `about.js` both run as part of early boot, before the function is reliably available to all callers in those two files. This is why those files use raw `document.getElementById()`. Some other files (e.g., `card-view.js`, `inventory.js`) also use raw lookups in pre-init or legacy paths — these are acceptable but new code should prefer `safeGetElement`.
 
 ```js
-// ALLOWED — inside js/about.js or js/init.js only
+// EXPECTED — inside js/about.js, js/init.js, or legacy paths
 const el = document.getElementById('aboutVersion');
 ```
 
 ```js
-// WRONG — do not use raw getElementById anywhere else
-const el = document.getElementById('settingsPanel'); // in settings.js — use safeGetElement instead
+// PREFERRED for new code — use safeGetElement
+const el = safeGetElement('settingsPanel');
 ```
 
 ---

--- a/wiki/health.md
+++ b/wiki/health.md
@@ -2,7 +2,7 @@
 title: "Health & Diagnostics"
 category: infrastructure
 owner: staktrakr-api
-lastUpdated: v3.33.18
+lastUpdated: v3.33.19
 date: 2026-02-25
 sourceFiles: []
 relatedPages: []
@@ -89,7 +89,7 @@ fly ssh console --app staktrakr -C "tail -20 /var/log/goldback-poller.log"
 ## GitHub Actions Status
 
 ```bash
-# Merge Poller Branches (runs */15)
+# Merge Poller Branches (retired/manual-only)
 gh run list --repo lbruton/StakTrakrApi --workflow "Merge Poller Branches" --limit 5
 
 # Spot poller (retired — manual trigger only)
@@ -128,8 +128,8 @@ Expected: rows from both `api` (Fly.io) and `home` (LXC) pollers within the last
 | OOM on Fly.io | Concurrent api-export.js invocations | Verify `run-local.sh` does NOT call `api-export.js` |
 | Monument Metals missing at year-start | Random-year SKU on pre-order | Switch to year-specific SKU in providers.json |
 | JMBullion presale coins show OOS | Pre-order pattern matching | Verify `PREORDER_TOLERANT_PROVIDERS` includes `jmbullion` |
-| Merge workflow failing | Branch conflict or jq parse error | Check GHA run logs; verify `api` branch has valid JSON |
-| Both pollers firing at same time | `CRON_SCHEDULE` set to `*/15` instead of `0` | `fly ssh console -C "head -1 /etc/cron.d/retail-poller"` — must show `0` |
+| Merge workflow failing | Branch conflict or jq parse error | Retired/manual-only — `api` branch is now served directly by GitHub Pages |
+| Both pollers firing at same time | `CRON_SCHEDULE` set to `*/15` instead of `15,45` | `fly ssh console -C "head -1 /etc/cron.d/retail-poller"` — must show `15,45` |
 | `api-export.js` import crash | `db.js` missing export after refactor | `fly ssh console -C "sh -c 'tail -5 /var/log/publish.log'"` — look for `SyntaxError` |
 
 ---
@@ -185,7 +185,7 @@ ssh stakpoller@192.168.1.81 "rm -f /tmp/retail-poller.lock"
 
 **Fix:** Commit `c80442f` on StakTrakrApi main:
 - Added `readLatestPerVendor()` to `db.js` (latest non-failed row per vendor within lookback window)
-- Changed `CRON_SCHEDULE` default from `*/15` to `15,45` (later relaxed to `0` in 2026-02-26)
+- Changed `CRON_SCHEDULE` default from `*/15` to `15,45`
 - Three deploys total to restore full pipeline
 
 **Lesson:** After any `git mv` refactor that touches the Fly.io deploy path, verify all ES module imports resolve on the deployed container before moving on. The `SyntaxError` is fatal at parse time -- nothing runs.

--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -2,8 +2,8 @@
 title: Home Poller (Ubuntu VM)
 category: infrastructure
 owner: staktrakr-api
-lastUpdated: v3.33.18
-date: 2026-02-25
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles: []
 relatedPages: []
 ---
@@ -98,7 +98,7 @@ Node.js HTTP server (`/opt/poller/dashboard.js`) showing:
 - All poller runs from Turso (`poller_runs` table — home + Fly.io)
 - Home poller log tail (last 300 lines)
 - **`/providers`** — Provider URL editor (inline CRUD against Turso — see [Provider Database](provider-database.md))
-- **`/failures`** — Failure queue (URLs with 3+ failures in last 10 days from Turso)
+- **`/failures`** — Failure queue (URLs with 3+ failures in last 7 days from Turso)
 
 ### Grafana (`http://192.168.1.81:3000`)
 
@@ -128,13 +128,13 @@ As of 2026-02-24, this VM runs **tinyproxy** as an HTTP proxy for the Fly.io con
 
 | Property | Value |
 |----------|-------|
-| Proxy URL | `http://100.112.198.50:8888` |
+| Proxy URL | `http://100.112.198.50:8889` (referenced as `HOME_PROXY_URL_2` on Fly) |
 | Accepts connections from | Tailscale IPs only (100.112.198.50, 100.90.171.110) |
 | Residential egress IP | `98.184.142.225` |
 | Config | `/etc/tinyproxy/tinyproxy.conf` |
 | `DisableViaHeader` | Yes (no proxy fingerprint) |
 
-The Fly.io container sets `PROXY_SERVER=http://100.112.198.50:8888` and routes scraper traffic through it. The home VM exits as a residential IP — retail bullion dealers don't block residential IPs.
+The Fly.io container sets `HOME_PROXY_URL_2=http://100.112.198.50:8889` and the Playwright service routes scraper traffic through it. The home VM exits as a residential IP — retail bullion dealers don't block residential IPs.
 
 **Previous approach (deprecated):** Tailscale exit node — `sudo tailscale set --advertise-exit-node=true`. This was replaced by tinyproxy in Feb 2026 for better reliability and selective routing.
 
@@ -166,8 +166,8 @@ The home poller runs Playwright with **local Chromium** — no Docker, no Browse
 | Property | Home Poller | Fly.io Container |
 |----------|-------------|------------------|
 | `BROWSER_MODE` | `local` | `local` |
-| Playwright package | `playwright` (full, from npm) | `playwright-core` (connects to service) |
-| Chromium source | Playwright-managed (`npx playwright install chromium`) | Playwright Service image (port 3003) |
+| Playwright package | `playwright` (full, from npm) | `playwright-core` with local Chromium launch (`PLAYWRIGHT_LAUNCH=1`) |
+| Chromium source | Playwright-managed (`npx playwright install chromium`) | Dockerfile-installed Chromium; separate Playwright service (port 3003) is used by Firecrawl, not by `price-extract.js` directly |
 | Browser path | `/usr/local/share/playwright/` + `/root/.cache/ms-playwright/` | `/usr/local/share/playwright/` (copied from Docker stage) |
 | System deps | Ubuntu apt packages (pre-installed) | Dockerfile `apt-get install` |
 

--- a/wiki/image-pipeline.md
+++ b/wiki/image-pipeline.md
@@ -1,19 +1,27 @@
 ---
 title: "Image Pipeline"
-category: infrastructure
-owner: staktrakr-api
-lastUpdated: v3.32.42
-date: 2026-02-25
-sourceFiles: []
+category: frontend
+owner: staktrakr
+lastUpdated: v3.33.19
+date: 2026-03-01
+sourceFiles:
+  - js/image-cache.js
+  - js/image-processor.js
+  - js/events.js
+  - js/viewModal.js
+  - js/inventory.js
+  - js/card-view.js
+  - js/bulk-image-cache.js
+  - js/image-cache-modal.js
 relatedPages:
-  - health.md
-  - spot-pipeline.md
-  - fly-container.md
+  - frontend-overview.md
+  - data-model.md
+  - dom-patterns.md
 ---
 
 # Image Pipeline
 
-> **Last updated:** v3.32.42 — 2026-02-25
+> **Last updated:** v3.33.19 — 2026-03-01
 > **Source files:** `js/image-cache.js`, `js/image-processor.js`, `js/events.js`, `js/viewModal.js`, `js/inventory.js`, `js/card-view.js`, `js/bulk-image-cache.js`, `js/image-cache-modal.js`
 
 ## Overview
@@ -180,6 +188,6 @@ Pattern rules let a single image cover many items that share a name pattern.
 
 ## Related Pages
 
-- [health.md](health.md) — API and poller health checks
-- [spot-pipeline.md](spot-pipeline.md) — Spot price data pipeline
-- [fly-container.md](fly-container.md) — Fly.io container management
+- [Frontend Overview](frontend-overview.md) — File load order, script block, constants role
+- [Data Model](data-model.md) — Item schema, storage patterns, spot state
+- [DOM Patterns](dom-patterns.md) — `safeGetElement()` and element access rules

--- a/wiki/providers.md
+++ b/wiki/providers.md
@@ -2,8 +2,8 @@
 title: "providers.json"
 category: infrastructure
 owner: staktrakr-api
-lastUpdated: v3.33.18
-date: 2026-02-24
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles: []
 relatedPages: []
 ---
@@ -109,7 +109,7 @@ Monument Metals maintains **parallel SKUs** for each coin:
 | `ase` | `2026-american-silver-eagle.html` | Year-specific (random was pre-order) |
 | `age` | `2026-american-1-oz-gold-eagle-bu.html` | Year-specific (random was pre-order) |
 | `maple-gold` | `2026-1oz-gold-maple.html` | Year-specific (random was pre-order) |
-| `krugerrand-silver` | `south-africa-1-oz-silver-krugerrand-bu-random-date.html` | Random-date (2026 was pre-order — opposite) |
+| `krugerrand-silver` | `2026-south-africa-1-oz-silver-krugerrand-bu.html` | Year-specific (committed 2026 SKU) |
 
 > Check Monument Metals in late March/April to see if random-year SKUs are back in stock.
 

--- a/wiki/secrets.md
+++ b/wiki/secrets.md
@@ -2,8 +2,8 @@
 title: "Secrets & Keys"
 category: infrastructure
 owner: staktrakr-api
-lastUpdated: v3.33.18
-date: 2026-02-24
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles: []
 relatedPages: []
 ---
@@ -36,9 +36,10 @@ Set with `fly secrets set KEY=VALUE --app staktrakr`.
 | `TURSO_AUTH_TOKEN` | Turso auth | Rotate in Turso dashboard |
 | `GEMINI_API_KEY` | Vision pipeline (Gemini API) | Google AI Studio |
 | `METAL_PRICE_API_KEY` | Spot price API | MetalPriceAPI dashboard |
-| `WEBSHARE_PROXY_USER` | Playwright service proxy | Webshare dashboard |
-| `WEBSHARE_PROXY_PASS` | Playwright service proxy | Webshare dashboard |
-| `CRON_SCHEDULE` | Override retail poller cron frequency | Currently set to `0` (once per hour at :00) |
+| `WEBSHARE_PROXY_USER` | Webshare credentials for Playwright fallback / `run-retry.sh` | Webshare dashboard |
+| `WEBSHARE_PROXY_PASS` | Webshare credentials for Playwright fallback / `run-retry.sh` | Webshare dashboard |
+| `HOME_PROXY_URL_2` | Playwright service proxy input (home residential IP via Tailscale) | Set in `fly.toml` env or as Fly secret |
+| `CRON_SCHEDULE` | Override retail poller cron frequency | Default is `15,45` (twice per hour at :15 and :45) |
 
 ---
 

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -2,8 +2,8 @@
 title: Storage Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.32.23
-date: 2026-02-23
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles:
   - js/utils.js
   - js/constants.js
@@ -13,15 +13,12 @@ relatedPages:
 ---
 # Storage Patterns
 
-> **Last updated:** v3.32.23 — 2026-02-23
+> **Last updated:** v3.33.19 — 2026-03-01
 > **Source files:** `js/utils.js`, `js/constants.js`
 
 ## Overview
 
-StakTrakr persists all application state in `localStorage`. Direct calls to
-`localStorage.setItem` / `localStorage.getItem` are **forbidden**. All reads
-and writes must go through the wrapper functions `saveData` / `loadData` (async)
-or `saveDataSync` / `loadDataSync` (sync), defined in `js/utils.js`.
+StakTrakr persists all application state in `localStorage`. For structured JSON app data, direct calls to `localStorage.setItem` / `localStorage.getItem` are **forbidden** — all reads and writes must go through the wrapper functions `saveData` / `loadData` (async) or `saveDataSync` / `loadDataSync` (sync), defined in `js/utils.js`. Direct `localStorage` access is permitted for intentional scalar string cases (e.g., cloud sync cursor, idle timeout keys) where the overhead of JSON serialization and compression is unnecessary.
 
 The wrappers exist for three reasons:
 
@@ -42,7 +39,7 @@ The wrappers exist for three reasons:
 
 ## Key Rules (read before touching this area)
 
-- **Never** call `localStorage.setItem()` or `localStorage.getItem()` directly.
+- **Never** call `localStorage.setItem()` or `localStorage.getItem()` directly for structured JSON app data. Direct localStorage is allowed for intentional scalar string cases (cloud sync cursor, idle timeout keys, etc.).
 - **Never** introduce a new storage key without first adding it to
   `ALLOWED_STORAGE_KEYS` in `js/constants.js`.
 - New keys written outside the allowlist will be deleted by `cleanupStorage()`.
@@ -78,8 +75,7 @@ propagated to the caller. A `console.error` is emitted on failure (e.g.
 
 If `key` is **not** in `ALLOWED_STORAGE_KEYS`, the write still succeeds at the
 `localStorage` level — there is no runtime guard inside `saveData` itself. The
-key is removed the next time `cleanupStorage()` runs (called during startup and
-after imports). Always add the key to the allowlist first.
+key is removed the next time `cleanupStorage()` runs (called during startup). Always add the key to the allowlist first.
 
 ---
 
@@ -178,7 +174,7 @@ const cleanupStorage = () => {
 };
 ```
 
-Called automatically during app startup. Any key not present in
+Called automatically during app startup (`DOMContentLoaded`). Any key not present in
 `ALLOWED_STORAGE_KEYS` is permanently deleted. This is the primary mechanism
 that enforces the allowlist contract.
 

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,8 +2,8 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.32.41
-date: 2026-02-25
+lastUpdated: v3.33.19
+date: 2026-03-01
 sourceFiles:
   - js/cloud-sync.js
   - js/cloud-storage.js
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.32.41 — 2026-02-25
+> **Last updated:** v3.33.19 — 2026-03-01
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -24,12 +24,14 @@ relatedPages:
 
 StakTrakr supports Dropbox-based cloud sync that automatically pushes an encrypted vault snapshot whenever inventory changes, and polls for remote updates on other devices.
 
-Two files live in Dropbox under `/StakTrakr/`:
+Two files live in Dropbox under `/StakTrakr/sync/`:
 
 | File | Purpose |
 |---|---|
 | `staktrakr-sync.stvault` | Full encrypted inventory snapshot |
 | `staktrakr-sync.json` | Lightweight metadata pointer, polled for change detection |
+
+> **Legacy paths:** Flat-root paths (`/StakTrakr/staktrakr-sync.*`) are retained as `*_LEGACY` constants in `js/constants.js` for migration only. Active sync uses `/StakTrakr/sync/`; backups go to `/StakTrakr/backups/`.
 
 The poller compares the remote `staktrakr-sync.json` revision against the last-seen cursor. When it detects a change it calls `handleRemoteChange()`, which decides between a clean pull or a conflict modal.
 
@@ -38,7 +40,7 @@ The poller compares the remote `staktrakr-sync.json` revision against the last-s
 ## Key Rules (read before touching this area)
 
 1. **Never bypass `getSyncPasswordSilent()`** — do not add your own `localStorage.getItem('cloud_vault_password')` reads inline. All key derivation logic (Simple mode migration, Unified mode construction) is encapsulated there.
-2. **All `pushSyncVault()` and `pullSyncVault()` call sites must have `.catch()` handlers** — bare calls cause silent unhandled rejections on token failures. This was the root cause of the v3.32.24 regression.
+2. **`.catch()` on `pushSyncVault()` / `pullSyncVault()` is optional** — both functions catch internally. Attach `.catch()` only when the caller wants extra fallback logging or UI beyond the built-in handling.
 3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before opening any modal. If you add new pull paths, replicate this cancel guard.
 4. **Do not duplicate `getSyncPassword()` logic** — the fast-path check at the top of that function delegates to `getSyncPasswordSilent()`, which handles both modes. Adding a second localStorage read before it breaks Simple-mode migration.
 
@@ -88,18 +90,12 @@ getSyncPassword()
 
 1. Guards: `syncIsEnabled()`, token present, no push already in-flight, `getSyncPasswordSilent()` returns a key.
 2. Encrypts the sync-scoped inventory with `vaultEncryptToBytesScoped()` (falls back to `vaultEncryptToBytes()`).
-3. Uploads the encrypted bytes to `/StakTrakr/staktrakr-sync.stvault` (overwrite mode).
-4. Writes the metadata pointer to `/StakTrakr/staktrakr-sync.json`.
+3. Uploads the encrypted bytes to `/StakTrakr/sync/staktrakr-sync.stvault` (overwrite mode).
+4. Writes the metadata pointer to `/StakTrakr/sync/staktrakr-sync.json`.
 5. Persists the push meta (timestamp, syncId, itemCount) via `syncSetLastPush()`.
 6. Handles 429 rate-limit with exponential backoff (caps at 5 minutes).
 
-**All call sites must have `.catch()` handlers.** Example:
-
-```js
-pushSyncVault().catch(function (err) {
-  debugLog('[CloudSync] pushSyncVault failed:', err);
-});
-```
+`.catch()` is optional — `pushSyncVault()` catches internally. Add one only when the caller needs extra fallback logging or UI.
 
 ### `pullSyncVault()`
 
@@ -109,7 +105,16 @@ pushSyncVault().catch(function (err) {
 4. Decrypts and restores via `vaultDecryptAndRestore()`.
 5. Persists pull meta via `syncSetLastPull()`.
 
-**All call sites must have `.catch()` handlers.**
+`pullSyncVault()` is the lower-level restore call. The primary remote-pull path for both "no local changes" and "Keep Theirs" flows is `pullWithPreview()`, which wraps `pullSyncVault()` with a manifest-first diff preview.
+
+### `pullWithPreview()`
+
+The primary entry point for remote pulls. Attempts a manifest-first path (lightweight diff preview without full vault download). Falls back to vault-first path if the manifest is unavailable or fails.
+
+1. Downloads the lightweight `.stmanifest` file and decrypts it.
+2. Builds a diff preview via `DiffModal` showing added/removed/edited items.
+3. If manifest is unavailable (404, decrypt failure, `DiffModal` missing), falls through to vault-first: downloads the full `.stvault`, decrypts, and shows a summary modal.
+4. On user confirm, calls `pullSyncVault(remoteMeta)` to apply the restore.
 
 ### `handleRemoteChange()`
 
@@ -120,10 +125,10 @@ handleRemoteChange(remoteMeta)
   ├─ If password prompt is active → defer (return, retry next poll)
   ├─ scheduleSyncPush.cancel()           ← CRITICAL: cancels any queued push
   ├─ syncHasLocalChanges()?
-  │    No  → showSyncUpdateModal() → pullSyncVault()
+  │    No  → showSyncUpdateModal() → pullWithPreview()
   │    Yes → showSyncConflictModal()
   │             ├─ Keep Mine  → pushSyncVault()
-  │             └─ Keep Theirs → pullSyncVault().catch(...)
+  │             └─ Keep Theirs → pullWithPreview().catch(...)
 ```
 
 **The `scheduleSyncPush.cancel()` call is mandatory.** Without it:
@@ -203,7 +208,7 @@ When both sides have unsaved changes, the conflict modal shows:
 
 Choices:
 - **Keep Mine** → `pushSyncVault()` (overwrites remote with local)
-- **Keep Theirs** → `pullSyncVault(remoteMeta).catch(...)` (overwrites local with remote)
+- **Keep Theirs** → `pullWithPreview(remoteMeta).catch(...)` (shows diff preview, then overwrites local with remote)
 
 The override backup (`syncSaveOverrideBackup`) is always written before any pull, enabling the "Restore Override Backup" button in the sync history section.
 
@@ -219,7 +224,7 @@ SYNC_PUSH_DEBOUNCE = 2000 ms
 
 Any inventory change fires `scheduleSyncPush()`. If another change arrives within 2 seconds, the timer resets. The actual `pushSyncVault()` only fires after 2 seconds of quiet.
 
-If the `debounce` utility is not available at init time, a plain `setTimeout` fallback is used (no deduplication in that case).
+If the `debounce` utility is not available at init time, a `clearTimeout`/`setTimeout` fallback is used. This fallback still coalesces rapid calls (clears the prior timer before rescheduling), but lacks the helper's `.cancel()` method.
 
 ---
 
@@ -257,18 +262,6 @@ var pw = localStorage.getItem('cloud_vault_password');
 
 // CORRECT — handles all modes and migration
 var pw = getSyncPasswordSilent();
-```
-
-### Bare push/pull calls without `.catch()`
-
-```js
-// WRONG — silent unhandled rejection if token is missing
-pullSyncVault(remoteMeta);
-
-// CORRECT
-pullSyncVault(remoteMeta).catch(function (err) {
-  debugLog('[CloudSync] pull failed:', err);
-});
 ```
 
 ### Adding a new pull path without cancelling the debounced push

--- a/wiki/vendor-quirks.md
+++ b/wiki/vendor-quirks.md
@@ -2,7 +2,7 @@
 title: "Vendor Scraping Quirks"
 category: infrastructure
 owner: staktrakr-api
-lastUpdated: v3.33.18
+lastUpdated: v3.33.19
 date: 2026-03-01
 sourceFiles: []
 relatedPages: []
@@ -176,7 +176,7 @@ Per-vendor scraping behavior, known issues, and workarounds. This is the runbook
 
 **Known issues:**
 
-1. **Single URL for all denominations**: All goldback coins (G1, G2, G5, G10, G25, G50) use the same URL (`/exchange-rate/`). Price extraction must parse the correct denomination row.
+1. **Single URL for all denominations**: All goldback coins (G1, G2, G5, G10, G25, G50) use the same URL (`/exchange-rates/`). Price extraction must parse the correct denomination row.
 
 2. **Separate pipeline**: Goldback prices are handled by the dedicated goldback pipeline, not the retail poller. Failures here are separate from the main failure queue.
 


### PR DESCRIPTION
## Summary

- Full wiki accuracy sweep driven by independent Gemini + Codex audits (2026-03-01)
- Fixed ~85 confirmed inaccuracies across 27 of 29 wiki pages (28 files modified)
- 550 lines added, 447 removed — all documentation, zero runtime code changes

### Key corrections

| Theme | Pages | What changed |
|-------|-------|-------------|
| Cron schedules | 8 | Matched to `docker-entrypoint.sh`: retail `15,45`, spot `0,30`, goldback `1` |
| Turso integration | 5 | `spot_prices` + `provider_failures` tables documented, data flow corrected |
| Goldback pipeline | 4 | Restored as active with standalone cron at `:01` |
| Coin counts | 5 | Corrected to 11 committed (73 labeled as live-Turso) |
| Frontend patterns | 8 | Feature flags 3→10, globals table, melt formula with purity, 13 storage keys |
| Sync paths | 2 | `/StakTrakr/` → `/StakTrakr/sync/` |
| Release workflow | 1 | Claims array lock model, correct cleanup semantics |
| Infra details | 6 | Fly 8GB RAM, Tailscale active, proxy port 8889, Playwright launch mode |
| Navigation | 2 | Sidebar + README now link all 27 pages |

### Linear

- Closes STAK-392
- Subsumes STAK-391 (MARKET_LIST_VIEW default)

### Audit reports

- `devops/WIKI_AUDIT_GEM.md` (Gemini)
- `devops/WIKI_AUDIT_CODEX.md` (Codex)

## Test plan

- [ ] Spot-check 3-4 high-change pages against source files
- [ ] Verify sidebar links resolve in Docsify preview
- [ ] Confirm no runtime code was modified (`git diff --stat` shows only `wiki/` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)