### PR TITLE
Update Nightwatch log with retail-modal.md inaccuracy finding

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 6,
+  "nextIndex": 7,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -35,6 +35,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "Claims 'TTL is 30 minutes per claim' but devops/version-lock-protocol.md defines three tiers: Hotfix = 30min, Spec implementation = 4h, Pre-assigned queued slot = 4h.",
+      "verified": []
+    },
+    {
+      "date": "2026-03-02",
+      "page": "retail-modal.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "Page incorrectly claims initRetailPrices() calls syncRetailPrices({ ui: false }) in the background. Code shows initRetailPrices() only loads storage and listeners; background sync is actually started by startRetailBackgroundSync().",
       "verified": []
     }
   ]


### PR DESCRIPTION
I've completed the Nightwatch task.

* Read `wiki/.nightwatch-log.json` to identify `retail-modal.md` as the current rotation target (`nextIndex: 6`).
* Analyzed `wiki/retail-modal.md` and cross-checked it with `js/retail.js` and `js/retail-view-modal.js`.
* Discovered a factual inaccuracy: The wiki states that `initRetailPrices()` triggers `syncRetailPrices({ ui: false })` in the background. However, the code proves that `initRetailPrices()` only performs local storage reads and listener wiring, while the background synchronization is actually initiated by `startRetailBackgroundSync()`.
* Formulated the finding and appended it to `wiki/.nightwatch-log.json`.
* Incremented `nextIndex` and preserved the cap on the `history` log (max 30 entries).
* Verified changes, ran tests, and committed the update.

---
*PR created automatically by Jules for task [15992701809788966970](https://jules.google.com/task/15992701809788966970) started by @lbruton*