### PR TITLE
docs(wiki): update Last verified dates + home-poller overview (STAK-393 follow-up)

### DIFF
--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -10,13 +10,13 @@ relatedPages: []
 
 # Home Poller (Ubuntu VM)
 
-> **Last verified:** 2026-02-25 — Ubuntu 24.04.3 LTS LXC at 192.168.1.81, user `stakpoller`. Verified from VM console.
+> **Last verified:** 2026-03-02 — Ubuntu 24.04.3 LTS LXC at 192.168.1.81, user `stakpoller`. Verified from VM console. Home spot poller (`/etc/cron.d/spot-poller` at `15,45`) confirmed active.
 
 ---
 
 ## Overview
 
-A secondary retail poller running on an Ubuntu Server LXC container. Runs at `:30` past every hour (once per hour). The Fly.io poller runs at `:00` — with the 30-minute offset, fresh data arrives every 30 minutes.
+A secondary poller host running on an Ubuntu Server LXC container. Hosts two cron-driven pollers: a **retail scraper** (`run-home.sh` at `:30`) and a **spot price poller** (`run-spot-home.sh` at `:15/:45`). The retail scraper offsets 30 min from Fly.io retail at `:00`. The spot poller interleaves with Fly.io spot at `:00/:30`, giving fresh spot prices every 15 minutes across both hosts.
 
 Both pollers write to the **same Turso database**. `run-publish.sh` on Fly.io merges their data using `readLatestPerVendor()`. The home poller never touches Git.
 

--- a/wiki/retail-pipeline.md
+++ b/wiki/retail-pipeline.md
@@ -16,7 +16,7 @@ relatedPages:
 
 # Retail Market Price Pipeline
 
-> **Last verified:** 2026-02-25 — dual-poller architecture, Turso shared DB, readLatestPerVendor() merge logic
+> **Last verified:** 2026-03-02 — dual-poller architecture, Turso shared DB, readLatestPerVendor() merge logic; Fly.io retail cron corrected to `0 * * * *` (`CRON_SCHEDULE=0`)
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #661 — addresses Copilot review threads that were open when the PR merged.

- **retail-pipeline.md**: bump `Last verified` from 2026-02-25 → 2026-03-02; note Fly.io cron correction in the description
- **home-poller.md**: bump `Last verified` from 2026-02-25 → 2026-03-02; expand overview paragraph to describe both the retail scraper (`:30`) and the spot poller (`:15/:45`) — the intro previously read as a retail-only host even after the Specs table was updated

## Test plan

- [ ] Verify `Last verified` dates updated in both files
- [ ] Verify home-poller.md overview mentions both retail and spot pollers

🤖 Generated with [Claude Code](https://claude.com/claude-code)