### PR TITLE
v3.33.20 — Market Panel Bug Fixes (STAK-389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.20] - 2026-03-02
+
+### Fixed — Market Panel Bug Fixes (STAK-389)
+
+- **Fixed**: API-driven item names — all rendering paths now use `getRetailCoinMeta()` with manifest as source of truth, fallback parser corrected to denomination-first format (STAK-389)
+- **Fixed**: Grid/list view sync status shows "just now" after sync, time-ago when lingering, "Sync error — prices may be stale" on API failure (STAK-389)
+- **Fixed**: Activity log dropdown dynamically populated from API manifest instead of hardcoded HTML (STAK-389)
+
+---
+
 ## [3.33.19] - 2026-03-01
 
 ### Added — DiffMerge Integration: Selective Apply for Cloud Sync and Vault Restore (STAK-190)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Market Panel Bug Fixes (v3.33.20)**: API-driven item names via getRetailCoinMeta() as source of truth. Grid/list sync status shows "just now" after sync, time-ago when lingering, error state on API failure. Activity log dropdown dynamically populated from API manifest
 - **DiffMerge Integration (v3.33.19)**: Selective apply for cloud sync pull and encrypted vault restore. DiffModal preview replaces full overwrite — users choose which changes to accept. Shared _applyAndFinalize helper consolidates post-apply sequence
 - **Diff/Merge Architecture Foundation (v3.33.18)**: Manifest path constants, pruning threshold storage key, diffReviewModal HTML scaffold, and diff-modal.js script registration for the reusable change-review UI
 - **Realized Gains/Losses (v3.33.17)**: Disposition workflow to mark items as Sold, Traded, Lost, Gifted, or Returned. Calculates realized gain/loss, adds disposition badges, filter toggle, portfolio summary breakdown, and CSV export columns
-- **Clone Mode Redesign (v3.33.16)**: Clone button activates clone mode on the edit modal with field-level checkboxes. Edit modal sections always visible, date N/A restyled as toggle button, Numista refresh button removed
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,10 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.20 &ndash; Market Panel Bug Fixes</strong>: API-driven item names via getRetailCoinMeta() as source of truth. Grid/list sync status shows &ldquo;just now&rdquo; after sync, time-ago when lingering, error state on API failure. Activity log dropdown dynamically populated from API manifest</li>
     <li><strong>v3.33.19 &ndash; DiffMerge Integration</strong>: Selective apply for cloud sync pull and encrypted vault restore. DiffModal preview replaces full overwrite &mdash; users choose which changes to accept. Shared _applyAndFinalize helper consolidates post-apply sequence</li>
     <li><strong>v3.33.18 &ndash; Diff/Merge Architecture Foundation</strong>: Manifest path constants, pruning threshold storage key, diffReviewModal HTML scaffold, and diff-modal.js script registration for the reusable change-review UI</li>
     <li><strong>v3.33.17 &ndash; Realized Gains/Losses</strong>: Disposition workflow to mark items as Sold, Traded, Lost, Gifted, or Returned. Calculates realized gain/loss, adds disposition badges, filter toggle, portfolio summary breakdown, and CSV export columns</li>
-    <li><strong>v3.33.16 &ndash; Clone Mode Redesign</strong>: Clone button activates clone mode on the edit modal with field-level checkboxes. Edit modal sections always visible, date N/A restyled as toggle button, Numista refresh button removed</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.19";
+const APP_VERSION = "3.33.20";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.20-b1772417198';
+const CACHE_NAME = 'staktrakr-v3.33.20-b1772419091';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.19-b1772404151';
+const CACHE_NAME = 'staktrakr-v3.33.20-b1772417198';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.19",
-  "releaseDate": "2026-03-01",
+  "version": "3.33.20",
+  "releaseDate": "2026-03-02",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: API-driven item names — all rendering paths now use `getRetailCoinMeta()` with manifest as source of truth, fallback parser corrected to denomination-first format
- **Fixed**: Grid/list view sync status shows "just now" after sync, time-ago when lingering, "Sync error — prices may be stale" on API failure
- **Fixed**: Activity log dropdown dynamically populated from API manifest instead of hardcoded HTML

## Linear Issues

- [STAK-389: BUG: Market Panel](https://linear.app/lbruton/issue/STAK-389/bug-market-panel)

## Spec

- `.spec-workflow/specs/market-panel-bug/` — 5 tasks completed (3 code, 1 E2E test, 1 wiki)

🤖 Generated with [Claude Code](https://claude.com/claude-code)