### PR TITLE
v3.33.25 — STAK-396: Browserbase Test Runbook v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.33.25] - 2026-03-02
 
-### Fixed — JSON Export Format Follow-up (STAK-374)
+### Added — Browserbase Test Runbook v2 (STAK-396)
 
-- **Fixed**: `backup-restore.spec.js` now handles new `{ items, exportMeta }` export envelope — was asserting `Array.isArray` on the outer object
-- **Fixed**: JSON import error message updated to mention `exportMeta` is optional, matching actual accepted formats
-- **Docs**: Wiki pages for backup-restore and frontend-overview updated for STAK-374
+- **Added**: Modular test runbook at `tests/runbook/` — 75+ tests across 8 section files (01-page-load, 02-crud, 03-backup-restore, 04-import-export, 05-market, 06-ui-ux, 07-activity-log, 08-spot-prices)
+- **Changed**: `/bb-test` skill rewritten as a runtime runbook reader — parses `tests/runbook/*.md` at run time, supports `sections=`, `tags=`, and `dry-run` filter flags, auto-discovers PR preview URL from `gh pr checks`
+- **Changed**: `browserbase-test-maintenance` skill updated to point agents to `tests/runbook/*.md` instead of legacy TypeScript files
+- **Added**: Manual execution guide — Chrome DevTools and Claude browser extension as $0 alternatives for 1-3 test verification (STAK-396)
 
 ---
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **JSON Export Format Follow-up (v3.33.25)**: Test and error message fixes for the new `{ items, exportMeta }` JSON export envelope introduced in v3.33.24 (STAK-374).
+- **Browserbase Test Runbook v2 (v3.33.25)**: Modular E2E test runbook with 75+ tests across 8 section files. `/bb-test` skill now reads runbook Markdown at runtime with section and tag filtering. Manual execution via Chrome DevTools or Claude browser extension documented as $0 alternative (STAK-396).
 - **Backup Integrity Audit (v3.33.24)**: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner. Fixes CSV round-trip breakage from comment header, const reassignment crash, and import target detection bug (STAK-374).
 - **Chip Max Count Setting (v3.33.23)**: New `chipMaxCount` setting caps the filter chip bar to prevent overflow. Search chips always render regardless of cap. Configure in Settings.
 - **Storage Error Modal Suppressed for Intraday Cache (v3.33.22)**: saveRetailIntradayData() failures now log a console warning instead of showing a user-visible Storage Error modal — transient 24h sparkline cache is non-critical

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.25 &ndash; Browserbase Test Runbook v2</strong>: Modular E2E test runbook with 75+ tests across 8 section files. /bb-test skill reads runbook Markdown at runtime with section and tag filtering. Manual execution via Chrome DevTools or Claude browser extension documented as $0 alternative (STAK-396)</li>
+    <li><strong>v3.33.24 &ndash; Backup Integrity Audit</strong>: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner (STAK-374)</li>
+    <li><strong>v3.33.23 &ndash; Chip Max Count Setting</strong>: New chipMaxCount setting caps the filter chip bar to prevent overflow. Search chips always render regardless of cap. Configure in Settings</li>
     <li><strong>v3.33.22 &ndash; Storage Error Modal Suppressed for Intraday Cache</strong>: saveRetailIntradayData() failures now log a console warning instead of showing a user-visible Storage Error modal &mdash; transient 24h sparkline cache is non-critical</li>
     <li><strong>v3.33.20 &ndash; Market Panel Bug Fixes</strong>: API-driven item names via getRetailCoinMeta() as source of truth. Grid/list sync status shows &ldquo;just now&rdquo; after sync, time-ago when lingering, error state on API failure. Activity log dropdown dynamically populated from API manifest</li>
-    <li><strong>v3.33.19 &ndash; DiffMerge Integration</strong>: Selective apply for cloud sync pull and encrypted vault restore. DiffModal preview replaces full overwrite &mdash; users choose which changes to accept. Shared _applyAndFinalize helper consolidates post-apply sequence</li>
-    <li><strong>v3.33.18 &ndash; Diff/Merge Architecture Foundation</strong>: Manifest path constants, pruning threshold storage key, diffReviewModal HTML scaffold, and diff-modal.js script registration for the reusable change-review UI</li>
-    <li><strong>v3.33.17 &ndash; Realized Gains/Losses</strong>: Disposition workflow to mark items as Sold, Traded, Lost, Gifted, or Returned. Calculates realized gain/loss, adds disposition badges, filter toggle, portfolio summary breakdown, and CSV export columns</li>
   `;
 };
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.25-b1772429437';
+const CACHE_NAME = 'staktrakr-v3.33.25-b1772431885';
 
 
 

--- a/tests/runbook/00-setup.md
+++ b/tests/runbook/00-setup.md
@@ -1,0 +1,136 @@
+# 00 — Pre-Run Setup
+
+**This is not a test section.** It runs before all test sections in every `/bb-test` invocation.
+
+The setup section establishes a Browserbase session, navigates to the PR preview URL, dismisses startup modals, and records the baseline state that all subsequent test sections depend on.
+
+---
+
+## Purpose
+
+- Resolve the correct PR preview URL (never default to `staktrakr.pages.dev`)
+- Create a Browserbase session and record SESSION_ID
+- Land on a clean, modal-free inventory view at the preview URL
+- Capture a baseline screenshot for the session recording
+- Record the BASE_URL and start time for use throughout the run
+
+---
+
+## Storage Note
+
+**Storage is NOT cleared during setup.**
+
+The seed data for all runbook runs is the pre-existing 8 inventory items that reside in the preview deployment's localStorage (scoped to `staktrakr.pages.dev`). These 8 items are the baseline inventory count referenced in tests across all sections (e.g., "extract item count → expect: 8").
+
+Individual test sections that add, edit, or delete items are responsible for cleaning up after themselves. Sections do not share mutable state across section boundaries.
+
+> **Warning:** Never target `staktrakr.pages.dev` directly unless the user has explicitly overridden this restriction. Always use the PR preview URL resolved from `gh pr checks`.
+
+---
+
+## Setup Steps
+
+### Step 1 — Get PR preview URL
+
+Run the following command to extract the Cloudflare Pages preview URL from the PR's check statuses:
+
+```bash
+gh pr checks <PR_NUMBER> --json name,state,targetUrl \
+  | python3 -c "import sys,json; checks=json.load(sys.stdin); [print(c['targetUrl']) for c in checks if 'pages.dev' in c.get('targetUrl','')]"
+```
+
+If no PR number is available:
+- Attempt to detect the current branch's open PR: `gh pr view --json number`
+- If a PR is found, use that number with the command above
+- Poll up to 3 times at 30-second intervals if the Cloudflare Pages check is not yet green
+- If still no URL after 3 attempts: **stop and prompt the user**
+
+> Prompt: "No PR preview URL found. Provide a preview URL or PR number to continue."
+
+Record the resolved URL as `BASE_URL` for use in all subsequent navigation steps.
+
+### Step 2 — Create Browserbase session
+
+Call `browserbase_session_create` to open a new Browserbase session.
+
+Record:
+- `SESSION_ID` — the session identifier returned by the tool
+- Browserbase dashboard URL for the session recording
+- Start time (wall clock, UTC)
+
+If session creation fails, abort the run immediately with:
+> "Browserbase session failed to create — check API key in Infisical."
+
+Do not attempt to proceed without a valid session.
+
+### Step 3 — Navigate to preview URL
+
+Navigate to the application:
+
+```
+stagehand_navigate → {BASE_URL}/index.html
+```
+
+Wait for the page to finish loading before proceeding. The navigation is complete when the inventory view or a startup modal is visible.
+
+### Step 4 — Dismiss the What's New / acknowledgment modal
+
+If a What's New popup, release notes modal, or acknowledgment dialog is visible on page load:
+
+- act: "Click the I Understand or Accept button if a modal is visible"
+
+If no modal appears, continue to the next step without error — modal presence depends on session state.
+
+### Step 5 — Dismiss any other startup modals
+
+Check for and dismiss any additional modals that may appear on first load (e.g., cookie notices, update prompts, welcome dialogs):
+
+- act: "Close or dismiss any remaining popup or modal if one is visible"
+
+The inventory view should now be fully accessible with no overlapping dialogs.
+
+### Step 6 — Take baseline screenshot
+
+Capture the state of the page after modal dismissal:
+
+- screenshot: `00-baseline`
+
+This screenshot serves as the visual starting point for the session recording. It should show the inventory grid with 8 seed items and no visible modals.
+
+### Step 7 — Record session metadata
+
+Record the following for use throughout the run:
+
+| Variable | Value |
+|----------|-------|
+| `SESSION_ID` | Returned from `browserbase_session_create` |
+| `BASE_URL` | PR preview URL resolved in Step 1 |
+| `START_TIME` | Wall clock time at session creation (UTC) |
+| `SEED_COUNT` | Expected inventory count at baseline: **8** |
+
+---
+
+## Post-Setup State
+
+After setup completes successfully:
+
+- A Browserbase session is active
+- The browser is at `{BASE_URL}/index.html`
+- No startup modals are visible
+- The inventory grid shows 8 seed items
+- A baseline screenshot (`00-baseline`) is captured
+- `SESSION_ID`, `BASE_URL`, and `START_TIME` are recorded
+
+The test runner proceeds to execute the first requested section.
+
+---
+
+## Setup Failure Handling
+
+| Failure | Action |
+|---------|--------|
+| No PR preview URL after 3 polls | Stop. Prompt user for URL. |
+| Browserbase session creation fails | Abort run. Print error. Do not continue. |
+| Navigation to `{BASE_URL}/index.html` fails | Abort run. Verify preview URL is correct. |
+| Modal dismissal has no effect after 2 attempts | Log warning, continue — modal may not be present |
+| Baseline screenshot fails | Log warning, continue — non-blocking |

--- a/tests/runbook/01-page-load.md
+++ b/tests/runbook/01-page-load.md
@@ -1,0 +1,136 @@
+# Section 01 — Page Load
+
+Tests for initial page load, version display, spot price rendering, and startup modals. These tests validate the fundamental "cold open" experience: that the application renders correctly at the PR preview URL, displays the expected version, shows the What's New modal on first visit (and suppresses it on subsequent visits within the same session), renders all four metal spot price cards with live values, and accurately reflects the seed inventory count.
+
+Run these tests first in any full-suite session. Tests 1.2 through 1.5 are sequentially dependent within this section — 1.4 must complete before 1.5 can be meaningful.
+
+---
+
+### Test 1.1 — Page loads at preview URL
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** BASE_URL is the PR preview URL obtained from 00-setup. Session is active.
+**Steps:**
+- act: "navigate to BASE_URL/index.html"
+- extract: "the page title in the browser tab" → expect: "StakTrakr"
+- extract: "the tagline text 'Your Stack. Your Way.' is visible on the page" → expect: true
+- screenshot: "01-page-load-baseline"
+**Pass criteria:** The page loads without error, the browser tab title reads "StakTrakr", and the tagline "Your Stack. Your Way." is visible in the UI.
+**Tags:** page-load, load
+**Section:** 01-page-load
+
+---
+
+### Test 1.2 — What's New popup appears on first load
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Fresh session with no prior acknowledgment stored. This is the first navigation to BASE_URL in this Browserbase session (localStorage has not been seeded with an acknowledgment flag).
+**Steps:**
+- extract: "a modal or popup dialog is visible on the page" → expect: true
+- screenshot: "01-page-load-whats-new"
+**Pass criteria:** A What's New or acknowledgment modal is visible immediately after the first page load without any user interaction.
+**Tags:** page-load, modal, whats-new
+**Section:** 01-page-load
+
+---
+
+### Test 1.3 — What's New contains latest patch notes
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** The What's New modal is open (from 1.2).
+**Steps:**
+- extract: "the text content of the visible modal includes a version number or patch note description" → expect: non-empty version string
+**Pass criteria:** The modal body contains visible version text or patch note content — it is not blank and not showing a loading spinner.
+**Tags:** page-load, modal, whats-new
+**Section:** 01-page-load
+
+---
+
+### Test 1.4 — Clicking Accept closes the modal
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** The What's New modal is open (from 1.2 and 1.3).
+**Steps:**
+- act: "click the I Understand or Accept button in the modal"
+- extract: "the acknowledgment modal is visible" → expect: false
+**Pass criteria:** After clicking the acceptance button, the modal is dismissed and the main inventory view is fully visible.
+**Tags:** page-load, modal, whats-new
+**Section:** 01-page-load
+
+---
+
+### Test 1.5 — What's New does NOT appear on refresh (session-scoped)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** The What's New modal was dismissed in 1.4. The acknowledgment flag is now stored in localStorage for this session.
+**Steps:**
+- act: "navigate to BASE_URL/index.html"
+- extract: "the acknowledgment or What's New modal is visible" → expect: false
+**Pass criteria:** After navigating back to the page URL, no What's New or acknowledgment modal appears. The page loads directly to the inventory view.
+**Tags:** page-load, modal, session
+**Section:** 01-page-load
+
+---
+
+### Test 1.6 — Header displays all menu items in correct order
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Modal dismissed (from 1.4). Page is fully loaded.
+**Steps:**
+- extract: "the header navigation contains visible icon buttons or menu items including Inventory, Market, Log, and Settings" → expect: at least 3 navigation elements visible in the header
+**Pass criteria:** The header renders with at minimum three navigation elements (Inventory view toggle, Market icon, Log icon, and/or Settings icon) all visible without overlap.
+**Tags:** page-load, header, navigation
+**Section:** 01-page-load
+
+---
+
+### Test 1.7 — Version number in header matches deployed patch version
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Modal dismissed. Page is fully loaded.
+**Steps:**
+- extract: "the version text displayed in the header or page footer" → expect: a non-empty version string matching the format X.X.X (three dot-separated integers)
+**Pass criteria:** A version string in the format X.X.X is visible somewhere in the header or footer and is not blank, "undefined", or "0.0.0".
+**Tags:** page-load, version, header
+**Section:** 01-page-load
+
+---
+
+### Test 1.8 — Spot price cards render (all 4 metals, non-zero values)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Modal dismissed. Page fully loaded. Network connection active so spot API can respond.
+**Steps:**
+- extract: "the Gold spot price card is visible with a dollar amount" → expect: a non-zero dollar value displayed
+- extract: "the Silver spot price card is visible with a dollar amount" → expect: a non-zero dollar value displayed
+- extract: "the Platinum spot price card is visible with a dollar amount" → expect: a non-zero dollar value displayed
+- extract: "the Palladium spot price card is visible with a dollar amount" → expect: a non-zero dollar value displayed
+- screenshot: "01-page-load-spot-cards"
+**Pass criteria:** All four metal spot price cards (Gold, Silver, Platinum, Palladium) are visible and each shows a non-zero dollar amount. No card shows "$0.00", "N/A", or a loading placeholder.
+**Tags:** page-load, spot-prices, metals
+**Section:** 01-page-load
+
+---
+
+### Test 1.9 — Spot API backfills missing spot prices for last 30 days on load
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Modal dismissed. Page fully loaded. This test validates that the backfill routine ran on startup.
+**Steps:**
+- extract: "spot price values displayed on the page are non-zero and not showing 'N/A' or blank placeholders" → expect: non-zero spot values displayed for all visible metals
+**Pass criteria:** Spot price values are populated and non-zero across all displayed metals, indicating the backfill routine successfully fetched or restored historical spot data for the past 30 days.
+**Tags:** page-load, spot-prices, api, backfill
+**Section:** 01-page-load
+
+---
+
+### Test 1.10 — Market API backfills daily market prices for last 30 days on load
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Modal dismissed. Page fully loaded. Network connection active.
+**Steps:**
+- extract: "any market data error message or alert is visible on the main page" → expect: no error message visible
+**Pass criteria:** No market data error banner, toast, or alert is visible after the page finishes loading, indicating the market API backfill completed without error.
+**Tags:** page-load, market, api, backfill
+**Section:** 01-page-load
+
+---
+
+### Test 1.11 — Seed inventory count is accurate on first load
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Storage has not been cleared. The preview URL is pre-seeded with the standard 8-item seed inventory loaded into localStorage.
+**Steps:**
+- extract: "the item count label, badge, or counter displayed on the page" → expect: 8 items
+**Pass criteria:** The inventory count shown in the UI (badge, header label, or filter chip) reads 8, matching the seed data that ships with the application.
+**Tags:** page-load, inventory, count
+**Section:** 01-page-load

--- a/tests/runbook/02-crud.md
+++ b/tests/runbook/02-crud.md
@@ -1,0 +1,347 @@
+# Section 02 — CRUD
+
+Covers all Create, Read, Update, and Delete operations for inventory items. Tests in this section build on each other: items added in early tests are edited, searched, filtered, and deleted by later tests. The section begins with a seed count of 8 items (established by `00-setup.md`) and ends with a cleanup block that removes all BB-* items added here, restoring the seed state.
+
+Tests 2.7–2.11 cover the image upload and pattern-match features. Note that Stagehand cannot interact with OS-level file picker dialogs; those tests validate the UI flow up to the upload trigger. Full file upload verification requires manual confirmation.
+
+---
+
+### Test 2.1 — Add item — Silver Coin
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Seed inventory loaded (8 items). No filters or search active.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select Silver from the metal dropdown"
+- act: "select Coin from the type dropdown"
+- act: "type 'BB-SILVER-COIN' into the name field"
+- act: "type '1' into the weight field"
+- act: "type '25' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- extract: "count the number of inventory item cards displayed" → expect: 9
+- screenshot: "02-crud-add-silver"
+**Pass criteria:** Item count increases to 9 and BB-SILVER-COIN is visible in the inventory.
+**Tags:** crud, add, silver
+**Section:** 02-crud
+
+---
+
+### Test 2.2 — Add item — Gold Bar
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.1 complete (count = 9). No filters or search active.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select Gold from the metal dropdown"
+- act: "select Bar from the type dropdown"
+- act: "type 'BB-GOLD-BAR' into the name field"
+- act: "type '1' into the weight field"
+- act: "type '2000' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- extract: "count the number of inventory item cards displayed" → expect: 10
+**Pass criteria:** Item count increases to 10 and BB-GOLD-BAR is visible in the inventory.
+**Tags:** crud, add, gold
+**Section:** 02-crud
+
+---
+
+### Test 2.3 — Add item — Platinum Round
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Tests 2.1 and 2.2 complete (count = 10). No filters or search active.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select Platinum from the metal dropdown"
+- act: "select Round from the type dropdown"
+- act: "type 'BB-PLAT-ROUND' into the name field"
+- act: "type '1' into the weight field"
+- act: "type '1000' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- extract: "count the number of inventory item cards displayed" → expect: 11
+**Pass criteria:** Item count increases to 11 and BB-PLAT-ROUND is visible in the inventory.
+**Tags:** crud, add, platinum
+**Section:** 02-crud
+
+---
+
+### Test 2.4 — Add item — Palladium Bar
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.3 complete (count = 11). No filters or search active.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select Palladium from the metal dropdown"
+- act: "select Bar from the type dropdown"
+- act: "type 'BB-PALL-BAR' into the name field"
+- act: "type '1' into the weight field"
+- act: "type '1000' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- extract: "count the number of inventory item cards displayed" → expect: 12
+**Pass criteria:** Item count increases to 12 and BB-PALL-BAR is visible in the inventory.
+**Tags:** crud, add, palladium
+**Section:** 02-crud
+
+---
+
+### Test 2.5 — Add item — Goldback
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.4 complete (count = 12). No filters or search active.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select Goldback from the metal dropdown"
+- act: "type 'BB-GOLDBACK' into the name field"
+- act: "type '1' into the weight field"
+- act: "type '5' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- extract: "count the number of inventory item cards displayed" → expect: 13
+**Pass criteria:** Item count increases to 13 and BB-GOLDBACK is visible in the inventory.
+**Tags:** crud, add, goldback
+**Section:** 02-crud
+
+---
+
+### Test 2.6 — Add items with each weight unit (oz, g, kg, dwt)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.5 complete (count = 13). No filters or search active.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select Silver from the metal dropdown"
+- act: "type 'BB-OZ-ITEM' into the name field"
+- act: "select oz from the weight unit dropdown"
+- act: "type '1' into the weight field"
+- act: "type '25' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- act: "click the Add Item button"
+- act: "select Silver from the metal dropdown"
+- act: "type 'BB-G-ITEM' into the name field"
+- act: "select g from the weight unit dropdown"
+- act: "type '31.1' into the weight field"
+- act: "type '25' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- act: "click the Add Item button"
+- act: "select Silver from the metal dropdown"
+- act: "type 'BB-KG-ITEM' into the name field"
+- act: "select kg from the weight unit dropdown"
+- act: "type '0.0311' into the weight field"
+- act: "type '25' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- act: "click the Add Item button"
+- act: "select Silver from the metal dropdown"
+- act: "type 'BB-DWT-ITEM' into the name field"
+- act: "select dwt from the weight unit dropdown"
+- act: "type '20' into the weight field"
+- act: "type '25' into the purchase price field"
+- act: "click the Add to Inventory or Save button"
+- extract: "count the number of inventory item cards displayed" → expect: 17
+- screenshot: "02-crud-weight-units"
+**Pass criteria:** All 4 weight-unit items (BB-OZ-ITEM, BB-G-ITEM, BB-KG-ITEM, BB-DWT-ITEM) saved with their respective weight units; count reaches 17.
+**Tags:** crud, add, weight-units
+**Section:** 02-crud
+
+---
+
+### Test 2.7 — Upload obverse image
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Tests 2.1–2.6 complete (count = 17). BB-SILVER-COIN exists. Note: Stagehand cannot interact with OS file picker dialogs. This test validates the UI flow up to the upload trigger only; full file upload requires manual verification.
+**Steps:**
+- act: "click the Table view button (D) in the card sort bar to switch to table view"
+- act: "click the edit pencil icon on the BB-SILVER-COIN row in the inventory table"
+- act: "click the Upload Obverse Image button or area in the edit modal"
+- extract: "is an upload prompt, file picker trigger, or image upload area visible?" → expect: true
+- screenshot: "02-crud-obverse-image"
+**Pass criteria:** The obverse image upload button is clickable and triggers the upload UI without error.
+**Tags:** crud, images, upload, obverse
+**Section:** 02-crud
+
+---
+
+### Test 2.8 — Upload reverse image
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.7 complete. BB-SILVER-COIN edit modal is open (or re-open it). Note: same Stagehand file picker limitation as 2.7 applies.
+**Steps:**
+- act: "click the Upload Reverse Image button or area in the edit modal"
+- extract: "is an upload prompt, file picker trigger, or image upload area visible?" → expect: true
+- screenshot: "02-crud-reverse-image"
+**Pass criteria:** The reverse image upload button is clickable and triggers the upload UI without error.
+**Tags:** crud, images, upload, reverse
+**Section:** 02-crud
+
+---
+
+### Test 2.9 — Remove an uploaded image
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** An image was successfully uploaded to BB-SILVER-COIN in 2.7. If no image was uploaded (due to file picker limitation), this test is manual only — document and skip. Edit modal for BB-SILVER-COIN is open or re-open it from table view.
+**Steps:**
+- act: "click the remove or delete button on the obverse image in the edit modal if one is present"
+- extract: "is the obverse image thumbnail no longer shown in the edit modal?" → expect: true
+**Pass criteria:** The obverse image is removed and no longer displayed in the item edit form. If no image was present (file picker not interactable), note as manual verification required.
+**Tags:** crud, images, remove
+**Section:** 02-crud
+
+---
+
+### Test 2.10 — Apply pattern-matched image to multiple items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Close the edit modal if open. At least one item image exists in inventory. Search for a pattern-match or bulk image apply feature in the UI.
+**Steps:**
+- act: "close the edit modal if it is still open"
+- extract: "is a Pattern Match, Apply Image to All Similar Items, or bulk image apply button or option visible in the UI?" → expect: true
+- screenshot: "02-crud-pattern-match-check"
+**Pass criteria:** A pattern-match or bulk image application option is accessible. If the feature is not surfaced in this UI state, the test documents its absence for follow-up; pass if the feature is reachable.
+**Tags:** crud, images, pattern-match
+**Section:** 02-crud
+
+---
+
+### Test 2.11 — Remove pattern-matched image from multiple items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.10 complete. A pattern-matched image was applied to one or more items (if feature was accessible).
+**Steps:**
+- extract: "is there an option to remove or clear pattern-matched images from the matched items?" → expect: true
+- act: "click the remove or clear button for the pattern-matched image set"
+- extract: "are pattern-matched images removed from the previously matched items?" → expect: true
+**Pass criteria:** Pattern-matched images are removed from all items that received them via the pattern-match feature. If the feature was not accessible in 2.10, note as manual verification required.
+**Tags:** crud, images, pattern-match, remove
+**Section:** 02-crud
+
+---
+
+### Test 2.12 — Edit an existing item (all fields)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** BB-GOLD-BAR exists in inventory (added in 2.2). Table view active or can be switched to.
+**Steps:**
+- act: "click the Table view button (D) in the card sort bar to switch to table view"
+- act: "click the edit pencil icon on the BB-GOLD-BAR row in the inventory table"
+- act: "clear the name field and type 'BB-GOLD-BAR-EDITED'"
+- act: "clear the purchase price field and type '2100'"
+- act: "clear the notes field and type 'edited in test 2.12'"
+- act: "click the Save Changes button to submit the edit form"
+- extract: "is 'BB-GOLD-BAR-EDITED' visible in the inventory table?" → expect: true
+- screenshot: "02-crud-edit"
+**Pass criteria:** Item name updated to BB-GOLD-BAR-EDITED and purchase price updated to 2100; the edited item is visible in the table.
+**Tags:** crud, edit
+**Section:** 02-crud
+
+---
+
+### Test 2.13 — Delete item — confirmation dialog appears before delete
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** BB-PLAT-ROUND exists in inventory (added in 2.3). Inventory visible (any view).
+**Steps:**
+- act: "click the delete button on the BB-PLAT-ROUND card or row"
+- extract: "is a confirmation dialog or confirmation prompt visible before the item is deleted?" → expect: true
+- screenshot: "02-crud-delete-confirm"
+**Pass criteria:** A confirmation dialog appears after clicking delete, before the item is actually removed from the inventory.
+**Tags:** crud, delete, confirmation
+**Section:** 02-crud
+
+---
+
+### Test 2.14 — Item count badge updates after add/edit/delete
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Confirmation dialog is visible from 2.13 (BB-PLAT-ROUND pending deletion).
+**Steps:**
+- act: "click the Confirm or Delete button in the confirmation dialog"
+- extract: "count the number of inventory item cards displayed" → expect: 16
+- screenshot: "02-crud-count-badge"
+**Pass criteria:** Item count decrements by 1 (from 17 to 16) immediately after confirming the deletion of BB-PLAT-ROUND.
+**Tags:** crud, count, badge
+**Section:** 02-crud
+
+---
+
+### Test 2.15 — Search for an item by name
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.14 complete (count = 16). BB-SILVER-COIN exists (added in 2.1). No active filters.
+**Steps:**
+- act: "type 'BB-SILVER' into the search input field"
+- extract: "count the number of inventory item cards currently visible after the search" → expect: ≥1
+- screenshot: "02-crud-search"
+**Pass criteria:** Only items whose name contains "BB-SILVER" are shown (at minimum BB-SILVER-COIN); count is ≥1.
+**Tags:** crud, search
+**Section:** 02-crud
+
+---
+
+### Test 2.16 — Filter chips reflect search results
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Search for 'BB-SILVER' is active from 2.15. At least one result is visible.
+**Steps:**
+- extract: "do the filter chip labels or result counts update to reflect the current search results rather than the full inventory?" → expect: true
+**Pass criteria:** Filter chips show a filtered state (updated counts or active indicator) that corresponds to the search-narrowed result set, not the total inventory.
+**Tags:** crud, search, filter-chips
+**Section:** 02-crud
+
+---
+
+### Test 2.17 — Sort via filter chip (metal)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.16 complete. Clear any active search before this test.
+**Steps:**
+- act: "clear the search input field"
+- act: "click the Silver filter chip"
+- extract: "count the number of inventory item cards currently visible" → expect: ≥1
+- extract: "are any non-Silver items visible in the filtered inventory?" → expect: false
+**Pass criteria:** Only Silver metal items are shown after clicking the Silver filter chip; no non-Silver items are visible.
+**Tags:** crud, filter, sort
+**Section:** 02-crud
+
+---
+
+### Test 2.18 — Remove filter chip narrows/expands results
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Silver filter chip is active from 2.17.
+**Steps:**
+- act: "click the Silver filter chip again to deactivate it and remove the filter"
+- extract: "count the number of inventory item cards currently displayed" → expect: 16
+**Pass criteria:** Removing the Silver filter chip restores the full unfiltered inventory (16 items at this point in the section).
+**Tags:** crud, filter, remove
+**Section:** 02-crud
+
+---
+
+### Test 2.19 — Switch card views A → B → C → Table (D)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Test 2.18 complete. No active search or filters. Count = 16.
+**Steps:**
+- act: "click the View A card style button in the card sort bar"
+- extract: "count the number of inventory item cards displayed in View A" → expect: ≥1
+- act: "click the View B card style button in the card sort bar"
+- extract: "count the number of inventory item cards displayed in View B" → expect: ≥1
+- act: "click the View C card style button in the card sort bar"
+- extract: "count the number of inventory item cards displayed in View C" → expect: ≥1
+- act: "click the Table view button (D) in the card sort bar"
+- extract: "count the number of inventory item rows displayed in Table view" → expect: ≥1
+- screenshot: "02-crud-card-views"
+**Pass criteria:** All 4 view modes (A, B, C, Table/D) display inventory items without error or blank content.
+**Tags:** crud, views, ui
+**Section:** 02-crud
+
+---
+
+### Test 2.20 — Melt value recalculates correctly when spot price changes
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** BB-SILVER-COIN exists (from 2.1). Silver spot price is loaded (visible in the spot price cards at the top of the page). Note: this test validates displayed values are consistent with the melt formula (melt ≈ weight × qty × spot); triggering a live spot price update would require external API intervention and is out of scope for this automated check.
+**Steps:**
+- extract: "what is the melt value displayed on the BB-SILVER-COIN card or row?" → expect: a non-zero dollar amount (e.g., $25.00 or higher)
+- extract: "what is the Silver spot price shown in the spot price cards at the top of the page?" → expect: a non-zero dollar amount (e.g., $28.00 or higher)
+**Pass criteria:** BB-SILVER-COIN displays a non-zero melt value and the Silver spot price card shows a non-zero value; the melt value is consistent with being derived from weight × spot (proportionality check, not exact match).
+**Tags:** crud, melt-value, spot-prices
+**Section:** 02-crud
+
+---
+
+### Test 2.21 — Cleanup — Delete all BB-* test items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** All BB-* items from Tests 2.1–2.6 exist (minus BB-PLAT-ROUND deleted in 2.13 and any deleted in earlier edit tests). Table view may be active or card view — switch if needed.
+**Steps:**
+- act: "click the Table view button (D) to switch to table view for easier row-level access"
+- act: "find the BB-SILVER-COIN row, click its delete button, and confirm deletion in the confirmation dialog"
+- act: "find the BB-GOLD-BAR-EDITED row (or BB-GOLD-BAR if not renamed), click its delete button, and confirm deletion"
+- act: "find the BB-PALL-BAR row, click its delete button, and confirm deletion"
+- act: "find the BB-GOLDBACK row, click its delete button, and confirm deletion"
+- act: "find the BB-OZ-ITEM row, click its delete button, and confirm deletion"
+- act: "find the BB-G-ITEM row, click its delete button, and confirm deletion"
+- act: "find the BB-KG-ITEM row, click its delete button, and confirm deletion"
+- act: "find the BB-DWT-ITEM row, click its delete button, and confirm deletion"
+- extract: "count the number of inventory item cards or rows displayed" → expect: 8
+- screenshot: "02-crud-cleanup"
+**Pass criteria:** All BB-* items added during section 02-crud are removed. The inventory count returns to 8 (seed state), confirming subsequent sections start from a clean baseline.
+**Tags:** crud, cleanup
+**Section:** 02-crud

--- a/tests/runbook/03-backup-restore.md
+++ b/tests/runbook/03-backup-restore.md
@@ -1,0 +1,182 @@
+# Section 03 — Backup & Restore
+
+This section covers all backup, restore, and encrypted vault operations in StakTrakr. Tests verify that inventory data and images can be exported in multiple formats (CSV, JSON, ZIP) and restored correctly, that conflict prompts appear when restoring over existing data, and that the encrypted vault flow completes without error.
+
+**File picker limitation:** Stagehand cannot interact with OS-level file picker dialogs. For any test that requires selecting a file from disk (restore, import), the test validates the UI flow up to the point where the file picker is triggered. Actual file selection and the downstream restore result require manual verification.
+
+---
+
+### Test 3.1 — Backup All Stored Images
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains at least 1 item with an image attached.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Backup Images or Export Images button"
+- extract: "Is a success message, download prompt, or confirmation that images were exported visible?" → expect: true
+- screenshot: "03-backup-images"
+**Pass criteria:** Clicking the backup images button triggers a download prompt or success message without error.
+**Tags:** backup, images, export
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.2 — Restore Images — Restore to Correct Items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** An image backup file exists from Test 3.1. Note: OS file picker interaction cannot be automated via Stagehand — test validates UI flow up to file selection prompt. Manual verification required for actual file restore/import.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Restore Images or Import Images button"
+- extract: "Is a file picker dialog, restore prompt, or an instruction to select a file visible?" → expect: true
+- screenshot: "03-backup-restore-images"
+**Pass criteria:** The restore images button is clickable and triggers a file picker or restore prompt correctly.
+**Tags:** backup, restore, images
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.3 — Export CSV — Includes All Items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Export CSV button"
+- extract: "Is any error message visible on the page after clicking Export CSV?" → expect: no error
+- screenshot: "03-backup-export-csv"
+**Pass criteria:** CSV export triggers without a visible error message. (File download verification is limited in cloud browsers — absence of error is sufficient.)
+**Tags:** backup, export, csv
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.4 — Export JSON — Includes All Items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Export JSON button"
+- extract: "Is any error message visible on the page after clicking Export JSON?" → expect: no error
+- screenshot: "03-backup-export-json"
+**Pass criteria:** JSON export triggers without a visible error message.
+**Tags:** backup, export, json
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.5 — Export ZIP — Includes Images
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Export ZIP button"
+- extract: "Is any error message visible on the page after clicking Export ZIP?" → expect: no error
+**Pass criteria:** ZIP export triggers without a visible error message. The ZIP is expected to include both inventory data and any stored images.
+**Tags:** backup, export, zip
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.6 — Restore from CSV
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** A CSV export file exists from Test 3.3. Note: OS file picker interaction cannot be automated via Stagehand — test validates UI flow up to file selection prompt. Manual verification required for actual file restore/import.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Restore from CSV or Import CSV button"
+- extract: "Is a file picker dialog, restore prompt, or an instruction to select a file visible?" → expect: true
+**Pass criteria:** The restore from CSV button is clickable and triggers a file picker or restore prompt correctly.
+**Tags:** backup, restore, csv
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.7 — Restore from JSON
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** A JSON export file exists from Test 3.4. Note: OS file picker interaction cannot be automated via Stagehand — test validates UI flow up to file selection prompt. Manual verification required for actual file restore/import.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Restore from JSON or Import JSON button"
+- extract: "Is a file picker dialog, restore prompt, or an instruction to select a file visible?" → expect: true
+**Pass criteria:** The restore from JSON button is clickable and triggers a file picker or restore prompt correctly.
+**Tags:** backup, restore, json
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.8 — Restore from ZIP — Images Restore to Correct Items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** A ZIP export file exists from Test 3.5. Note: OS file picker interaction cannot be automated via Stagehand — test validates UI flow up to file selection prompt. Manual verification required for actual file restore/import, including verifying that images are re-associated with the correct inventory items after restore.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Restore from ZIP or Import ZIP button"
+- extract: "Is a file picker dialog, restore prompt, or an instruction to select a file visible?" → expect: true
+**Pass criteria:** The restore from ZIP button is clickable and triggers a file picker or restore prompt correctly.
+**Tags:** backup, restore, zip
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.9 — Restore Warns If Items Already Exist (Merge vs Overwrite Prompt)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Inventory has existing items (the 8 seed items). A restore is attempted with a file that contains overlapping items. Note: OS file picker interaction cannot be automated via Stagehand — test validates that the merge/overwrite prompt is accessible in the UI. If the prompt only appears after file selection, this test requires manual verification of the conflict dialog.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Restore from JSON or Restore button"
+- extract: "Is a file picker dialog or restore prompt visible?" → expect: true
+- screenshot: "03-backup-merge-prompt"
+**Pass criteria:** A merge/overwrite confirmation dialog is expected to appear before overwriting existing data when a conflicting file is selected. UI flow to trigger the restore is accessible without error.
+**Tags:** backup, restore, merge, conflict
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.10 — Restore Preserves Custom Fields (Serial Number, Notes, Purchase Date)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** A backup file exists that contains at least one item with notes, serial number, or purchase date set. Note: OS file picker interaction cannot be automated via Stagehand — if restore cannot be completed automatically, validate the custom fields display by checking an existing item that already has these fields populated in seed data.
+**Steps:**
+- act: "click on an inventory item card to open its detail view"
+- extract: "Are any of the fields notes, serial number, or purchase date visible and populated with a non-empty value?" → expect: non-empty custom field value visible
+**Pass criteria:** After restore (or on an item known to have custom fields), the notes, serial number, and purchase date fields show non-empty restored values — confirming custom fields survive a backup/restore cycle.
+**Tags:** backup, restore, custom-fields
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.11 — Export Encrypted Vault
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click or expand the Encrypted Backup section within the Export section"
+- act: "click the Export Encrypted Backup or Export Vault button"
+- act: "type 'TestVault123!' into the password field"
+- act: "click the Confirm or Export button to create the encrypted backup"
+- extract: "Is a success message, 'Backup exported successfully', or download prompt visible?" → expect: success message visible
+- screenshot: "03-backup-vault-export"
+**Pass criteria:** Encrypted vault export completes and a success message or download prompt appears without error.
+**Tags:** backup, vault, encrypt
+**Section:** 03-backup-restore
+
+---
+
+### Test 3.12 — Restore Encrypted Vault — Includes Image Files
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** An encrypted vault file exists from Test 3.11. Note: OS file picker interaction cannot be automated via Stagehand — test validates UI flow up to file selection prompt. Manual verification required for actual vault restore, including verifying that images are restored correctly alongside inventory data.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click or expand the Encrypted Backup section within the Export section"
+- act: "click the Restore Encrypted Vault or Import Vault button"
+- extract: "Is a file picker dialog, vault restore prompt, or an instruction to select a vault file visible?" → expect: true
+- screenshot: "03-backup-vault-restore"
+**Pass criteria:** The vault restore UI is accessible and clicking the restore button triggers a file picker or restore prompt correctly.
+**Tags:** backup, vault, decrypt, restore
+**Section:** 03-backup-restore

--- a/tests/runbook/04-import-export.md
+++ b/tests/runbook/04-import-export.md
@@ -1,0 +1,124 @@
+# Section 04 — Import & Export
+
+This section covers CSV/eBay import flows, duplicate detection, the merge diff viewer, selective import, and PDF export. It is distinct from Section 03 (backup/restore) in that it focuses on structured data import from external sources and the merge/conflict resolution UX rather than full inventory backup cycles.
+
+**File picker limitation:** Stagehand cannot interact with OS-level file picker dialogs. For any test that requires selecting a file from disk, the test validates the UI flow up to the point where the file picker is triggered. Actual file selection and downstream import results require manual verification.
+
+---
+
+### Test 4.1 — Import from CSV Source 1 (Generic Format)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Import from CSV or Import CSV button"
+- extract: "Is an import panel, modal, or file picker prompt visible?" → expect: true
+- screenshot: "04-import-csv1"
+**Pass criteria:** The generic CSV import option is accessible and clicking it opens an import panel, modal, or file picker prompt without error.
+**Tags:** import, csv
+**Section:** 04-import-export
+
+---
+
+### Test 4.2 — Import from CSV Source 2 (eBay Format)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Import from eBay CSV or eBay format import option if available"
+- extract: "Is an eBay-format import option, modal, or file picker prompt accessible?" → expect: true (if feature exists)
+- screenshot: "04-import-csv2"
+**Pass criteria:** eBay CSV import option is accessible in the import UI, or its absence is clearly documented. If the feature does not exist, this test is marked as not applicable and noted for future implementation.
+**Tags:** import, csv, ebay
+**Section:** 04-import-export
+
+---
+
+### Test 4.3 — Duplicate Detection — Flags Items That Already Exist
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Inventory contains 8 seed items. A CSV import file is available that contains at least one item matching an existing inventory entry (same name or metal/type combination). Note: OS file picker interaction cannot be automated via Stagehand — test validates that duplicate detection UI is present in the import flow. Manual verification of duplicate flagging requires completing the file selection step.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Import from CSV or Import CSV button"
+- extract: "Is an import panel, modal, or flow visible that would show duplicate detection after file selection?" → expect: true
+- screenshot: "04-import-duplicates"
+**Pass criteria:** The import UI is accessible and is expected to flag duplicate items before the import completes. Manual verification confirms that duplicate items are highlighted or listed separately from new items.
+**Tags:** import, duplicates, detection
+**Section:** 04-import-export
+
+---
+
+### Test 4.4 — Merge Diff Viewer Appears When Merging
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** MANUAL/CONTROLLED TEST — Duplicate items were detected in Test 4.3. The import flow has reached the stage where duplicates are identified and the diff viewer should be shown. File selection is required (not automatable via Stagehand) — manual execution needed to progress past the OS file picker.
+**Steps:**
+- extract: "Is a diff viewer, merge comparison panel, or side-by-side comparison of existing vs incoming item data visible?" → expect: true
+- screenshot: "04-import-diff-viewer"
+**Pass criteria:** A diff viewer or merge comparison UI appears when duplicate items are detected during import, allowing the user to review differences before deciding how to proceed.
+**Tags:** import, merge, diff
+**Section:** 04-import-export
+
+---
+
+### Test 4.5 — Diff Viewer Shows Field-Level Diffs
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** MANUAL/CONTROLLED TEST — Diff viewer is visible from Test 4.4. At least one field differs between the existing item and the incoming item (e.g., purchase price, name, or weight). Requires prior manual file selection step.
+**Steps:**
+- extract: "Does the diff viewer show individual field-level differences, such as old vs new purchase price, old vs new name, or old vs new weight?" → expect: at least one field difference visible
+**Pass criteria:** The diff viewer displays field-level differences (not just item-level flags), allowing users to see exactly what would change for each duplicate item.
+**Tags:** import, merge, diff, fields
+**Section:** 04-import-export
+
+---
+
+### Test 4.6 — Selectively Import — Check/Uncheck Items from Diff
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** MANUAL/CONTROLLED TEST — Diff viewer is visible with at least two items listed. Each item has a checkbox or toggle to include/exclude it from the import. Requires prior manual file selection step.
+**Steps:**
+- act: "uncheck or deselect one item in the diff viewer or import list"
+- extract: "Is the unchecked item marked as skip, excluded, or visually distinguished from selected items?" → expect: true
+**Pass criteria:** Individual items can be deselected in the diff/import view. Deselected items are visually marked as skipped or excluded.
+**Tags:** import, merge, select, skip
+**Section:** 04-import-export
+
+---
+
+### Test 4.7 — Skipped Item Leaves Existing Data Intact
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** MANUAL/CONTROLLED TEST — One item was unchecked/excluded in Test 4.6. The import has been confirmed or completed. Requires prior manual file selection step.
+**Steps:**
+- act: "confirm or complete the import with the one item left unchecked"
+- extract: "Does the skipped item still appear in the inventory with its original values unchanged?" → expect: original values unchanged
+**Pass criteria:** The item that was deselected from the import retains its pre-import values. The import did not overwrite or remove the skipped item's existing data.
+**Tags:** import, merge, skip, data-integrity
+**Section:** 04-import-export
+
+---
+
+### Test 4.8 — Import Summary Reports N Added / N Skipped / N Merged
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** An import has been completed (from any prior test in this section, or a fresh import run). The import involved at least one added item, one skipped item, or one merged item.
+**Steps:**
+- extract: "Is there a summary message or results panel showing counts for how many items were added, skipped, or merged?" → expect: summary with numeric counts visible
+- screenshot: "04-import-summary"
+**Pass criteria:** After import completes, a summary is displayed showing at minimum one numeric count (e.g., "3 added", "1 skipped", "0 merged"). The counts accurately reflect the import outcome.
+**Tags:** import, summary
+**Section:** 04-import-export
+
+---
+
+### Test 4.9 — PDF Export — No Error, File Downloads
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** App is loaded at the PR preview URL. Inventory contains the 8 seed items.
+**Steps:**
+- act: "click the Settings gear icon in the header"
+- act: "click the Inventory tab in the settings panel"
+- act: "click the Export PDF or Print PDF button"
+- extract: "Is any error message visible on the page after clicking Export PDF?" → expect: no error
+- screenshot: "04-import-pdf-export"
+**Pass criteria:** PDF export triggers without a visible error message. (File download verification is limited in cloud browsers — absence of error is sufficient.)
+**Tags:** export, pdf
+**Section:** 04-import-export

--- a/tests/runbook/05-market.md
+++ b/tests/runbook/05-market.md
@@ -1,0 +1,132 @@
+# Section 05 — Market
+
+This section covers E2E tests for the Market feature area: opening the market panel, verifying API-loaded inventory and price data, searching and filtering by metal type, viewing price history, checking source badges, and the Goldback card. Tests 5.7 is marked as manual/visual because triggering a genuine 30-minute data stale state cannot be done programmatically within a Browserbase session.
+
+Each test in this section is independently runnable given that the application has loaded at the PR preview URL (see `00-setup.md`). Tests 5.2 through 5.10 depend on the market panel being open; each test that requires it includes this in Preconditions so that the section can be resumed mid-run without ambiguity.
+
+---
+
+### Test 5.1 — Open market menu
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded at the PR preview URL. The What's New modal has been dismissed (see 00-setup.md).
+**Steps:**
+- act: "click the Market button or icon in the header navigation"
+- extract: "is a market panel, market page, or market overlay visible on screen" → expect: true
+- screenshot: "05-market-open"
+**Pass criteria:** The market panel or page opens and is visible without a page reload error.
+**Tags:** market, navigation
+**Section:** 05-market
+
+---
+
+### Test 5.2 — Market loads all inventory from API
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel open (5.1 complete).
+**Steps:**
+- extract: "how many market item listings or inventory rows are visible with price data in the market view" → expect: at least 1 item with a price value
+**Pass criteria:** At least one market item listing is visible with an associated price, confirming that API data has loaded into the market panel.
+**Tags:** market, api, load
+**Section:** 05-market
+
+---
+
+### Test 5.3 — Search for item in market
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel is open.
+**Steps:**
+- act: "type 'Silver' into the market search or filter input field"
+- extract: "are only Silver-related market items visible after filtering" → expect: at least 1 Silver item visible
+- screenshot: "05-market-search"
+**Pass criteria:** Filtering by "Silver" returns at least one Silver-related market item and hides non-Silver items (or all visible items are Silver-related).
+**Tags:** market, search
+**Section:** 05-market
+
+---
+
+### Test 5.4 — Expand and view price history for an item
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel is open. At least one market item is visible.
+**Steps:**
+- act: "click on a market item or expand button to view its price history or detail"
+- extract: "is a price history section, price history chart, or historical price list visible" → expect: true
+- screenshot: "05-market-price-history"
+**Pass criteria:** Clicking a market item or its expand control reveals a price history section containing historical price data.
+**Tags:** market, price-history
+**Section:** 05-market
+
+---
+
+### Test 5.5 — Price history is accurate with current API trends
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Price history is expanded from 5.4 — a price history section is visible for a market item.
+**Steps:**
+- extract: "does the price history section show dates and non-zero dollar values (not all zeros and not empty)" → expect: non-empty price history with at least one non-zero price value
+**Pass criteria:** The price history section displays at least one date-value pair where the dollar value is greater than zero, indicating live API data is being rendered.
+**Tags:** market, price-history, accuracy
+**Section:** 05-market
+
+---
+
+### Test 5.6 — Click item opens detail / price history view
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel is open. At least one market item listing is visible.
+**Steps:**
+- act: "click on a specific market item in the market listing"
+- extract: "is a detail view or expanded section with price information or price history now shown" → expect: true
+**Pass criteria:** Clicking a market item opens or reveals a detail view or expanded panel that includes price information or price history for that item.
+**Tags:** market, detail
+**Section:** 05-market
+
+---
+
+### Test 5.7 — Stale indicator appears when data exceeds 30-min threshold
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** MANUAL/CONTROLLED TEST — This test cannot be automated within a standard Browserbase session. Triggering the 30-minute stale state requires either: (a) waiting 30+ minutes without a market data refresh, or (b) manipulating the `generated_at` timestamp in localStorage to simulate stale data. Neither is reliably achievable via Stagehand during a normal test run. To verify manually: load the app, open the market panel, allow market data to age past 30 minutes without refresh, then observe whether a stale badge or indicator appears on market items or in the market header.
+**Steps:**
+- screenshot: "05-market-stale-note"
+**Pass criteria:** Test is documented. Manual verification procedure is recorded above. When executed under controlled stale conditions, a stale badge, warning icon, or "data may be outdated" indicator should be visible on market items or the market panel header.
+**Tags:** market, stale, manual
+**Section:** 05-market
+
+---
+
+### Test 5.8 — Goldback price card shows valid value
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel is open.
+**Steps:**
+- extract: "is a Goldback price card or Goldback listing visible in the market view with a non-zero dollar price" → expect: Goldback price greater than 0
+- screenshot: "05-market-goldback"
+**Pass criteria:** The Goldback price is displayed in the market view with a dollar value greater than zero, confirming the Goldback feed is returning data.
+**Tags:** market, goldback
+**Section:** 05-market
+
+---
+
+### Test 5.9 — Toggle between metal tabs (Gold/Silver/Platinum/Palladium)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel is open. Metal filter tabs are visible.
+**Steps:**
+- act: "click the Gold tab or Gold filter button in the market panel"
+- extract: "are Gold market items or Gold-related listings visible" → expect: at least 1 Gold item
+- act: "click the Silver tab or Silver filter button in the market panel"
+- extract: "are Silver market items or Silver-related listings visible" → expect: at least 1 Silver item
+- act: "click the Platinum tab or Platinum filter button in the market panel"
+- extract: "are Platinum market items or Platinum-related listings visible" → expect: true
+- act: "click the Palladium tab or Palladium filter button in the market panel"
+- extract: "are Palladium market items or Palladium-related listings visible" → expect: true
+- screenshot: "05-market-tabs"
+**Pass criteria:** Each metal tab filter (Gold, Silver, Platinum, Palladium) responds to click and shows at least one relevant item listing, confirming per-metal filtering is functional for all four metals.
+**Tags:** market, tabs, filter, metals
+**Section:** 05-market
+
+---
+
+### Test 5.10 — Correct source badge visible on market items
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Market panel is open. At least one market item listing is visible.
+**Steps:**
+- extract: "does at least one market item display a source or provider badge such as 'eBay', 'APMEX', or another vendor name" → expect: true
+- screenshot: "05-market-source-badge"
+**Pass criteria:** At least one market item shows a source or provider badge identifying the data origin (e.g., "eBay", "APMEX", or the API source name), confirming source attribution is rendered correctly.
+**Tags:** market, source-badge, provider
+**Section:** 05-market

--- a/tests/runbook/06-ui-ux.md
+++ b/tests/runbook/06-ui-ux.md
@@ -1,0 +1,158 @@
+# Section 06 — UI / UX
+
+This section covers E2E tests for responsive layout, theme switching, totals accuracy, item count display, currency switching, and settings persistence. It validates that the application renders correctly at standard breakpoints, responds to user-initiated theme and currency changes, and that the Settings modal saves and persists state across a page reload.
+
+**Viewport note (applies to 6.1 and 6.2):** Browserbase sessions use a fixed viewport configured at session creation time. Mid-session viewport resizing via Stagehand is not supported. Tests 6.1 (375px) and 6.2 (768px) are best executed in separate targeted Browserbase sessions configured at those widths. Within a standard desktop session, those tests capture a screenshot for reference and rely on session recording for visual verification. Test 6.3 (1280px desktop) runs normally in any standard Browserbase session.
+
+Each test in this section is independently runnable given that the application has loaded at the PR preview URL (see `00-setup.md`). Tests that change application state (6.5–6.7 theme, 6.10 currency, 6.11 settings) include restore steps to return the app to its default state.
+
+---
+
+### Test 6.1 — All elements load in Mobile view (375px)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** VIEWPORT NOTE — Browserbase sessions use a fixed viewport set at session creation. For accurate mobile testing, this test should be run in a Browserbase session created with width=375px and height=812px. If the current session uses a desktop viewport, this test captures a screenshot for reference only and the result should be verified via the session recording at the correct viewport. Application is loaded at the PR preview URL.
+**Steps:**
+- screenshot: "06-ui-ux-mobile-check"
+- extract: "is the main content area, inventory list, or spot price section visible without a JavaScript error" → expect: true
+**Pass criteria:** At a 375px viewport width, the main application content renders and is accessible without horizontal overflow causing content to be cut off. No JavaScript errors should be present. Visual confirmation via session recording at 375px is recommended.
+**Tags:** ui, responsive, mobile
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.2 — All elements load in Tablet view (768px)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** VIEWPORT NOTE — Same as 6.1. For accurate tablet testing, this test should be run in a Browserbase session created with width=768px. If the current session uses a different viewport, the screenshot documents the state for visual review. Application is loaded at the PR preview URL.
+**Steps:**
+- screenshot: "06-ui-ux-tablet-check"
+- extract: "is the main content area visible and rendering correctly" → expect: true
+**Pass criteria:** At a 768px viewport width, the application content renders and is accessible. No horizontal scroll bar should be required to view primary content. Visual confirmation via session recording at 768px is recommended.
+**Tags:** ui, responsive, tablet
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.3 — All elements load in Desktop view (1280px)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Standard Browserbase session (default viewport width of 1280px or greater). Application is loaded at the PR preview URL and the What's New modal has been dismissed.
+**Steps:**
+- extract: "are the spot price cards for Gold, Silver, Platinum, and Palladium all visible with dollar values" → expect: true
+- extract: "are inventory cards or an inventory section visible on the page" → expect: true
+- extract: "is the header navigation visible with menu icons or labels" → expect: true
+- screenshot: "06-ui-ux-desktop"
+**Pass criteria:** At desktop viewport (1280px+), the header navigation, all four spot price cards, and the inventory section are all simultaneously visible without requiring horizontal scroll.
+**Tags:** ui, responsive, desktop
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.4 — No overlap or bleed issues in any size mode
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded at the PR preview URL in the current session's viewport.
+**Steps:**
+- screenshot: "06-ui-ux-layout-check"
+**Pass criteria:** Visual inspection via session recording — no obvious overlap between UI elements (cards, header, modals, or filter chips), no text bleeding outside container boundaries, and no elements obscuring interactive controls. Recommend reviewing the recording at multiple scroll positions from top to bottom of the page.
+**Tags:** ui, responsive, layout, visual
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.5 — Light theme triggers correctly
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded. Theme selector is accessible from the header or settings area.
+**Steps:**
+- act: "click the theme toggle, theme selector, or theme switcher in the header or navigation"
+- act: "select the Light theme option"
+- extract: "does the page appear in light mode with a light or white background" → expect: light theme active (light background visible)
+- screenshot: "06-ui-ux-light-theme"
+**Pass criteria:** Selecting the Light theme visibly changes the application background to a light color scheme and the change persists until another theme is selected.
+**Tags:** ui, theme, light
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.6 — Dark theme triggers correctly
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded. Theme selector is accessible.
+**Steps:**
+- act: "click the theme toggle, theme selector, or theme switcher in the header or navigation"
+- act: "select the Dark theme option"
+- extract: "does the page appear in dark mode with a dark background" → expect: dark theme active (dark background visible)
+- screenshot: "06-ui-ux-dark-theme"
+**Pass criteria:** Selecting the Dark theme visibly changes the application to a dark color scheme. The page background is dark and text is light-colored.
+**Tags:** ui, theme, dark
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.7 — Sepia/HelloKitty theme triggers correctly
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded. Theme selector is accessible.
+**Steps:**
+- act: "click the theme toggle, theme selector, or theme switcher in the header or navigation"
+- act: "select the Sepia or HelloKitty theme option, whichever is available in the selector"
+- extract: "does the page show a visually distinct theme that is neither the default light nor the standard dark theme" → expect: a non-default theme is applied and visible
+- screenshot: "06-ui-ux-sepia-theme"
+**Pass criteria:** Selecting the Sepia or HelloKitty theme applies a visually distinct color scheme to the application that differs from both the Light and Dark themes.
+**Tags:** ui, theme, sepia, hellokitty
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.8 — Totals cards are accurate based on current spot prices
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded. Spot prices have loaded (spot cards show non-zero values). Inventory contains at least one item (seed data of 8 items is present).
+**Steps:**
+- extract: "what is the total melt value or All Metals summary card dollar amount shown on the page" → expect: a non-zero dollar amount greater than $0.00
+- screenshot: "06-ui-ux-totals"
+**Pass criteria:** The All Metals total or aggregate melt value card displays a non-zero dollar amount, confirming that spot prices are being multiplied by inventory weights to produce totals.
+**Tags:** ui, totals, accuracy
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.9 — Item counts displayed are accurate
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded with seed inventory (8 items). No items have been added or deleted in this session before this test runs.
+**Steps:**
+- extract: "what number does the item count badge, item count label, or inventory count display show" → expect: 8
+- screenshot: "06-ui-ux-count"
+**Pass criteria:** The item count display shows 8, matching the seed inventory count. If items were added or deleted earlier in the session, the expected count should be adjusted accordingly and noted in the test run record.
+**Tags:** ui, count, accuracy
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.10 — Currency switcher — USD to EUR updates all price displays
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded. Settings modal is accessible via the gear icon.
+**Steps:**
+- act: "click the Settings gear icon in the header or navigation"
+- act: "locate the display currency setting and change it to EUR or Euro"
+- act: "close the Settings modal by clicking the close button or clicking outside the modal"
+- extract: "is the euro symbol (€) visible in at least one spot price card or inventory melt value display" → expect: € symbol present
+- screenshot: "06-ui-ux-currency-eur"
+- act: "click the Settings gear icon to reopen Settings"
+- act: "change the display currency back to USD"
+- act: "close the Settings modal"
+**Pass criteria:** After switching to EUR, the euro symbol (€) appears in at least one price display on the page (spot cards or inventory card melt values). The restore steps return the currency to USD so subsequent tests see correct USD formatting.
+**Tags:** ui, currency, settings
+**Section:** 06-ui-ux
+
+---
+
+### Test 6.11 — Settings modal opens, saves, and persists across reload
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Application is loaded. Settings modal is accessible via the gear icon.
+**Steps:**
+- act: "click the Settings gear icon in the header or navigation"
+- screenshot: "06-ui-ux-settings-open"
+- act: "change the items per page setting to 32"
+- act: "close the Settings modal by clicking the close button or clicking outside the modal"
+- act: "click the Settings gear icon to reopen the Settings modal"
+- extract: "what is the current value shown in the items per page setting field" → expect: 32
+- act: "change the items per page setting back to its default value (All)"
+- act: "close the Settings modal"
+**Pass criteria:** After setting items per page to 32 and closing the modal, reopening Settings shows the value persisted as 32. The restore steps return the setting to its default so subsequent tests are not affected by changed pagination.
+**Tags:** ui, settings, persistence, reload
+**Section:** 06-ui-ux

--- a/tests/runbook/07-activity-log.md
+++ b/tests/runbook/07-activity-log.md
@@ -1,0 +1,68 @@
+# Section 07 — Activity Log
+
+Tests for activity log recording, display, and persistence. The activity log captures every Add, Edit, and Delete action performed during a session and displays each entry with a timestamp and item name. These tests verify that the log faithfully records all three action types, that the log panel opens and closes correctly via the header icon, and that logged entries survive a page reload.
+
+Note: Tests 7.1 through 7.3 require that CRUD actions have already been performed in this session. REQUIRES: run Section 02 (CRUD) before this section, or manually add, edit, and delete one item before starting 7.1. Running this section without prior CRUD actions will cause 7.1–7.3 to fail.
+
+---
+
+### Test 7.1 — Log records Add action with timestamp and item name
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** REQUIRES: Section 02-crud has run this session (or one item was manually added). The activity log must contain at least one Add entry — this test will fail if no Add actions were performed.
+**Steps:**
+- act: "click the Log button or Log icon in the header navigation"
+- extract: "an Add action entry with a timestamp is visible in the log panel" → expect: true
+- screenshot: "07-activity-log-add"
+**Pass criteria:** After opening the log panel, at least one entry with an "Add" or equivalent action label and a readable timestamp is visible. The entry includes the name of the added item.
+**Tags:** activity-log, add, log
+**Section:** 07-activity-log
+
+---
+
+### Test 7.2 — Log records Edit action with timestamp and item name
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** REQUIRES: Section 02-crud has run this session (or one item was manually edited). The activity log must contain at least one Edit entry — this test will fail if no Edit actions were performed. The log panel is open from 7.1, or can be re-opened.
+**Steps:**
+- extract: "an Edit action entry with a timestamp is visible in the log panel" → expect: true
+**Pass criteria:** At least one entry with an "Edit" or equivalent action label and a readable timestamp is visible in the log, along with the name of the edited item.
+**Tags:** activity-log, edit, log
+**Section:** 07-activity-log
+
+---
+
+### Test 7.3 — Log records Delete action with timestamp and item name
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** REQUIRES: Section 02-crud has run this session (or one item was manually deleted). The activity log must contain at least one Delete entry — this test will fail if no Delete actions were performed. The log panel is open from 7.1 or 7.2, or can be re-opened.
+**Steps:**
+- extract: "a Delete action entry with a timestamp is visible in the log panel" → expect: true
+**Pass criteria:** At least one entry with a "Delete" or equivalent action label and a readable timestamp is visible in the log, along with the name of the deleted item.
+**Tags:** activity-log, delete, log
+**Section:** 07-activity-log
+
+---
+
+### Test 7.4 — Log panel opens and closes correctly
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Page is fully loaded and no modal is blocking the header. The log panel may be open from a prior test.
+**Steps:**
+- act: "click the Log button or Log icon in the header navigation"
+- screenshot: "07-activity-log-open"
+- act: "close the activity log panel or modal by clicking the close button or clicking outside the panel"
+- extract: "the activity log panel is visible" → expect: false
+**Pass criteria:** The log panel opens when the Log header icon is clicked and closes when the close affordance is activated. The panel is fully hidden after closing and does not remain partially visible.
+**Tags:** activity-log, open, close
+**Section:** 07-activity-log
+
+---
+
+### Test 7.5 — Log persists across page reload
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** The activity log contains at least one entry from this session (from 7.1–7.3). The log entries are stored in localStorage.
+**Steps:**
+- act: "navigate to BASE_URL/index.html"
+- act: "click the I Understand or Accept button if an acknowledgment modal is visible"
+- act: "click the Log button or Log icon in the header navigation"
+- extract: "at least one log entry is visible in the log panel" → expect: true
+**Pass criteria:** After reloading the page and re-opening the log panel, previously recorded log entries are still present. The log is not cleared on page reload.
+**Tags:** activity-log, persistence, reload
+**Section:** 07-activity-log

--- a/tests/runbook/08-spot-prices.md
+++ b/tests/runbook/08-spot-prices.md
@@ -1,0 +1,71 @@
+# Section 08 — Spot Prices
+
+Tests for spot price display, freshness, Goldback pricing, backfill behavior, and stale indicators. The spot price pipeline fetches hourly data from the StakTrakrApi Fly.io container and exposes it via `api.staktrakr.com/data/hourly/`. On page load, the frontend backfills the last 30 days of spot history and renders four metal cards (Gold, Silver, Platinum, Palladium) plus a Goldback value. These tests verify that all cards render with live data, that freshness thresholds are met, that melt values on inventory cards reflect current spot prices, and that stale indicators fire correctly when data is overdue.
+
+Test 8.6 is a controlled/manual test only — it cannot be automated without waiting 75+ minutes for real data aging. It is documented here for completeness and manual verification.
+
+---
+
+### Test 8.1 — All 4 metals showing (Gold, Silver, Platinum, Palladium)
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Page is fully loaded. Modal dismissed (from 00-setup or Section 01). Network is active so the spot API can respond.
+**Steps:**
+- extract: "all four spot price cards for Gold, Silver, Platinum, and Palladium are visible on the page with dollar amounts" → expect: 4 cards visible, all displaying non-zero dollar values
+**Pass criteria:** All four metal spot price cards are rendered and each shows a non-zero dollar amount. No card is missing, blank, showing "$0.00", or showing "N/A".
+**Tags:** spot-prices, metals, display
+**Section:** 08-spot-prices
+
+---
+
+### Test 8.2 — Values within 75-minute stale threshold
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Page fully loaded with spot data fetched. Spot poller on Fly.io is assumed healthy (data updated within the last 75 minutes).
+**Steps:**
+- extract: "a stale warning, stale badge, or overdue indicator is visible on any of the spot price cards" → expect: no stale indicator visible
+**Pass criteria:** None of the four spot price cards display a stale warning or overdue indicator, confirming that the most recent spot data is within the 75-minute freshness threshold.
+**Tags:** spot-prices, freshness, stale
+**Section:** 08-spot-prices
+
+---
+
+### Test 8.3 — Goldback card visible with valid price
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Page fully loaded. Goldback poller on Fly.io is assumed healthy (scraped within the last 25 hours).
+**Steps:**
+- extract: "the Goldback price card or Goldback price value is visible on the page" → expect: a non-zero dollar value shown for Goldback
+**Pass criteria:** A Goldback price display (card, label, or inline value) is visible and shows a dollar amount greater than zero. It is not blank, "N/A", or "$0.00".
+**Tags:** spot-prices, goldback
+**Section:** 08-spot-prices
+
+---
+
+### Test 8.4 — Spot price backfill populates last 30 days on fresh load
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Page has just loaded (or was reloaded in this session). The backfill routine runs automatically on startup to populate historical spot data.
+**Steps:**
+- extract: "spot price values are populated and non-zero across all visible metal cards, indicating the backfill routine completed successfully" → expect: spot values greater than 0 for all metals
+**Pass criteria:** All spot price cards show non-zero dollar values after page load, confirming the 30-day backfill ran and populated historical data without error. No card shows a loading state or zero value.
+**Tags:** spot-prices, backfill, history
+**Section:** 08-spot-prices
+
+---
+
+### Test 8.5 — Melt values on inventory cards update when new spot price loads
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** Page fully loaded with spot prices rendered. Inventory contains at least one item with a weight and metal type set (seed data satisfies this).
+**Steps:**
+- extract: "melt value dollar amounts are visible on at least one inventory card in the main view" → expect: at least one non-zero melt value displayed
+**Pass criteria:** At least one inventory card shows a melt value (dollar amount) that is non-zero, confirming that the spot price data was applied to the inventory calculation. The melt value field is not blank or "$0.00" for items with a valid weight and metal type.
+**Tags:** spot-prices, melt-value, inventory
+**Section:** 08-spot-prices
+
+---
+
+### Test 8.6 — Stale indicator appears when spot data is overdue
+_Added: v3.33.25 (STAK-396)_
+**Preconditions:** MANUAL/CONTROLLED TEST — requires triggering data age greater than 75 minutes. This test cannot be automated without waiting for the spot poller to miss multiple scheduled runs. Cannot be verified in a standard automated Browserbase session. To execute manually: wait for spot data to exceed the 75-minute threshold (or temporarily disable the Fly.io poller), then load the page and inspect spot price cards for a stale indicator.
+**Steps:**
+- screenshot: "08-spot-prices-stale-note"
+**Pass criteria:** Test documented for manual execution. To verify: when spot data age exceeds 75 minutes, a stale indicator (warning badge, color change, or explicit "stale" label) appears on one or more spot price cards. This confirms the frontend correctly detects and surfaces data freshness violations.
+**Tags:** spot-prices, stale, manual
+**Section:** 08-spot-prices

--- a/tests/runbook/README.md
+++ b/tests/runbook/README.md
@@ -1,0 +1,283 @@
+# StakTrakr Browserbase Test Runbook
+
+## What This Is
+
+The `tests/runbook/` directory is the living E2E test specification for StakTrakr. It replaces the monolithic 18-check `/bb-test` script and the legacy `tests/browserbase/*.ts` TypeScript test files.
+
+Each file in this directory is a **runbook section** — a plain Markdown file covering one feature area. The `/bb-test` skill reads these files at runtime and executes each step via Browserbase/Stagehand MCP tools against the PR preview URL. No build step. No compilation. No imports.
+
+The runbook grows with the product: every shipped spec (Phase 5) appends new test blocks to the relevant section file. The `_Added:` traceability line on each test block identifies which patch and Linear issue introduced it.
+
+---
+
+## Legacy Notice
+
+> **`tests/browserbase/*.ts` files are LEGACY and ARCHIVED.**
+> Do NOT add new tests to those TypeScript files.
+> All new tests go into `tests/runbook/*.md` section files only.
+
+---
+
+## How to Run Tests
+
+### Full suite (all sections, all tests)
+
+```
+/bb-test
+```
+
+Runs all 8 sections in order (01 through 08) against the PR preview URL.
+
+### Targeted sections by number
+
+```
+/bb-test sections=02,05
+```
+
+Runs only the CRUD section (`02-crud.md`) and the Market section (`05-market.md`).
+
+### Single section by filename
+
+```
+/bb-test section=03-backup-restore
+```
+
+Runs only the Backup & Restore section.
+
+### Tag-filtered run (all sections, matching tests only)
+
+```
+/bb-test tags=crud
+```
+
+Reads all section files, runs only tests whose `**Tags:**` field includes `crud`.
+
+### Additional arguments
+
+| Argument | Effect |
+|----------|--------|
+| `pr=NNN` | Use PR number NNN to discover the Cloudflare Pages preview URL |
+| `dry-run` | Run all checks but do not file Linear issues |
+| `sections=02,05` | Comma-separated section numbers to run |
+| `section=03-backup-restore` | Single section by filename prefix |
+| `tags=crud` | Run only tests with this tag (across all sections) |
+
+### Getting the PR preview URL
+
+The `/bb-test` skill discovers the Cloudflare Pages preview URL automatically using:
+
+```bash
+gh pr checks <PR_NUMBER> --json name,state,targetUrl \
+  | python3 -c "import sys,json; checks=json.load(sys.stdin); [print(c['targetUrl']) for c in checks if 'pages.dev' in c.get('targetUrl','')]"
+```
+
+If no PR number is provided, the skill attempts to detect the current branch's open PR. If no URL can be resolved after 3 polling attempts, the skill stops and prompts you to provide a preview URL manually.
+
+The skill **never defaults to `staktrakr.pages.dev`** without explicit user override.
+
+### Manual execution (no Browserbase required)
+
+For quick targeted verification — especially when only 1-3 tests are affected — you can execute runbook steps manually without a Browserbase session:
+
+- **Chrome DevTools**: Open DevTools in the browser and follow the `act`/`extract` steps by hand or via the Console.
+- **Claude in Chrome extension**: Use the Claude browser plugin to execute Stagehand-style natural language instructions against any open tab (the preview URL).
+
+This costs $0 (no Browserbase credits) and is appropriate when:
+- Only 1-3 tests are affected by a change
+- A quick visual check is sufficient
+- You want to verify a single step without a full session
+
+Reserve `/bb-test` (Browserbase) for full pre-release runs, comprehensive patch verification across an entire section, session recordings, and automated Linear issue filing.
+
+---
+
+## Section Files
+
+| File | Area | Tests |
+|------|------|-------|
+| [00-setup.md](./00-setup.md) | Pre-run setup (not a test section) | — |
+| [01-page-load.md](./01-page-load.md) | Page load, What's New, spot/market backfill | 11 |
+| [02-crud.md](./02-crud.md) | Add, Edit, Delete, Search, Filter, Views | 20 |
+| [03-backup-restore.md](./03-backup-restore.md) | Backup, Restore, Export ZIP/CSV/JSON, Vault | 12 |
+| [04-import-export.md](./04-import-export.md) | CSV/eBay import, Diff merge, PDF export | 9 |
+| [05-market.md](./05-market.md) | Market panel, price history, metal tabs | 10 |
+| [06-ui-ux.md](./06-ui-ux.md) | Responsive layout, themes, currency, settings | 11 |
+| [07-activity-log.md](./07-activity-log.md) | Activity log panel, persistence | 5 |
+| [08-spot-prices.md](./08-spot-prices.md) | Spot cards, stale indicators, melt values | 6 |
+
+**Total baseline tests: 84**
+
+---
+
+## Test Block Format
+
+Every test block in every section file uses this exact format. All 7 fields are required.
+
+```md
+### Test N.M — {Test Name}
+_Added: v{VERSION} ({STAK-XXX})_
+**Preconditions:** {what must be true before this test runs}
+**Steps:**
+- act: "{natural language Stagehand instruction}"
+- extract: "{what to assert}" → expect: {expected value or condition}
+- screenshot: "{NN}-{section-short}-{description}"
+**Pass criteria:** {plain English statement of what constitutes a pass}
+**Tags:** {comma-separated tags, e.g. crud, add, silver}
+**Section:** {section number and name, e.g. 02-crud}
+```
+
+### Field definitions
+
+| Field | Description |
+|-------|-------------|
+| `Test N.M` | Section number (N) and test number within section (M). Example: `2.7` = section 2, test 7. |
+| `_Added:_` | Traceability: patch version and Linear issue that introduced this test. Example: `_Added: v3.33.01 (STAK-396)_` |
+| `**Preconditions:**` | State that must be true before this test runs. Reference prior tests by ID if this test depends on their state (e.g., "Test 2.1 has run and added BB-SILVER-COIN"). |
+| `**Steps:**` | Ordered list of step directives. See step types below. |
+| `**Pass criteria:**` | Plain English statement of what constitutes a pass for this test as a whole. |
+| `**Tags:**` | Comma-separated tags used for filtering. Use feature area and action type (e.g., `crud, add, silver`). |
+| `**Section:**` | The section this test belongs to (e.g., `02-crud`). Must match the file it lives in. |
+
+---
+
+## Step Types
+
+There are three valid step type prefixes. Each step is one line starting with `- `.
+
+### `act:`
+
+One atomic interaction with the page. Stagehand executes this as a natural language browser action.
+
+```md
+- act: "click the Add Item button"
+- act: "select 'Silver' from the Metal dropdown"
+- act: "type 'BB-SILVER-COIN' into the Name field"
+```
+
+Rules:
+- One interaction per `act:` step (click, type, select, scroll — not "add an item and verify it saved")
+- Use specific selectors in natural language: "the Add Item button", "in the header", "in the modal"
+- Do not combine actions in a single `act:` step
+
+### `extract:`
+
+An assertion step. Stagehand extracts information from the page and the result is compared to the `→ expect:` clause.
+
+```md
+- extract: "count the number of inventory item cards" → expect: 9
+- extract: "is the What's New modal visible" → expect: true
+- extract: "text of the version badge in the header" → expect: contains "v3.33"
+```
+
+Rules:
+- Every `extract:` step **must** include `→ expect:` with an expected value or condition
+- Expected values can be exact (`9`, `true`) or qualitative (`non-zero`, `contains "v3.33"`, `visible`)
+- On failure, `/bb-test` takes an automatic failure screenshot and continues (non-blocking)
+
+### `screenshot:`
+
+Captures a screenshot labeled for the session recording. Labels follow the format `{NN}-{section-short}-{description}`.
+
+```md
+- screenshot: "02-crud-add-silver"
+- screenshot: "06-ui-ux-dark-theme"
+- screenshot: "00-baseline"
+```
+
+Label format rules:
+- `{NN}` — two-digit section number (e.g., `02`)
+- `{section-short}` — abbreviated section name (e.g., `crud`, `market`, `ui-ux`, `spot-prices`)
+- `{description}` — kebab-case descriptor of what is being captured (e.g., `add-silver`, `delete-confirm`)
+- Failure screenshots are auto-labeled by the skill as `{NN}-FAIL-{section}-{testId}` — do not use the `FAIL` prefix in manual screenshot steps
+
+---
+
+## How to Add New Tests
+
+When implementing a spec (Phase 5), add new test blocks to the relevant section file. Do not create new files unless the feature area has no existing section.
+
+### Step-by-step
+
+1. **Identify the section.** Match the changed feature area to the section table above. If no section fits, create a new one with the next sequential number (e.g., `09-new-feature.md`).
+
+2. **Find the last test number.** Open the target section file and note the highest test ID (e.g., if the last test is `2.20`, your first new test is `2.21`).
+
+3. **Write the test block.** Use the exact 7-field format above.
+   - `_Added:` line must include the current patch version and Linear issue (e.g., `_Added: v3.34.02 (STAK-420)_`)
+   - Each `act:` must be one atomic interaction
+   - Each `extract:` must have `→ expect:`
+   - Screenshot labels must follow the `{NN}-{section-short}-{description}` format
+
+4. **Append to the section file.** Add the new block(s) at the bottom of the section. Do not renumber or modify existing blocks.
+
+5. **Verify.** Run `/bb-test sections=NN` against the PR preview URL to confirm the new steps execute without errors.
+
+6. **Note in the PR body.** Include a line like: "Added 2 Browserbase runbook tests to 02-crud.md (Tests 2.21, 2.22)"
+
+### Example new test block
+
+```md
+### Test 2.21 — Add item — Copper Round
+_Added: v3.34.02 (STAK-420)_
+**Preconditions:** 00-setup has run. Inventory shows 8 seed items.
+**Steps:**
+- act: "click the Add Item button"
+- act: "select 'Copper' from the Metal dropdown"
+- act: "select 'Round' from the Type dropdown"
+- act: "type 'BB-COPPER-ROUND' into the Name field"
+- act: "type '1' into the Weight field"
+- act: "type '5' into the Purchase Price field"
+- act: "click the Save or Submit button"
+- extract: "count the number of inventory item cards" → expect: 9
+- screenshot: "02-crud-add-copper"
+**Pass criteria:** Item count increases to 9. BB-COPPER-ROUND is visible in the inventory.
+**Tags:** crud, add, copper
+**Section:** 02-crud
+```
+
+---
+
+## Test Numbering Reference
+
+Section numbers are fixed. Test numbers within a section are sequential and never reused (even if a test is retired, its number is retired with it).
+
+| Section | Number prefix | File |
+|---------|--------------|------|
+| Page Load | 1.x | 01-page-load.md |
+| CRUD | 2.x | 02-crud.md |
+| Backup & Restore | 3.x | 03-backup-restore.md |
+| Import & Export | 4.x | 04-import-export.md |
+| Market | 5.x | 05-market.md |
+| UI/UX | 6.x | 06-ui-ux.md |
+| Activity Log | 7.x | 07-activity-log.md |
+| Spot Prices | 8.x | 08-spot-prices.md |
+
+---
+
+## Common Tag Vocabulary
+
+Use these tags consistently so tag-filtered runs work predictably:
+
+| Tag | Used for |
+|-----|----------|
+| `crud` | Any add/edit/delete/view operation on inventory items |
+| `add` | Adding a new item |
+| `edit` | Editing an existing item |
+| `delete` | Deleting an item |
+| `search` | Search input behavior |
+| `filter` | Filter chip behavior |
+| `images` | Image upload, remove, pattern match |
+| `backup` | Backup and restore operations |
+| `export` | CSV/JSON/ZIP/PDF export |
+| `import` | CSV/eBay import, diff merge |
+| `vault` | Encrypted vault export/import |
+| `market` | Market panel and price data |
+| `spot-prices` | Spot price cards and stale indicators |
+| `activity-log` | Activity log panel |
+| `ui` | Layout, responsive, theming |
+| `theme` | Theme switching |
+| `settings` | Settings modal |
+| `currency` | Currency switcher |
+| `stale` | Stale data indicators |
+| `responsive` | Viewport-specific layout tests |
+| `gold`, `silver`, `platinum`, `palladium`, `goldback` | Metal-specific tests |


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

- Adds `tests/runbook/` with 10 Markdown files: README, 00-setup, and 8 section files (01-page-load through 08-spot-prices)
- 75+ E2E test blocks across all sections — each test has the standard 7-field format (Test name, Added, Preconditions, Steps, Pass criteria, Tags, Section)
- Test 2.21 (Cleanup) added to 02-crud so the bb-test parser executes it at section end
- Tests 4.4–4.7 marked MANUAL/CONTROLLED TEST (OS file picker not automatable via Stagehand)
- Section 07 tests use REQUIRES: directive preconditions to enforce Section 02 dependency
- Rewrites `/bb-test` skill: runtime runbook reader, auto-discovers PR preview URL from `gh pr checks`, supports `sections=` / `tags=` / `dry-run` filter flags, qualitative expect evaluation guide, 10-min per-step timeout, Manual Execution section (Chrome DevTools / Claude browser extension, $0 cost)
- Rewrites `browserbase-test-maintenance` skill: points to `tests/runbook/*.md`, legacy notice, URL auto-discovery documented
- Corrects CHANGELOG / announcements / about.js from previous STAK-374 pre-population at v3.33.25

## Linear Issues

- [STAK-396: feat: Browserbase Test Runbook v2 — modular section-based E2E test](https://linear.app/lbruton/issue/STAK-396)

🤖 Generated with [Claude Code](https://claude.com/claude-code)