### PR TITLE
v3.33.31 — STAK-402: Fix manifest-first pull showing empty diff for seeded items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.31] - 2026-03-03
+
+### Fixed — Manifest-First Pull Shows Real Diff (STAK-402)
+
+- **Fixed**: `pullWithPreview` manifest-first path now falls through to vault-first when manifest reports zero changes but remote item count differs from local — seeded/imported items have no changeLog entries, so the manifest was always empty for first-time sync
+- **Fixed**: `DiffModal._onApply` passes `null` (not `[]`) when no diff items were shown, signaling callers to do a full restore rather than apply zero changes
+
+---
+
 ## [3.33.30] - 2026-03-03
 
 ### Fixed — Bi-Directional Sync Fix (STAK-398)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Sync Diff Preview Fix (v3.33.31)**: Pull preview now shows real item differences instead of "No changes detected" when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402).
 - **Bi-Directional Sync Fix (v3.33.30)**: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398).
 - **Cloud Backup/Restore Pipeline Fix (v3.33.29)**: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382).
 - **Documentation Accuracy Cleanup (v3.33.27)**: Full audit fix — script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved across instruction files, skills, and wiki (STAK-397).

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.31 &ndash; Sync Diff Preview Fix</strong>: Pull preview now shows real item differences instead of &ldquo;No changes detected&rdquo; when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402)</li>
     <li><strong>v3.33.30 &ndash; Bi-Directional Sync Fix</strong>: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398)</li>
     <li><strong>v3.33.29 &ndash; Cloud Backup/Restore Pipeline Fix</strong>: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382)</li>
     <li><strong>v3.33.27 &ndash; Documentation Accuracy Cleanup</strong>: Full audit fix &mdash; script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved (STAK-397)</li>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2402,6 +2402,18 @@ async function pullWithPreview(remoteMeta) {
           // Build diff-like result from manifest data
           var manifestDiff = _buildDiffFromManifest(manifest);
 
+          // STAK-402: If the manifest shows zero changes but the remote item count
+          // differs from the local inventory, the manifest was built from an empty
+          // changeLog (seeded/imported items have no changeLog entries). Fall through
+          // to the vault-first path which does a full DiffEngine.compareItems comparison.
+          var _mChanges = manifestDiff.added.length + manifestDiff.modified.length + manifestDiff.deleted.length;
+          var _mRemoteCount = remoteMeta ? (remoteMeta.itemCount || 0) : 0;
+          var _mLocalCount = typeof inventory !== 'undefined' ? inventory.length : 0;
+          if (_mChanges === 0 && _mRemoteCount !== _mLocalCount) {
+            debugLog('[CloudSync] Manifest diff empty but item counts differ (' + _mRemoteCount + ' remote vs ' + _mLocalCount + ' local) — using vault-first');
+            throw new Error('Manifest stale: empty diff with count mismatch');
+          }
+
           // Stash pull metadata
           _previewPullMeta = {
             syncId: remoteMeta ? remoteMeta.syncId : null,

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2408,7 +2408,7 @@ async function pullWithPreview(remoteMeta) {
           // to the vault-first path which does a full DiffEngine.compareItems comparison.
           var _mChanges = manifestDiff.added.length + manifestDiff.modified.length + manifestDiff.deleted.length;
           var _mRemoteCount = remoteMeta ? (remoteMeta.itemCount || 0) : 0;
-          var _mLocalCount = typeof inventory !== 'undefined' ? inventory.length : 0;
+          var _mLocalCount = (typeof inventory !== 'undefined' && inventory) ? inventory.length : 0;
           if (_mChanges === 0 && _mRemoteCount !== _mLocalCount) {
             debugLog('[CloudSync] Manifest diff empty but item counts differ (' + _mRemoteCount + ' remote vs ' + _mLocalCount + ' local) — using vault-first');
             throw new Error('Manifest stale: empty diff with count mismatch');

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.30";
+const APP_VERSION = "3.33.31";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -364,7 +364,7 @@
         // Detail line
         var detail = [];
         if (item.metal) detail.push(_esc(item.metal));
-        if (item.weight != null) detail.push(item.weight + (item.weightUnit || 'oz'));
+        if (item.weight != null) detail.push(item.weight + _esc(item.weightUnit || 'oz'));
         if (item.qty != null) detail.push('\u00d7 ' + item.qty);
         if (detail.length > 0) {
           html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -519,6 +519,12 @@
 
   function _onApply() {
     var selected = _buildSelectedChanges();
+    // STAK-402: When _checkedItems is empty (empty diff — no selectable items were shown),
+    // pass null instead of [] to signal "accept all / full overwrite". Callers that
+    // check `selectedChanges &&` treat null as "no selective picks, do full restore".
+    // This differs from the intentional "deselect all" case where _checkedItems has
+    // entries but they are all false (then selected is [] and apply-nothing is correct).
+    if (Object.keys(_checkedItems).length === 0) selected = null;
     // Capture callback before close() — close() nullifies _options
     var callback = _options && _options.onApply;
     DiffModal.close();

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.31-b1772564092';
+const CACHE_NAME = 'staktrakr-v3.33.31-b1772564096';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.31-b1772563428';
+const CACHE_NAME = 'staktrakr-v3.33.31-b1772564092';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.30-b1772562537';
+const CACHE_NAME = 'staktrakr-v3.33.31-b1772563428';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.30",
+  "version": "3.33.31",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after testing passes.

## Changes

- **`pullWithPreview`**: Falls through to vault-first path when the manifest diff is empty but remote item count differs from local. The manifest records field-level changeLog entries — seeded/imported items have no changeLog history, so `manifest.changes = []` even though inventories differ. This caused "No changes detected" on every first-time sync.
- **`DiffModal._onApply`**: Passes `null` (not `[]`) to `onApply` when `_checkedItems` is empty. This signals callers to do a full vault restore rather than "apply zero changes". Previously, clicking Apply on an empty diff recorded `lastPull` and unblocked the push guard — the debounced push then fired and overwrote the remote vault with local data.

## Linear Issues

- [STAK-402: Manifest-first pull shows empty diff for seeded items](https://linear.app/lbruton/issue/STAK-402)

## Test scenario

1. Device A: 8 items (or 16 items)
2. Device B: different item count
3. Device B polls → Sync Update Available → Accept Update
4. **Before fix**: Review Sync Changes shows "No changes detected", Apply does nothing, push fires after modal closes
5. **After fix**: Review Sync Changes shows actual added/deleted items from vault-first diff, Apply restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)