### PR TITLE
v3.33.29 — Migration check async fix (STAK-398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.29] - 2026-03-03
+
+### Fixed — Cloud Backup/Restore Pipeline Fix (STAK-398, STAK-382)
+
+- **Fixed**: All 4 backup path functions now target `/StakTrakr/backups/` subfolder instead of root (STAK-398)
+- **Fixed**: Backup history dropdown async/sync mismatch — was showing `[object Promise]` instead of saved value
+- **Fixed**: Prune depth read async/sync mismatch — was getting `NaN` from Promise
+- **Fixed**: Migration check async/sync mismatch — `loadData` → `loadDataSync` for `cloud_sync_migrated` flag
+- **Fixed**: Conflict check reads `latest.json` from `/backups/` with legacy root fallback
+- **Security**: Sync metadata file encrypted with AES-256-GCM, backward-compatible plaintext fallback (STAK-382)
+- **Changed**: Cloud card restructured — auto-sync first, manual backup section with count badge, View Sync Log on main card
+- **Changed**: Export button descriptions converted to native `title` tooltips
+- **Changed**: `CLOUD_LATEST_FILENAME` promoted to `constants.js` global
+
+---
+
 ## [3.33.27] - 2026-03-03
 
 ### Fixed — Documentation & Instruction Accuracy Cleanup (STAK-397)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,9 @@
 ## What's New
 
+- **Cloud Backup/Restore Pipeline Fix (v3.33.29)**: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382).
 - **Documentation Accuracy Cleanup (v3.33.27)**: Full audit fix — script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved across instruction files, skills, and wiki (STAK-397).
-- **Browserbase Test Runbook v2 (v3.33.25)**: Modular E2E test runbook with 75+ tests across 8 section files. `/bb-test` skill now reads runbook Markdown at runtime with section and tag filtering. Manual execution via Chrome DevTools or Claude browser extension documented as $0 alternative (STAK-396).
-- **Backup Integrity Audit (v3.33.24)**: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner. Fixes CSV round-trip breakage from comment header, const reassignment crash, and import target detection bug (STAK-374).
-- **Chip Max Count Setting (v3.33.23)**: New `chipMaxCount` setting caps the filter chip bar to prevent overflow. Search chips always render regardless of cap. Configure in Settings.
-- **Storage Error Modal Suppressed for Intraday Cache (v3.33.22)**: saveRetailIntradayData() failures now log a console warning instead of showing a user-visible Storage Error modal — transient 24h sparkline cache is non-critical
+- **Browserbase Test Runbook v2 (v3.33.25)**: Modular E2E test runbook with 75+ tests across 8 section files. `/bb-test` skill now reads runbook Markdown at runtime with section and tag filtering (STAK-396).
+- **Backup Integrity Audit (v3.33.24)**: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner (STAK-374).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.33.27 &ndash; Documentation Accuracy Cleanup</strong>: Full audit fix &mdash; script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved across instruction files, skills, and wiki (STAK-397)</li>
-    <li><strong>v3.33.25 &ndash; Browserbase Test Runbook v2</strong>: Modular E2E test runbook with 75+ tests across 8 section files. /bb-test skill reads runbook Markdown at runtime with section and tag filtering. Manual execution via Chrome DevTools or Claude browser extension documented as $0 alternative (STAK-396)</li>
+    <li><strong>v3.33.29 &ndash; Cloud Backup/Restore Pipeline Fix</strong>: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382)</li>
+    <li><strong>v3.33.27 &ndash; Documentation Accuracy Cleanup</strong>: Full audit fix &mdash; script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved (STAK-397)</li>
+    <li><strong>v3.33.25 &ndash; Browserbase Test Runbook v2</strong>: Modular E2E test runbook with 75+ tests across 8 section files. /bb-test skill reads runbook Markdown at runtime with section and tag filtering (STAK-396)</li>
     <li><strong>v3.33.24 &ndash; Backup Integrity Audit</strong>: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner (STAK-374)</li>
-    <li><strong>v3.33.23 &ndash; Chip Max Count Setting</strong>: New chipMaxCount setting caps the filter chip bar to prevent overflow. Search chips always render regardless of cap. Configure in Settings</li>
-    <li><strong>v3.33.22 &ndash; Storage Error Modal Suppressed for Intraday Cache</strong>: saveRetailIntradayData() failures now log a console warning instead of showing a user-visible Storage Error modal &mdash; transient 24h sparkline cache is non-critical</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -899,7 +899,7 @@ async function pushSyncVault() {
     // Layer 3 — Folder migration check (REQ-3)
     // Migrate legacy flat /StakTrakr/ layout to /sync/ + /backups/ on first run.
     // -----------------------------------------------------------------------
-    if (loadData('cloud_sync_migrated') !== 'v2') {
+    if (loadDataSync('cloud_sync_migrated', '') !== 'v2') {
       debugLog('[CloudSync] Migration needed — running cloudMigrateToV2');
       try {
         await cloudMigrateToV2(_syncProvider);
@@ -1215,7 +1215,7 @@ async function pollForRemoteChanges() {
   if (!token) return;
 
   // Layer 3 — Folder migration check (REQ-3)
-  if (loadData('cloud_sync_migrated') !== 'v2') {
+  if (loadDataSync('cloud_sync_migrated', '') !== 'v2') {
     debugLog('[CloudSync] Poll: migration needed — running cloudMigrateToV2');
     try {
       await cloudMigrateToV2(_syncProvider);

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.27";
+const APP_VERSION = "3.33.29";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.27-b1772509891';
+const CACHE_NAME = 'staktrakr-v3.33.29-b1772511140';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.27",
+  "version": "3.33.29",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Two `loadData()` → `loadDataSync()` migration check bugs in `cloud-sync.js` (lines 902, 1218) that caused v2 migration to re-run on every sync/poll cycle
- **Bumped**: Version to v3.33.29 across all 7 files (constants, changelog, announcements, about, version.json, sw.js)

## Linear Issues

- STAK-398: Cloud backup/restore pipeline broken — path bugs, async bug, UI cleanup

## Context

Follow-up to PR #685 (v3.33.28). QA revealed two additional `loadData()` calls in migration guard checks that returned Promises instead of string values, causing the `!== 'v2'` comparison to always be true and re-triggering migration on every sync cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)