### PR TITLE
docs(wiki): fix cron schedule inaccuracies — Fly retail at :00, add home-spot (STAK-393)

### DIFF
--- a/wiki/cron-schedule.md
+++ b/wiki/cron-schedule.md
@@ -45,16 +45,16 @@ Written dynamically by `docker-entrypoint.sh` at container start. The `CRON_SCHE
 
 ```
 :00  Fly.io retail scrape (run-local.sh — Firecrawl + Vision → Turso)
-:00  Fly.io spot poll #1 (run-spot.sh — MetalPriceAPI → Turso + hourly files)
+:00  Fly.io spot poll #1 (run-spot.sh — MetalPriceAPI → Turso + hourly & 15-min snapshot files)
 :01  Goldback rate scrape (run-goldback.sh — skips if today's price already captured)
 :08  Publisher #1 (run-publish.sh — Turso → JSON → git push api branch)
-:15  Home spot poll #1 (run-spot-home.sh — MetalPriceAPI → Turso + hourly files)
+:15  Home spot poll #1 (run-spot-home.sh — MetalPriceAPI → Turso + hourly & 15-min snapshot files)
 :15  T3 Retry (run-retry.sh — re-scrape failures with Webshare proxy)
 :23  Publisher #2 ← picks up :00 retail data
-:30  Fly.io spot poll #2 (run-spot.sh — MetalPriceAPI → Turso + hourly files)
+:30  Fly.io spot poll #2 (run-spot.sh — MetalPriceAPI → Turso + hourly & 15-min snapshot files)
 :30  Home retail scrape (run-home.sh — Firecrawl → Turso)
 :38  Publisher #3 ← picks up :30 home retail data
-:45  Home spot poll #2 (run-spot-home.sh — MetalPriceAPI → Turso + hourly files)
+:45  Home spot poll #2 (run-spot-home.sh — MetalPriceAPI → Turso + hourly & 15-min snapshot files)
 :53  Publisher #4
 :00  ──────────────────────────────────────────────
 ```

--- a/wiki/cron-schedule.md
+++ b/wiki/cron-schedule.md
@@ -19,7 +19,7 @@ relatedPages:
 
 ## Fly.io Container Cron
 
-Written dynamically by `docker-entrypoint.sh` at container start. `CRON_SCHEDULE` env var controls retail poller cadence (default: `15,45`; production: `0`).
+Written dynamically by `docker-entrypoint.sh` at container start. The `CRON_SCHEDULE` env var controls the retail poller minute field: by default containers use `15,45` (twice-hourly), but production Fly.io apps override this to `0` via `fly secrets set CRON_SCHEDULE=0`. Any references in other docs to `:15/:45` describe the default, not the production override.
 
 | Minute | Script | Purpose | Log file |
 |--------|--------|---------|----------|

--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -3,7 +3,7 @@ title: Home Poller (Ubuntu VM)
 category: infrastructure
 owner: staktrakr-api
 lastUpdated: v3.33.19
-date: 2026-03-01
+date: 2026-03-02
 sourceFiles: []
 relatedPages: []
 ---
@@ -59,8 +59,10 @@ See `homepoller-ssh` skill in the StakTrakr repo for full diagnostic commands an
 | Install path | `/opt/poller/` |
 | Config repo | `github.com/lbruton/stakscrapr` (Claude config, CLAUDE.md) |
 | Poller source | `github.com/lbruton/StakTrakrApi` → `devops/fly-poller/` (source of truth) |
-| Log | `/var/log/retail-poller.log` |
-| Cron | `30 * * * *` (`:30` every hour, runs as `root`) |
+| Retail log | `/var/log/retail-poller.log` |
+| Spot log | `/var/log/spot-poller.log` |
+| Retail cron | `30 * * * *` — `/etc/cron.d/retail-poller` (runs as `root`) |
+| Spot cron | `15,45 * * * *` — `/etc/cron.d/spot-poller` (runs as `root`) |
 
 ---
 
@@ -195,12 +197,14 @@ cd /opt/poller && sudo npm install playwright && sudo npx playwright install --w
 | `/opt/playwright-service/` | Playwright microservice |
 | `/usr/local/share/playwright/` | Chromium for Playwright |
 | `/etc/supervisor/conf.d/staktrakr.conf` | Supervisord config |
-| `/etc/cron.d/retail-poller` | Cron schedule |
+| `/etc/cron.d/retail-poller` | Retail poller cron (`30 * * * *`) |
+| `/etc/cron.d/spot-poller` | Spot poller cron (`15,45 * * * *`) |
 | `/etc/cron.d/flyio-health` | Fly.io health check cron (every 5 min) |
 | `/etc/tinyproxy/tinyproxy.conf` | tinyproxy config |
 | `/etc/grafana/provisioning/` | Grafana datasource + dashboard provisioning |
 | `/etc/prometheus/prometheus.yml` | Prometheus scrape config |
-| `/var/log/retail-poller.log` | Poller output (written by root) |
+| `/var/log/retail-poller.log` | Retail poller output (written by root) |
+| `/var/log/spot-poller.log` | Spot poller output (written by root) |
 | `/var/log/supervisor/` | Firecrawl/Playwright/dashboard/metrics service logs |
 | `/tmp/flyio-health.json` | Fly.io health check result (read by dashboard) |
 

--- a/wiki/retail-pipeline.md
+++ b/wiki/retail-pipeline.md
@@ -3,7 +3,7 @@ title: Retail Market Price Pipeline
 category: infrastructure
 owner: staktrakr-api
 lastUpdated: v3.33.19
-date: 2026-02-25
+date: 2026-03-02
 sourceFiles: []
 relatedPages:
   - rest-api-reference.md
@@ -34,7 +34,7 @@ Two independent pollers write to the **same Turso database**. A single publisher
 
 | Poller | Location | Cron | Script | POLLER_ID |
 |--------|----------|------|--------|-----------|
-| **Fly.io** (primary) | `staktrakr` app, `dfw` region | `15,45 * * * *` | `run-local.sh` | `api` |
+| **Fly.io** (primary) | `staktrakr` app, `dfw` region | `0 * * * *` (1×/hr) | `run-local.sh` | `api` |
 | **Home LXC** (secondary) | Proxmox Ubuntu @ 192.168.1.81 | `30 * * * *` (1×/hr) | `run-home.sh` | `home` |
 
 **Why two pollers?**
@@ -71,7 +71,7 @@ Two independent pollers write to the **same Turso database**. A single publisher
 
 ```
 Fly.io run-local.sh  ──┐
-(15,45 * * * *)        ├──► Turso (price_snapshots) ──► api-export.js ──► data/api/ JSON
+(0 * * * *)            ├──► Turso (price_snapshots) ──► api-export.js ──► data/api/ JSON
 Home LXC run-home.sh ──┘    readLatestPerVendor()        (run-publish.sh, 8,23,38,53)
 (30 * * * *)
                                                               │
@@ -228,7 +228,7 @@ Requires `GEMINI_API_KEY`. Non-fatal — failure is logged and scrape continues.
 
 | Script | Cron | Purpose |
 |--------|------|---------|
-| `run-local.sh` | `15,45 * * * *` | Retail scrape (2x/hr) |
+| `run-local.sh` | `0 * * * *` | Retail scrape (1x/hr, `CRON_SCHEDULE=0`) |
 | `run-spot.sh` | `0,30 * * * *` | Spot price poll (MetalPriceAPI → Turso + JSON) |
 | `run-publish.sh` | `8,23,38,53 * * * *` | Export Turso → JSON, push to `api` branch |
 | `run-retry.sh` | `15 * * * *` | T3 proxy retry of failed SKUs |


### PR DESCRIPTION
## Summary

- **`retail-pipeline.md`** — Fly.io retail cron corrected from `15,45 * * * *` to `0 * * * *` (`CRON_SCHEDULE=0` Fly secret); data flow diagram and cron summary table updated
- **`cron-schedule.md`** — Fly retail row, raw crontab block, and timeline view all corrected; Home LXC section expanded to show both cron files (`/etc/cron.d/retail-poller` at `:30` and `/etc/cron.d/spot-poller` at `:15/:45`); home-spot poller (`run-spot-home.sh`) added throughout
- **`home-poller.md`** — Specs table now shows both retail cron and spot cron; Key Paths table includes `/etc/cron.d/spot-poller` and `/var/log/spot-poller.log`

## Source of truth
Verified against:
- Live dashboard poller run table (fly-retail at :00, home-retail at :30, fly-spot at :00/:30, home-spot at :15/:45)
- `ssh -T homepoller 'cat /etc/cron.d/retail-poller /etc/cron.d/spot-poller'`

Fixes: STAK-393

🤖 Generated with [Claude Code](https://claude.com/claude-code)