### PR TITLE
v3.33.30 — Fix vault password prompt during sync setup (STAK-398)

### DIFF
--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -478,23 +478,32 @@ async function cloudExchangeCode(code, state) {
     };
     cloudStoreToken(provider, tokenData);
 
-    // Fetch Dropbox account ID for Simple mode key derivation (non-blocking, Dropbox-only)
+    // Store Dropbox account ID for key derivation.
+    // The token exchange response includes account_id — grab it directly (synchronous, no race).
+    // Fall back to get_current_account API only if the token response didn't include it.
     if (provider === 'dropbox') {
-      fetch('https://api.dropboxapi.com/2/users/get_current_account', {
-        method: 'POST',
-        headers: {
-          Authorization: 'Bearer ' + tokenData.access_token,
-          'Content-Type': 'application/json',
-        },
-        body: 'null',
-      }).then(function (r) { return r.ok ? r.json() : null; })
-        .then(function (info) {
-          if (info && info.account_id) {
-            localStorage.setItem('cloud_dropbox_account_id', info.account_id);
-            debugLog('[CloudStorage] Stored Dropbox account ID for Simple mode');
-          }
-        })
-        .catch(function (e) { debugLog('[CloudStorage] Failed to fetch Dropbox account ID', e); });
+      if (data.account_id) {
+        localStorage.setItem('cloud_dropbox_account_id', data.account_id);
+        console.warn('[CloudStorage] Stored Dropbox account ID from token exchange:', data.account_id);
+      } else {
+        // Fallback: fetch account ID from API (still non-blocking since enableCloudSync will check)
+        console.warn('[CloudStorage] Token exchange did not include account_id — fetching from API');
+        fetch('https://api.dropboxapi.com/2/users/get_current_account', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer ' + tokenData.access_token,
+            'Content-Type': 'application/json',
+          },
+          body: 'null',
+        }).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (info) {
+            if (info && info.account_id) {
+              localStorage.setItem('cloud_dropbox_account_id', info.account_id);
+              console.warn('[CloudStorage] Stored Dropbox account ID from API fallback');
+            }
+          })
+          .catch(function (e) { console.warn('[CloudStorage] Failed to fetch Dropbox account ID', e); });
+      }
     }
     sessionStorage.removeItem('cloud_oauth_state');
     if (typeof syncCloudUI === 'function') syncCloudUI();

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -484,25 +484,25 @@ async function cloudExchangeCode(code, state) {
     if (provider === 'dropbox') {
       if (data.account_id) {
         localStorage.setItem('cloud_dropbox_account_id', data.account_id);
-        console.warn('[CloudStorage] Stored Dropbox account ID from token exchange:', data.account_id);
+        debugWarn('[CloudStorage] Stored Dropbox account ID from token exchange');
       } else {
-        // Fallback: fetch account ID from API (still non-blocking since enableCloudSync will check)
-        console.warn('[CloudStorage] Token exchange did not include account_id — fetching from API');
-        fetch('https://api.dropboxapi.com/2/users/get_current_account', {
-          method: 'POST',
-          headers: {
-            Authorization: 'Bearer ' + tokenData.access_token,
-            'Content-Type': 'application/json',
-          },
-          body: 'null',
-        }).then(function (r) { return r.ok ? r.json() : null; })
-          .then(function (info) {
-            if (info && info.account_id) {
-              localStorage.setItem('cloud_dropbox_account_id', info.account_id);
-              console.warn('[CloudStorage] Stored Dropbox account ID from API fallback');
-            }
-          })
-          .catch(function (e) { console.warn('[CloudStorage] Failed to fetch Dropbox account ID', e); });
+        // Fallback: fetch account ID from API — awaited so syncCloudUI runs after account_id is stored
+        debugWarn('[CloudStorage] Token exchange did not include account_id — fetching from API');
+        try {
+          var acctResp = await fetch('https://api.dropboxapi.com/2/users/get_current_account', {
+            method: 'POST',
+            headers: {
+              Authorization: 'Bearer ' + tokenData.access_token,
+              'Content-Type': 'application/json',
+            },
+            body: 'null',
+          });
+          var info = acctResp.ok ? await acctResp.json() : null;
+          if (info && info.account_id) {
+            localStorage.setItem('cloud_dropbox_account_id', info.account_id);
+            debugWarn('[CloudStorage] Stored Dropbox account ID from API fallback');
+          }
+        } catch (e) { debugWarn('[CloudStorage] Failed to fetch Dropbox account ID', e); }
       }
     }
     sessionStorage.removeItem('cloud_oauth_state');

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -542,8 +542,9 @@ function getSyncPassword() {
       if (typeof appPrompt === 'function') {
         appPrompt(prompt, '', 'Cloud Sync').then(function (pw) {
           if (pw && pw.length >= 8) {
+            var freshId = localStorage.getItem('cloud_dropbox_account_id');
             try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
-            resolve(accountId ? pw + ':' + accountId : pw);
+            resolve(freshId ? pw + ':' + freshId : pw);
           } else {
             resolve(null);
           }
@@ -582,11 +583,14 @@ function getSyncPassword() {
         }
         return;
       }
+      // Re-read accountId at confirm time — it may have been stored after the modal opened
+      // (e.g., async Dropbox token exchange completing while the user types their password).
+      var freshAccountId = localStorage.getItem('cloud_dropbox_account_id');
       try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
       cleanup();
       if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
       // Do NOT push here — the caller (enableCloudSync / initCloudSync) handles sync after resolving.
-      resolve(accountId ? pw + ':' + accountId : pw);
+      resolve(freshAccountId ? pw + ':' + freshAccountId : pw);
     };
 
     var onCancel = function () { cleanup(); resolve(null); };
@@ -2484,7 +2488,7 @@ async function enableCloudSync(provider) {
   _syncProvider = provider || 'dropbox';
   try { localStorage.setItem('cloud_sync_enabled', 'true'); } catch (_) { /* ignore */ }
 
-  console.warn('[CloudSync] Enabling auto-sync for', _syncProvider);
+  debugWarn('[CloudSync] Enabling auto-sync for', _syncProvider);
 
   // Ensure we have a device ID
   getSyncDeviceId();
@@ -2499,15 +2503,25 @@ async function enableCloudSync(provider) {
   // setup), poll/push silently skip and the user sees "Connected" with no sync.
   // -----------------------------------------------------------------------
   var password = await getSyncPassword();
-  console.warn('[CloudSync] enableCloudSync: password obtained:', !!password,
-    'accountId:', !!localStorage.getItem('cloud_dropbox_account_id'));
+  var hasAccountId = !!localStorage.getItem('cloud_dropbox_account_id');
+  debugWarn('[CloudSync] enableCloudSync: password obtained:', !!password, 'accountId:', hasAccountId);
   if (!password) {
     // User cancelled password prompt — revert sync enabled flag
-    console.warn('[CloudSync] No password set — reverting auto-sync enable');
+    debugWarn('[CloudSync] No password set — reverting auto-sync enable');
     try { localStorage.setItem('cloud_sync_enabled', 'false'); } catch (_) { /* ignore */ }
     refreshSyncUI();
     if (typeof showCloudToast === 'function') {
       showCloudToast('Cloud sync requires a vault password. Please try again.');
+    }
+    return;
+  }
+  // Guard: account_id must be present for composite key derivation
+  if (!hasAccountId) {
+    debugWarn('[CloudSync] No account_id — cannot derive sync key, reverting');
+    try { localStorage.setItem('cloud_sync_enabled', 'false'); } catch (_) { /* ignore */ }
+    refreshSyncUI();
+    if (typeof showCloudToast === 'function') {
+      showCloudToast('Cloud sync setup incomplete — please reconnect your Dropbox account.');
     }
     return;
   }
@@ -2587,17 +2601,17 @@ function initCloudSync() {
   debugLog('[CloudSync] Resuming auto-sync from previous session');
 
   var hasPw = getSyncPasswordSilent();
-  console.warn('[CloudSync] initCloudSync: password available:', !!hasPw,
+  debugWarn('[CloudSync] initCloudSync: password available:', !!hasPw,
     'accountId:', !!localStorage.getItem('cloud_dropbox_account_id'));
   updateCloudSyncHeaderBtn();
 
   if (!hasPw) {
     // No password available — prompt interactively instead of just showing a toast.
     // STAK-398 fix: the toast-and-return pattern left sync silently broken.
-    console.warn('[CloudSync] No vault password — prompting user');
+    debugWarn('[CloudSync] No vault password — prompting user');
     getSyncPassword().then(function (pw) {
       if (pw) {
-        console.warn('[CloudSync] Password set via prompt — starting sync');
+        debugWarn('[CloudSync] Password set via prompt — starting sync');
         updateCloudSyncHeaderBtn();
         startSyncPoller();
         // Poll + push after a short delay to let UI settle
@@ -2605,7 +2619,7 @@ function initCloudSync() {
           pollForRemoteChanges().then(function () { pushSyncVault(); });
         }, 1000);
       } else {
-        console.warn('[CloudSync] User cancelled password prompt — sync paused');
+        debugWarn('[CloudSync] User cancelled password prompt — sync paused');
         updateCloudSyncHeaderBtn();
         if (typeof showCloudToast === 'function') {
           showCloudToast('Cloud sync paused — tap the cloud icon to set your vault password', 5000);

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -585,7 +585,7 @@ function getSyncPassword() {
       try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
       cleanup();
       if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
-      setTimeout(function () { if (typeof pushSyncVault === 'function') pushSyncVault(); }, 100);
+      // Do NOT push here — the caller (enableCloudSync / initCloudSync) handles sync after resolving.
       resolve(accountId ? pw + ':' + accountId : pw);
     };
 
@@ -2484,13 +2484,33 @@ async function enableCloudSync(provider) {
   _syncProvider = provider || 'dropbox';
   try { localStorage.setItem('cloud_sync_enabled', 'true'); } catch (_) { /* ignore */ }
 
-  debugLog('[CloudSync] Enabling auto-sync for', _syncProvider);
+  console.warn('[CloudSync] Enabling auto-sync for', _syncProvider);
 
   // Ensure we have a device ID
   getSyncDeviceId();
 
   // Update UI immediately so Sync Now button is enabled before the async push
   refreshSyncUI();
+
+  // -----------------------------------------------------------------------
+  // STAK-398 fix: Prompt for password BEFORE any sync operations.
+  // getSyncPasswordSilent() requires both cloud_vault_password and
+  // cloud_dropbox_account_id in localStorage. If either is missing (first-time
+  // setup), poll/push silently skip and the user sees "Connected" with no sync.
+  // -----------------------------------------------------------------------
+  var password = await getSyncPassword();
+  console.warn('[CloudSync] enableCloudSync: password obtained:', !!password,
+    'accountId:', !!localStorage.getItem('cloud_dropbox_account_id'));
+  if (!password) {
+    // User cancelled password prompt — revert sync enabled flag
+    console.warn('[CloudSync] No password set — reverting auto-sync enable');
+    try { localStorage.setItem('cloud_sync_enabled', 'false'); } catch (_) { /* ignore */ }
+    refreshSyncUI();
+    if (typeof showCloudToast === 'function') {
+      showCloudToast('Cloud sync requires a vault password. Please try again.');
+    }
+    return;
+  }
 
   // Poll first to check for existing remote data before pushing (STAK-398 fix).
   // This ensures a second browser joining sync sees the first browser's data
@@ -2567,16 +2587,31 @@ function initCloudSync() {
   debugLog('[CloudSync] Resuming auto-sync from previous session');
 
   var hasPw = getSyncPasswordSilent();
+  console.warn('[CloudSync] initCloudSync: password available:', !!hasPw,
+    'accountId:', !!localStorage.getItem('cloud_dropbox_account_id'));
   updateCloudSyncHeaderBtn();
 
   if (!hasPw) {
-    // No password available — show orange indicator, wait for user to tap
-    debugLog('[CloudSync] No vault password — showing setup toast');
-    setTimeout(function () {
-      if (typeof showCloudToast === 'function') {
-        showCloudToast('Cloud sync paused — tap the cloud icon to set your vault password', 5000);
+    // No password available — prompt interactively instead of just showing a toast.
+    // STAK-398 fix: the toast-and-return pattern left sync silently broken.
+    console.warn('[CloudSync] No vault password — prompting user');
+    getSyncPassword().then(function (pw) {
+      if (pw) {
+        console.warn('[CloudSync] Password set via prompt — starting sync');
+        updateCloudSyncHeaderBtn();
+        startSyncPoller();
+        // Poll + push after a short delay to let UI settle
+        setTimeout(function () {
+          pollForRemoteChanges().then(function () { pushSyncVault(); });
+        }, 1000);
+      } else {
+        console.warn('[CloudSync] User cancelled password prompt — sync paused');
+        updateCloudSyncHeaderBtn();
+        if (typeof showCloudToast === 'function') {
+          showCloudToast('Cloud sync paused — tap the cloud icon to set your vault password', 5000);
+        }
       }
-    }, 1000);
+    });
     return;
   }
 

--- a/js/events.js
+++ b/js/events.js
@@ -3196,7 +3196,21 @@ function _openCloudSyncPopover() {
     try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
     if (typeof cloudCachePassword === 'function') cloudCachePassword('dropbox', pw);
     if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
-    setTimeout(function () { if (typeof pushSyncVault === 'function') pushSyncVault(); }, 100);
+    // STAK-398: poll for remote changes first, then push. Check account_id is present.
+    var hasAccountId = !!localStorage.getItem('cloud_dropbox_account_id');
+    console.warn('[CloudSync] Popover unlock: password set, accountId:', hasAccountId);
+    if (!hasAccountId) {
+      console.warn('[CloudSync] Popover unlock: WARNING — no account_id, sync password will be incomplete');
+    }
+    setTimeout(function () {
+      if (typeof pollForRemoteChanges === 'function') {
+        pollForRemoteChanges().then(function () {
+          if (typeof pushSyncVault === 'function') pushSyncVault();
+        });
+      } else if (typeof pushSyncVault === 'function') {
+        pushSyncVault();
+      }
+    }, 100);
   }
 
   if (unlockBtn) unlockBtn.onclick = onUnlock;

--- a/js/events.js
+++ b/js/events.js
@@ -3198,10 +3198,15 @@ function _openCloudSyncPopover() {
     if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
     // STAK-398: poll for remote changes first, then push. Check account_id is present.
     var hasAccountId = !!localStorage.getItem('cloud_dropbox_account_id');
-    console.warn('[CloudSync] Popover unlock: password set, accountId:', hasAccountId);
+    debugWarn('[CloudSync] Popover unlock: password set, accountId:', hasAccountId);
     if (!hasAccountId) {
-      console.warn('[CloudSync] Popover unlock: WARNING — no account_id, sync password will be incomplete');
+      debugWarn('[CloudSync] Popover unlock: no account_id — sync key incomplete, skipping sync');
+      if (typeof showCloudToast === 'function') {
+        showCloudToast('Cloud sync setup incomplete — please reconnect your Dropbox account.');
+      }
+      return;
     }
+    // Short delay lets popover cleanup / DOM update finish before async sync starts
     setTimeout(function () {
       if (typeof pollForRemoteChanges === 'function') {
         pollForRemoteChanges().then(function () {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772550787';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772553790';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772553790';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772554798';
 
 
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fix password never prompted during sync setup**: `enableCloudSync()` now calls `getSyncPassword()` (interactive prompt) before attempting poll/push. Previously used `getSyncPasswordSilent()` which silently returned null and skipped all sync ops.
- **Fix account_id race condition**: Store `cloud_dropbox_account_id` directly from Dropbox token exchange response (synchronous) instead of fire-and-forget API call
- **Fix initCloudSync() passive toast**: On page reload without password, prompt interactively instead of showing "tap the cloud icon" toast
- **Fix popover onUnlock**: Poll before push, warn if account_id missing
- **Remove double-push**: `getSyncPassword()` onConfirm no longer fires redundant `pushSyncVault()` — callers handle sync

## Root Cause

When a user connects to Dropbox and enables auto-sync:
1. OAuth callback stores token but fires off account_id fetch asynchronously (may not complete)
2. `enableCloudSync()` runs poll + push, both using `getSyncPasswordSilent()`
3. `getSyncPasswordSilent()` requires BOTH `cloud_vault_password` AND `cloud_dropbox_account_id`
4. Neither is set → returns `null` → poll/push silently skip
5. User sees "Connected" but nothing syncs. No password prompt ever appears.

## Linear Issues

- STAK-398: Cloud backup/restore pipeline broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)