### PR TITLE
v3.33.25 — fix: JSON export test + import error message follow-up (STAK-374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.25] - 2026-03-02
+
+### Fixed — JSON Export Format Follow-up (STAK-374)
+
+- **Fixed**: `backup-restore.spec.js` now handles new `{ items, exportMeta }` export envelope — was asserting `Array.isArray` on the outer object
+- **Fixed**: JSON import error message updated to mention `exportMeta` is optional, matching actual accepted formats
+- **Docs**: Wiki pages for backup-restore and frontend-overview updated for STAK-374
+
+---
+
 ## [3.33.24] - 2026-03-02
 
 ### Added — Backup Integrity Audit (STAK-374)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **JSON Export Format Follow-up (v3.33.25)**: Test and error message fixes for the new `{ items, exportMeta }` JSON export envelope introduced in v3.33.24 (STAK-374).
 - **Backup Integrity Audit (v3.33.24)**: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner. Fixes CSV round-trip breakage from comment header, const reassignment crash, and import target detection bug (STAK-374).
 - **Chip Max Count Setting (v3.33.23)**: New `chipMaxCount` setting caps the filter chip bar to prevent overflow. Search chips always render regardless of cap. Configure in Settings.
 - **Storage Error Modal Suppressed for Intraday Cache (v3.33.22)**: saveRetailIntradayData() failures now log a console warning instead of showing a user-visible Storage Error modal — transient 24h sparkline cache is non-critical

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.24";
+const APP_VERSION = "3.33.25";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -3563,7 +3563,7 @@ const importJson = (file, override = false) => {
         parsedMeta = rawParsed.exportMeta || null;
       } else {
         if (typeof showAppAlert === 'function') {
-          showAppAlert('Invalid JSON format. Expected an array of inventory items or { items: [], settings: {} }.', 'JSON Import');
+          showAppAlert('Invalid JSON format. Expected an array of inventory items, { items: [], settings: {} }, or { items: [], exportMeta: {} } (exportMeta is optional).', 'JSON Import');
         }
         return;
       }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.24-b1772429341';
+const CACHE_NAME = 'staktrakr-v3.33.25-b1772429437';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.24-b1772429230';
+const CACHE_NAME = 'staktrakr-v3.33.24-b1772429341';
 
 
 

--- a/tests/backup-restore.spec.js
+++ b/tests/backup-restore.spec.js
@@ -54,7 +54,9 @@ test.describe('Backup and Restore', () => {
     
     const jsonContent = fs.readFileSync(downloadPath, 'utf8');
     const backupData = JSON.parse(jsonContent);
-    expect(Array.isArray(backupData)).toBeTruthy();
+    // exportJson now emits { items: [...], exportMeta: {...} }; plain array is also accepted for legacy imports
+    const backupItems = Array.isArray(backupData) ? backupData : backupData.items;
+    expect(Array.isArray(backupItems)).toBeTruthy();
     
     const storageSection = page.locator('#settingsModal .settings-nav-item[data-section="storage"]');
     await storageSection.click();

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.24",
+  "version": "3.33.25",
   "releaseDate": "2026-03-02",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

Follow-up to STAK-374 (v3.33.24) — two fixes that missed the original merge window:

- **Test fix**: `backup-restore.spec.js` updated to handle new `{ items, exportMeta }` JSON export envelope (was asserting `Array.isArray` on the outer object, which now fails)
- **Error message**: JSON import error now mentions `exportMeta` is optional, matching the actual accepted formats
- **Wiki**: Docs for backup-restore and frontend-overview updated for STAK-374 (from earlier wiki update commit)

## Test plan

- [ ] CI passes
- [ ] `backup-restore.spec.js` green
- [ ] JSON import with old plain-array format still works
- [ ] JSON import with new `{ items, exportMeta }` format works
- [ ] JSON import with invalid format shows updated error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)