### PR TITLE
chore: recover 10 missing skills, spec-workflow dirs, and 3 wiki fixes

### DIFF
--- a/.claude/skills/bb-test/SKILL.md
+++ b/.claude/skills/bb-test/SKILL.md
@@ -1,0 +1,445 @@
+---
+name: bb-test
+description: Browserbase runbook test runner for StakTrakr — reads tests/runbook/*.md section files and executes them via Stagehand against the PR preview URL. Supports targeted sections, tag filtering, and dry-run mode.
+allowed-tools: Bash, Read, mcp__browserbase__browserbase_session_create, mcp__browserbase__browserbase_session_close, mcp__browserbase__browserbase_stagehand_navigate, mcp__browserbase__browserbase_stagehand_act, mcp__browserbase__browserbase_stagehand_extract, mcp__browserbase__browserbase_stagehand_observe, mcp__browserbase__browserbase_screenshot, mcp__claude_ai_Linear__create_issue, mcp__claude_ai_Linear__update_issue
+---
+
+# Browserbase Runbook Test Runner — StakTrakr
+
+> ## REQUIRES EXPLICIT USER APPROVAL BEFORE RUNNING
+>
+> **Browserbase uses paid cloud credits.** This skill must NOT be invoked unless the user has explicitly requested it in this session (e.g., "run bb-test", "run the Browserbase test", "run section 02").
+>
+> **Default testing tool is browserless (local Docker) — free and self-hosted.**
+> Use `/smoke-test` for scripted Playwright checks. Reserve `/bb-test` for:
+> - Full pre-release QA suite runs
+> - Comprehensive patch verification (entire affected section)
+> - Session recording needed for the run record
+> - Automated Linear issue filing
+>
+> If in doubt, ask before running.
+
+---
+
+## Manual Execution (No Browserbase Required)
+
+The runbook files (`tests/runbook/*.md`) are plain Markdown — any agent or human can read them and execute the steps manually without spending Browserbase credits.
+
+**For 1-3 tests or quick targeted verification**, execute steps using:
+
+- **Chrome DevTools** — open DevTools in the browser at the preview URL, follow the `act`/`extract` steps by hand or use the Console for assertions
+- **Claude in Chrome extension** — use the Claude browser plugin to execute Stagehand-style natural language instructions against any open tab pointed at the preview URL
+
+This approach costs $0 and is appropriate when:
+- Only 1-3 tests are relevant to a change
+- A quick visual check is sufficient
+- You want to verify a single step without a full Browserbase session
+
+Reserve `/bb-test` (Browserbase) for:
+- Full section runs (10+ tests)
+- Pre-release QA that needs a session recording
+- Automated Linear issue filing
+- Cases where the full execution pipeline (act + extract + screenshot + Linear) is needed
+
+---
+
+## Arguments
+
+`$ARGUMENTS` can be:
+- *(blank)* — full suite (all sections 01-08 in order)
+- `sections=02,05` — run only sections 02 and 05 (comma-separated section numbers)
+- `section=03-backup-restore` — single section by filename prefix
+- `tags=crud` — all tests tagged `crud` across all sections
+- `pr=NNN` — explicit PR number for preview URL discovery
+- `dry-run` — all checks execute normally, no Linear issue filing
+
+Multiple arguments can be combined: `sections=02,05 dry-run`, `tags=crud pr=701`.
+
+Parse and store before Phase 0:
+- `SECTIONS_FILTER` — list of section numbers (e.g. `["02", "05"]`), or empty for all
+- `TAG_FILTER` — tag string (e.g. `"crud"`), or empty
+- `PR_NUMBER` — integer, or empty
+- `DRY_RUN` — boolean
+
+---
+
+## Phase 0: Pre-Run Setup
+
+### Step 1: Resolve which sections to run
+
+Determine the set of runbook section files to read based on parsed arguments:
+
+- No args → sections 01, 02, 03, 04, 05, 06, 07, 08 (all, in order)
+- `sections=NN,NN` → only those numbered files (e.g. `sections=02,05` → read `02-crud.md` and `05-market.md`)
+- `section=NN-name` → only that single file (e.g. `section=03-backup-restore` → read `03-backup-restore.md`)
+- `tags=xyz` → all 8 sections will be read, but only tests where the Tags line includes `xyz` will run
+
+Record `SECTION_FILES` — the ordered list of section filenames to read.
+
+### Step 2: Get PR preview URL
+
+Resolve `PREVIEW_URL` using the following sequence:
+
+1. If `pr=NNN` was provided, use that PR number directly.
+2. If no PR number, run:
+   ```bash
+   gh pr view --json number --jq '.number'
+   ```
+   If this returns a number, use it as the PR number. If it returns an error or empty, proceed to step 3.
+3. Once a PR number is known, run:
+   ```bash
+   gh pr checks NNN --json name,state,targetUrl | python3 -c "import sys,json; checks=json.load(sys.stdin); [print(c['targetUrl']) for c in checks if 'pages.dev' in c.get('targetUrl','')]"
+   ```
+   Capture the Cloudflare Pages URL (contains `pages.dev`).
+4. If the Cloudflare Pages check is not yet green, poll up to 3 times with 30-second waits between attempts.
+5. After 3 failed attempts with no URL: **STOP** and prompt the user:
+   > "No PR preview URL found after 3 attempts. Please provide the preview URL or a PR number to continue."
+6. **NEVER default to `staktrakr.pages.dev` without explicit user override.** If the user provides a URL directly, use that as `PREVIEW_URL`.
+
+### Step 3: Create Browserbase session
+
+```
+mcp__browserbase__browserbase_session_create
+```
+
+Record:
+- `SESSION_ID` from the response
+- `SESSION_DASHBOARD_URL` — the Browserbase dashboard URL for viewing the session recording
+
+If session creation fails, abort immediately with:
+> "Browserbase session failed to create — check the BROWSERBASE_API_KEY in Infisical (`/secrets` → StakTrakrApi → dev)."
+
+### Step 4: Execute 00-setup.md
+
+Read `tests/runbook/00-setup.md` using the Read tool, then execute each step in the setup section:
+
+1. Navigate to the preview URL:
+   ```
+   mcp__browserbase__browserbase_stagehand_navigate → PREVIEW_URL/index.html
+   ```
+2. Dismiss startup modals:
+   ```
+   mcp__browserbase__browserbase_stagehand_act: "Click the I Understand or Accept button if a modal is visible"
+   ```
+   If no modal appears, continue — this is not an error.
+3. Dismiss any other startup modals that may appear.
+4. Take baseline screenshot:
+   ```
+   mcp__browserbase__browserbase_screenshot → "00-baseline"
+   ```
+5. Record run metadata:
+   - `BASE_URL` = PREVIEW_URL
+   - Start time (YYYY-MM-DD HH:MM UTC)
+   - `SESSION_ID` and `SESSION_DASHBOARD_URL`
+   - Arguments used
+
+---
+
+## Phase 1: Execute Sections
+
+For each file in `SECTION_FILES`, execute the following sequence:
+
+### 1. Read the section file
+
+Use the Read tool to read the section file from `tests/runbook/{filename}`. Example:
+```
+Read: tests/runbook/02-crud.md
+```
+
+### 2. Parse all test blocks
+
+Scan the file for test blocks matching this structure:
+```
+### Test N.M — {Test Name}
+_Added: ..._
+**Preconditions:** ...
+**Steps:**
+- act: "..."
+- extract: "..." → expect: ...
+- screenshot: "..."
+**Pass criteria:** ...
+**Tags:** ...
+**Section:** ...
+```
+
+Extract for each test block:
+- `testId` — the `N.M` identifier (e.g. `2.7`)
+- `testName` — the name after the `—`
+- `preconditions` — the Preconditions text
+- `steps` — ordered list of step objects: `{ type: "act"|"extract"|"screenshot", instruction: string, expect?: string, label?: string }`
+- `passCriteria` — the Pass criteria text
+- `tags` — comma-separated tag list
+- `section` — the Section value
+
+### 3. Apply tag filter (if TAG_FILTER is set)
+
+If `TAG_FILTER` is non-empty, skip any test where the `tags` field does not include the filter value.
+
+Log skipped tests: `Skipping Test N.M — {name} (tag filter: {TAG_FILTER} not matched)`
+
+### 4. Execute each test
+
+For each test that passes the tag filter:
+
+**a. Log the start:**
+```
+Running Test N.M — {testName}...
+```
+
+**b. Execute each step in order:**
+
+- **`act:` step** — call `mcp__browserbase__browserbase_stagehand_act` with the quoted instruction text.
+  - **10-MINUTE TIMEOUT PER STEP**: If the act call does not return within 10 minutes, skip this step, record step status as `timeout`, log a warning (`TIMEOUT: act step in Test N.M — {name}`), and continue to the next step. Do not abort the test or section.
+
+- **`extract:` step** — call `mcp__browserbase__browserbase_stagehand_extract` with the assertion text. Compare the returned result to the `→ expect:` value.
+  - If the result matches the expected value: step passes.
+  - If the result does not match: record the step as `fail`. Take a failure screenshot labeled `{NN}-FAIL-{section-short}-{testId}` (e.g., `02-FAIL-crud-2.3`).
+  - **10-MINUTE TIMEOUT PER STEP**: Same timeout rule applies.
+  - **Qualitative expect evaluation:** Many `→ expect:` values are qualitative rather than exact. Use these rules:
+    - `non-zero dollar amount` — pass if the returned value is a dollar amount greater than $0.00 (e.g., "$34.50" passes, "$0.00" fails)
+    - `non-empty version string` — pass if any version-like string (e.g., "v3.33.25", "3.33") or non-blank text is present
+    - `8` / `N` (exact count) — pass only if the count matches exactly
+    - `true` — pass if the element/condition is present and visible
+    - `false` — pass if the element/condition is absent or not visible
+    - `≥1` or `at least one` — pass if one or more matches are present
+    - `contains X` — pass if X appears anywhere in the returned text
+    - `no error` — pass if no error message, alert, or JavaScript console error is visible
+    - `light theme active` / `dark theme active` — use visual judgment: background color shift is the primary indicator
+    - `original values unchanged` — compare the extracted values to the values noted before the action was performed
+
+- **`screenshot:` step** — call `mcp__browserbase__browserbase_screenshot` with the label text from the step.
+
+**c. Determine test status from step results:**
+- All steps pass → `pass`
+- All steps pass but one or more produce marginal/approximate matches → `warn`
+- One or more steps fail → `fail`
+- Test was skipped by tag filter → `skip`
+- One or more steps timed out and remaining steps passed → `warn`
+- Critical steps timed out → `timeout`
+
+**d. Record RunResult:**
+```
+RunResult {
+  testId:     "2.7"
+  testName:   "Upload obverse image"
+  section:    "02-crud"
+  status:     "pass" | "warn" | "fail" | "skip" | "timeout"
+  notes:      "observed: ..., expected: ..."
+  screenshot: "02-FAIL-crud-2.7" | null
+}
+```
+
+**e. Failures are non-blocking** — a failed test does not stop the section. Continue to the next test immediately.
+
+---
+
+## Phase 2: Results Table
+
+After all sections have run, print the full per-test results table:
+
+```
+Results
+=======
+| Test | Name                          | Section          | Status | Notes                    |
+|------|-------------------------------|------------------|--------|--------------------------|
+| 1.1  | Page loads at preview URL     | 01-page-load     | ✅     | title = StakTrakr        |
+| 1.2  | What's New popup appears      | 01-page-load     | ✅     |                          |
+| 2.1  | Add item — Silver Coin        | 02-crud          | ❌     | count: 8, expected: 9    |
+| ...  | ...                           | ...              | ...    | ...                      |
+```
+
+Status symbols:
+- `✅` — pass
+- `⚠️` — warn
+- `❌` — fail
+- `⏭️` — skip
+- `⏱️` — timeout
+
+**Overall result** (print after the table):
+- All ✅ (and ⏭️, ⏱️ where no timeout led to a critical failure) → `✅ PASS`
+- Any ⚠️, no ❌ → `✅ PASS WITH WARNINGS`
+- Any ❌ → `❌ FAIL`
+
+Print: `Browserbase session recording: SESSION_DASHBOARD_URL`
+
+---
+
+## Phase 3: Known Bugs Registry
+
+Before filing any Linear issues, check each `fail` or `warn` result against the known active bugs table. **Do NOT file a new Linear issue for a known active bug.** Reference it in the run record only.
+
+### Currently Known Active Bugs
+
+| Bug ID | Description | Notes |
+|--------|-------------|-------|
+| BUG-001 | Search returns 0 results intermittently | Intermittent — not always triggered |
+| BUG-002 | Autocomplete ghost text persists after modal close | Not always triggered |
+
+### Resolved Bugs (do not re-file)
+
+| Bug ID | Description | Resolved In |
+|--------|-------------|-------------|
+| BUG-006 | Delete executed immediately with no confirmation dialog | v3.31.5 — replaced with `showBulkConfirm` DOM modal |
+| STAK-205 | Edit Item — item disappears after edit flow | Automation artifact — use table view (D) for edits; cards have no direct edit button |
+| STAK-206 | Card view items-per-page constraint never applied | Fixed in dev — `pagination.js` row vs item unit mismatch corrected |
+
+For each `fail` or `warn` result:
+- If it matches a known active bug → mark "known — skipping Linear issue". Note which bug ID.
+- If it matches a resolved bug → mark "REGRESSION — filing as new issue" and proceed to Phase 4.
+- If it is new → proceed to Phase 4.
+
+---
+
+## Phase 4: Linear Issue Filing
+
+**Skip this phase entirely if `DRY_RUN` is true.** Instead, print what WOULD be filed (title, priority, description preview) and continue to Phase 5.
+
+For each new failure (not in the known active bugs list):
+
+Call `mcp__claude_ai_Linear__create_issue`:
+- **team:** `f876864d-ff80-4231-ae6c-a8e5cb69aca4`
+- **title:** `BUG: [{Section} Test {N.M} — {testName}] — {brief description of failure}`
+- **priority:** `2` (High) for ❌ fail · `3` (Normal) for ⚠️ warn
+- **labels:** Bug label
+- **description:**
+
+```markdown
+## Bug Report — Runbook Run {DATE}
+
+**Test:** {Section} Test {N.M} — {testName}
+**Status:** ❌ Fail / ⚠️ Warn
+**Section:** {section filename}
+**Environment:** {PREVIEW_URL} (PR preview)
+**Session Recording:** {SESSION_DASHBOARD_URL}
+
+## Observed Behavior
+
+{What was extracted or observed — include actual extract return values}
+
+## Expected Behavior
+
+{The → expect: value from the test step}
+
+## Reproduction Steps
+
+1. Navigate to {PREVIEW_URL}/index.html
+2. Run `/bb-test section={NN-section-name}` (or `/bb-test sections={NN}`)
+3. {Relevant steps from the test block definition}
+
+---
+_Surfaced during runbook run on {DATE} via /bb-test skill (Browserbase Stagehand automation). Test ID: {N.M}._
+```
+
+Record each filed issue's ID and URL in `NEW_ISSUES` for use in Phase 5.
+
+---
+
+## Phase 5: Run Record Issue
+
+**Skip this phase entirely if `DRY_RUN` is true.**
+
+Call `mcp__claude_ai_Linear__create_issue`:
+- **team:** `f876864d-ff80-4231-ae6c-a8e5cb69aca4`
+- **title:** `QA: Runbook Run — {DATE formatted as "Mar 01, 2026"} {EMOJI} {RESULT}`
+  - EMOJI: ✅ for PASS or PASS WITH WARNINGS, ❌ for FAIL
+- **priority:** `4` (Low)
+- **description:**
+
+```markdown
+## Runbook Run — {DATE}
+
+**Overall Result:** {OVERALL_RESULT}
+**Run Method:** /bb-test skill via Claude Code (Browserbase Stagehand automation)
+**Environment:** {PREVIEW_URL}
+**Session Recording:** {SESSION_DASHBOARD_URL}
+**Arguments:** {ARGUMENTS or "full suite (no args)"}
+**Sections Run:** {comma-separated list}
+
+---
+
+## Results
+
+| Test | Name | Section | Status | Notes |
+|------|------|---------|--------|-------|
+{results table rows}
+
+---
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✅ Pass | N |
+| ⚠️ Warn | N |
+| ❌ Fail | N |
+| ⏭️ Skip | N |
+| ⏱️ Timeout | N |
+
+---
+
+## New Issues Filed
+
+{List new Linear issues with ID, title, and URL — or "None — all findings matched known active bugs or no failures occurred"}
+
+## Known Issues Observed (not re-filed)
+
+{List known bug IDs triggered this run — or "None"}
+
+## Known Issues Not Triggered This Run
+
+{List known bug IDs that did NOT appear — or "None"}
+
+---
+_Logged by Claude via /bb-test skill. Run covered: {list of sections with test counts}._
+```
+
+After creating the run record issue, call `mcp__claude_ai_Linear__update_issue` to set the status to **Done**.
+
+---
+
+## Phase 6: Cleanup
+
+Close the Browserbase session:
+```
+mcp__browserbase__browserbase_session_close → SESSION_ID
+```
+
+Print final summary:
+
+```
+BB Test complete!
+=================
+Environment:       {PREVIEW_URL}
+Session Recording: {SESSION_DASHBOARD_URL}
+Arguments:         {ARGUMENTS or "full suite"}
+
+Overall: {OVERALL_RESULT}
+
+Run Record: {RUN_RECORD_ISSUE_ID} → Done
+  {run record URL}
+
+New bugs filed:
+  {STAK-XXX — title (or "None")}
+
+Known bugs observed (not re-filed):
+  {BUG-XXX — description (or "None")}
+```
+
+---
+
+## Dry Run Mode
+
+If `DRY_RUN` is true:
+- Execute all checks normally via Browserbase (session is still created, steps still run)
+- Print the full results table
+- Print what Linear issues WOULD be created (title, priority, description preview)
+- Do NOT call `mcp__claude_ai_Linear__create_issue` or `mcp__claude_ai_Linear__update_issue`
+- End with: `Dry run complete — no Linear issues created.`
+
+---
+
+## Maintaining the Known Bugs Registry
+
+When a bug is resolved and the fix is shipped, move it from the Known Active Bugs table to the Resolved Bugs table. Include the version it was resolved in. This ensures future runs correctly flag regressions rather than silently skipping re-filed known issues.
+
+When a new persistent bug is confirmed across multiple runs, add it to the Known Active Bugs table with a BUG-NNN identifier and a description. This prevents duplicate Linear issues from being filed on every subsequent run.

--- a/.claude/skills/browserbase-test-maintenance/SKILL.md
+++ b/.claude/skills/browserbase-test-maintenance/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: browserbase-test-maintenance
+description: Add new tests to the StakTrakr runbook after implementing a spec. Guides agents to identify the correct section, write test blocks in the standard format, append to tests/runbook/*.md, and verify by running the affected sections.
+trigger: After completing feature implementation, bug fixes, or Phase 5 of any spec
+allowed-tools: Read, Write, Edit, Bash, mcp__browserbase__browserbase_session_create, mcp__browserbase__browserbase_stagehand_act, mcp__browserbase__browserbase_stagehand_extract, mcp__browserbase__browserbase_screenshot, mcp__browserbase__browserbase_session_close
+---
+
+# Browserbase Test Maintenance Skill
+
+## When to Use This Skill
+
+Automatically trigger after:
+
+- Implementing a new feature (especially UI features)
+- Fixing a user-facing bug
+- Adding new Settings tabs, modals, or form interactions
+- Phase 5 of any spec-workflow spec (mandatory gate)
+- User explicitly requests adding Browserbase tests
+
+---
+
+## IMPORTANT — Test Files Have Moved
+
+> ## Tests Are No Longer in TypeScript Files
+>
+> **DO NOT** add new test steps to `tests/browserbase/*.ts` — those files are LEGACY/ARCHIVED.
+>
+> **All new tests go into `tests/runbook/*.md` section files.**
+>
+> The runbook is committed to the repo and grows with every shipped spec.
+
+If you find yourself looking at `tests/browserbase/test-basic-ui-flow.ts` or `tests/browserbase/test-goldback-flow.ts`, stop. Do not add to those files. Open the relevant file in `tests/runbook/` instead.
+
+---
+
+## Step 1 — Review Implementation Logs
+
+Read the spec's implementation logs from `.spec-workflow/specs/{specName}/Implementation Logs/` before writing any test blocks.
+
+Understand:
+- What user-facing features changed
+- Which UI components were added or modified
+- What user journeys are now different
+- Which JavaScript files were touched (maps to UI areas)
+
+For example: if `js/market.js` was modified, affected sections include `05-market.md`. If `js/backup.js` was touched, look at `03-backup-restore.md` and `04-import-export.md`.
+
+---
+
+## Step 2 — Identify Affected Sections
+
+Map implementation changes to runbook section files in `tests/runbook/`:
+
+| Changed Area | Runbook Section File |
+|---|---|
+| Page load, initial render, API backfill, What's New modal | `01-page-load.md` |
+| Add/Edit/Delete items, search, filter chips, card views, melt value | `02-crud.md` |
+| Backup, restore, export/import ZIP/JSON/CSV, encrypted vault | `03-backup-restore.md` |
+| CSV import, eBay import, merge diff viewer, PDF export | `04-import-export.md` |
+| Market panel, price history, market search, tabs, source badges | `05-market.md` |
+| Responsive layout, themes, currency switcher, settings modal | `06-ui-ux.md` |
+| Activity log panel, log entries | `07-activity-log.md` |
+| Spot price cards, stale indicators, melt values, Goldback price | `08-spot-prices.md` |
+
+If the new feature does not fit any existing section: create a new section file following the `NN-feature-name.md` naming convention with the next available number (e.g., `09-numista.md`). Give it a section header matching the pattern used in existing files.
+
+---
+
+## Step 3 — Write Test Blocks
+
+Use the EXACT standard format. All 7 fields are required. Missing any field will cause the `/bb-test` skill to skip or misparse the test block.
+
+```md
+### Test N.M — {Test Name}
+_Added: v{VERSION} ({STAK-XXX})_
+**Preconditions:** {what must be true before this test runs}
+**Steps:**
+- act: "{atomic natural language Stagehand instruction}"
+- extract: "{what to assert}" → expect: {expected value or condition}
+- screenshot: "{NN}-{section-short}-{description}"
+**Pass criteria:** {plain English statement of what constitutes a pass}
+**Tags:** {comma-separated tags}
+**Section:** {NN-section-name}
+```
+
+### Field rules
+
+**`_Added:` line** — MUST include the current patch version AND the Linear issue that shipped this feature. Example: `_Added: v3.33.25 (STAK-396)_`. Never leave either value blank.
+
+**`act:` steps** — each step is ONE atomic interaction: a click, a type, a select, or a scroll. Never compound multiple actions in a single `act:`. Wrong: `act: "add a Silver Coin item"`. Right: three separate steps — click Add Item, select Silver, type the name.
+
+**`extract:` steps** — every `extract:` MUST include `→ expect:` with an expected value or condition. Accepted forms: exact value (`9`), boolean (`true`, `false`), qualitative (`non-zero`, `contains "v3.33"`, `visible`). Never write an `extract:` without `→ expect:`.
+
+**`screenshot:` labels** — follow the format `{NN}-{section-short}-{description}`. Examples: `02-crud-add-silver`, `06-ui-ux-dark-theme`, `03-backup-export-csv`. Do not use the `FAIL` prefix — that is reserved for auto-generated failure screenshots from `/bb-test`.
+
+**Test numbering** — open the target section file and find the highest existing test number. Increment by 1. If the last test in `02-crud.md` is `2.20`, your first new test is `2.21`. Never reuse a retired test number.
+
+**Preconditions** — if prior state is required (e.g., "an item must have been added in Test 2.1"), document it explicitly in `**Preconditions:**`. Do not assume the reader knows. Reference prior tests by ID when applicable.
+
+---
+
+## Step 4 — Append to Section File
+
+Append the new test block(s) to the BOTTOM of the relevant section file.
+
+Rules:
+- Do NOT renumber existing tests
+- Do NOT modify existing test blocks in any way
+- Append after the last existing test block (after its `**Section:**` line)
+- Use the Edit tool with `old_string` equal to the last line of the file to ensure a clean append
+
+---
+
+## Step 5 — Verify by Running
+
+After appending new tests, verify them against the PR preview URL.
+
+1. Note the section number (e.g., `02` for CRUD, `05` for Market)
+2. The `/bb-test` skill auto-discovers the PR preview URL from `gh pr checks` — no need to pass the URL manually. It polls up to 3 times if the Cloudflare Pages build is still in progress.
+3. Run the affected section: `/bb-test sections=NN` against the PR preview URL
+4. If a step fails: refine the natural language instruction — add location context ("in the header", "in the modal", "in the settings panel") or rephrase to use visible UI text
+5. If Stagehand stalls longer than 10 minutes: the skill auto-skips that step — rephrase the instruction to be more specific and retry
+6. For smaller changes (1-3 tests): consider manual verification using Chrome DevTools or the Claude browser extension instead of a full Browserbase session — this costs $0
+
+The `/bb-test` skill reads the runbook files at runtime. No rebuild, no compilation needed before running.
+
+---
+
+## Step 6 — Document in PR
+
+Add a note in the PR body so reviewers know what test coverage was added:
+
+```
+Added X Browserbase runbook tests to tests/runbook/NN-section.md (Tests N.X through N.Y)
+```
+
+Example: `Added 2 Browserbase runbook tests to tests/runbook/02-crud.md (Tests 2.21 through 2.22)`
+
+---
+
+## Good Test Patterns
+
+### Pattern 1 — Modal Open → Interact → Close
+
+```md
+- act: "click the [button] to open the modal"
+- act: "click the [Tab] tab in the modal"
+- act: "type '[value]' into the [field] field"
+- act: "click the Close button"
+- extract: "modal is no longer visible" → expect: false
+```
+
+### Pattern 2 — Form Fill → Submit → Verify
+
+```md
+- act: "click the Add Item button"
+- act: "select [Metal] from the metal dropdown"
+- act: "type '[name]' into the Name field"
+- act: "type '[weight]' into the Weight field"
+- act: "click the Save or Add to Inventory button"
+- extract: "count of inventory item cards" → expect: [N+1]
+- screenshot: "{NN}-{section-short}-add-[item]"
+```
+
+### Pattern 3 — State Verify → Action → Re-Verify
+
+```md
+- extract: "count of inventory item cards" → expect: [N]
+- act: "click the delete button on [item name]"
+- act: "click the Confirm button in the confirmation dialog"
+- extract: "count of inventory item cards" → expect: [N-1]
+- screenshot: "{NN}-{section-short}-delete-confirm"
+```
+
+### Stagehand instruction tips
+
+- Be specific about the element: "the Settings gear button" not "Settings"
+- Reference location when ambiguous: "in the header", "in the modal", "in the sidebar", "at the bottom of the panel"
+- Use visible text, not internal IDs: what the user sees on screen
+- If a step stalls: add more context about the element's location or rephrase using the button's label text exactly as shown
+
+---
+
+## When NOT to Add Tests
+
+Skip runbook tests for:
+
+- CSS-only changes (color, spacing, font size)
+- Backend-only changes with no UI surface
+- Minor copy edits (tooltip text, label changes)
+- Performance optimizations with no UX change
+- Pure refactoring with identical UI output
+
+Add tests for:
+
+- New modal or dialog
+- New Settings tab or section
+- New multi-field form interaction
+- New filter, search, or sort capability
+- Multi-step user workflow
+- Critical bug fix in a user journey
+
+---
+
+## Quick Reference — Feature Type to Section
+
+| Feature Type | Section File | Suggested Tags |
+|---|---|---|
+| New item type or form field | `02-crud.md` | crud, add, [metal] |
+| New export format | `03-backup-restore.md` or `04-import-export.md` | export, [format] |
+| New import source | `04-import-export.md` | import, [source] |
+| New market data source | `05-market.md` | market, [source] |
+| New theme | `06-ui-ux.md` | ui, theme, [name] |
+| New log event | `07-activity-log.md` | activity-log, [action] |
+| New spot price source | `08-spot-prices.md` | spot-prices, [source] |
+| New page-load behavior | `01-page-load.md` | page-load, [feature] |
+| New Settings tab | `06-ui-ux.md` | ui, settings, [tab-name] |
+| New filter chip | `02-crud.md` | crud, filter, [type] |
+| New card view | `02-crud.md` | crud, ui, views |
+
+---
+
+## Maintenance Checklist
+
+After adding tests, verify all of the following before marking the Phase 5 task complete:
+
+- [ ] Test blocks use the exact 7-field format (Test name, Added, Preconditions, Steps, Pass criteria, Tags, Section)
+- [ ] `_Added:` line includes the current patch version and the Linear issue
+- [ ] `act:` steps are atomic — one interaction each, not compound actions
+- [ ] `extract:` steps each include a `→ expect:` clause
+- [ ] Screenshot labels follow `{NN}-{section-short}-{description}` format
+- [ ] New blocks are appended to the bottom of the section file — no existing blocks modified
+- [ ] Affected section verified by running `/bb-test sections=NN`
+- [ ] PR body updated with the test coverage note (Tests N.X through N.Y)

--- a/.claude/skills/devops-dashboard/SKILL.md
+++ b/.claude/skills/devops-dashboard/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: devops-dashboard
+description: Use when modifying the spec-workflow MCP plugin — templates, dashboard UI, MCP tools, build, or configuration. Also use for any devops dashboard/tooling work tracked under the DevOps Linear team. Triggers on mentions of spec-workflow plugin, dashboard customization, template edits, MCP tool changes, or devops tooling.
+---
+
+# DevOps Dashboard — Spec-Workflow Plugin
+
+Local fork of `@pimzino/spec-workflow-mcp` with dashboard + custom templates.
+
+## Linear Team
+
+**DevOps** — `38d57c9f-388c-41ec-9cd2-259a21a5df1c`
+All dashboard/tooling/infra issues go here.
+
+## Plugin Location
+
+```
+~/.claude/plugins/marketplaces/spec-workflow-mcp-marketplace/
+```
+
+## Key Paths
+
+| What | Path (relative to plugin root) |
+|------|------|
+| **MCP entry point** | `src/index.ts` → `dist/index.js` |
+| **MCP server class** | `src/server.ts` |
+| **MCP tools** | `src/tools/` (5 tools: spec-workflow-guide, steering-guide, spec-status, approvals, log-implementation) |
+| **Markdown templates** | `src/markdown/templates/` (requirements, design, tasks, product, tech, structure) |
+| **Dashboard backend** | `src/dashboard/multi-server.ts` (Fastify on port 5000) |
+| **Dashboard frontend** | `src/dashboard_frontend/` (React 18 + Vite + Tailwind v4) |
+| **Frontend entry** | `src/dashboard_frontend/src/main.tsx` |
+| **Frontend components** | `src/dashboard_frontend/src/modules/` |
+| **i18n locales** | `src/dashboard_frontend/src/locales/` (13 languages) |
+| **Post-build copier** | `scripts/copy-static.cjs` |
+| **Plugin manifests** | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
+| **Built output** | `dist/` (compiled TS + React build + templates + locales) |
+
+## Build Commands
+
+```bash
+cd ~/.claude/plugins/marketplaces/spec-workflow-mcp-marketplace
+
+# Full production build (validates i18n → compiles TS → builds React → copies static)
+npm run build
+
+# Dev mode — dashboard frontend with HMR (port 5173, proxies API to 5000)
+npm run dev:dashboard
+
+# Dev mode — MCP server via tsx (no compilation)
+npm run dev
+
+# Start compiled server
+npm run start
+```
+
+## Template System
+
+Templates live in `src/markdown/templates/`. After `npm run build`, they're copied to `dist/markdown/templates/` with LF normalization.
+
+At MCP server startup, `WorkspaceInitializer` copies them to `.spec-workflow/templates/` in the project workspace. Users can override via `.spec-workflow/user-templates/`.
+
+**Template priority:** user-templates/ > templates/ (defaults)
+
+## Dashboard Architecture
+
+- **Backend:** Fastify on `127.0.0.1:5000` (localhost only by default)
+- **Frontend:** React 18 + HashRouter + Tailwind v4 + MDX Editor
+- **Real-time:** WebSocket at `/ws` for spec change broadcasts
+- **API:** REST at `/api/*` (projects, specs, approvals, implementation logs)
+- **Session:** Tracked in `~/.spec-workflow-mcp/session.json`
+- **Project registry:** `~/.spec-workflow-mcp/projects.json`
+
+## MCP Server Registration
+
+All three agents run the local fork (not the npm package):
+
+| Agent | Config file | Command |
+|-------|------------|---------|
+| **Claude Code** | Plugin auto-registered via `.claude-plugin/with-dashboard/.mcp.json` | `node dist/index.js .` |
+| **Gemini** | `~/.gemini/settings.json` | `node dist/index.js /Volumes/DATA/GitHub/StakTrakr` |
+| **Codex** | `~/.codex/config.toml` | `node dist/index.js /Volumes/DATA/GitHub/StakTrakr` |
+
+## Workflow for Making Changes
+
+1. Create a Linear issue in the **DevOps** team
+2. Edit source files in `src/` (never edit `dist/` directly)
+3. Run `npm run build` from the plugin root
+4. Restart Claude Code session to reload the MCP server
+5. Test: create a spec or open dashboard at `http://localhost:5000`
+
+## Common Tasks
+
+### Edit a template
+1. Modify `src/markdown/templates/{name}-template.md`
+2. `npm run build`
+3. Restart session — new specs will use the updated template
+
+### Edit dashboard UI
+1. Run `npm run dev:dashboard` for HMR (port 5173)
+2. Edit components in `src/dashboard_frontend/src/modules/`
+3. When done: `npm run build` to compile for production
+
+### Add/modify an MCP tool
+1. Edit or create in `src/tools/`
+2. Register in `src/tools/index.ts`
+3. `npm run build`
+4. Restart session
+
+### Add a locale
+1. Add JSON file in `src/dashboard_frontend/src/locales/`
+2. Update `src/dashboard_frontend/src/i18n.ts`
+3. `npm run build` (i18n validation runs first)

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: frontend-design
+description: Use when mocking up new UI elements, exploring layout concepts, or generating visual prototypes for StakTrakr. Creative exploration is welcome — but all output must use StakTrakr's CSS token system and component patterns so mockups can actually integrate.
+---
+
+<!-- StakTrakr project override — wraps frontend-design@claude-plugins-official.
+     Adds token constraints and integration rules so mockup output is integrable.
+     Last reviewed: 2026-02-24. -->
+
+# StakTrakr Frontend Design
+
+## When to use this skill
+
+- Mocking up a new UI element you haven't built yet
+- Exploring layout or visual direction before committing to code
+- Generating playground prototypes (`playground` skill output)
+- Getting a second creative opinion on an existing component
+
+**Not for:** Writing production code directly into StakTrakr. Any output from this skill goes through the Playground → ui-design checklist → integration flow before landing in the codebase.
+
+---
+
+## StakTrakr Design Constraints
+
+These apply to all output — mockups included. They ensure generated HTML is integrable without a full rewrite.
+
+### Tokens — always use CSS variables
+
+Never hardcode colors, spacing, border-radius, or shadows. StakTrakr's 4 themes (light/dark/sepia/system) depend entirely on CSS vars:
+
+| Category | Variables |
+|----------|-----------|
+| Colors | `--primary`, `--secondary`, `--success`, `--info`, `--warning`, `--danger` (+ `-hover`) |
+| Backgrounds | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-card` |
+| Text | `--text-primary`, `--text-secondary` |
+| Metals | `--silver`, `--gold`, `--platinum`, `--palladium` |
+| Borders | `--border`, `--border-hover` |
+| Shadows | `--shadow-sm`, `--shadow`, `--shadow-lg` |
+| Spacing | `--spacing-xs` `--spacing-sm` `--spacing` `--spacing-lg` `--spacing-xl` |
+| Radius | `--radius` (8px), `--radius-lg` (12px modals) |
+
+### Typography — no CDN fonts
+
+StakTrakr is served from `file://` — external font imports won't load. Use system font stack only:
+
+```css
+font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+```
+
+Creative typographic expression should come from weight, size, spacing, and letter-spacing — not from font family choices.
+
+### Motion — CSS only, no external libraries
+
+No Motion/GSAP/anime.js. CSS transitions and `@keyframes` only. Keep it subtle — StakTrakr has `--transition` for interactive elements.
+
+### Core component patterns
+
+When generating mockups that include these elements, use StakTrakr's patterns:
+
+| Element | Pattern |
+|---------|---------|
+| Button (modal actions) | Pill buttons: `.btn secondary`, `.btn`, `.btn premium` with `border-radius: 999px` scoped CSS — see `ui-standards/style.html` |
+| Button (page-level) | `.btn` or `.btn-sm` — never `.btn-primary` or `.btn-lg` |
+| Modal header | Glass style: `background: var(--bg-secondary); border-bottom: 1px solid var(--border)` — NOT gradient banner |
+| Modal | `.modal` > `.modal-content` with flex header/body/footer + pill action buttons |
+| Settings row | `.settings-fieldset` > `.settings-group` |
+| Boolean toggle | `.chip-sort-toggle` > `.chip-sort-btn` — never `<input type="checkbox">` |
+| Card | `background:var(--bg-card); border:1px solid var(--border); border-radius:var(--radius-lg)` |
+
+**Migration reference:** `ui-standards/style.html` has a Migration Checklist section listing old patterns and what to replace them with. Check it when building modal mockups.
+
+### File protocol safe
+
+No `fetch()` calls to localhost. No ES module imports. No bundler assumptions. Vanilla JS only.
+
+---
+
+## Creative latitude within these constraints
+
+Within the constraints above, creative exploration is fully encouraged:
+
+- **Layout**: asymmetry, overlap, negative space, grid-breaking — all fair game in mockups
+- **Color emphasis**: use the token palette boldly — pick a dominant accent, vary weight
+- **Spatial rhythm**: tight density vs generous breathing room — explore both
+- **Micro-interactions**: CSS hover states, transitions, `details/summary` accordion patterns
+- **Dark/light mood**: mockups can target dark theme (`prefers-color-scheme: dark`) or light — just use the vars
+
+**The goal**: find what's visually interesting *within* StakTrakr's system, not outside it. The best mockups reveal a direction that could realistically ship.
+
+---
+
+## After generating a mockup
+
+1. Save as a playground file: `playground/YYYY-MM-DD-<topic>.html`
+2. Open in browser: `open playground/YYYY-MM-DD-<topic>.html`
+3. User reviews and approves
+4. If approved for integration → hand off to `ui-design` skill for production implementation
+
+Do not write mockup output directly into `index.html` or any live StakTrakr file.

--- a/.claude/skills/jules-review/SKILL.md
+++ b/.claude/skills/jules-review/SKILL.md
@@ -1,0 +1,116 @@
+# jules-review
+
+Review and triage Jules nightly PRs (Bolt/Sentinel/Scribe) against StakTrakr coding standards.
+
+## Trigger
+
+`/jules-review` or `/jules-review <PR#>` or "review Jules PRs"
+
+## Phase 0 — Discover Jules PRs
+
+```bash
+gh pr list --repo lbruton/StakTrakr --state open --author app/jules-app --json number,title,labels,headRefName
+```
+
+- If no PR# given, list all open Jules PRs and let user pick
+- Identify PR type from title: **Bolt** (Security), **Sentinel** (Performance), **Scribe** (Documentation)
+- If no open Jules PRs found, report that and stop
+
+## Phase 1 — Diff Analysis (parallel agents)
+
+Fetch the full diff:
+
+```bash
+gh pr diff <PR#> --repo lbruton/StakTrakr
+```
+
+Launch **2 parallel subagents** (use `dispatching-parallel-agents`):
+
+### Agent 1 — StakTrakr Compatibility Check
+
+Diff every changed file against `coding-standards` skill rules:
+
+- **Script load order**: Any new JS file MUST be added to both `sw.js` CORE_ASSETS and `index.html` (56 scripts, strict order)
+- **DOM access**: Must use `safeGetElement(id)` — never raw `document.getElementById()` (except startup in `about.js` / `init.js`)
+- **Storage**: Must use `saveData()`/`loadData()` from `js/utils.js` — never direct `localStorage` for non-scalar data
+- **Storage keys**: New keys must be in `ALLOWED_STORAGE_KEYS` in `js/constants.js`
+- **innerHTML**: Must use `sanitizeHtml()` on user content
+- **No `var`**: Only `const` and `let`
+- **No `.then()` chains**: Use `async/await`
+- **Version**: `constants.js` version number must NOT be modified (managed by `/release`)
+- **Duplicate functions**: Check `events.js` AND `api.js` for duplicate function definitions
+
+### Agent 2 — Edge Case Hunter
+
+- DOM breakage: elements referenced that may not exist at runtime
+- Event listener conflicts: duplicate listeners, missing cleanup
+- State mutation side effects: localStorage race conditions, global state corruption
+- CSS custom property violations: check against StakTrakr's CSS variable system
+- Duplicate function definitions across `events.js` / `api.js`
+
+## Phase 2 — Suppressions Check
+
+Load `.github/jules-suppressions.json` (create with empty structure if missing).
+
+- Cross-reference diff hunks against `suppressions[].pattern` entries
+- Any matched line: mark as "Known suppressed — skip"
+- Any NEW finding not in suppressions: flag for human triage
+- Report suppression match count and new finding count
+
+## Phase 3 — Triage & Recommendation
+
+Present findings in a table:
+
+| # | File:Line | Category | Verdict | Rationale |
+|---|-----------|----------|---------|-----------|
+| 1 | js/utils.js:42 | DOM Safety | Safe | Uses safeGetElement correctly |
+| 2 | js/api.js:100 | Storage | Reject | Raw localStorage without saveData() |
+
+**Verdicts:**
+
+- **Safe to merge** — No violations found, passes all gates
+- **Fix required** — Describe the fix but do NOT auto-fix (Jules PRs are their own branch)
+- **Reject PR** — Hard violation of StakTrakr patterns
+- **Suppress (false positive)** — Offer to add to suppressions via `/jules-suppress`
+
+### Hard Failure Gates (automatic reject)
+
+Any of these in the diff = immediate reject verdict:
+
+1. New `document.getElementById()` without `safeGetElement` wrapper
+2. New file not added to `sw.js` CORE_ASSETS and `index.html` script order
+3. Raw `innerHTML` assignment without `sanitizeHtml()`
+4. `var` keyword usage
+5. `.then()` chain (should be `async/await`)
+6. New `localStorage.setItem`/`localStorage.getItem` for non-scalar data (should use `saveData()`/`loadData()`)
+7. Modification to `constants.js` `APP_VERSION` (version managed by `/release`)
+
+## Phase 4 — Execute Decision
+
+**Safe to merge:**
+
+```bash
+gh pr review <PR#> --approve --body "Jules PR reviewed by Claude — all StakTrakr coding standards verified. No violations found."
+gh pr merge <PR#> --squash --delete-branch
+```
+
+**Reject:**
+
+```bash
+gh pr close <PR#> --comment "Rejected: <rationale>. See jules-suppressions.json for known false positives."
+```
+
+Offer to add false positive patterns to suppressions via `/jules-suppress add`.
+
+**Fix required:**
+
+- Leave detailed review comment on the PR with specific line-by-line feedback
+- Do NOT merge
+- Advise user on next steps (manual fix or reject)
+
+## Important Notes
+
+- Jules PRs always target `dev` — verify with `gh pr view <PR#> --json baseRefName`
+- If PR targets `main`, reject immediately and comment
+- Jules has no memory between runs — false positives WILL recur. Use `/jules-suppress` to manage them.
+- Never rewrite Jules PR branches — review only, merge or reject as-is

--- a/.claude/skills/jules-suppress/SKILL.md
+++ b/.claude/skills/jules-suppress/SKILL.md
@@ -1,0 +1,113 @@
+# jules-suppress
+
+Manage the Jules suppressions file to prevent repeat false positives from nightly Bolt/Sentinel/Scribe PRs.
+
+## Trigger
+
+`/jules-suppress` or `/jules-suppress <command>` or "manage Jules suppressions"
+
+## Suppressions File
+
+**Location:** `.github/jules-suppressions.json`
+
+```json
+{
+  "version": 1,
+  "suppressions": [
+    {
+      "id": "JULES-S001",
+      "type": "bolt|sentinel|scribe",
+      "pattern": "regex or file:line pattern",
+      "reason": "Why this is a false positive",
+      "added": "YYYY-MM-DD",
+      "addedBy": "claude|user"
+    }
+  ],
+  "prompt_exclusions": [
+    "Human-readable exclusion clause for pasting into Jules prompt settings"
+  ]
+}
+```
+
+## Commands
+
+### `/jules-suppress list`
+
+Display all active suppressions in a table:
+
+| ID | Type | Pattern | Reason | Added |
+|----|------|---------|--------|-------|
+
+If no suppressions exist, show "No active suppressions."
+
+### `/jules-suppress add <pattern> --type bolt|sentinel|scribe --reason "..."`
+
+1. Load `.github/jules-suppressions.json` (create if missing)
+2. Auto-generate next ID: `JULES-S{NNN}` (zero-padded, incrementing)
+3. Add the new suppression entry
+4. Write the updated file
+5. Confirm addition with the assigned ID
+
+### `/jules-suppress remove <id>`
+
+1. Load suppressions file
+2. Find and remove entry matching `id`
+3. Write updated file
+4. Confirm removal
+
+### `/jules-suppress audit`
+
+1. Load all suppression patterns
+2. For each pattern, check if the referenced file/code still exists in the codebase
+3. Report stale suppressions (patterns that no longer match anything)
+4. Offer to remove stale entries
+
+### `/jules-suppress prompt`
+
+Generate copy-pasteable exclusion clauses for the Jules scheduled prompt settings.
+
+1. Load suppressions and `prompt_exclusions`
+2. Group by type (bolt/sentinel/scribe)
+3. Output formatted text:
+
+```
+## Exclusion Clauses for Jules Prompt
+
+Paste these into your Bolt/Sentinel/Scribe scheduled prompt settings:
+
+### Bolt (Security) Exclusions
+- Do not flag localStorage.getItem/setItem for scalar string preferences — this is intentional
+- ...
+
+### Sentinel (Performance) Exclusions
+- Do not suggest lazy-loading for scripts in index.html — load order is critical
+- ...
+
+### Scribe (Documentation) Exclusions
+- ...
+
+### General Exclusions (all prompts)
+- This is a vanilla JS single-page app with no build step — do not suggest framework migrations
+- Do not modify constants.js version numbers — versioning is managed externally
+- Do not add new files without updating sw.js CORE_ASSETS and index.html script order
+```
+
+4. Also include any entries from `prompt_exclusions` array verbatim
+
+## Notes
+
+- Jules reads `AGENTS.md` automatically on every run — this is the **primary** suppression mechanism. The "Jules Scheduled Scan Exclusions" section in `AGENTS.md` contains all active exclusions organized by agent type (Bolt/Sentinel/Scribe)
+- Jules also writes `.jules/*.md` learning journals (sentinel.md, bolt.md, scribe.md) — these give Jules context about past findings but do NOT prevent re-flagging (they are write-only memory, not a skip list)
+- The `.github/jules-suppressions.json` file is our **audit trail** — it tracks suppression IDs, reasons, and which PRs were closed. Jules does not read this file directly
+- The `prompt_exclusions` array is for generating text to paste into the Jules dashboard scheduled task prompts — a secondary reinforcement layer on top of AGENTS.md
+- `/jules-review` Phase 2 reads the suppressions file to auto-skip known false positives during PR review
+- `/pr-resolve` Phase 2.5 automatically adds suppressions when closing Jules PRs as "Won't fix" or "False positive"
+
+### Three-layer suppression architecture
+
+| Layer | File | Who reads it | When |
+|---|---|---|---|
+| **Primary** | `AGENTS.md` (exclusions section) | Jules | Every scan run (automatic) |
+| **Secondary** | Jules dashboard prompts (via `/jules-suppress prompt`) | Jules | Per scheduled task |
+| **Audit trail** | `.github/jules-suppressions.json` | Claude (`/pr-resolve`, `/jules-review`) | During PR triage |
+| **Context** | `.jules/bolt.md`, `.jules/sentinel.md`, `.jules/scribe.md` | Jules | Write-only learning journals |

--- a/.claude/skills/scan-mentions/SKILL.md
+++ b/.claude/skills/scan-mentions/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: scan-mentions
+description: Use when asked to check user feedback, scan public threads, review what users are saying about StakTrakr, or monitor Reddit/forum posts for bug reports. Triggers on /scan-mentions or any request to check mentions or user posts.
+---
+
+# scan-mentions
+
+Scrapes all watched public threads using Firecrawl and summarizes bug reports, feature requests, and user feedback. No Reddit API or extra setup needed.
+
+## Watched URLs
+
+Add new entries here whenever the user drops a URL.
+
+| URL | Platform | Notes |
+|-----|----------|-------|
+| https://www.reddit.com/r/staktrakr/ | r/staktrakr | Our subreddit — scan new posts for bug reports and feedback. |
+| https://www.reddit.com/r/Silverbugs/comments/1r1aerl/comment/o6iznvt/ | r/Silverbugs | Main StakTrakr showcase thread — use comment-anchored URL, root URL gets gated by Reddit. PumpkinCrouton is a power user — read all their comments carefully. |
+| https://www.reddit.com/r/Silverbugs/comments/1r6vc71/ | r/Silverbugs | Second Silverbugs thread mentioning StakTrakr. |
+
+## Steps
+
+1. For each URL in the table above, call `mcp__firecrawl-local__firecrawl_scrape` with:
+   ```
+   formats: ["markdown"]
+   onlyMainContent: true
+   ```
+2. Scrape all URLs in parallel for speed.
+3. For each thread, scan for:
+   - **Bugs** — errors, crashes, wrong behavior, missing data
+   - **Feature requests** — things users wish it did
+   - **UX confusion** — questions that reveal unclear flows
+   - **Praise** — useful for understanding what's working
+4. If a comment contains "Continue this thread" links with unread replies, scrape those child URLs too.
+5. Output a summary per thread:
+   - Thread title + URL
+   - Actionable bugs with username + direct quote
+   - Feature requests
+   - Notable praise or confusion
+6. Flag anything that looks like it warrants a Linear issue.
+
+## Key Users
+
+- **PumpkinCrouton** — power user, stress-tester, pushes the app to edge cases. Prioritize their comments.
+- **orphenshadow** — that's the developer (you). Skip their comments in the summary.
+
+## Adding a New URL
+
+When the user drops a URL, add a row to the Watched URLs table above with the platform and any relevant notes. Commit the change.

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: smoke-test
+description: Automated smoke test runner for StakTrakr — starts a local HTTP server, runs Playwright specs via self-hosted browserless Docker, collects results, then files Linear bug issues for new findings and creates a run-record issue.
+allowed-tools: Bash, mcp__claude_ai_Linear__create_issue, mcp__claude_ai_Linear__update_issue
+---
+
+# Smoke Test — StakTrakr
+
+> **Test suite architecture:** `tests/runbook/` via the `/bb-test` skill is the **primary NL E2E suite** (Stagehand/Browserbase, runs against PR preview URLs). This `/smoke-test` skill covers the **complementary scripted suite** — `tests/*.spec.js` via self-hosted browserless Docker.
+
+Automated QA smoke test running Playwright specs via self-hosted **browserless** Docker against the local app. No Browserbase, no cloud credits. The browser runs inside Docker and connects to the app at `host.docker.internal:8765` (which resolves to the host machine from inside the container).
+
+**Spec inventory:** `tests/*.spec.js` — 27 active tests, 4 skipped (API keys required).
+
+| Spec | Tests | Coverage |
+|---|---|---|
+| `smoke.spec.js` | 4 | Page load, About/Settings/Add Item modals |
+| `crud.spec.js` | 3 | Add/Edit/Delete item (custom `#appDialogModal` wipe in beforeEach) |
+| `calculations.spec.js` | 2 | Melt value math (injects spot price), gram→oz conversion |
+| `backup-restore.spec.js` | 3 | CSV export, JSON round-trip, vault AES encrypt/decrypt |
+| `live-demo.spec.js` | 1 | Load + hover spot cards + About modal |
+| `ui-checks.spec.js` | 7 | Spot prices, summary cards, seed count, filter chips, search, card views A/B/C/D, activity log |
+| `connection.spec.js` | 1 | browserless connection + page load (@smoke tagged) |
+| `hello-kitty.spec.js` | 1 | Sepia easter egg theme |
+| `cloud-sync.spec.js` | 5 | Dropbox: connected state, backup upload, restore list, disconnect, auto-sync toggle (mocked API) |
+| `api-integrations.spec.js` | 4 | ⏭️ Skipped — need API keys |
+
+## Arguments
+
+`$ARGUMENTS` can be:
+- *(blank)* — full spec suite (`npm test`)
+- `dry-run` — run all checks, no Linear issues
+- `smoke` — smoke-tagged specs only (`npm run test:smoke`)
+
+---
+
+## Phase 0: Setup
+
+### Step 1: Start HTTP server (if needed)
+
+Check if the app is already being served:
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8765/index.html
+```
+
+If not `200`, start one from the project root:
+```bash
+npx http-server . -p 8765 --silent &
+sleep 1
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8765/index.html
+```
+
+If still not `200`, abort with:
+> "HTTP server failed to start on port 8765."
+
+Record `BASE_URL = http://host.docker.internal:8765`
+
+### Step 2: Verify browserless is running
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
+```
+
+browserless v2 returns **404** at the root path — that is normal and healthy. Only abort if the connection is refused entirely (curl exits with non-zero or returns `000`). If you get `200` or `404`, browserless is running.
+
+If connection refused:
+> "browserless is not running. Start it with:
+> `cd devops/browserless && docker compose up -d`
+> Then wait ~5 seconds and retry."
+
+Abort if browserless cannot be reached.
+
+### Step 3: Record run metadata
+
+Note:
+- Today's date (YYYY-MM-DD) and start time
+- `BASE_URL`
+- Arguments used
+
+---
+
+## Phase 1: Run Playwright Tests
+
+Run the appropriate test command based on arguments:
+
+**Full suite (default):**
+```bash
+BROWSER_BACKEND=browserless TEST_URL=http://host.docker.internal:8765 npm test
+```
+
+**Smoke-tagged only:**
+```bash
+BROWSER_BACKEND=browserless TEST_URL=http://host.docker.internal:8765 npm run test:smoke
+```
+
+Capture the full stdout/stderr output. Playwright will report:
+- Number of tests run / passed / failed / skipped
+- Test names and durations
+- Failure details with error messages and line references
+
+Classify results:
+- All passed → `✅ PASS`
+- Any skipped, no failures → `✅ PASS WITH WARNINGS`
+- Any failures → `❌ FAIL`
+
+---
+
+## Video Recording & Dashboard
+
+Test runs capture video and screenshots automatically (configured in `playwright.config.js`).
+Output lands in `test-results/<ISO-timestamp>/` — override with `TEST_RUN_ID` env var.
+Ad-hoc screenshots go to `devops/screenshots/`.
+
+**Start the dashboard:**
+
+```bash
+npm run dash   # http://localhost:8766
+```
+
+Auto-refresh polls `/api/files` every 3 seconds while tests run. Use the "Capture Now"
+button for an instant full-page screenshot of `TEST_URL` (defaults to `http://localhost:8765`).
+
+**When asking the user for visual clarification during a test run:**
+
+1. Click "Capture Now" in the dashboard (or run `npx playwright screenshot <url> devops/screenshots/<name>.png --browser=chromium --full-page`)
+2. Tell the user: `"Check the Playwright Dashboard and refresh — screenshot at [name]"`
+
+---
+
+## Phase 2: Results Summary
+
+Print a results table:
+
+```
+Results
+=======
+| Spec                       | Tests | Status       | Notes |
+|----------------------------|-------|--------------|-------|
+| smoke.spec.js              | 4     | ✅/⚠️/❌    | ... |
+| crud.spec.js               | 3     | ✅/⚠️/❌    | ... |
+| calculations.spec.js       | 2     | ✅/⚠️/❌    | ... |
+| backup-restore.spec.js     | 3     | ✅/⚠️/❌    | KF-007 if vault times out |
+| live-demo.spec.js          | 1     | ✅/⚠️/❌    | KF-003 if timing failure |
+| ui-checks.spec.js          | 7     | ✅/⚠️/❌    | ... |
+| connection.spec.js         | 1     | ✅/⚠️/❌    | ... |
+| hello-kitty.spec.js        | 1     | ✅/⚠️/❌    | ... |
+| cloud-sync.spec.js         | 5     | ✅/⚠️/❌    | ... |
+| market-toggle.spec.js      | 5     | ✅/⚠️/❌    | KF-004, KF-005 if broken |
+| import-export.spec.js      | 3     | ✅/⚠️/❌    | KF-006 against HTTPS URLs |
+| api-integrations.spec.js   | 4+    | ⏭️/⚠️/❌   | 4 skipped (API keys); KF-001, KF-002 may appear |
+
+Overall: ✅ PASS / ✅ PASS WITH WARNINGS / ❌ FAIL
+```
+
+---
+
+## Phase 3: Known Bugs Registry
+
+Before filing any issues, check each failure against the known active bugs.
+**Full registry with root-cause notes:** `docs/tests/known-failures.md`
+
+**Do NOT file a new Linear issue for a known active bug.** Reference it in the run record only.
+After triaging a new failure, add it to `docs/tests/known-failures.md` AND the table below.
+
+### Currently Known Active Issues
+
+| ID | Spec | Test | Status | Root Cause |
+|----|------|------|--------|------------|
+| KF-001 | `api-integrations.spec.js` | `STAK-255: hourlyBaseUrls and RETAIL_API_ENDPOINTS use correct paths` | ⚠️ Flaky | Asserts exact URL structure; breaks when API constants reorganised |
+| KF-002 | `api-integrations.spec.js` | `STAK-215: syncStatus shows save-failure message...` | ⚠️ Flaky | Forces localStorage quota error — not reproducible on Cloudflare Pages |
+| KF-003 | `live-demo.spec.js` | `live demo — load, hover spot cards, open About` | ⚠️ Flaky | No hard assertions — pure timing; ack modal timing differs HTTPS vs local |
+| KF-004 | `market-toggle.spec.js` | `Test 1: New user sees all 5 header buttons by default` | 🔴 Broken | `#headerMarketBtn` not visible on fresh load — selector or render order changed |
+| KF-005 | `market-toggle.spec.js` | `Test 4: Responsive grid layout (3-col → 2-col → 1-col)` | 🔴 Broken | Mobile col count assertion fragile with browserless viewport sizing |
+| KF-006 | `import-export.spec.js` | `JSON round-trip preserves serialNumber` | ⚠️ Flaky | `waitForEvent('download')` unreliable against HTTPS — passes on local HTTP |
+| KF-007 | `backup-restore.spec.js` | `Vault encrypted backup flow` | ⚠️ Flaky | Timeout — vault crypto + seed inventory size; intermittent in Docker |
+
+### Resolved Bugs (do not re-file)
+
+| ID | Description | Resolved In |
+|----|-------------|-------------|
+| BUG-001 | Search returns 0 results intermittently | Fixed in dev |
+| BUG-002 | Autocomplete ghost text persists after modal close | Fixed in dev |
+| BUG-006 | Delete executed immediately with no confirmation dialog | v3.31.5 |
+| STAK-229 | Vault backup test timeout (seed inventory too large for Docker) | Fixed — wipe + `test.setTimeout(120_000)` |
+| STAK-206 | Card view items-per-page constraint never applied | Fixed in dev |
+
+If a failure matches a known issue → mark "known — skipping Linear issue".
+If a failure is **new** → file a Linear issue in Phase 4, add to `docs/tests/known-failures.md`.
+
+---
+
+## Phase 4: File Linear Issues (new findings only)
+
+**Skip entirely if `dry-run` mode.** Instead, print what WOULD be filed.
+
+For each **new** failure:
+
+Call `mcp__claude_ai_Linear__create_issue`:
+- **team:** `f876864d-ff80-4231-ae6c-a8e5cb69aca4`
+- **title:** `BUG: [Test Name] — [brief description]`
+- **priority:** `2` (High) for ❌ fail · `3` (Normal) for ⚠️ warn
+- **labels:** `["Bug", "268350a3-f7e5-467c-b793-4924a40b922a"]` (Bug + Sonnet)
+- **description:**
+
+```markdown
+## Bug Report — Smoke Test Run [DATE]
+
+**Test:** [Test Name]
+**Status:** ❌ Fail / ⚠️ Warn
+**Environment:** http://host.docker.internal:8765; seed inventory
+**Backend:** browserless Docker (local)
+
+## Observed Behavior
+
+[Playwright error output — include error message and line reference]
+
+## Expected Behavior
+
+[What should have happened]
+
+## Reproduction Steps
+
+1. Start browserless: `cd devops/browserless && docker compose up -d`
+2. Start HTTP server: `npx http-server . -p 8765 --silent &`
+3. Run: `BROWSER_BACKEND=browserless TEST_URL=http://host.docker.internal:8765 npm test`
+
+---
+_Surfaced during smoke test run on [DATE] via /smoke-test skill (Playwright + browserless)._
+```
+
+---
+
+## Phase 5: Create Run Record Issue
+
+**Skip if `dry-run` mode.**
+
+Call `mcp__claude_ai_Linear__create_issue`:
+
+- **team:** `f876864d-ff80-4231-ae6c-a8e5cb69aca4`
+- **title:** `QA: Smoke Test Run — [DATE formatted as "Feb 20, 2026"] [EMOJI] [RESULT]`
+- **priority:** `4` (Low)
+- **labels:** `["645a4bb1-0c34-477f-a8a6-14b75762178e", "268350a3-f7e5-467c-b793-4924a40b922a"]` (Improvement + Sonnet)
+- **description:**
+
+```markdown
+## Smoke Test Run — [DATE]
+
+**Overall Result:** [OVERALL_RESULT]
+**Run Method:** /smoke-test skill via Claude Code (Playwright + browserless Docker)
+**Environment:** http://host.docker.internal:8765; seed inventory ([N] items)
+**Backend:** browserless self-hosted Docker (local)
+**Arguments:** [ARGUMENTS or "full suite"]
+
+---
+
+## Results
+
+| Test Name | Status | Notes |
+|---|---|---|
+[results table rows]
+
+---
+
+## New Issues Filed
+
+[List new Linear issues, or "None — all findings matched known active bugs"]
+
+## Known Issues Observed (not re-filed)
+
+[List known bugs triggered this run]
+
+## Known Issues Not Triggered
+
+[List known bugs that did NOT appear this run]
+
+---
+
+_Logged by Claude via /smoke-test skill. Running Playwright specs against local browserless Docker._
+_Full 13-check coverage pending STAK-210._
+```
+
+After creating the run record issue, call `mcp__claude_ai_Linear__update_issue` to set status to **Done**.
+
+---
+
+## Phase 6: Confirm
+
+```
+Smoke test complete!
+====================
+Environment: http://host.docker.internal:8765 (local)
+Backend: browserless Docker
+
+Run Record: STAK-XXX → Done
+  [url]
+
+New bugs filed:
+  STAK-XXX — [title]  (or "None")
+
+Known bugs observed (not re-filed):
+  BUG-001 — search intermittent  (or "None")
+```
+
+---
+
+## Dry Run Mode
+
+If `dry-run`:
+- Run all Playwright specs normally
+- Print the results table
+- Show what Linear issues WOULD be created (title, priority, description preview)
+- Do NOT call any Linear MCP tools
+- End with: `Dry run complete — no Linear issues created.`
+
+---
+
+## Maintaining the Known Bugs Registry
+
+When a bug is resolved and shipped, move it from Known Active Bugs to the Resolved table above. This ensures future runs correctly flag regressions rather than silently skipping them.

--- a/.claude/skills/sync-poller/SKILL.md
+++ b/.claude/skills/sync-poller/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: sync-poller
+description: >
+  Sync home poller files from the VM to StakTrakrApi repo via PR. Use whenever you've edited
+  files on the home poller (dashboard.js, provider-db.js, metrics-exporter.js, check-flyio.sh,
+  run-home.sh, etc.) and need to preserve those changes in version control. Also use when the
+  user says "sync poller", "push poller changes", "commit dashboard changes", "sync homepoller
+  to repo", or after any session that modified files in /opt/poller/ via SSH. This skill ensures
+  no work is lost — every VM edit gets a PR to the shared repo.
+---
+
+# Sync Poller — Home VM to StakTrakrApi
+
+The home poller runs on an Ubuntu VM (`homepoller` / 192.168.1.81) at `/opt/poller/`. These files
+are shared with the Fly.io container via the `StakTrakrApi` repo. After editing files on the VM,
+this skill copies them to the local repo clone and creates (or updates) a PR to main.
+
+## Why this matters
+
+Files edited directly on the VM via SSH are not version-controlled. If the VM dies, or someone
+pulls fresh from main, those changes are gone. This skill is the bridge — it copies live files
+from the VM into the repo and opens a PR so the changes are reviewed and preserved.
+
+## File mapping
+
+Home poller files map to two directories in `StakTrakrApi`:
+
+| VM path (`/opt/poller/`) | Repo path | Notes |
+|---|---|---|
+| `dashboard.js` | `devops/home-scraper/dashboard.js` | Home-only (not on Fly) |
+| `metrics-exporter.js` | `devops/home-scraper/metrics-exporter.js` | Home-only |
+| `check-flyio.sh` | `devops/home-scraper/check-flyio.sh` | Home-only |
+| `run-home.sh` | `devops/home-scraper/run-home.sh` | Home-only entry point |
+| `setup-lxc.sh` | `devops/home-scraper/setup-lxc.sh` | Provisioning script |
+| `provider-db.js` | `devops/fly-poller/provider-db.js` AND `devops/home-scraper/provider-db.js` | Shared — copy to both |
+| `db.js` | `devops/fly-poller/db.js` | Shared with Fly |
+| `turso-client.js` | `devops/fly-poller/turso-client.js` | Shared with Fly |
+| `price-extract.js` | `devops/fly-poller/price-extract.js` | Shared with Fly |
+| `capture.js` | `devops/fly-poller/capture.js` | Shared with Fly |
+| `spot-extract.js` | `devops/fly-poller/spot-extract.js` | Shared with Fly |
+| `goldback-scraper.js` | `devops/fly-poller/goldback-scraper.js` | Shared with Fly |
+
+**Rule of thumb:** If a file exists in `devops/fly-poller/`, it's shared — copy there. If it's
+home-specific (dashboard, metrics, check-flyio), it goes in `devops/home-scraper/` only. Files
+like `provider-db.js` that appear in both get copied to both locations.
+
+## Workflow
+
+### Step 1 — Identify changed files
+
+Ask the user which files were modified, or detect from the current session's SSH commands.
+Common sets:
+
+- **Dashboard work:** `dashboard.js`, `provider-db.js`
+- **Poller logic:** `price-extract.js`, `capture.js`, `db.js`
+- **Spot pipeline:** `spot-extract.js`, `provider-db.js`
+- **Infrastructure:** `run-home.sh`, `setup-lxc.sh`, `check-flyio.sh`
+
+### Step 2 — Copy files from VM to local
+
+```bash
+# Create a temp staging area
+mkdir -p /tmp/homepoller-snapshot
+
+# Copy each changed file (adjust list as needed)
+scp homepoller:/opt/poller/dashboard.js /tmp/homepoller-snapshot/
+scp homepoller:/opt/poller/provider-db.js /tmp/homepoller-snapshot/
+```
+
+### Step 3 — Check for existing sync PR
+
+```bash
+cd /Volumes/DATA/GitHub/StakTrakrApi
+gh pr list --state open --head sync/home-poller-files --json number,title
+```
+
+- **If PR exists:** Use it (reuse the branch).
+- **If no PR:** Create branch `sync/home-poller-files` from main.
+
+### Step 4 — Create or checkout worktree
+
+```bash
+cd /Volumes/DATA/GitHub/StakTrakrApi
+
+# If worktree already exists, reuse it
+git worktree list | grep sync-home && echo "Worktree exists" || \
+  git worktree add .worktrees/sync-home sync/home-poller-files
+```
+
+If the branch doesn't exist yet:
+
+```bash
+git fetch origin
+git worktree add .worktrees/sync-home -b sync/home-poller-files origin/main
+```
+
+### Step 5 — Copy files into worktree
+
+Use the file mapping table above. For shared files, copy to both locations:
+
+```bash
+WT=/Volumes/DATA/GitHub/StakTrakrApi/.worktrees/sync-home
+
+# Home-only files
+cp /tmp/homepoller-snapshot/dashboard.js    "$WT/devops/home-scraper/dashboard.js"
+
+# Shared files — copy to BOTH directories
+cp /tmp/homepoller-snapshot/provider-db.js  "$WT/devops/fly-poller/provider-db.js"
+cp /tmp/homepoller-snapshot/provider-db.js  "$WT/devops/home-scraper/provider-db.js"
+```
+
+Create the `devops/home-scraper/` directory if files don't exist there yet:
+
+```bash
+mkdir -p "$WT/devops/home-scraper"
+```
+
+### Step 6 — Commit and push
+
+```bash
+cd "$WT"
+git add devops/home-scraper/ devops/fly-poller/
+git diff --cached --stat  # Show what's changing
+
+git commit -m "$(cat <<'EOF'
+chore: sync home poller files — <brief description>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+
+git push origin sync/home-poller-files
+```
+
+Write a meaningful commit message describing what changed (not just "sync files").
+
+### Step 7 — Create PR if needed
+
+Only if no PR exists yet:
+
+```bash
+cd /Volumes/DATA/GitHub/StakTrakrApi
+gh pr create \
+  --head sync/home-poller-files \
+  --base main \
+  --title "chore: sync home poller files to repo" \
+  --body "$(cat <<'EOF'
+## Summary
+- Syncs modified files from home poller VM to version control
+- Files: <list changed files>
+
+## Context
+<Brief description of what was changed and why>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Step 8 — Clean up worktree
+
+```bash
+cd /Volumes/DATA/GitHub/StakTrakrApi
+git worktree remove .worktrees/sync-home
+```
+
+### Step 9 — Report
+
+Tell the user:
+- Which files were synced
+- PR number and URL
+- Reminder to merge when ready
+
+## Common mistakes
+
+**Forgetting shared files need two copies.** `provider-db.js` must go to both `devops/fly-poller/`
+and `devops/home-scraper/`. If you only copy to one, the other location goes stale.
+
+**Committing from the wrong directory.** Always `cd` into the worktree before committing. If your
+cwd is the main repo, you'll commit to the wrong branch.
+
+**Force-pushing.** Never force-push `sync/home-poller-files`. The branch accumulates commits across
+sessions — each sync adds a commit. The PR body can be updated when merging.
+
+**Not verifying syntax first.** Before copying files, run `node --check` on the VM:
+```bash
+ssh -T homepoller 'node --check /opt/poller/dashboard.js && echo OK'
+```
+
+## Merging the PR
+
+The sync PR stays open as a running collection of changes. Merge it when:
+- A batch of related changes is complete
+- Before a release that depends on the poller changes
+- The user explicitly asks to merge
+
+After merging, the home poller's "Updating Poller Code" flow (in the `homepoller-ssh` skill)
+can pull from main to verify round-trip integrity.

--- a/.claude/skills/ui-mockup/SKILL.md
+++ b/.claude/skills/ui-mockup/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: ui-mockup
+description: Use when designing a new multi-element UI component (card grid, modal, panel, dashboard) where layout or visual hierarchy is uncertain, or when a plan references a "visually bare" component needing a design pass.
+---
+
+# UI Mockup — Three-Stage Design Workflow
+
+Three gates before any production code is written:
+
+1. **Stitch** — visual concept (does this look right?)
+2. **Playground** — interactive proof of concept in Bootstrap/vanilla JS (does this feel right?)
+3. **Implementation** — integrate approved design into the codebase
+
+Never skip to implementation until the user has approved both the Stitch concept and the playground prototype.
+
+## Workflow
+
+### Step 1 — Find or create the StakTrakr Stitch project
+
+```
+mcp__stitch__list_projects
+```
+
+- If a StakTrakr project exists, note its ID.
+- If not, call `mcp__stitch__create_project`:
+  - **name:** `StakTrakr`
+  - **description:** `Precious metals inventory tracker — single HTML page, 4-state theme (light/dark/sepia/system), glassmorphic cards, pill-shaped buttons, CSS variable system`
+
+### Step 2 — Generate the screen
+
+Call `mcp__stitch__generate_screen_from_text` with a detailed prompt (see Prompt Guide below).
+
+Good prompts include:
+- Component type and context (settings panel section, card grid, modal body)
+- All data elements (badge, stats row, vendor list, sparkline, footer buttons)
+- All states: loading skeleton, empty/no-data, error
+- Hover/focus interactions explicitly described
+- Theme context (light + dark mode values)
+
+### Step 3 — Review with user
+
+Present the Stitch output (screen ID + summary). Ask:
+
+> "Does this match the intended design direction? Any changes before I write the plan?"
+
+### Step 4 — Iterate if needed
+
+| Need | Tool |
+|------|------|
+| Alternative color/layout options | `mcp__stitch__generate_variants` |
+| Targeted change to a specific element | `mcp__stitch__edit_screens` |
+| Retrieve approved screen later | `mcp__stitch__get_screen` |
+
+Repeat until user approves.
+
+### Step 5 — Extract the design spec
+
+From the approved screen, document:
+- Exact color values, spacing, border-radius decisions
+- Component hierarchy and data layout
+- Interaction states (hover, loading, empty)
+- CSS delta: what changes from the current app baseline
+
+### Step 6 — Playground proof of concept
+
+Invoke the `playground` skill to build an interactive prototype using the approved Stitch design as the spec.
+
+The playground must use StakTrakr's actual tech stack:
+- Bootstrap 5 classes and utility system
+- CSS custom properties matching `--primary`, `--bg-secondary`, `--text-muted`, etc.
+- `data-theme` attribute for theme switching (light/dark/sepia)
+- Pill-shaped buttons (`border-radius: 999px`), 8px card radius, glassmorphic borders
+- Realistic sample data (not lorem ipsum — use coin/metal names, prices, vendor names)
+
+The playground should be interactive enough to validate the UX:
+- All button clicks should respond (even if just a toast or state toggle)
+- Hover and focus states visible
+- All data states: populated, loading skeleton, empty/no-data, error
+
+Present the playground output to the user:
+
+> "Here's the interactive prototype. Try clicking around — does this feel right before I write the implementation plan?"
+
+Iterate on the playground until the user approves.
+
+### Step 7 — Hand off to implementation
+
+Only after explicit user approval of the playground, invoke `writing-plans` with:
+- Stitch screen ID(s) as visual reference
+- Playground file path (or inline CSS/HTML excerpts) as the implementation baseline
+- Extracted CSS delta from Step 5
+- Note: "Playground approved — proceed to implementation"
+
+---
+
+## Prompt Guide for StakTrakr Components
+
+Open every Stitch prompt with this context block:
+
+```
+StakTrakr is a precious metals inventory tracker with a 4-state theme system
+(light/dark/sepia/system). Design language: glassmorphic transparent overlays,
+pill-shaped buttons (border-radius: 999px), CSS variable system
+(--primary #3b82f6, --bg-secondary, --text-muted), 8px border radius on cards,
+subtle 1px borders.
+
+Dark mode: cards use rgba(255,255,255,0.03) background, rgba(255,255,255,0.1) border.
+Light mode: cards use #f8fafc background, #cbd5e1 border.
+```
+
+Then describe the specific component fully.
+
+---
+
+## When to Use
+
+- Card grids or dashboard panels with ≥3 distinct data elements
+- Modals with non-trivial layout (multiple sections, tabbed content)
+- Redesigning an existing component flagged as "visually bare"
+- Any component where the plan or brainstorm notes "design uncertain"
+
+## When to Skip
+
+- Single-element additions (a button, a badge, a tooltip)
+- Components with a clear 1:1 analogue already in the codebase
+- Pure behavior changes with no layout impact
+- Bug fixes
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skipping theme context in the prompt | Always include light + dark mode values |
+| Forgetting empty/loading states | Describe them explicitly in the prompt |
+| Jumping to `writing-plans` without user approval | Wait for explicit sign-off on the screen |
+| Using `edit_screens` for major redesigns | Use `generate_variants` instead |

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,16 @@
 !.claude/skills/retail-provider-fix/
 !.claude/skills/repo-boundaries/
 !.claude/skills/homepoller-ssh/
+!.claude/skills/bb-test/
+!.claude/skills/browserbase-test-maintenance/
+!.claude/skills/devops-dashboard/
+!.claude/skills/frontend-design/
+!.claude/skills/jules-review/
+!.claude/skills/jules-suppress/
+!.claude/skills/scan-mentions/
+!.claude/skills/smoke-test/
+!.claude/skills/sync-poller/
+!.claude/skills/ui-mockup/
 .claude/commands/
 .mcp.json
 SPRINT.md
@@ -99,10 +109,14 @@ devops/hub/
 
 # Git worktrees for isolated agent work — content dirs are transient, not project history
 .claude/worktrees/
-# Ignore spec-workflow transient data (specs, logs, approvals) but track user-templates
+# Ignore spec-workflow transient data (specs, logs, approvals) but track user-templates, steering, and templates
 .spec-workflow/*
 !.spec-workflow/user-templates/
 !.spec-workflow/user-templates/**
+!.spec-workflow/steering/
+!.spec-workflow/steering/**
+!.spec-workflow/templates/
+!.spec-workflow/templates/**
 
 # Wiki nightwatch — local rotation state, not project history
 wiki/.nightwatch-log.json

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -20,5 +20,8 @@
   },
   "MD035": {
     "style": "---"
+  },
+  "MD025": {
+    "front_matter_title": ""
   }
 }

--- a/.spec-workflow/steering/product.md
+++ b/.spec-workflow/steering/product.md
@@ -1,0 +1,61 @@
+# Product Overview
+
+## Product Purpose
+StakTrakr is a precious metals inventory tracker for individual collectors and investors. It solves the problem of tracking portfolio value across gold, silver, platinum, palladium, and goldback holdings — providing real-time melt value calculations, retail price comparisons, and gain/loss analysis without requiring accounts, servers, or cloud infrastructure.
+
+## Target Users
+Individual precious metals collectors and investors who want to:
+- Track their physical holdings (coins, bars, rounds, goldbacks) in one place
+- See real-time portfolio value based on live spot prices
+- Compare retail dealer prices across multiple providers
+- Export portfolio data for tax reporting or insurance documentation
+- Keep their financial data private and under their control (no accounts, no server storage)
+
+## Key Features
+
+1. **Portfolio Tracking**: Add items with purchase price, weight, quantity, and metal type. Automatic melt value calculation: `meltValue = weight * qty * spotPrice`
+2. **Three-Price Model**: Every item shows Purchase Price (what you paid), Melt Value (intrinsic metal value), and Retail Price (current dealer asking price)
+3. **Live Spot Prices**: Multi-provider spot price integration with automatic failover (StakTrakr API, Metals.dev, Metal Price API, custom endpoints)
+4. **Retail Price Comparison**: Aggregated retail prices from major dealers, displayed per-item with premium calculations
+5. **Cloud Sync**: AES-encrypted ZIP backup/restore to cloud storage — data never leaves your control unencrypted
+6. **Import/Export**: CSV and JSON import/export for migration and reporting; PDF export with jsPDF for printable portfolio summaries
+7. **Catalog Integration**: Numista and PCGS catalog lookup for coin identification, grading, and metadata enrichment
+8. **Encrypted Vault**: Password-protected vault for storing sensitive notes per item (AES encryption via Forge)
+9. **Image Management**: Per-item photo storage with local caching, bulk download, and format optimization
+10. **Offline PWA**: Installable progressive web app with Service Worker caching — works fully offline and on `file://` protocol
+
+## Business Objectives
+
+- **Zero-dependency operation**: No accounts, no server, no build step — open `index.html` and it works
+- **Privacy by default**: All data stored in browser localStorage; cloud sync is opt-in and encrypted
+- **Offline-first**: Full functionality without internet; spot prices cached for offline portfolio viewing
+- **Cross-platform**: Runs in any modern browser, on any OS, from local file or hosted URL
+
+## Success Metrics
+
+- **Reliability**: App loads and functions on file://, HTTP, and HTTPS without errors
+- **Data integrity**: Zero data loss across version upgrades and cloud sync round-trips
+- **Price freshness**: Spot prices within 75 minutes, retail prices within 30 minutes when online
+- **Performance**: Sub-second render for inventories up to 1,000 items
+
+## Product Principles
+
+1. **Zero Build Step**: No webpack, no bundling, no transpilation. Raw HTML/CSS/JS that runs directly in the browser. This keeps the project accessible and eliminates build tooling failures.
+2. **File Protocol Compatible**: Must work when opened as `file://index.html` — no CORS, no server assumptions. This enables USB/offline distribution.
+3. **Privacy First**: No telemetry, no analytics, no external calls except explicit spot/retail price fetches. User data never leaves the browser unless the user initiates cloud sync.
+4. **Vanilla JavaScript Only**: No React, no Vue, no frameworks. Direct DOM manipulation keeps the dependency surface at zero and the mental model simple.
+5. **Offline Resilient**: Service Worker pre-caches all assets. Vendor libraries bundled locally with CDN fallback. App degrades gracefully when offline (cached spot prices, no retail).
+
+## Monitoring & Visibility
+
+- **Dashboard Type**: Single-page web app with card and table views
+- **Real-time Updates**: Polling-based spot price refresh (configurable interval), manual retail price fetch
+- **Key Metrics Displayed**: Total portfolio value (melt + retail), per-item gain/loss, spot price charts with history, API health status indicators
+- **Sharing Capabilities**: PDF export, CSV export, JSON backup (encrypted), cloud sync for cross-device access
+
+## Future Vision
+
+### Potential Enhancements
+- **Remote Access**: Cloud-hosted version with authentication for multi-device access without manual sync
+- **Analytics**: Historical portfolio value trends, metal allocation charts, tax lot tracking
+- **Collaboration**: Shared read-only portfolio links for insurance or estate planning purposes

--- a/.spec-workflow/steering/structure.md
+++ b/.spec-workflow/steering/structure.md
@@ -1,0 +1,206 @@
+# Project Structure
+
+## Directory Organization
+
+```
+StakTrakr/
+├── index.html              # Single-page application entry point (4,900+ lines)
+├── sw.js                   # Service Worker — offline caching, auto-stamped CACHE_NAME
+├── manifest.json           # PWA manifest (installable app)
+├── version.json            # Current version metadata
+├── package.json            # Dev dependencies only (ESLint, Playwright)
+├── js/                     # Application JavaScript (57 files)
+│   ├── constants.js        # Global config: version, API providers, currencies, storage keys
+│   ├── state.js            # In-memory state container
+│   ├── utils.js            # Core utilities: saveData/loadData, safeGetElement, sanitizeHtml
+│   ├── dialogs.js          # Generic dialog/modal helpers
+│   ├── events.js           # All DOM event listeners and handlers
+│   ├── inventory.js        # Item CRUD, calculations, rendering (largest file)
+│   ├── api.js              # Spot/retail price fetching, provider abstraction
+│   ├── settings.js         # Settings UI and persistence
+│   ├── init.js             # Startup sequence (always loads last)
+│   └── ... (48 more)       # Modular feature files (see load order below)
+├── css/
+│   └── styles.css          # All styling in one file (264 KB)
+├── vendor/                 # Bundled third-party libraries (CDN fallback)
+│   ├── chart.min.js        # Chart.js 3.9.1
+│   ├── chartjs-plugin-datalabels.min.js
+│   ├── forge.min.js        # Forge 0.10.0
+│   ├── jspdf.umd.min.js    # jsPDF 2.5.1
+│   ├── jspdf.plugin.autotable.min.js
+│   ├── jszip.min.js        # JSZip 3.10.1
+│   └── papaparse.min.js    # PapaParse 5.4.1
+├── images/                 # Static image assets (icons, logos)
+├── about/                  # About page content (announcements, changelog source)
+├── data/                   # API data feeds (hourly spot, manifests, goldback)
+│   └── spot-history-bundle.js  # Seed spot prices (loaded as script)
+├── tests/                  # Playwright E2E specs (16 test files)
+├── devops/                 # Infrastructure: CGC Docker, version lock, git hooks, CI/CD
+│   ├── cgc/                # Code Graph Context Docker setup
+│   ├── hooks/              # Git pre-commit hooks (cache stamp, version check)
+│   └── version.lock        # Mutex for concurrent patch versioning
+├── docs/                   # Documentation: JSDoc HTML output, plans, runbooks
+├── deprecated/             # Archived legacy code
+├── .spec-workflow/         # Spec workflow plugin (specs, steering docs, approvals)
+├── .claude/                # Claude Code config (skills, worktrees, plans)
+├── .github/                # GitHub Actions workflows, Copilot instructions
+└── .codacy.yml             # Code quality gate configuration
+```
+
+## Naming Conventions
+
+### Files
+- **JS modules**: `kebab-case.js` (e.g., `cloud-sync.js`, `card-view.js`, `api-health.js`)
+- **Single-word modules**: `lowercase.js` (e.g., `utils.js`, `state.js`, `init.js`)
+- **Vendor libraries**: Original upstream names (e.g., `chart.min.js`, `forge.min.js`)
+- **Tests**: `kebab-case.spec.js` (e.g., `cloud-sync.spec.js`, `crud.spec.js`)
+
+### Code
+- **Functions/Methods**: `camelCase` (e.g., `saveData()`, `loadData()`, `safeGetElement()`)
+- **Constants**: `UPPER_SNAKE_CASE` (e.g., `ALLOWED_STORAGE_KEYS`, `API_PROVIDERS`, `VERSION`)
+- **Variables**: `camelCase` (e.g., `currentSpot`, `inventoryItems`, `filterState`)
+- **DOM IDs**: `kebab-case` in HTML (e.g., `spot-price-display`, `inventory-table`)
+- **CSS classes**: `kebab-case` (e.g., `.card-view-item`, `.spot-badge`)
+
+## Script Load Order (Critical)
+
+All 57 JS files load via `<script defer>` in strict dependency order in `index.html`. This order **must** be maintained — reordering breaks the app.
+
+```
+Phase 1 — Synchronous (before DOM):
+  file-protocol-fix.js          # localStorage polyfill for file:// protocol
+
+Phase 2 — Vendor libraries (deferred):
+  papaparse.min.js, jspdf.umd.min.js, jspdf.plugin.autotable.min.js,
+  chart.min.js, chartjs-plugin-datalabels.min.js, jszip.min.js, forge.min.js
+
+Phase 3 — Inline scripts:
+  CDN fallback loader            # Checks vendor load, falls back to CDNJS with SRI
+  Theme flash prevention         # Applies dark mode before paint
+
+Phase 4 — Application (deferred, strict order):
+  debug-log.js                   # Debug logging utility
+  constants.js                   # Config, API providers, storage keys, version
+  state.js                       # Global state container
+  utils.js                       # Core utilities (saveData, loadData, sanitizeHtml)
+  dialogs.js                     # Modal/dialog helpers
+  image-processor.js             # Image format conversion
+  image-cache.js                 # Image localStorage cache
+  bulk-image-cache.js            # Bulk image download
+  image-cache-modal.js           # Cache management UI
+  fuzzy-search.js                # Fuzzy matching algorithm
+  autocomplete.js                # Autocomplete widget
+  numista-lookup.js              # Numista API client
+  seed-images.js                 # Seed product images
+  versionCheck.js                # Version update detection
+  changeLog.js                   # Changelog display
+  diff-engine.js                 # Change detection for sync
+  charts.js                      # Chart.js wrapper
+  theme.js                       # Dark/light mode toggle
+  search.js                      # Global item search
+  chip-grouping.js               # Tag/chip rendering
+  tags.js                        # Item tagging system
+  filters.js                     # Multi-criteria filtering
+  sorting.js                     # Item sort logic
+  pagination.js                  # Result pagination
+  detailsModal.js                # Item metadata modal
+  viewModal.js                   # Item detail modal
+  debugModal.js                  # Debug info modal
+  numista-modal.js               # Numista lookup modal
+  spot.js                        # Spot price history & alerts
+  data/spot-history-bundle.js    # Seed spot price data
+  seed-data.js                   # Seed inventory data
+  priceHistory.js                # Price trend charts
+  spotLookup.js                  # Spot price lookup UI
+  goldback.js                    # Goldback-specific pricing
+  retail.js                      # Retail price integration
+  retail-view-modal.js           # Retail modal UI
+  api.js                         # API orchestration (spot/retail fetching)
+  catalog-api.js                 # Numista/PCGS catalog API
+  pcgs-api.js                    # PCGS grading integration
+  catalog-providers.js           # Catalog provider abstraction
+  catalog-manager.js             # Catalog data management
+  inventory.js                   # Core CRUD, calculations, rendering
+  card-view.js                   # Card display layout
+  vault.js                       # Encrypted vault
+  cloud-storage.js               # Cloud sync abstraction
+  cloud-sync.js                  # Cloud data sync logic
+  about.js                       # About page
+  api-health.js                  # API freshness checks
+  faq.js                         # FAQ content
+  customMapping.js               # Custom field mapping
+  settings.js                    # Settings UI
+  settings-listeners.js          # Settings event handlers
+  bulkEdit.js                    # Batch item editing
+  events.js                      # All DOM event listeners (must be near-last)
+  test-loader.js                 # Test framework loader
+  init.js                        # Startup sequence (always last)
+```
+
+**Rule**: When adding a new JS file, it must be added to **both** `index.html` (in correct dependency position) **and** `sw.js` CORE_ASSETS array.
+
+## Code Structure Patterns
+
+### Mandatory Safety Patterns
+```javascript
+// DOM access — ALWAYS use safeGetElement, never raw getElementById
+const el = safeGetElement('my-element-id');
+
+// innerHTML — ALWAYS sanitize user content
+el.innerHTML = sanitizeHtml(userProvidedContent);
+
+// Storage — ALWAYS use saveData/loadData from utils.js
+saveData('myKey', myValue);
+const data = loadData('myKey');
+
+// Storage keys — MUST be registered in constants.js
+// ALLOWED_STORAGE_KEYS in js/constants.js
+```
+
+### Module Organization Pattern
+Each JS file follows a consistent structure:
+```
+1. 'use strict' (if present)
+2. Constants / config specific to this module
+3. DOM element references (via safeGetElement)
+4. Core functions (public API)
+5. Helper/private functions
+6. Event listener setup (if any)
+7. Exports to window/global scope (implicit — no ES modules)
+```
+
+### State Flow
+```
+User action → events.js handler → state.js mutation → render function → DOM update
+                                → saveData() → localStorage persistence
+```
+
+### Import Pattern
+No ES modules — all scripts share the global scope via `window`. Dependencies are resolved by script load order in `index.html`. Functions are accessed directly by name (e.g., `saveData()`, `safeGetElement()`, `renderInventory()`).
+
+## Module Boundaries
+
+| Layer | Files | Depends On |
+|-------|-------|------------|
+| **Constants** | `constants.js` | Nothing |
+| **State** | `state.js` | `constants.js` |
+| **Utilities** | `utils.js`, `dialogs.js`, `debug-log.js` | `constants.js`, `state.js` |
+| **Data/Cache** | `image-cache.js`, `diff-engine.js`, `seed-data.js` | Utilities |
+| **Search/Filter** | `fuzzy-search.js`, `search.js`, `filters.js`, `sorting.js`, `pagination.js` | Utilities, State |
+| **UI Components** | `viewModal.js`, `detailsModal.js`, `card-view.js`, `chip-grouping.js` | Utilities, State |
+| **API** | `api.js`, `spot.js`, `retail.js`, `catalog-api.js`, `goldback.js` | Constants, Utilities |
+| **Domain** | `inventory.js`, `vault.js`, `cloud-sync.js`, `bulkEdit.js` | All above layers |
+| **Orchestration** | `events.js`, `settings.js` | All above layers |
+| **Bootstrap** | `init.js` | Everything (runs startup sequence) |
+
+## Code Size Guidelines
+
+- **Target file size**: Under 50 KB per file (aspiration — several core files exceed this)
+- **Current large files**: `inventory.js` (164 KB), `events.js` (110 KB), `api.js` (108 KB), `utils.js` (97 KB), `settings.js` (89 KB) — these are candidates for future decomposition
+- **Function size**: Aim for under 50 lines; complex render functions may exceed this
+- **Nesting depth**: Maximum 4 levels of indentation
+
+## Documentation Standards
+- JSDoc comments on public functions (auto-generated HTML in `docs/api/`)
+- Inline comments only where logic is non-obvious
+- No README files per module — project-level CLAUDE.md and wiki serve as documentation

--- a/.spec-workflow/steering/tech.md
+++ b/.spec-workflow/steering/tech.md
@@ -1,0 +1,114 @@
+# Technology Stack
+
+## Project Type
+Single-page web application — vanilla JavaScript with zero build step. Runs directly from `index.html` on `file://` protocol, local HTTP server, or static hosting (GitHub Pages). No framework, no transpilation, no bundling.
+
+## Core Technologies
+
+### Primary Language(s)
+- **Language**: JavaScript (ES6+), HTML5, CSS3
+- **Runtime**: Browser-native (no Node.js runtime required for production)
+- **Language-specific tools**: ESLint for linting; no compiler or transpiler
+
+### Key Dependencies/Libraries
+All vendored locally in `vendor/` with CDN SRI fallback:
+
+- **Chart.js 3.9.1 + DataLabels 2.2.0**: Portfolio allocation charts, spot price history visualization
+- **jsPDF 2.5.1 + AutoTable 3.5.25**: PDF export with formatted tables for portfolio reports
+- **PapaParse 5.4.1**: CSV parsing for data import/export
+- **JSZip 3.10.1**: ZIP compression for encrypted cloud sync backups
+- **Forge 0.10.0**: AES encryption for vault password protection and cloud sync encryption
+
+### Application Architecture
+Event-driven single-page application with imperative DOM manipulation:
+
+- **State**: Global state container in `state.js` — inventory, filters, UI preferences held in memory
+- **Rendering**: Direct DOM updates via vanilla JS; no virtual DOM, no reactivity framework
+- **Events**: Centralized event listeners in `events.js`; UI actions trigger state mutations then re-renders
+- **Initialization**: Sequential startup in `init.js` — load data, fetch spot prices, render inventory
+- **Change detection**: `diff-engine.js` compares local vs cloud state for sync conflict resolution
+
+### Data Storage
+- **Primary storage**: `localStorage` via `saveData(key, value)` / `loadData(key)` utilities in `js/utils.js`
+- **Storage key registry**: All keys must be declared in `ALLOWED_STORAGE_KEYS` in `js/constants.js`
+- **Cloud sync**: AES-encrypted ZIP archive (JSZip + Forge) uploaded/downloaded to user-controlled cloud storage
+- **Image cache**: Base64-encoded images stored in localStorage with LRU eviction in `image-cache.js`
+- **Data formats**: JSON throughout (localStorage values, API responses, import/export)
+
+### External Integrations
+- **Spot Price APIs**: Multi-provider with failover chain — StakTrakr API (primary, self-hosted on Fly.io), Metals.dev, Metal Price API, custom user endpoint
+- **Retail Price API**: StakTrakr API aggregated dealer prices at `api.staktrakr.com/data/api/manifest.json`
+- **Goldback Spot**: Dedicated feed at `api.staktrakr.com/data/api/goldback-spot.json`
+- **Numista API**: Coin catalog lookup for identification and metadata enrichment
+- **PCGS API**: Grading service lookup for certified coin data
+- **Protocols**: HTTP/HTTPS REST (JSON responses)
+- **Authentication**: API keys for third-party providers (stored in Infisical vault, not in frontend code)
+
+### Monitoring & Dashboard Technologies
+- **Dashboard Framework**: Vanilla JS — no framework
+- **Real-time Communication**: Polling-based spot price refresh (configurable interval)
+- **Visualization Libraries**: Chart.js 3.9.1 for line/doughnut/bar charts
+- **State Management**: localStorage as source of truth; in-memory `state.js` for runtime
+
+## Development Environment
+
+### Build & Development Tools
+- **Build System**: None — zero build step by design
+- **Package Management**: npm (dev dependencies only — ESLint, Playwright)
+- **Development workflow**: Open `index.html` in browser; edit JS/CSS files; refresh. No hot reload, no dev server required.
+
+### Code Quality Tools
+- **Static Analysis**: ESLint 9.21.0 with custom rules; Codacy automated PR quality gates
+- **Formatting**: ESLint-enforced style (no Prettier)
+- **Testing Framework**: Playwright 1.50.0 for E2E browser tests (16 spec files)
+- **Documentation**: JSDoc comments; auto-generated HTML docs in `docs/api/`
+
+### Version Control & Collaboration
+- **VCS**: Git (GitHub)
+- **Branching Strategy**: `dev` (active development) → `main` (releases only). Feature work on `patch/VERSION` worktree branches that PR into `dev`. Never push directly to `dev` or `main` — both are branch-protected with Codacy quality gates.
+- **Code Review Process**: Draft PRs with Codacy checks; Cloudflare preview deployments for QA; `/pr-resolve` skill for review thread resolution
+
+## Deployment & Distribution
+- **Target Platform(s)**: Any modern web browser (Chrome, Firefox, Safari, Edge). Desktop and mobile.
+- **Distribution Method**: GitHub Pages static hosting at `staktrakr.com`; also distributable as a folder (works from `file://`)
+- **Installation Requirements**: None — open in browser. PWA installable via browser "Add to Home Screen"
+- **Update Mechanism**: Service Worker cache invalidation on version bump; `versionCheck.js` detects new versions and prompts user
+
+## Technical Requirements & Constraints
+
+### Performance Requirements
+- Sub-second render for inventories up to 1,000 items
+- Spot price fetch and portfolio recalculation under 2 seconds
+- Service Worker install/activate under 3 seconds on first load
+
+### Compatibility Requirements
+- **Platform Support**: All modern browsers (ES6+ required). `file://` protocol support via `file-protocol-fix.js` polyfill
+- **Dependency Versions**: Vendor libraries pinned (bundled in `vendor/`); no runtime dependency resolution
+- **Standards Compliance**: PWA (Web App Manifest + Service Worker); Web Crypto API for encryption fallback
+
+### Security & Compliance
+- **Security Requirements**: `sanitizeHtml()` on all user-controlled innerHTML; `safeGetElement()` for DOM access; AES encryption for cloud sync and vault
+- **No telemetry**: Zero external analytics, no tracking pixels, no third-party scripts except explicit API calls
+- **Threat Model**: localStorage data accessible to same-origin scripts; cloud sync encrypted at rest; API keys never stored in frontend
+
+### Scalability & Reliability
+- **Expected Load**: Single-user application; no concurrent access concerns
+- **Availability Requirements**: Offline-capable via Service Worker; no server uptime dependency for core functionality
+- **Growth Projections**: localStorage limit (~5-10MB) is the primary constraint; image cache uses LRU eviction to stay within bounds
+
+## Technical Decisions & Rationale
+
+### Decision Log
+1. **Vanilla JS over React/Vue**: Eliminates build tooling, reduces complexity, enables `file://` distribution. Trade-off: larger individual files, manual DOM management.
+2. **localStorage over IndexedDB**: Simpler API, synchronous access, sufficient for inventory data. Trade-off: ~5MB limit, no structured queries.
+3. **Vendored libraries over npm/CDN-only**: Ensures offline and `file://` operation. CDN fallback with SRI hashes provides redundancy without requiring network.
+4. **Service Worker caching**: Enables PWA installation and offline use. Cache name auto-stamped by pre-commit hook to force updates on version bumps.
+5. **Multi-provider spot price failover**: Avoids single point of failure for price data. Primary (StakTrakr API on Fly.io) with automatic cascade to third-party providers.
+
+## Known Limitations
+
+- **File size**: Several core JS files exceed 100KB (`inventory.js` 164KB, `events.js` 110KB, `api.js` 108KB) — candidates for future modularization
+- **localStorage cap**: ~5-10MB browser limit constrains total data + image cache size
+- **No concurrent editing**: Single-browser assumption; cloud sync handles cross-device but not simultaneous edits
+- **Script load order**: 67 `<script>` tags with strict dependency ordering — adding new files requires updating both `index.html` and `sw.js` CORE_ASSETS
+- **Version propagation**: Version number lives in 7 files — automated by `/release` skill but fragile if done manually

--- a/.spec-workflow/templates/code-quality-reviewer-template.md
+++ b/.spec-workflow/templates/code-quality-reviewer-template.md
@@ -1,0 +1,76 @@
+# Code Quality Reviewer
+
+You are reviewing code changes for production readiness. Only dispatch this review AFTER spec compliance has passed.
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Git Range to Review
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## Review Checklist
+
+**Code Quality:**
+- Clean separation of concerns?
+- Proper error handling?
+- Type safety (if applicable)?
+- DRY principle followed?
+- Edge cases handled?
+
+**Architecture:**
+- Sound design decisions?
+- Scalability considerations?
+- Performance implications?
+- Security concerns?
+
+**Testing:**
+- Tests actually test logic (not just mocks)?
+- Edge cases covered?
+- Integration tests where needed?
+- All tests passing?
+- Test execution results logged in implementation artifacts? (name, status, pass/fail counts)
+- Tests linked to user stories from spec requirements?
+
+**Requirements:**
+- All plan requirements met?
+- Implementation matches spec?
+- No scope creep?
+- Breaking changes documented?
+
+**Production Readiness:**
+- Backward compatibility considered?
+- Documentation complete?
+- No obvious bugs?
+
+## Output Format
+
+### Strengths
+[What's well done? Be specific with file:line references.]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (Should Fix)
+[Architecture problems, missing features, poor error handling, test gaps]
+
+#### Minor (Nice to Have)
+[Code style, optimization opportunities, documentation improvements]
+
+**For each issue:**
+- File:line reference
+- What's wrong
+- Why it matters
+- How to fix (if not obvious)
+
+### Assessment
+
+**Ready to proceed?** [Yes / No / With fixes]
+
+**Reasoning:** [1-2 sentence technical assessment]

--- a/.spec-workflow/templates/design-template.md
+++ b/.spec-workflow/templates/design-template.md
@@ -1,0 +1,102 @@
+# Design Document
+
+## References
+
+- **Linear Issue:** [PROJ-XXX](https://linear.app/team/issue/PROJ-XXX)
+- **GitHub PR:** [#NNN](https://github.com/owner/repo/pull/NNN)
+- **Spec Path:** `.spec-workflow/specs/{spec-name}/`
+
+## Overview
+
+[High-level description of the feature and its place in the overall system]
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+[How the design follows documented technical patterns and standards]
+
+### Project Structure (structure.md)
+[How the implementation will follow project organization conventions]
+
+## Code Reuse Analysis
+[What existing code will be leveraged, extended, or integrated with this feature]
+
+### Existing Components to Leverage
+- **[Component/Utility Name]**: [How it will be used]
+- **[Service/Helper Name]**: [How it will be extended]
+
+### Integration Points
+- **[Existing System/API]**: [How the new feature will integrate]
+- **[Database/Storage]**: [How data will connect to existing schemas]
+
+## Architecture
+
+[Describe the overall architecture and design patterns used]
+
+### Modular Design Principles
+- **Single File Responsibility**: Each file should handle one specific concern or domain
+- **Component Isolation**: Create small, focused components rather than large monolithic files
+- **Service Layer Separation**: Separate data access, business logic, and presentation layers
+- **Utility Modularity**: Break utilities into focused, single-purpose modules
+
+```mermaid
+graph TD
+    A[Component A] --> B[Component B]
+    B --> C[Component C]
+```
+
+## Components and Interfaces
+
+### Component 1
+- **Purpose:** [What this component does]
+- **Interfaces:** [Public methods/APIs]
+- **Dependencies:** [What it depends on]
+- **Reuses:** [Existing components/utilities it builds upon]
+
+### Component 2
+- **Purpose:** [What this component does]
+- **Interfaces:** [Public methods/APIs]
+- **Dependencies:** [What it depends on]
+- **Reuses:** [Existing components/utilities it builds upon]
+
+## Data Models
+
+### Model 1
+```
+[Define the structure of Model1 in your language]
+- id: [unique identifier type]
+- name: [string/text type]
+- [Additional properties as needed]
+```
+
+### Model 2
+```
+[Define the structure of Model2 in your language]
+- id: [unique identifier type]
+- [Additional properties as needed]
+```
+
+## Error Handling
+
+### Error Scenarios
+1. **Scenario 1:** [Description]
+   - **Handling:** [How to handle]
+   - **User Impact:** [What user sees]
+
+2. **Scenario 2:** [Description]
+   - **Handling:** [How to handle]
+   - **User Impact:** [What user sees]
+
+## Testing Strategy
+
+### Unit Testing
+- [Unit testing approach]
+- [Key components to test]
+
+### Integration Testing
+- [Integration testing approach]
+- [Key flows to test]
+
+### End-to-End Testing
+- [E2E testing approach]
+- [User scenarios to test]

--- a/.spec-workflow/templates/implementer-prompt-template.md
+++ b/.spec-workflow/templates/implementer-prompt-template.md
@@ -1,0 +1,91 @@
+# Implementer Subagent Template
+
+Use this template when dispatching an implementer subagent for a spec-workflow task. Paste the full task text — don't make the subagent read the file.
+
+## Template
+
+```
+You are implementing Task {TASK_ID}: {TASK_NAME}
+
+## Task Description
+
+{FULL TASK TEXT from tasks.md — paste it here}
+
+## Context
+
+{Where this fits, dependencies, architectural context from design.md}
+
+## Before You Begin
+
+If you have questions about:
+- The requirements or acceptance criteria
+- The approach or implementation strategy
+- Dependencies or assumptions
+- Anything unclear in the task description
+
+**Ask them now.** Raise any concerns before starting work.
+
+## Your Job
+
+Once you're clear on requirements:
+1. Implement exactly what the task specifies
+2. Follow _Leverage fields to use existing code/utilities
+3. Test your implementation
+4. Commit your work
+5. Self-review (see below)
+6. Log implementation using log-implementation tool
+7. Report back
+
+**While you work:** If you encounter something unexpected or unclear, ask questions.
+Don't guess or make assumptions.
+
+## Self-Review (before reporting back)
+
+Review your work with fresh eyes:
+
+**Completeness:**
+- Did I fully implement everything in the spec?
+- Did I miss any requirements?
+- Are there edge cases I didn't handle?
+
+**Quality:**
+- Is this my best work?
+- Are names clear and accurate?
+- Is the code clean and maintainable?
+
+**Discipline:**
+- Did I avoid overbuilding (YAGNI)?
+- Did I only build what was requested?
+- Did I follow existing patterns in the codebase?
+
+**Testing:**
+- Do tests actually verify behavior (not just mocks)?
+- Are tests comprehensive (unit, integration, E2E as appropriate)?
+- Were all tests RUN and did they PASS? (status must be captured in log-implementation)
+- Do tests cover the user stories from the spec requirements?
+
+If you find issues during self-review, fix them now.
+
+## After Commit: Log Implementation (MANDATORY)
+
+Call the log-implementation MCP tool with:
+- **specName**: {SPEC_NAME}
+- **taskId**: {TASK_ID}
+- **summary**: What you implemented (1-2 sentences)
+- **filesModified** / **filesCreated**: Accurate file lists
+- **statistics**: { linesAdded, linesRemoved }
+- **artifacts**: ALL that apply:
+  - apiEndpoints, functions, components, classes, integrations
+  - **tests**: name, type, framework, location, status, pass/fail counts, userStories (linked requirement IDs)
+
+Do not skip this step. Future agents search logs to avoid duplicating work. Tests MUST be run before logging — do not log tests you only wrote but never executed.
+
+## Report Format
+
+When done, report:
+- What you implemented
+- What you tested and test results
+- Files changed
+- Self-review findings (if any)
+- Any issues or concerns
+```

--- a/.spec-workflow/templates/product-template.md
+++ b/.spec-workflow/templates/product-template.md
@@ -1,0 +1,51 @@
+# Product Overview
+
+## Product Purpose
+[Describe the core purpose of this product/project. What problem does it solve?]
+
+## Target Users
+[Who are the primary users of this product? What are their needs and pain points?]
+
+## Key Features
+[List the main features that deliver value to users]
+
+1. **Feature 1**: [Description]
+2. **Feature 2**: [Description]
+3. **Feature 3**: [Description]
+
+## Business Objectives
+[What are the business goals this product aims to achieve?]
+
+- [Objective 1]
+- [Objective 2]
+- [Objective 3]
+
+## Success Metrics
+[How will we measure the success of this product?]
+
+- [Metric 1]: [Target]
+- [Metric 2]: [Target]
+- [Metric 3]: [Target]
+
+## Product Principles
+[Core principles that guide product decisions]
+
+1. **[Principle 1]**: [Explanation]
+2. **[Principle 2]**: [Explanation]
+3. **[Principle 3]**: [Explanation]
+
+## Monitoring & Visibility (if applicable)
+[How do users track progress and monitor the system?]
+
+- **Dashboard Type**: [e.g., Web-based, CLI, Desktop app]
+- **Real-time Updates**: [e.g., WebSocket, polling, push notifications]
+- **Key Metrics Displayed**: [What information is most important to surface]
+- **Sharing Capabilities**: [e.g., read-only links, exports, reports]
+
+## Future Vision
+[Where do we see this product evolving in the future?]
+
+### Potential Enhancements
+- **Remote Access**: [e.g., Tunnel features for sharing dashboards with stakeholders]
+- **Analytics**: [e.g., Historical trends, performance metrics]
+- **Collaboration**: [e.g., Multi-user support, commenting]

--- a/.spec-workflow/templates/requirements-template.md
+++ b/.spec-workflow/templates/requirements-template.md
@@ -1,0 +1,56 @@
+# Requirements Document
+
+## References
+
+- **Linear Issue:** [PROJ-XXX](https://linear.app/team/issue/PROJ-XXX)
+- **GitHub PR:** [#NNN](https://github.com/owner/repo/pull/NNN)
+- **Spec Path:** `.spec-workflow/specs/{spec-name}/`
+
+## Introduction
+
+[Provide a brief overview of the feature, its purpose, and its value to users]
+
+## Alignment with Product Vision
+
+[Explain how this feature supports the goals outlined in product.md]
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As a [role], I want [feature], so that [benefit]
+
+#### Acceptance Criteria
+
+1. WHEN [event] THEN [system] SHALL [response]
+2. IF [precondition] THEN [system] SHALL [response]
+3. WHEN [event] AND [condition] THEN [system] SHALL [response]
+
+### Requirement 2
+
+**User Story:** As a [role], I want [feature], so that [benefit]
+
+#### Acceptance Criteria
+
+1. WHEN [event] THEN [system] SHALL [response]
+2. IF [precondition] THEN [system] SHALL [response]
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+- **Single Responsibility Principle**: Each file should have a single, well-defined purpose
+- **Modular Design**: Components, utilities, and services should be isolated and reusable
+- **Dependency Management**: Minimize interdependencies between modules
+- **Clear Interfaces**: Define clean contracts between components and layers
+
+### Performance
+- [Performance requirements]
+
+### Security
+- [Security requirements]
+
+### Reliability
+- [Reliability requirements]
+
+### Usability
+- [Usability requirements]

--- a/.spec-workflow/templates/spec-reviewer-template.md
+++ b/.spec-workflow/templates/spec-reviewer-template.md
@@ -1,0 +1,58 @@
+# Spec Compliance Reviewer
+
+You are reviewing whether an implementation matches its specification. Your job is to verify the implementer built what was requested — nothing more, nothing less.
+
+## What Was Requested
+
+{TASK_REQUIREMENTS}
+
+## What Implementer Claims They Built
+
+{IMPLEMENTER_REPORT}
+
+## CRITICAL: Do Not Trust the Report
+
+The implementer may have been optimistic. You MUST verify everything independently by reading the actual code.
+
+**DO NOT:**
+- Take their word for what they implemented
+- Trust claims about completeness
+- Accept their interpretation of requirements
+
+**DO:**
+- Read the actual code they wrote
+- Compare implementation to requirements line by line
+- Check for missing pieces they claimed to implement
+- Look for extra features they didn't mention
+
+## Review Checklist
+
+**Missing requirements:**
+- Did they implement everything that was requested?
+- Are there requirements they skipped or missed?
+- Did they claim something works but didn't actually implement it?
+
+**Extra/unneeded work:**
+- Did they build things that weren't requested?
+- Did they over-engineer or add unnecessary features?
+- Did they add "nice to haves" that weren't in spec?
+
+**Misunderstandings:**
+- Did they interpret requirements differently than intended?
+- Did they solve the wrong problem?
+- Did they implement the right feature the wrong way?
+
+## Output
+
+Verify by reading code, not by trusting the report.
+
+- **Pass:** All requirements met, nothing extra, nothing missing
+- **Fail:** List specifically what's missing or extra, with file:line references
+
+```
+Spec Compliance: ✅ PASS / ❌ FAIL
+
+Issues (if any):
+1. [MISSING/EXTRA/WRONG] — description — file:line
+2. ...
+```

--- a/.spec-workflow/templates/structure-template.md
+++ b/.spec-workflow/templates/structure-template.md
@@ -1,0 +1,145 @@
+# Project Structure
+
+## Directory Organization
+
+```
+[Define your project's directory structure. Examples below - adapt to your project type]
+
+Example for a library/package:
+project-root/
+├── src/                    # Source code
+├── tests/                  # Test files  
+├── docs/                   # Documentation
+├── examples/               # Usage examples
+└── [build/dist/out]        # Build output
+
+Example for an application:
+project-root/
+├── [src/app/lib]           # Main source code
+├── [assets/resources]      # Static resources
+├── [config/settings]       # Configuration
+├── [scripts/tools]         # Build/utility scripts
+└── [tests/spec]            # Test files
+
+Common patterns:
+- Group by feature/module
+- Group by layer (UI, business logic, data)
+- Group by type (models, controllers, views)
+- Flat structure for simple projects
+```
+
+## Naming Conventions
+
+### Files
+- **Components/Modules**: [e.g., `PascalCase`, `snake_case`, `kebab-case`]
+- **Services/Handlers**: [e.g., `UserService`, `user_service`, `user-service`]
+- **Utilities/Helpers**: [e.g., `dateUtils`, `date_utils`, `date-utils`]
+- **Tests**: [e.g., `[filename]_test`, `[filename].test`, `[filename]Test`]
+
+### Code
+- **Classes/Types**: [e.g., `PascalCase`, `CamelCase`, `snake_case`]
+- **Functions/Methods**: [e.g., `camelCase`, `snake_case`, `PascalCase`]
+- **Constants**: [e.g., `UPPER_SNAKE_CASE`, `SCREAMING_CASE`, `PascalCase`]
+- **Variables**: [e.g., `camelCase`, `snake_case`, `lowercase`]
+
+## Import Patterns
+
+### Import Order
+1. External dependencies
+2. Internal modules
+3. Relative imports
+4. Style imports
+
+### Module/Package Organization
+```
+[Describe your project's import/include patterns]
+Examples:
+- Absolute imports from project root
+- Relative imports within modules
+- Package/namespace organization
+- Dependency management approach
+```
+
+## Code Structure Patterns
+
+[Define common patterns for organizing code within files. Below are examples - choose what applies to your project]
+
+### Module/Class Organization
+```
+Example patterns:
+1. Imports/includes/dependencies
+2. Constants and configuration
+3. Type/interface definitions
+4. Main implementation
+5. Helper/utility functions
+6. Exports/public API
+```
+
+### Function/Method Organization
+```
+Example patterns:
+- Input validation first
+- Core logic in the middle
+- Error handling throughout
+- Clear return points
+```
+
+### File Organization Principles
+```
+Choose what works for your project:
+- One class/module per file
+- Related functionality grouped together
+- Public API at the top/bottom
+- Implementation details hidden
+```
+
+## Code Organization Principles
+
+1. **Single Responsibility**: Each file should have one clear purpose
+2. **Modularity**: Code should be organized into reusable modules
+3. **Testability**: Structure code to be easily testable
+4. **Consistency**: Follow patterns established in the codebase
+
+## Module Boundaries
+[Define how different parts of your project interact and maintain separation of concerns]
+
+Examples of boundary patterns:
+- **Core vs Plugins**: Core functionality vs extensible plugins
+- **Public API vs Internal**: What's exposed vs implementation details  
+- **Platform-specific vs Cross-platform**: OS-specific code isolation
+- **Stable vs Experimental**: Production code vs experimental features
+- **Dependencies direction**: Which modules can depend on which
+
+## Code Size Guidelines
+[Define your project's guidelines for file and function sizes]
+
+Suggested guidelines:
+- **File size**: [Define maximum lines per file]
+- **Function/Method size**: [Define maximum lines per function]
+- **Class/Module complexity**: [Define complexity limits]
+- **Nesting depth**: [Maximum nesting levels]
+
+## Dashboard/Monitoring Structure (if applicable)
+[How dashboard or monitoring components are organized]
+
+### Example Structure:
+```
+src/
+└── dashboard/          # Self-contained dashboard subsystem
+    ├── server/        # Backend server components
+    ├── client/        # Frontend assets
+    ├── shared/        # Shared types/utilities
+    └── public/        # Static assets
+```
+
+### Separation of Concerns
+- Dashboard isolated from core business logic
+- Own CLI entry point for independent operation
+- Minimal dependencies on main application
+- Can be disabled without affecting core functionality
+
+## Documentation Standards
+- All public APIs must have documentation
+- Complex logic should include inline comments
+- README files for major modules
+- Follow language-specific documentation conventions

--- a/.spec-workflow/templates/tasks-template.md
+++ b/.spec-workflow/templates/tasks-template.md
@@ -1,0 +1,144 @@
+# Tasks Document
+
+## References
+
+- **Linear Issue:** [PROJ-XXX](https://linear.app/team/issue/PROJ-XXX)
+- **GitHub PR:** [#NNN](https://github.com/owner/repo/pull/NNN)
+- **Spec Path:** `.spec-workflow/specs/{spec-name}/`
+
+- [ ] 1. Create core interfaces in src/types/feature.ts
+  - File: src/types/feature.ts
+  - Define TypeScript interfaces for feature data structures
+  - Extend existing base interfaces from base.ts
+  - Purpose: Establish type safety for feature implementation
+  - _Leverage: src/types/base.ts_
+  - _Requirements: 1.1_
+  - _Prompt: Role: TypeScript Developer specializing in type systems and interfaces | Task: Create comprehensive TypeScript interfaces for the feature data structures following requirements 1.1, extending existing base interfaces from src/types/base.ts | Restrictions: Do not modify existing base interfaces, maintain backward compatibility, follow project naming conventions | Success: All interfaces compile without errors, proper inheritance from base types, full type coverage for feature requirements_
+
+- [ ] 2. Create base model class in src/models/FeatureModel.ts
+  - File: src/models/FeatureModel.ts
+  - Implement base model extending BaseModel class
+  - Add validation methods using existing validation utilities
+  - Purpose: Provide data layer foundation for feature
+  - _Leverage: src/models/BaseModel.ts, src/utils/validation.ts_
+  - _Requirements: 2.1_
+  - _Prompt: Role: Backend Developer with expertise in Node.js and data modeling | Task: Create a base model class extending BaseModel and implementing validation following requirement 2.1, leveraging existing patterns from src/models/BaseModel.ts and src/utils/validation.ts | Restrictions: Must follow existing model patterns, do not bypass validation utilities, maintain consistent error handling | Success: Model extends BaseModel correctly, validation methods implemented and tested, follows project architecture patterns_
+
+- [ ] 3. Add specific model methods to FeatureModel.ts
+  - File: src/models/FeatureModel.ts (continue from task 2)
+  - Implement create, update, delete methods
+  - Add relationship handling for foreign keys
+  - Purpose: Complete model functionality for CRUD operations
+  - _Leverage: src/models/BaseModel.ts_
+  - _Requirements: 2.2, 2.3_
+  - _Prompt: Role: Backend Developer with expertise in ORM and database operations | Task: Implement CRUD methods and relationship handling in FeatureModel.ts following requirements 2.2 and 2.3, extending patterns from src/models/BaseModel.ts | Restrictions: Must maintain transaction integrity, follow existing relationship patterns, do not duplicate base model functionality | Success: All CRUD operations work correctly, relationships are properly handled, database operations are atomic and efficient_
+
+- [ ] 4. Create model unit tests in tests/models/FeatureModel.test.ts
+  - File: tests/models/FeatureModel.test.ts
+  - Write tests for model validation and CRUD methods
+  - Use existing test utilities and fixtures
+  - Purpose: Ensure model reliability and catch regressions
+  - _Leverage: tests/helpers/testUtils.ts, tests/fixtures/data.ts_
+  - _Requirements: 2.1, 2.2_
+  - _Prompt: Role: QA Engineer with expertise in unit testing and Jest/Mocha frameworks | Task: Create comprehensive unit tests for FeatureModel validation and CRUD methods covering requirements 2.1 and 2.2, using existing test utilities from tests/helpers/testUtils.ts and fixtures from tests/fixtures/data.ts | Restrictions: Must test both success and failure scenarios, do not test external dependencies directly, maintain test isolation | Success: All model methods are tested with good coverage, edge cases covered, tests run independently and consistently_
+
+- [ ] 5. Create service interface in src/services/IFeatureService.ts
+  - File: src/services/IFeatureService.ts
+  - Define service contract with method signatures
+  - Extend base service interface patterns
+  - Purpose: Establish service layer contract for dependency injection
+  - _Leverage: src/services/IBaseService.ts_
+  - _Requirements: 3.1_
+  - _Prompt: Role: Software Architect specializing in service-oriented architecture and TypeScript interfaces | Task: Design service interface contract following requirement 3.1, extending base service patterns from src/services/IBaseService.ts for dependency injection | Restrictions: Must maintain interface segregation principle, do not expose internal implementation details, ensure contract compatibility with DI container | Success: Interface is well-defined with clear method signatures, extends base service appropriately, supports all required service operations_
+
+- [ ] 6. Implement feature service in src/services/FeatureService.ts
+  - File: src/services/FeatureService.ts
+  - Create concrete service implementation using FeatureModel
+  - Add error handling with existing error utilities
+  - Purpose: Provide business logic layer for feature operations
+  - _Leverage: src/services/BaseService.ts, src/utils/errorHandler.ts, src/models/FeatureModel.ts_
+  - _Requirements: 3.2_
+  - _Prompt: Role: Backend Developer with expertise in service layer architecture and business logic | Task: Implement concrete FeatureService following requirement 3.2, using FeatureModel and extending BaseService patterns with proper error handling from src/utils/errorHandler.ts | Restrictions: Must implement interface contract exactly, do not bypass model validation, maintain separation of concerns from data layer | Success: Service implements all interface methods correctly, robust error handling implemented, business logic is well-encapsulated and testable_
+
+- [ ] 7. Add service dependency injection in src/utils/di.ts
+  - File: src/utils/di.ts (modify existing)
+  - Register FeatureService in dependency injection container
+  - Configure service lifetime and dependencies
+  - Purpose: Enable service injection throughout application
+  - _Leverage: existing DI configuration in src/utils/di.ts_
+  - _Requirements: 3.1_
+  - _Prompt: Role: DevOps Engineer with expertise in dependency injection and IoC containers | Task: Register FeatureService in DI container following requirement 3.1, configuring appropriate lifetime and dependencies using existing patterns from src/utils/di.ts | Restrictions: Must follow existing DI container patterns, do not create circular dependencies, maintain service resolution efficiency | Success: FeatureService is properly registered and resolvable, dependencies are correctly configured, service lifetime is appropriate for use case_
+
+- [ ] 8. Create service unit tests in tests/services/FeatureService.test.ts
+  - File: tests/services/FeatureService.test.ts
+  - Write tests for service methods with mocked dependencies
+  - Test error handling scenarios
+  - Purpose: Ensure service reliability and proper error handling
+  - _Leverage: tests/helpers/testUtils.ts, tests/mocks/modelMocks.ts_
+  - _Requirements: 3.2, 3.3_
+  - _Prompt: Role: QA Engineer with expertise in service testing and mocking frameworks | Task: Create comprehensive unit tests for FeatureService methods covering requirements 3.2 and 3.3, using mocked dependencies from tests/mocks/modelMocks.ts and test utilities | Restrictions: Must mock all external dependencies, test business logic in isolation, do not test framework code | Success: All service methods tested with proper mocking, error scenarios covered, tests verify business logic correctness and error handling_
+
+- [ ] 4. Create API endpoints
+  - Design API structure
+  - _Leverage: src/api/baseApi.ts, src/utils/apiUtils.ts_
+  - _Requirements: 4.0_
+  - _Prompt: Role: API Architect specializing in RESTful design and Express.js | Task: Design comprehensive API structure following requirement 4.0, leveraging existing patterns from src/api/baseApi.ts and utilities from src/utils/apiUtils.ts | Restrictions: Must follow REST conventions, maintain API versioning compatibility, do not expose internal data structures directly | Success: API structure is well-designed and documented, follows existing patterns, supports all required operations with proper HTTP methods and status codes_
+
+- [ ] 4.1 Set up routing and middleware
+  - Configure application routes
+  - Add authentication middleware
+  - Set up error handling middleware
+  - _Leverage: src/middleware/auth.ts, src/middleware/errorHandler.ts_
+  - _Requirements: 4.1_
+  - _Prompt: Role: Backend Developer with expertise in Express.js middleware and routing | Task: Configure application routes and middleware following requirement 4.1, integrating authentication from src/middleware/auth.ts and error handling from src/middleware/errorHandler.ts | Restrictions: Must maintain middleware order, do not bypass security middleware, ensure proper error propagation | Success: Routes are properly configured with correct middleware chain, authentication works correctly, errors are handled gracefully throughout the request lifecycle_
+
+- [ ] 4.2 Implement CRUD endpoints
+  - Create API endpoints
+  - Add request validation
+  - Write API integration tests
+  - _Leverage: src/controllers/BaseController.ts, src/utils/validation.ts_
+  - _Requirements: 4.2, 4.3_
+  - _Prompt: Role: Full-stack Developer with expertise in API development and validation | Task: Implement CRUD endpoints following requirements 4.2 and 4.3, extending BaseController patterns and using validation utilities from src/utils/validation.ts | Restrictions: Must validate all inputs, follow existing controller patterns, ensure proper HTTP status codes and responses | Success: All CRUD operations work correctly, request validation prevents invalid data, integration tests pass and cover all endpoints_
+
+- [ ] 5. Add frontend components
+  - Plan component architecture
+  - _Leverage: src/components/BaseComponent.tsx, src/styles/theme.ts_
+  - _Requirements: 5.0_
+  - _Prompt: Role: Frontend Architect with expertise in React component design and architecture | Task: Plan comprehensive component architecture following requirement 5.0, leveraging base patterns from src/components/BaseComponent.tsx and theme system from src/styles/theme.ts | Restrictions: Must follow existing component patterns, maintain design system consistency, ensure component reusability | Success: Architecture is well-planned and documented, components are properly organized, follows existing patterns and theme system_
+
+- [ ] 5.1 Create base UI components
+  - Set up component structure
+  - Implement reusable components
+  - Add styling and theming
+  - _Leverage: src/components/BaseComponent.tsx, src/styles/theme.ts_
+  - _Requirements: 5.1_
+  - _Prompt: Role: Frontend Developer specializing in React and component architecture | Task: Create reusable UI components following requirement 5.1, extending BaseComponent patterns and using existing theme system from src/styles/theme.ts | Restrictions: Must use existing theme variables, follow component composition patterns, ensure accessibility compliance | Success: Components are reusable and properly themed, follow existing architecture, accessible and responsive_
+
+- [ ] 5.2 Implement feature-specific components
+  - Create feature components
+  - Add state management
+  - Connect to API endpoints
+  - _Leverage: src/hooks/useApi.ts, src/components/BaseComponent.tsx_
+  - _Requirements: 5.2, 5.3_
+  - _Prompt: Role: React Developer with expertise in state management and API integration | Task: Implement feature-specific components following requirements 5.2 and 5.3, using API hooks from src/hooks/useApi.ts and extending BaseComponent patterns | Restrictions: Must use existing state management patterns, handle loading and error states properly, maintain component performance | Success: Components are fully functional with proper state management, API integration works smoothly, user experience is responsive and intuitive_
+
+- [ ] 6. Integration and testing
+  - Plan integration approach
+  - _Leverage: src/utils/integrationUtils.ts, tests/helpers/testUtils.ts_
+  - _Requirements: 6.0_
+  - _Prompt: Role: Integration Engineer with expertise in system integration and testing strategies | Task: Plan comprehensive integration approach following requirement 6.0, leveraging integration utilities from src/utils/integrationUtils.ts and test helpers | Restrictions: Must consider all system components, ensure proper test coverage, maintain integration test reliability | Success: Integration plan is comprehensive and feasible, all system components work together correctly, integration points are well-tested_
+
+- [ ] 6.1 Write end-to-end tests
+  - Write user journey tests using Browserbase/Stagehand natural-language automation
+  - Test against the PR preview URL (get from Cloudflare Pages check on the draft PR)
+  - _Leverage: /bb-test skill, mcp__browserbase__* tools, PR preview URL from gh pr checks_
+  - _Requirements: All_
+  - _Prompt: Role: QA Automation Engineer with expertise in Browserbase/Stagehand natural-language browser automation | Task: Implement end-to-end tests for all critical user journeys using Browserbase Stagehand tools (browserbase_session_create, stagehand_navigate, stagehand_act, stagehand_extract, browserbase_screenshot). Test against the PR preview URL — get it with: gh pr checks <PR_NUMBER> --json name,state,targetUrl | python3 -c "import sys,json; checks=json.load(sys.stdin); [print(c['targetUrl']) for c in checks if 'pages.dev' in c.get('targetUrl','')]". Do NOT use Playwright or browserless — they are unavailable. Each test step has a 10-minute timeout: if a step stalls, skip it and log a warning. | Restrictions: Use stagehand_act for all interactions, stagehand_extract for all assertions, no javascript_tool. Test real user workflows end-to-end. | Success: All critical user journeys tested against PR preview URL, session recording available in Browserbase dashboard, results logged via log-implementation_
+
+- [ ] 6.2 Final integration and cleanup
+  - Integrate all components
+  - Fix any integration issues
+  - Clean up code and documentation
+  - _Leverage: src/utils/cleanup.ts, docs/templates/_
+  - _Requirements: All_
+  - _Prompt: Role: Senior Developer with expertise in code quality and system integration | Task: Complete final integration of all components and perform comprehensive cleanup covering all requirements, using cleanup utilities and documentation templates | Restrictions: Must not break existing functionality, ensure code quality standards are met, maintain documentation consistency | Success: All components are fully integrated and working together, code is clean and well-documented, system meets all requirements and quality standards_

--- a/.spec-workflow/templates/tech-template.md
+++ b/.spec-workflow/templates/tech-template.md
@@ -1,0 +1,99 @@
+# Technology Stack
+
+## Project Type
+[Describe what kind of project this is: web application, CLI tool, desktop application, mobile app, library, API service, embedded system, game, etc.]
+
+## Core Technologies
+
+### Primary Language(s)
+- **Language**: [e.g., Python 3.11, Go 1.21, TypeScript, Rust, C++]
+- **Runtime/Compiler**: [if applicable]
+- **Language-specific tools**: [package managers, build tools, etc.]
+
+### Key Dependencies/Libraries
+[List the main libraries and frameworks your project depends on]
+- **[Library/Framework name]**: [Purpose and version]
+- **[Library/Framework name]**: [Purpose and version]
+
+### Application Architecture
+[Describe how your application is structured - this could be MVC, event-driven, plugin-based, client-server, standalone, microservices, monolithic, etc.]
+
+### Data Storage (if applicable)
+- **Primary storage**: [e.g., PostgreSQL, files, in-memory, cloud storage]
+- **Caching**: [e.g., Redis, in-memory, disk cache]
+- **Data formats**: [e.g., JSON, Protocol Buffers, XML, binary]
+
+### External Integrations (if applicable)
+- **APIs**: [External services you integrate with]
+- **Protocols**: [e.g., HTTP/REST, gRPC, WebSocket, TCP/IP]
+- **Authentication**: [e.g., OAuth, API keys, certificates]
+
+### Monitoring & Dashboard Technologies (if applicable)
+- **Dashboard Framework**: [e.g., React, Vue, vanilla JS, terminal UI]
+- **Real-time Communication**: [e.g., WebSocket, Server-Sent Events, polling]
+- **Visualization Libraries**: [e.g., Chart.js, D3, terminal graphs]
+- **State Management**: [e.g., Redux, Vuex, file system as source of truth]
+
+## Development Environment
+
+### Build & Development Tools
+- **Build System**: [e.g., Make, CMake, Gradle, npm scripts, cargo]
+- **Package Management**: [e.g., pip, npm, cargo, go mod, apt, brew]
+- **Development workflow**: [e.g., hot reload, watch mode, REPL]
+
+### Code Quality Tools
+- **Static Analysis**: [Tools for code quality and correctness]
+- **Formatting**: [Code style enforcement tools]
+- **Testing Framework**: [Unit, integration, and/or end-to-end testing tools]
+- **Documentation**: [Documentation generation tools]
+
+### Version Control & Collaboration
+- **VCS**: [e.g., Git, Mercurial, SVN]
+- **Branching Strategy**: [e.g., Git Flow, GitHub Flow, trunk-based]
+- **Code Review Process**: [How code reviews are conducted]
+
+### Dashboard Development (if applicable)
+- **Live Reload**: [e.g., Hot module replacement, file watchers]
+- **Port Management**: [e.g., Dynamic allocation, configurable ports]
+- **Multi-Instance Support**: [e.g., Running multiple dashboards simultaneously]
+
+## Deployment & Distribution (if applicable)
+- **Target Platform(s)**: [Where/how the project runs: cloud, on-premise, desktop, mobile, embedded]
+- **Distribution Method**: [How users get your software: download, package manager, app store, SaaS]
+- **Installation Requirements**: [Prerequisites, system requirements]
+- **Update Mechanism**: [How updates are delivered]
+
+## Technical Requirements & Constraints
+
+### Performance Requirements
+- [e.g., response time, throughput, memory usage, startup time]
+- [Specific benchmarks or targets]
+
+### Compatibility Requirements  
+- **Platform Support**: [Operating systems, architectures, versions]
+- **Dependency Versions**: [Minimum/maximum versions of dependencies]
+- **Standards Compliance**: [Industry standards, protocols, specifications]
+
+### Security & Compliance
+- **Security Requirements**: [Authentication, encryption, data protection]
+- **Compliance Standards**: [GDPR, HIPAA, SOC2, etc. if applicable]
+- **Threat Model**: [Key security considerations]
+
+### Scalability & Reliability
+- **Expected Load**: [Users, requests, data volume]
+- **Availability Requirements**: [Uptime targets, disaster recovery]
+- **Growth Projections**: [How the system needs to scale]
+
+## Technical Decisions & Rationale
+[Document key architectural and technology choices]
+
+### Decision Log
+1. **[Technology/Pattern Choice]**: [Why this was chosen, alternatives considered]
+2. **[Architecture Decision]**: [Rationale, trade-offs accepted]
+3. **[Tool/Library Selection]**: [Reasoning, evaluation criteria]
+
+## Known Limitations
+[Document any technical debt, limitations, or areas for improvement]
+
+- [Limitation 1]: [Impact and potential future solutions]
+- [Limitation 2]: [Why it exists and when it might be addressed]

--- a/.spec-workflow/user-templates/README.md
+++ b/.spec-workflow/user-templates/README.md
@@ -1,0 +1,64 @@
+# User Templates
+
+This directory allows you to create custom templates that override the default Spec Workflow templates.
+
+## How to Use Custom Templates
+
+1. **Create your custom template file** in this directory with the exact same name as the default template you want to override:
+   - `requirements-template.md` - Override requirements document template
+   - `design-template.md` - Override design document template
+   - `tasks-template.md` - Override tasks document template
+   - `product-template.md` - Override product steering template
+   - `tech-template.md` - Override tech steering template
+   - `structure-template.md` - Override structure steering template
+
+2. **Template Loading Priority**:
+   - The system first checks this `user-templates/` directory
+   - If a matching template is found here, it will be used
+   - Otherwise, the default template from `templates/` will be used
+
+## Example Custom Template
+
+To create a custom requirements template:
+
+1. Create a file named `requirements-template.md` in this directory
+2. Add your custom structure, for example:
+
+```markdown
+# Requirements Document
+
+## Executive Summary
+[Your custom section]
+
+## Business Requirements
+[Your custom structure]
+
+## Technical Requirements
+[Your custom fields]
+
+## Custom Sections
+[Add any sections specific to your workflow]
+```
+
+## Template Variables
+
+Templates can include placeholders that will be replaced when documents are created:
+- `{{projectName}}` - The name of your project
+- `{{featureName}}` - The name of the feature being specified
+- `{{date}}` - The current date
+- `{{author}}` - The document author
+
+## Best Practices
+
+1. **Start from defaults**: Copy a default template from `../templates/` as a starting point
+2. **Keep structure consistent**: Maintain similar section headers for tool compatibility
+3. **Document changes**: Add comments explaining why sections were added/modified
+4. **Version control**: Track your custom templates in version control
+5. **Test thoroughly**: Ensure custom templates work with the spec workflow tools
+
+## Notes
+
+- Custom templates are project-specific and not included in the package distribution
+- The `templates/` directory contains the default templates which are updated with each version
+- Your custom templates in this directory are preserved during updates
+- If a custom template has errors, the system will fall back to the default template

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -121,7 +121,7 @@ Active feature flags as of v3.33.19:
 | Disposition (v3.33.17) | `js/inventory.js`, `js/constants.js` | Realized gains/losses workflow — dispose items as sold/traded/lost/gifted/returned; undo disposition; portfolio summary breakdown |
 | Retail pricing | `js/retail.js`, `js/api.js` | Polls `api.staktrakr.com/data/api/manifest.json` |
 | Market list view | `js/retail.js` | Full-width card layout with search/sort/charts (feature-flagged, v3.33.06) |
-| Spot prices | `js/spot.js`, `js/priceHistory.js` | Polls hourly and 15-min feeds from `api.staktrakr.com` |
+| Spot prices | `js/spot.js`, `js/api.js` | Polls hourly and 15-min feeds from `api.staktrakr.com` |
 | Cloud sync | `js/cloud-sync.js`, `js/cloud-storage.js` | Backup/restore via encrypted cloud vault |
 | Diff/Merge | `js/diff-engine.js`, `js/diff-modal.js` | Change-set diffing and interactive merge review UI (STAK-184). DiffModal accepts optional `backupCount`/`localCount` fields to render a live count header (Backup / Current / After import) with projected-count updates and a Select All toggle (STAK-374). |
 | Catalog | `js/catalog-manager.js`, `js/seed-images.js` | Coin/bar catalog with image cache |

--- a/wiki/retail-modal.md
+++ b/wiki/retail-modal.md
@@ -2,8 +2,8 @@
 title: "Retail View Modal & Market List View"
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.19
-date: 2026-03-01
+lastUpdated: v3.33.22
+date: 2026-03-02
 sourceFiles:
   - js/retail-view-modal.js
   - js/retail.js
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Retail View Modal & Market List View
 
-> **Last updated:** v3.33.19 — 2026-03-01
+> **Last updated:** v3.33.22 — 2026-03-02
 > **Source files:** `js/retail-view-modal.js`, `js/retail.js`, `css/styles.css`
 
 ## Overview
@@ -35,7 +35,7 @@ As of v3.32.25 the modal also forward-fills vendor prices across gap windows and
 ## Key Rules (read before touching this area)
 
 - **Never call `document.getElementById()` directly.** Use `safeGetElement(id)` for all DOM lookups.
-- **Do not access `localStorage` directly.** Retail data is read/written through `saveData()`/`loadData()` from `js/utils.js`. Specific retail helpers (`saveRetailPrices`, `saveRetailIntradayData`, etc.) are exported by `retail.js`.
+- **Do not access `localStorage` directly.** Retail data is read/written through `saveData()`/`loadData()` from `js/utils.js`. Specific retail helpers (`saveRetailPrices`, `saveRetailIntradayData`, etc.) are exported by `retail.js`. Note: `saveRetailIntradayData` failures are **non-critical** — the catch block calls `debugWarn()` for console-only logging and does NOT show a Storage Error modal. The intraday cache is a transient 24-hour sparkline store; losing it on a quota error is acceptable and the data is rebuilt on the next fetch.
 - `_buildIntradayChart` always calls `_buildIntradayTable` at the end. Do not call both independently.
 - `_buildVendorLegend` is called both on modal open and after the async background refresh completes. It must be idempotent — it clears the container on every call.
 - The Chart.js intraday chart instance is stored in the module-level `_retailViewIntradayChart` variable. Always destroy the old instance before creating a new one or you will leak canvas contexts.
@@ -473,6 +473,10 @@ Both `_retailViewModalChart` and `_retailViewIntradayChart` must be explicitly d
 ### Applying spike detection to estimated/OOS data points (v3.33.06)
 
 `_filterHistorySpikes` intentionally skips estimated points (OOS carry-forward) during temporal spike detection. If you modify the filter to include estimated points, OOS carry-forward prices — which are intentionally flat — will create false negatives in the neighbor stability check and allow real spikes to pass through.
+
+### Treating `saveRetailIntradayData` failures as critical (v3.33.22 — STAK-383)
+
+`saveRetailIntradayData()` uses `debugWarn()` in its catch block — NOT `_handleSaveError()`. Do not change this to `_handleSaveError()`. The intraday cache (`RETAIL_INTRADAY_KEY`) is a transient 24-hour sparkline store; a quota-exceeded error on save is non-critical and should degrade silently (console warn only, no modal, no `window._retailStorageFailure` flag). All other retail save functions (`saveRetailPrices`, `saveRetailPriceHistory`, `saveRetailProviders`, `saveRetailAvailability`) correctly use `_handleSaveError()` because they hold user-facing data that must persist.
 
 ---
 

--- a/wiki/service-worker.md
+++ b/wiki/service-worker.md
@@ -56,7 +56,7 @@ Requests are routed through different strategies based on URL matching in the `f
 | Bucket | Hosts / Paths | Strategy | Rationale |
 |---|---|---|---|
 | **Pre-cached shell** | `CORE_ASSETS` list | Cached on `install` via `cache.addAll()` | Ensures offline availability of core app |
-| **External API hosts** | `metalpriceapi.com`, `metals-api.com`, `gold-api.com`, `numista.com` | Network-first | Live price feeds must always return fresh data |
+| **External API hosts** | `api.metalpriceapi.com`, `metals-api.com`, `api.gold-api.com`, `en.numista.com` | Network-first | Live price feeds must always return fresh data |
 | **CDN libraries** | `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `unpkg.com` | Stale-while-revalidate | Serve fast from cache, update in background |
 | **StakTrakr API** | `api.staktrakr.com`, `api2.staktrakr.com` | Stale-while-revalidate | Hourly price feeds benefit from fast cached response with background refresh |
 | **Spot history seed data** | Local `/data/spot-history*` | Stale-while-revalidate | Seed files updated between releases |


### PR DESCRIPTION
## Summary

- **Root cause found:** `.gitignore` skill allowlist was never updated when new skills were created, causing 10 skills to be gitignored and invisible to git
- **Spec-workflow dirs:** `steering/` and `templates/` were fully gitignored despite containing project MCP customizations
- **Wiki fixes:** 3 corrections rescued from orphaned worktrees / unfixed Copilot flags

## Skills recovered (10)
`bb-test`, `browserbase-test-maintenance`, `devops-dashboard`, `frontend-design`, `jules-review`, `jules-suppress`, `scan-mentions`, `smoke-test`, `sync-poller`, `ui-mockup`

## Spec-workflow recovered
- `.spec-workflow/steering/` (product.md, structure.md, tech.md) — project context for spec-workflow MCP
- `.spec-workflow/templates/` (9 template files) — spec phase templates
- `.spec-workflow/user-templates/README.md` — was untracked despite glob pattern

## Wiki fixes
- `wiki/service-worker.md` — correct `API_HOSTS` to exact hostnames matching `sw.js` (`api.metalpriceapi.com`, `api.gold-api.com`, `en.numista.com`) — Copilot flagged in PR #658, never resolved
- `wiki/frontend-overview.md` — remove `js/priceHistory.js` from spot subsystem (it records snapshots, does not poll) — Copilot flagged in PR #658, never resolved
- `wiki/retail-modal.md` — document `saveRetailIntradayData` non-critical failure behavior (STAK-383) — was uncommitted in stale `patch-3.33.22` worktree

## Test plan
- [ ] Verify `.claude/skills/` shows all 25 skills in Claude Code
- [ ] Verify `.spec-workflow/steering/` and `templates/` are visible in git after merge
- [ ] Verify wiki pages render correctly in Docsify

🤖 Generated with [Claude Code](https://claude.com/claude-code)