### PR TITLE
v3.33.25 — Release to main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ GEMINI.md             export-ignore
 devops/               export-ignore
 functions/            export-ignore
 package.json          export-ignore
+package-lock.json     export-ignore
 
 # GitHub & hosting infrastructure
 .github/              export-ignore
@@ -32,11 +33,13 @@ CNAME                 export-ignore
 .codacy.yml           export-ignore
 .eslintrc.json        export-ignore
 eslint.config.js      export-ignore
+eslint.config.cjs     export-ignore
 .markdownlint.json    export-ignore
 ruleset.xml           export-ignore
 
 # Tests
 tests/                export-ignore
+playwright.config.js  export-ignore
 
 # Documentation & project management (internal)
 about/                export-ignore
@@ -45,9 +48,12 @@ ROADMAP.md            export-ignore
 SPRINT.md             export-ignore
 CHANGELOG.md          export-ignore
 
-# Dev reference pages
+# Dev reference pages & prototypes
 design-preview.html   export-ignore
 style.html            export-ignore
+playground/           export-ignore
+ui-standards/         export-ignore
+sample.csv            export-ignore
 
 # Data files not needed at runtime (bundle.js is the runtime artifact)
 data/hourly/          export-ignore
@@ -56,6 +62,9 @@ data/spot-history-*.json  export-ignore
 
 # Deprecated / archived
 deprecated/           export-ignore
+
+# Wiki (internal documentation)
+wiki/                 export-ignore
 
 # Misc repo assets
 ScreenshotStakTrakr.png  export-ignore


### PR DESCRIPTION
## Summary

Release v3.33.25 to main. Patches v3.33.01–v3.33.25 accumulated on dev since the v3.33.00 release.

> **Note:** Most runtime code from v3.33.01–v3.33.25 was already on main via PR #676 (which inadvertently branched from dev instead of main). This PR formally ships the release and adds the `.gitattributes` fix to exclude wiki/, playground/, and dev tooling from release archives.

### Patches included

- **v3.33.25** — STAK-396: Browserbase Test Runbook v2
- **v3.33.24** — STAK-374: Backup integrity audit — import transparency
- **v3.33.23** — STAK-169: Chip max count setting
- **v3.33.22** — STAK-383: Suppress storage error modal for intraday cache
- **v3.33.21** — STAK-388: Disposed items restore and view
- **v3.33.20** — STAK-389: Market panel bug fixes
- **v3.33.19** — STAK-190: DiffMerge integration — selective apply
- **v3.33.18** — STAK-184/380: Diff/Merge architecture + modal UX
- **v3.33.17** — STAK-72: Realized gains/losses — item disposition
- **v3.33.16** — STAK-375: Clone mode redesign + edit modal UX
- **v3.33.15** — STAK-376: Beta domain toast
- **v3.33.14** — STAK-373: Goldback G½ slug resolution
- **v3.33.13** — STAK-371: Market Page Phase 2
- **v3.33.12** — Version drift correction
- **v3.33.11** — STAK-274: Spot price card label root cause fix
- **v3.33.10** — STAK-285: Mobile long-press spot price entry
- **v3.33.09** — STAK-274: Spot price card cache label fix
- **v3.33.08** — STAK-370: Vendor medal ranking fix
- **v3.33.07** — STAK-370: Oklahoma Goldback G1 on market page
- **v3.33.06** — STAK-369: Market Page redesign Phase 1
- **v3.33.05** — Search cache cleanup, dead code removal
- **v3.33.04** — NGC lookup, fractional oz, cloud sync reorder
- **v3.33.03** — Clean up announcements
- **v3.33.02** — STAK-295/190/360: Cloud sync safety overhaul
- **v3.33.01** — STAK-345/346/354/362/363: Numista search overhaul

### Release archive fix
- `.gitattributes` updated to exclude `wiki/`, `playground/`, `ui-standards/`, `sample.csv`, `package-lock.json`, `eslint.config.cjs`, `playwright.config.js` from release zip

## Test plan
- [ ] `git archive` produces clean runtime-only archive
- [ ] GitHub Release tag points to merged main HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)