### PR TITLE
fix: STAK-398 account_id guard + pre-decrypt diagnostics (v3.33.30)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4477,6 +4477,7 @@
           </div>
           <div class="encryption-actions" style="margin-top:1.2rem;gap:0.5rem;flex-wrap:wrap">
             <button class="btn success" id="syncUpdateAcceptBtn">Accept Update</button>
+            <button class="btn warning" id="syncUpdatePushBtn">Push My Data</button>
             <button class="btn" id="syncUpdateDismissBtn">Not Now</button>
           </div>
         </div>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1680,22 +1680,26 @@ function showSyncUpdateModal(remoteMeta) {
 
     modal.style.display = 'flex';
 
-    function cleanup(result) {
-      modal.style.display = 'none';
-      acceptBtn.removeEventListener('click', onAccept);
-      dismissBtn.removeEventListener('click', onDismiss);
-      dismissX.removeEventListener('click', onDismiss);
-      resolve(result);
-    }
-
-    function onAccept()  { cleanup(true); }
-    function onDismiss() { cleanup(false); }
-
     var acceptBtn  = safeGetElement('syncUpdateAcceptBtn');
+    var pushBtn    = safeGetElement('syncUpdatePushBtn');
     var dismissBtn = safeGetElement('syncUpdateDismissBtn');
     var dismissX   = safeGetElement('syncUpdateDismissX');
 
+    function cleanup(result) {
+      modal.style.display = 'none';
+      if (acceptBtn)  acceptBtn.removeEventListener('click', onAccept);
+      if (pushBtn)    pushBtn.removeEventListener('click', onPush);
+      if (dismissBtn) dismissBtn.removeEventListener('click', onDismiss);
+      if (dismissX)   dismissX.removeEventListener('click', onDismiss);
+      resolve(result);
+    }
+
+    function onAccept()  { cleanup('accept'); }
+    function onPush()    { cleanup('push'); }
+    function onDismiss() { cleanup('dismiss'); }
+
     if (acceptBtn)  acceptBtn.addEventListener('click', onAccept);
+    if (pushBtn)    pushBtn.addEventListener('click', onPush);
     if (dismissBtn) dismissBtn.addEventListener('click', onDismiss);
     if (dismissX)   dismissX.addEventListener('click', onDismiss);
   });
@@ -1735,12 +1739,18 @@ async function handleRemoteChange(remoteMeta) {
     if (!hasLocal) {
       // Show the update-available modal — let user decide before password prompt
       console.warn('[CloudSync] handleRemoteChange: showing update modal');
-      var accepted = await showSyncUpdateModal(remoteMeta);
-      if (!accepted) {
+      var choice = await showSyncUpdateModal(remoteMeta);
+      if (choice === 'push') {
+        // User chose to assert local data as authoritative — push over remote
+        console.warn('[CloudSync] handleRemoteChange: user chose Push My Data');
+        pushSyncVault();
+        return;
+      }
+      if (!choice || choice === 'dismiss') {
         console.warn('[CloudSync] handleRemoteChange: user dismissed update — will retry next poll');
         return;
       }
-      // Layer 5 — Show restore preview instead of direct pull (REQ-5)
+      // choice === 'accept' — Layer 5: show restore preview instead of direct pull (REQ-5)
       await pullWithPreview(remoteMeta);
       return;
     }

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -565,7 +565,7 @@ function getSyncPassword(forcePrompt) {
           if (pw && pw.length >= 8) {
             var freshId = localStorage.getItem('cloud_dropbox_account_id');
             try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
-            resolve(freshId ? pw + ':' + freshId : pw);
+            resolve(freshId ? pw + ':' + freshId : null);
           } else {
             resolve(null);
           }
@@ -607,11 +607,18 @@ function getSyncPassword(forcePrompt) {
       // Re-read accountId at confirm time — it may have been stored after the modal opened
       // (e.g., async Dropbox token exchange completing while the user types their password).
       var freshAccountId = localStorage.getItem('cloud_dropbox_account_id');
+      if (!freshAccountId) {
+        if (errorEl) {
+          errorEl.textContent = 'No Dropbox account ID found. Please cancel and reconnect your Dropbox account.';
+          errorEl.style.display = '';
+        }
+        return;
+      }
       try { localStorage.setItem('cloud_vault_password', pw); } catch (_) {}
       cleanup();
       if (typeof updateCloudSyncHeaderBtn === 'function') updateCloudSyncHeaderBtn();
       // Do NOT push here — the caller (enableCloudSync / initCloudSync) handles sync after resolving.
-      resolve(freshAccountId ? pw + ':' + freshAccountId : pw);
+      resolve(pw + ':' + freshAccountId);
     };
 
     var onCancel = function () { cleanup(); resolve(null); };
@@ -638,8 +645,15 @@ function getSyncPassword(forcePrompt) {
  * @param {Uint8Array} fileBytes
  * @returns {Promise<Object>} Parsed vault payload
  */
-async function _tryDecryptVault(fileBytes) {
+async function _tryDecryptVault(fileBytes, artifactLabel) {
   var candidates = _getSyncKeyCandidates();
+  var _diagPw  = !!localStorage.getItem('cloud_vault_password');
+  var _diagAid = localStorage.getItem('cloud_dropbox_account_id');
+  console.warn('[CloudSync] decrypt attempt:',
+    'artifact=' + (artifactLabel || 'stvault'),
+    'vaultPw:', _diagPw,
+    'accountId:', _diagAid ? _diagAid.slice(0, 8) + '… (' + _diagAid.length + ' chars)' : 'MISSING',
+    'candidates:', candidates.length);
   for (var i = 0; i < candidates.length; i++) {
     try {
       var payload = await vaultDecryptToData(fileBytes, candidates[i].key);
@@ -675,6 +689,13 @@ function _getSyncKeyCandidates() {
  */
 async function _tryDecryptMetadata(parsed) {
   var candidates = _getSyncKeyCandidates();
+  var _diagPw  = !!localStorage.getItem('cloud_vault_password');
+  var _diagAid = localStorage.getItem('cloud_dropbox_account_id');
+  console.warn('[CloudSync] decrypt attempt:',
+    'artifact=metadata',
+    'vaultPw:', _diagPw,
+    'accountId:', _diagAid ? _diagAid.slice(0, 8) + '… (' + _diagAid.length + ' chars)' : 'MISSING',
+    'candidates:', candidates.length);
   for (var i = 0; i < candidates.length; i++) {
     try {
       var derivedKey = await vaultDeriveKey(candidates[i].key, parsed.salt, parsed.iterations);
@@ -1467,6 +1488,17 @@ async function pollForRemoteChanges() {
   var token = typeof cloudGetToken === 'function' ? await cloudGetToken(_syncProvider) : null;
   if (!token) return;
 
+  var _pollAccountId = localStorage.getItem('cloud_dropbox_account_id');
+  if (!_pollAccountId) {
+    console.warn('[CloudSync] Poll: cloud_dropbox_account_id missing — sync key incomplete');
+    if (typeof showCloudToast === 'function') {
+      showCloudToast(
+        'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
+      );
+    }
+    return;
+  }
+
   // Layer 3 — Folder migration check (REQ-3)
   if (loadDataSync('cloud_sync_migrated', '') !== 'v2') {
     debugLog('[CloudSync] Poll: migration needed — running cloudMigrateToV2');
@@ -1753,6 +1785,17 @@ async function pullSyncVault(remoteMeta) {
   }
   if (!password) {
     debugLog('[CloudSync] Pull cancelled — no password');
+    return;
+  }
+
+  var _pullAccountId = localStorage.getItem('cloud_dropbox_account_id');
+  if (!_pullAccountId) {
+    console.warn('[CloudSync] pullSyncVault: cloud_dropbox_account_id missing — aborting');
+    if (typeof showCloudToast === 'function') {
+      showCloudToast(
+        'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
+      );
+    }
     return;
   }
 
@@ -2223,7 +2266,7 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
     // ── Selective apply path ──
     if (selectedChanges && typeof DiffEngine !== 'undefined' && typeof DiffEngine.applySelectedChanges === 'function') {
       var payload = typeof vaultDecryptToData === 'function'
-        ? await _tryDecryptVault(bytes)
+        ? await _tryDecryptVault(bytes, 'stvault')
         : null;
 
       if (payload && payload.data) {
@@ -2271,7 +2314,7 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
 
     // ── Full-overwrite fallback (try all key variants) ──
     syncSaveOverrideBackup();
-    var fbPayload = await _tryDecryptVault(bytes);
+    var fbPayload = await _tryDecryptVault(bytes, 'stvault');
     await restoreVaultData(fbPayload);
     debugLog('[CloudSync] Deferred vault restore complete (full overwrite)');
 
@@ -2307,6 +2350,17 @@ async function pullWithPreview(remoteMeta) {
   }
   if (!password) {
     debugLog('[CloudSync] Pull preview cancelled — no password');
+    return;
+  }
+
+  var _pullPreviewAccountId = localStorage.getItem('cloud_dropbox_account_id');
+  if (!_pullPreviewAccountId) {
+    console.warn('[CloudSync] pullWithPreview: cloud_dropbox_account_id missing — aborting');
+    if (typeof showCloudToast === 'function') {
+      showCloudToast(
+        'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
+      );
+    }
     return;
   }
 
@@ -2444,7 +2498,7 @@ async function pullWithPreview(remoteMeta) {
 
     // Attempt to decrypt and preview
     try {
-      var remotePayload = await _tryDecryptVault(bytes);
+      var remotePayload = await _tryDecryptVault(bytes, 'stvault');
       var remoteItems = remotePayload.data || [];
       var localItems = typeof inventory !== 'undefined' ? inventory : [];
 
@@ -2530,7 +2584,7 @@ async function pullWithPreview(remoteMeta) {
         // Modal not in DOM — fall back to direct restore (try all key variants)
         debugLog('[CloudSync] Preview modal unavailable — falling back to direct restore');
         syncSaveOverrideBackup();
-        var fbPayload2 = await _tryDecryptVault(bytes);
+        var fbPayload2 = await _tryDecryptVault(bytes, 'stvault');
         await restoreVaultData(fbPayload2);
         syncSetLastPull(_previewPullMeta);
         _previewPullMeta = null;

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -640,20 +640,48 @@ function getSyncPassword(forcePrompt) {
 }
 
 /**
+ * Emit a structured pre-decrypt console.warn for QA isolation of identity vs crypto failures.
+ * @param {string} artifact - Label for what is being decrypted (e.g. 'metadata', 'stvault')
+ * @param {Array} candidates - Key candidates from _getSyncKeyCandidates()
+ */
+function _logDecryptAttempt(artifact, candidates) {
+  var _diagPw  = !!localStorage.getItem('cloud_vault_password');
+  var _diagAid = localStorage.getItem('cloud_dropbox_account_id');
+  console.warn('[CloudSync] decrypt attempt:',
+    'artifact=' + artifact,
+    'vaultPw:', _diagPw,
+    'accountId:', _diagAid ? _diagAid.slice(0, 8) + '… (' + _diagAid.length + ' chars)' : 'MISSING',
+    'candidates:', candidates.length);
+}
+
+/**
+ * Guard that cloud_dropbox_account_id is present before any pull/poll operation.
+ * Logs a warning and shows a reconnect toast when the accountId is missing.
+ * Returns true when the accountId is present (safe to proceed), false when absent (caller must return).
+ * @param {string} context - Caller label for the console warning (e.g. 'Poll', 'pullSyncVault')
+ * @returns {boolean}
+ */
+function _assertSyncAccountId(context) {
+  if (localStorage.getItem('cloud_dropbox_account_id')) return true;
+  console.warn('[CloudSync]', context + ': cloud_dropbox_account_id missing — aborting');
+  if (typeof showCloudToast === 'function') {
+    showCloudToast(
+      'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
+    );
+  }
+  return false;
+}
+
+/**
  * Try to decrypt a vault file using all known key variants.
  * Returns the decrypted payload on success, throws on total failure.
  * @param {Uint8Array} fileBytes
+ * @param {string} [artifactLabel] - Label for pre-decrypt log (e.g. 'stvault', 'stmanifest')
  * @returns {Promise<Object>} Parsed vault payload
  */
 async function _tryDecryptVault(fileBytes, artifactLabel) {
   var candidates = _getSyncKeyCandidates();
-  var _diagPw  = !!localStorage.getItem('cloud_vault_password');
-  var _diagAid = localStorage.getItem('cloud_dropbox_account_id');
-  console.warn('[CloudSync] decrypt attempt:',
-    'artifact=' + (artifactLabel || 'stvault'),
-    'vaultPw:', _diagPw,
-    'accountId:', _diagAid ? _diagAid.slice(0, 8) + '… (' + _diagAid.length + ' chars)' : 'MISSING',
-    'candidates:', candidates.length);
+  _logDecryptAttempt(artifactLabel || 'stvault', candidates);
   for (var i = 0; i < candidates.length; i++) {
     try {
       var payload = await vaultDecryptToData(fileBytes, candidates[i].key);
@@ -689,13 +717,7 @@ function _getSyncKeyCandidates() {
  */
 async function _tryDecryptMetadata(parsed) {
   var candidates = _getSyncKeyCandidates();
-  var _diagPw  = !!localStorage.getItem('cloud_vault_password');
-  var _diagAid = localStorage.getItem('cloud_dropbox_account_id');
-  console.warn('[CloudSync] decrypt attempt:',
-    'artifact=metadata',
-    'vaultPw:', _diagPw,
-    'accountId:', _diagAid ? _diagAid.slice(0, 8) + '… (' + _diagAid.length + ' chars)' : 'MISSING',
-    'candidates:', candidates.length);
+  _logDecryptAttempt('metadata', candidates);
   for (var i = 0; i < candidates.length; i++) {
     try {
       var derivedKey = await vaultDeriveKey(candidates[i].key, parsed.salt, parsed.iterations);
@@ -1488,16 +1510,7 @@ async function pollForRemoteChanges() {
   var token = typeof cloudGetToken === 'function' ? await cloudGetToken(_syncProvider) : null;
   if (!token) return;
 
-  var _pollAccountId = localStorage.getItem('cloud_dropbox_account_id');
-  if (!_pollAccountId) {
-    console.warn('[CloudSync] Poll: cloud_dropbox_account_id missing — sync key incomplete');
-    if (typeof showCloudToast === 'function') {
-      showCloudToast(
-        'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
-      );
-    }
-    return;
-  }
+  if (!_assertSyncAccountId('Poll')) return;
 
   // Layer 3 — Folder migration check (REQ-3)
   if (loadDataSync('cloud_sync_migrated', '') !== 'v2') {
@@ -1653,10 +1666,10 @@ function syncHasLocalChanges() {
 }
 
 /**
- * Show the "Update available" modal and return a Promise that resolves true
- * (user accepted) or false (user dismissed / closed).
+ * Show the "Update available" modal and return a Promise that resolves with the
+ * user's choice: 'accept', 'push', or 'dismiss'. Resolves null if the modal is not in the DOM.
  * @param {object} remoteMeta - The parsed staktrakr-sync.json content
- * @returns {Promise<boolean>}
+ * @returns {Promise<'accept'|'push'|'dismiss'|null>}
  */
 function showSyncUpdateModal(remoteMeta) {
   return new Promise(function (resolve) {
@@ -1743,7 +1756,7 @@ async function handleRemoteChange(remoteMeta) {
       if (choice === 'push') {
         // User chose to assert local data as authoritative — push over remote
         console.warn('[CloudSync] handleRemoteChange: user chose Push My Data');
-        pushSyncVault();
+        pushSyncVault().catch(function(e) { console.error('[CloudSync] Push My Data failed:', e); });
         return;
       }
       if (!choice || choice === 'dismiss') {
@@ -1798,16 +1811,7 @@ async function pullSyncVault(remoteMeta) {
     return;
   }
 
-  var _pullAccountId = localStorage.getItem('cloud_dropbox_account_id');
-  if (!_pullAccountId) {
-    console.warn('[CloudSync] pullSyncVault: cloud_dropbox_account_id missing — aborting');
-    if (typeof showCloudToast === 'function') {
-      showCloudToast(
-        'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
-      );
-    }
-    return;
-  }
+  if (!_assertSyncAccountId('pullSyncVault')) return;
 
   var token = typeof cloudGetToken === 'function' ? await cloudGetToken(_syncProvider) : null;
   if (!token) throw new Error('Not connected to cloud provider');
@@ -2363,16 +2367,7 @@ async function pullWithPreview(remoteMeta) {
     return;
   }
 
-  var _pullPreviewAccountId = localStorage.getItem('cloud_dropbox_account_id');
-  if (!_pullPreviewAccountId) {
-    console.warn('[CloudSync] pullWithPreview: cloud_dropbox_account_id missing — aborting');
-    if (typeof showCloudToast === 'function') {
-      showCloudToast(
-        'Cloud sync setup is incomplete on this device. Please reconnect Dropbox to refresh your account identity.'
-      );
-    }
-    return;
-  }
+  if (!_assertSyncAccountId('pullWithPreview')) return;
 
   var token = typeof cloudGetToken === 'function' ? await cloudGetToken(_syncProvider) : null;
   if (!token) {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -281,11 +281,15 @@
     }
 
     // Apply button count
+    // Only disable when there ARE selectable items but none are checked.
+    // When the diff is empty (no items at all), Apply should be enabled so the
+    // user can acknowledge "no changes" and let onApply record the pull timestamp.
     if (applyBtn) {
       var count = _checkedCount();
+      var hasSelectableItems = Object.keys(_checkedItems).length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
-      applyBtn.disabled = count === 0;
-      applyBtn.style.opacity = count === 0 ? '0.4' : '';
+      applyBtn.disabled = hasSelectableItems && count === 0;
+      applyBtn.style.opacity = (hasSelectableItems && count === 0) ? '0.4' : '';
     }
 
     // Count row (backup import flow only)
@@ -415,9 +419,10 @@
     var applyBtn = safeGetElement('diffReviewApplyBtn');
     if (applyBtn) {
       var count = _checkedCount();
+      var hasSelectableItems = Object.keys(_checkedItems).length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
-      applyBtn.disabled = count === 0;
-      applyBtn.style.opacity = count === 0 ? '0.4' : '';
+      applyBtn.disabled = hasSelectableItems && count === 0;
+      applyBtn.style.opacity = (hasSelectableItems && count === 0) ? '0.4' : '';
     }
     _updateCountRow();
   }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772561958';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772562537';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772560836';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772561958';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772559665';
+const CACHE_NAME = 'staktrakr-v3.33.30-b1772560836';
 
 
 

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,8 +2,8 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.30
+date: 2026-03-03
 sourceFiles:
   - js/cloud-storage.js
   - js/cloud-sync.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.30 — 2026-03-03
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`
 
 ## Overview
@@ -267,12 +267,13 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 
 ### Auto-Sync Pull (`pullSyncVault` in `cloud-sync.js`)
 
-1. `syncSaveOverrideBackup()` — snapshot all `SYNC_SCOPE_KEYS` to `cloud_sync_override_backup` in localStorage (rollback-only backup)
-2. Download inventory vault from `/StakTrakr/sync/staktrakr-sync.stvault`
-3. `vaultDecryptAndRestore(fileBytes, password)` — decrypt and write sync-scoped localStorage keys
-4. Check remote `staktrakr-sync.json` `imageVault.hash` vs last pull hash
-5. If image hash changed: download image vault → `vaultDecryptAndRestoreImages()`
-6. Post-restore sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`
+1. Guard: `cloud_dropbox_account_id` must be present — if missing, a toast is shown and the pull aborts before any network call
+2. `syncSaveOverrideBackup()` — snapshot all `SYNC_SCOPE_KEYS` to `cloud_sync_override_backup` in localStorage (rollback-only backup)
+3. Download inventory vault from `/StakTrakr/sync/staktrakr-sync.stvault`
+4. `vaultDecryptAndRestore(fileBytes, password)` — decrypt and write sync-scoped localStorage keys
+5. Check remote `staktrakr-sync.json` `imageVault.hash` vs last pull hash
+6. If image hash changed: download image vault → `vaultDecryptAndRestoreImages()`
+7. Post-restore sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`
 
 ### Auto-Sync Push (`pushSyncVault` in `cloud-sync.js`)
 

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,8 +2,8 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.30
+date: 2026-03-03
 sourceFiles:
   - js/cloud-sync.js
   - js/cloud-storage.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.30 — 2026-03-03
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -49,6 +49,7 @@ A separate image vault lives at:
 3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before opening any modal. If you add a new pull path, replicate this cancel guard or the vault overwrite race will reopen.
 4. **Do not duplicate `getSyncPassword()` logic** — the fast-path check at the top delegates to `getSyncPasswordSilent()`, which handles both modes and the migration edge case. Adding a second localStorage read before it breaks Simple-mode migration.
 5. **Only the leader tab pushes and polls** — `_syncIsLeader` guards both `pushSyncVault()` and `pollForRemoteChanges()`. Do not call the underlying network operations directly from UI code without this guard, or multi-tab races occur.
+6. **`cloud_dropbox_account_id` is required on every pull/poll path** — `pollForRemoteChanges()`, `pullSyncVault()`, and `pullWithPreview()` all check for a present `cloud_dropbox_account_id` before attempting any decrypt. Missing accountId yields an early-return with a "setup incomplete" toast instead of a misleading "Wrong Vault Password" error.
 
 ---
 
@@ -108,7 +109,7 @@ getSyncPasswordSilent()
   └─ null → caller must call getSyncPassword() to open the password modal
 ```
 
-`getSyncPassword()` checks `getSyncPasswordSilent()` first. If null, opens `cloudSyncPasswordModal`. On confirm, writes `cloud_vault_password` to localStorage and fires `pushSyncVault()` 100ms later.
+`getSyncPassword()` checks `getSyncPasswordSilent()` first. If null, opens `cloudSyncPasswordModal`. On confirm, re-reads `cloud_dropbox_account_id` — if still absent, an in-modal error is displayed ("No Dropbox account ID found. Please cancel and reconnect your Dropbox account.") and the modal stays open; if present, writes `cloud_vault_password` to localStorage and resolves the composite key.
 
 ### Multi-Tab Coordination
 
@@ -141,7 +142,7 @@ getSyncPasswordSilent()
 | `showSyncConflictModal(opts)` | `({local, remote, remoteMeta}) → void` | Display conflict modal with Keep Mine / Keep Theirs / Skip. |
 | `showSyncUpdateModal(remoteMeta)` | `(object) → Promise<boolean>` | Display "Update available" modal, resolves true/false on user action. |
 | `getSyncPasswordSilent()` | `() → string\|null` | Non-interactive key derivation — safe to call from background loops. |
-| `getSyncPassword()` | `() → Promise<string\|null>` | Interactive key prompt — falls back to modal if `getSyncPasswordSilent()` returns null. |
+| `getSyncPassword()` | `() → Promise<string\|null>` | Interactive key prompt — opens password modal; shows in-modal error if `cloud_dropbox_account_id` is absent at confirm time. |
 | `changeVaultPassword(newPassword)` | `(string) → Promise<boolean>` | Update vault password in localStorage and trigger re-encrypt push. |
 | `syncSaveOverrideBackup()` | `() → void` | Snapshot all `SYNC_SCOPE_KEYS` from localStorage before a pull overwrites them. |
 | `syncRestoreOverrideBackup()` | `() → Promise<void>` | Restore the pre-pull snapshot (with confirmation dialog). |
@@ -217,6 +218,7 @@ Rate limiting (HTTP 429): exponential backoff doubles `_syncRetryDelay` on each 
 ```
 pollForRemoteChanges()
   ├─ Guard: syncIsEnabled() + _syncIsLeader + !document.hidden + token
+  ├─ Guard: cloud_dropbox_account_id present (toast + return if missing)
   ├─ Download: /sync/staktrakr-sync.json
   ├─ Legacy fallback: if 404/409, retry at SYNC_META_PATH_LEGACY
   ├─ Echo detection: if remoteMeta.deviceId === getSyncDeviceId() → skip (our own push)
@@ -246,6 +248,7 @@ handleRemoteChange(remoteMeta)
 ```
 pullWithPreview(remoteMeta)
   ├─ getSyncPasswordSilent() or getSyncPassword()
+  ├─ Guard: cloud_dropbox_account_id present (toast + return if missing)
   │
   ├─ Manifest-first path (preferred):
   │    ├─ Download /sync/staktrakr-sync.stmanifest
@@ -267,6 +270,7 @@ pullWithPreview(remoteMeta)
 ```
 pullSyncVault(remoteMeta)
   ├─ getSyncPasswordSilent() or getSyncPassword()
+  ├─ Guard: cloud_dropbox_account_id present (toast + return if missing)
   ├─ token guard (THROWS if no token — callers MUST .catch())
   ├─ Download /sync/staktrakr-sync.stvault
   ├─ syncSaveOverrideBackup()
@@ -349,10 +353,27 @@ The override backup is the safety net for "Keep Theirs" conflicts or unwanted sy
 - **`pushSyncVault()`** — all errors caught internally; sets status indicator to `'error'`; returns silently. No caller catch required.
 - **`pullSyncVault()`** — token guard THROWS before the internal try/catch. All callers must `.catch()` or wrap in try/catch.
 - **`pullWithPreview()`** — catches internally; falls back to `pullSyncVault()` on outer error; sets status indicator to `'error'`.
+- **Missing `cloud_dropbox_account_id`** — `pollForRemoteChanges()`, `pullSyncVault()`, and `pullWithPreview()` all guard against a missing accountId. Each fires a `console.warn('[CloudSync] … cloud_dropbox_account_id missing')` and a `showCloudToast('Cloud sync setup is incomplete on this device. Please reconnect Dropbox…')` then returns early. No decrypt is attempted.
+- **`getSyncPassword()` missing accountId at confirm time** — the onConfirm handler re-reads `cloud_dropbox_account_id`; if absent, it injects an error message into the modal's error element and returns without closing (modal stays open for the user to cancel and reconnect). The `appPrompt` fallback path resolves `null` when accountId is missing.
 - **`buildAndUploadManifest()`** — must be called inside try/catch; failure is intentionally non-blocking relative to the vault push.
 - **Image vault** — all image upload/download errors are caught with `console.warn`; inventory sync continues uninterrupted.
 - **Rate limiting (429)** — `pushSyncVault()` and `pollForRemoteChanges()` both handle 429 by doubling `_syncRetryDelay` (capped at 5 min). Resets to `SYNC_POLL_INTERVAL` on success.
 - **Activity log** — `recordCloudActivity()` is called on every meaningful cloud operation (connect, disconnect, push, pull, backup, restore, refresh, auth failure) with action, provider, result, detail, and duration.
+
+### Pre-decrypt diagnostics
+
+`_tryDecryptVault(fileBytes, artifactLabel?)` and `_tryDecryptMetadata(parsed)` each emit a structured `console.warn` **before entering the key-candidate loop**:
+
+```
+[CloudSync] decrypt attempt: artifact=stvault vaultPw: true accountId: dbid:abc1… (40 chars) candidates: 3
+[CloudSync] decrypt attempt: artifact=metadata vaultPw: true accountId: MISSING candidates: 0
+```
+
+Fields logged:
+- `artifact` — `'stvault'` (all `_tryDecryptVault` call sites), `'metadata'` (`_tryDecryptMetadata`)
+- `vaultPw` — boolean presence of `cloud_vault_password`
+- `accountId` — first 8 chars + length if present, or `MISSING`
+- `candidates` — count from `_getSyncKeyCandidates()` (0 when accountId is missing, since no valid composite key can be formed)
 
 ---
 


### PR DESCRIPTION
## Summary

- **Account_id guard in `getSyncPassword()` `onConfirm`**: when `cloud_dropbox_account_id` is missing at confirm time, show an in-modal error ("No Dropbox account ID found. Please cancel and reconnect your Dropbox account.") instead of silently constructing a bare password key
- **`appPrompt` fallback now resolves `null`** when freshId is absent, so callers that check `!password` correctly abort
- **`pollForRemoteChanges()` guard**: early-return with a toast before any metadata download/decrypt when accountId is missing — prevents misleading "Wrong Vault Password" decrypt failure
- **`pullSyncVault()` guard**: same pattern after the password check, before vault download
- **`pullWithPreview()` guard**: same pattern before token fetch
- **Pre-decrypt structured logging**: `_tryDecryptVault()` and `_tryDecryptMetadata()` both emit a `console.warn` before entering the key-candidate loop showing `vaultPw` presence, `accountId` prefix + length (or `MISSING`), and candidate count
- **`_tryDecryptVault` `artifactLabel` param**: optional second arg; all 4 call sites now pass `'stvault'`

## What this fixes

Cross-device sync was failing with a generic "Wrong Vault Password" toast when the second browser had no `cloud_dropbox_account_id` in localStorage. The real cause was an incomplete sync key — missing accountId — not a bad password. These guards abort before any decrypt is attempted and give actionable feedback.

## Test plan

- [ ] Open browser with `cloud_dropbox_account_id` removed from localStorage, vault password set → enable auto-sync → toast reads "Cloud sync setup is incomplete…" (not "Wrong Vault Password")
- [ ] Click Sync Now in same state → same guard fires, no decrypt attempted
- [ ] DevTools console shows `accountId: MISSING` and `candidates: 0` in pre-decrypt log (guard fires before any decrypt)  
- [ ] After reconnecting Dropbox → accountId stored → full sync flow works normally
- [ ] Two browsers with correct accountId → console shows matching first-8-char prefix on both sides before decrypt

🤖 Generated with [Claude Code](https://claude.com/claude-code)