### PR TITLE
v3.33.30 — Bi-directional sync fix (STAK-398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.30] - 2026-03-03
+
+### Fixed — Bi-Directional Sync Fix (STAK-398)
+
+- **Fixed**: Pre-push remote check — `pushSyncVault()` now checks remote metadata before pushing; if another device pushed since last pull, routes to `handleRemoteChange()` instead of silently overwriting
+- **Fixed**: "Sync Now" button calls `syncNow()` (poll-then-push) instead of blind `pushSyncVault()`
+- **Fixed**: `enableCloudSync()` polls for existing remote data before initial push, preventing second browser from overwriting first browser's data
+- **Fixed**: `computeSettingsHash()` was using async `loadData()` without await — settings hash compared Promise objects instead of strings (now uses `loadDataSync`)
+- **Fixed**: `pullWithPreview` vault-first path was using async `loadData()` without await for local settings comparison (now uses `loadDataSync`)
+
+---
+
 ## [3.33.29] - 2026-03-03
 
 ### Fixed — Cloud Backup/Restore Pipeline Fix (STAK-398, STAK-382)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Bi-Directional Sync Fix (v3.33.30)**: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398).
 - **Cloud Backup/Restore Pipeline Fix (v3.33.29)**: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382).
 - **Documentation Accuracy Cleanup (v3.33.27)**: Full audit fix — script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved across instruction files, skills, and wiki (STAK-397).
 - **Browserbase Test Runbook v2 (v3.33.25)**: Modular E2E test runbook with 75+ tests across 8 section files. `/bb-test` skill now reads runbook Markdown at runtime with section and tag filtering (STAK-396).
-- **Backup Integrity Audit (v3.33.24)**: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner (STAK-374).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -3442,7 +3442,7 @@
                         <span class="cloud-status-value" id="cloudAutoSyncLastSync">Never</span>
                       </div>
                       <div style="margin-top:0.4rem">
-                        <button class="btn" id="cloudSyncNowBtn" disabled onclick="if(typeof pushSyncVault==='function')pushSyncVault();" style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0;width:100%">
+                        <button class="btn" id="cloudSyncNowBtn" disabled onclick="if(typeof syncNow==='function')syncNow();else if(typeof pushSyncVault==='function')pushSyncVault();" style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0;width:100%">
                           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
                           Sync Now
                         </button>

--- a/js/about.js
+++ b/js/about.js
@@ -283,10 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.30 &ndash; Bi-Directional Sync Fix</strong>: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398)</li>
     <li><strong>v3.33.29 &ndash; Cloud Backup/Restore Pipeline Fix</strong>: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382)</li>
     <li><strong>v3.33.27 &ndash; Documentation Accuracy Cleanup</strong>: Full audit fix &mdash; script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved (STAK-397)</li>
     <li><strong>v3.33.25 &ndash; Browserbase Test Runbook v2</strong>: Modular E2E test runbook with 75+ tests across 8 section files. /bb-test skill reads runbook Markdown at runtime with section and tag filtering (STAK-396)</li>
-    <li><strong>v3.33.24 &ndash; Backup Integrity Audit</strong>: exportOrigin metadata added to all export formats. Pre-import validation, DiffModal count header with Select All, and post-import summary banner (STAK-374)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -940,17 +940,47 @@ async function pushSyncVault() {
 
       if (prePushResp.ok) {
         // Decrypt metadata (encrypted format) or fall back to legacy plaintext JSON
-        var prePushMeta;
+        var prePushMeta = null;
+        var prePushBuffer = await prePushResp.arrayBuffer();
+        var prePushBytes = new Uint8Array(prePushBuffer);
+
+        // First, try to interpret the metadata as an encrypted .stvault file
+        var prePushParsed = null;
         try {
-          var prePushBuffer = await prePushResp.arrayBuffer();
-          var prePushParsed = parseVaultFile(new Uint8Array(prePushBuffer));
-          var prePushKey = await vaultDeriveKey(password, prePushParsed.salt, prePushParsed.iterations);
-          var prePushDecrypted = await vaultDecrypt(prePushParsed.ciphertext, prePushKey, prePushParsed.iv);
-          prePushMeta = JSON.parse(new TextDecoder().decode(prePushDecrypted));
-        } catch (prePushDecryptErr) {
-          debugLog('[CloudSync] Pre-push: metadata not encrypted, falling back to JSON:', prePushDecryptErr.message);
+          prePushParsed = parseVaultFile(prePushBytes);
+        } catch (prePushParseErr) {
+          // Not a .stvault — likely legacy plaintext JSON
+          debugLog('[CloudSync] Pre-push: metadata not in .stvault format, falling back to legacy JSON:', prePushParseErr.message);
+        }
+
+        if (prePushParsed) {
+          // Cap iterations to prevent a tampered remote file from hanging the UI
+          var prePushMaxIterations = (typeof VAULT_PBKDF2_ITERATIONS !== 'undefined' ? VAULT_PBKDF2_ITERATIONS : 600000) * 2;
+          if (prePushParsed.iterations > prePushMaxIterations) {
+            debugLog('[CloudSync] Pre-push: iterations exceeds safe cap (' + prePushParsed.iterations + ' > ' + prePushMaxIterations + '), aborting push');
+            logCloudSyncActivity('auto_sync_push', 'error', 'Remote metadata iterations exceed safe limit — possible tampering');
+            _syncPushInFlight = false;
+            updateSyncStatusIndicator('error', 'Sync metadata invalid');
+            return;
+          }
+
+          // Encrypted metadata exists; decryption must succeed or we abort the push
+          // (wrong password ≠ legacy plaintext — do not fail-open)
           try {
-            var prePushFallbackText = new TextDecoder().decode(new Uint8Array(prePushBuffer));
+            var prePushKey = await vaultDeriveKey(password, prePushParsed.salt, prePushParsed.iterations);
+            var prePushDecrypted = await vaultDecrypt(prePushParsed.ciphertext, prePushKey, prePushParsed.iv);
+            prePushMeta = JSON.parse(new TextDecoder().decode(prePushDecrypted));
+          } catch (prePushDecryptErr) {
+            debugLog('[CloudSync] Pre-push: encrypted metadata could not be decrypted, aborting push:', prePushDecryptErr.message);
+            logCloudSyncActivity('auto_sync_push', 'error', 'Encrypted sync metadata exists but could not be decrypted. Check your sync password.');
+            _syncPushInFlight = false;
+            updateSyncStatusIndicator('error', 'Wrong vault password?');
+            return;
+          }
+        } else {
+          // No valid .stvault header — attempt legacy plaintext JSON metadata
+          try {
+            var prePushFallbackText = new TextDecoder().decode(prePushBytes);
             prePushMeta = JSON.parse(prePushFallbackText);
           } catch (prePushJsonErr) {
             debugLog('[CloudSync] Pre-push: metadata parse failed:', prePushJsonErr.message);

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -160,7 +160,7 @@ async function computeSettingsHash() {
     var settings = {};
     for (var i = 0; i < keys.length; i++) {
       if (keys[i] === 'metalInventory') continue; // skip inventory — covered by inventoryHash
-      var val = loadData(keys[i]);
+      var val = loadDataSync(keys[i], null);
       if (val !== null && val !== undefined) settings[keys[i]] = val;
     }
     var sorted = JSON.stringify(settings, Object.keys(settings).sort());
@@ -906,6 +906,78 @@ async function pushSyncVault() {
       } catch (migErr) {
         debugLog('[CloudSync] Migration error (non-blocking):', migErr.message);
       }
+    }
+
+    // -----------------------------------------------------------------------
+    // Layer 0 — Pre-push remote check (STAK-398 fix)
+    // Before pushing, check if another device has pushed since our last pull.
+    // If so, route to handleRemoteChange() instead of overwriting.
+    // This prevents the push-races-poll bug where pushSyncVault (2s debounce)
+    // always beats pollForRemoteChanges (10min interval).
+    // -----------------------------------------------------------------------
+    try {
+      var prePushApiArg = JSON.stringify({ path: SYNC_META_PATH });
+      var prePushResp = await fetch('https://content.dropboxapi.com/2/files/download', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Dropbox-API-Arg': prePushApiArg,
+        },
+      });
+
+      // Try legacy path if new path not found
+      if (prePushResp.status === 409 || prePushResp.status === 404) {
+        var prePushLegacyArg = JSON.stringify({ path: SYNC_META_PATH_LEGACY });
+        var prePushLegacyResp = await fetch('https://content.dropboxapi.com/2/files/download', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer ' + token,
+            'Dropbox-API-Arg': prePushLegacyArg,
+          },
+        });
+        if (prePushLegacyResp.ok) prePushResp = prePushLegacyResp;
+      }
+
+      if (prePushResp.ok) {
+        // Decrypt metadata (encrypted format) or fall back to legacy plaintext JSON
+        var prePushMeta;
+        try {
+          var prePushBuffer = await prePushResp.arrayBuffer();
+          var prePushParsed = parseVaultFile(new Uint8Array(prePushBuffer));
+          var prePushKey = await vaultDeriveKey(password, prePushParsed.salt, prePushParsed.iterations);
+          var prePushDecrypted = await vaultDecrypt(prePushParsed.ciphertext, prePushKey, prePushParsed.iv);
+          prePushMeta = JSON.parse(new TextDecoder().decode(prePushDecrypted));
+        } catch (prePushDecryptErr) {
+          debugLog('[CloudSync] Pre-push: metadata not encrypted, falling back to JSON:', prePushDecryptErr.message);
+          try {
+            var prePushFallbackText = new TextDecoder().decode(new Uint8Array(prePushBuffer));
+            prePushMeta = JSON.parse(prePushFallbackText);
+          } catch (prePushJsonErr) {
+            debugLog('[CloudSync] Pre-push: metadata parse failed:', prePushJsonErr.message);
+            prePushMeta = null;
+          }
+        }
+
+        if (prePushMeta && prePushMeta.syncId && prePushMeta.deviceId) {
+          var myDeviceId = getSyncDeviceId();
+          var lastPull = syncGetLastPull();
+
+          // If a DIFFERENT device pushed AND we haven't pulled this syncId yet
+          if (prePushMeta.deviceId !== myDeviceId &&
+              (!lastPull || lastPull.syncId !== prePushMeta.syncId)) {
+            debugLog('[CloudSync] Pre-push: remote change from another device detected — routing to handleRemoteChange');
+            logCloudSyncActivity('auto_sync_push', 'deferred', 'Remote change detected from device ' + prePushMeta.deviceId.slice(0, 8) + ' — showing diff');
+            _syncPushInFlight = false;
+            updateSyncStatusIndicator('idle');
+            await handleRemoteChange(prePushMeta);
+            return; // Do NOT push — let the user decide via the update/conflict modal
+          }
+        }
+      }
+      // If meta fetch failed (409/404 = first push, or network error), proceed with push
+    } catch (prePushErr) {
+      debugLog('[CloudSync] Pre-push remote check failed (non-blocking):', prePushErr.message);
+      // Non-blocking: if the check fails, proceed with push (fail-open for first push scenarios)
     }
 
     // -----------------------------------------------------------------------
@@ -2159,7 +2231,7 @@ async function pullWithPreview(remoteMeta) {
       if (typeof SYNC_SCOPE_KEYS !== 'undefined') {
         for (var i = 0; i < SYNC_SCOPE_KEYS.length; i++) {
           if (SYNC_SCOPE_KEYS[i] === 'metalInventory') continue;
-          var v = loadData(SYNC_SCOPE_KEYS[i]);
+          var v = loadDataSync(SYNC_SCOPE_KEYS[i], null);
           if (v !== null && v !== undefined) localSettings[SYNC_SCOPE_KEYS[i]] = v;
         }
       }
@@ -2335,7 +2407,13 @@ async function enableCloudSync(provider) {
   // Update UI immediately so Sync Now button is enabled before the async push
   refreshSyncUI();
 
-  // Initial push (this will open the password modal if no cached password)
+  // Poll first to check for existing remote data before pushing (STAK-398 fix).
+  // This ensures a second browser joining sync sees the first browser's data
+  // instead of blindly overwriting it.
+  await pollForRemoteChanges();
+
+  // Push local data (the pre-push check inside pushSyncVault will detect if
+  // pollForRemoteChanges already handled a remote change and skip if needed)
   await pushSyncVault();
 
   // Start the poller
@@ -2438,12 +2516,30 @@ document.addEventListener('visibilitychange', function () {
 });
 
 // ---------------------------------------------------------------------------
+// Sync Now — smart bi-directional sync (STAK-398 fix)
+// Polls for remote changes first, then pushes if no conflict detected.
+// ---------------------------------------------------------------------------
+
+/**
+ * Smart sync: poll for remote changes first, then push local data.
+ * Called by the "Sync Now" button. Replaces the old blind-push behavior.
+ */
+async function syncNow() {
+  debugLog('[CloudSync] syncNow: polling for remote changes first…');
+  await pollForRemoteChanges();
+  // pushSyncVault has its own pre-push remote check, so even if poll missed
+  // something (race), the push will catch it and route to handleRemoteChange.
+  await pushSyncVault();
+}
+
+// ---------------------------------------------------------------------------
 // Window exports
 // ---------------------------------------------------------------------------
 
 window.initCloudSync = initCloudSync;
 window.enableCloudSync = enableCloudSync;
 window.disableCloudSync = disableCloudSync;
+window.syncNow = syncNow;
 window.pushSyncVault = pushSyncVault;
 window.pullSyncVault = pullSyncVault;
 window.pollForRemoteChanges = pollForRemoteChanges;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.29";
+const APP_VERSION = "3.33.30";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.29-b1772511140';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772512760';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772512760';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772514420';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.29",
+  "version": "3.33.30",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Pre-push remote check — `pushSyncVault()` now downloads remote metadata before pushing. If another device pushed since our last pull, routes to `handleRemoteChange()` (update/conflict modal) instead of silently overwriting.
- **Fixed**: "Sync Now" button calls new `syncNow()` function (poll-then-push) instead of blind `pushSyncVault()`
- **Fixed**: `enableCloudSync()` polls for existing remote data before initial push — prevents second browser from overwriting first browser's data on join
- **Fixed**: `computeSettingsHash()` was using async `loadData()` without await — settings hash compared Promise objects. Now uses `loadDataSync()`
- **Fixed**: `pullWithPreview` vault-first path used async `loadData()` for local settings comparison. Now uses `loadDataSync()`

## Root Cause

Push (2s debounce) always raced poll (10min interval). Each browser pushed independently, neither ever pulled, no diff popup appeared. The pre-push remote check closes the race by making every push check the cloud first.

## Linear Issues

- STAK-398: Cloud backup/restore pipeline broken — path bugs, async bug, UI cleanup

## QA Plan

1. Open beta.staktrakr.com in Firefox + Chrome, both logged into Dropbox
2. Verify Chrome: click "Sync Now" → should show update/diff modal (not blind push)
3. Verify Firefox: click "Sync Now" → should show update/diff modal if Chrome changed
4. Verify: enabling sync on a new browser detects existing remote data

🤖 Generated with [Claude Code](https://claude.com/claude-code)