### PR TITLE
v3.33.32 — STAK-403: Fix Keep Mine conflict resolution infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.32] - 2026-03-03
+
+### Fixed — Keep Mine Conflict Resolution Infinite Loop (STAK-403)
+
+- **Fixed**: `keepMineBtn.onclick` and "Push My Data" paths now set a one-shot `_syncConflictUserOverride` flag before calling `pushSyncVault()` — the pre-push Layer 0 check bypasses conflict re-detection exactly once, allowing the push to complete instead of looping back to `handleRemoteChange()`
+- **Fixed**: `appConfirm` fallback conflict path also sets the override flag, covering the modal-less conflict resolution case
+
+---
+
 ## [3.33.31] - 2026-03-03
 
 ### Fixed — Manifest-First Pull Shows Real Diff (STAK-402)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Keep Mine Conflict Fix (v3.33.32)**: Pressing Keep Mine or Push My Data now completes the push — a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403).
 - **Sync Diff Preview Fix (v3.33.31)**: Pull preview now shows real item differences instead of "No changes detected" when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402).
 - **Bi-Directional Sync Fix (v3.33.30)**: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398).
 - **Cloud Backup/Restore Pipeline Fix (v3.33.29)**: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382).
 - **Documentation Accuracy Cleanup (v3.33.27)**: Full audit fix — script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved across instruction files, skills, and wiki (STAK-397).
-- **Browserbase Test Runbook v2 (v3.33.25)**: Modular E2E test runbook with 75+ tests across 8 section files. `/bb-test` skill now reads runbook Markdown at runtime with section and tag filtering (STAK-396).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.32 &ndash; Keep Mine Conflict Fix</strong>: Pressing Keep Mine or Push My Data now completes the push &mdash; a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403)</li>
     <li><strong>v3.33.31 &ndash; Sync Diff Preview Fix</strong>: Pull preview now shows real item differences instead of &ldquo;No changes detected&rdquo; when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402)</li>
     <li><strong>v3.33.30 &ndash; Bi-Directional Sync Fix</strong>: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398)</li>
     <li><strong>v3.33.29 &ndash; Cloud Backup/Restore Pipeline Fix</strong>: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382)</li>
     <li><strong>v3.33.27 &ndash; Documentation Accuracy Cleanup</strong>: Full audit fix &mdash; script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved (STAK-397)</li>
-    <li><strong>v3.33.25 &ndash; Browserbase Test Runbook v2</strong>: Modular E2E test runbook with 75+ tests across 8 section files. /bb-test skill reads runbook Markdown at runtime with section and tag filtering (STAK-396)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -32,6 +32,9 @@ var _syncRemoteChangeActive = false;
 /** @type {boolean} Whether vault password was just changed — skip pre-push metadata decryption */
 var _syncPasswordJustChanged = false;
 
+/** @type {boolean} Set true when user explicitly chose Keep Mine or Push My Data — bypasses the pre-push conflict re-detection exactly once. */
+var _syncConflictUserOverride = false;
+
 /** @type {number} Retry backoff multiplier for 429 / network errors */
 var _syncRetryDelay = 2000;
 
@@ -1066,6 +1069,10 @@ async function pushSyncVault() {
     // always beats pollForRemoteChanges (10min interval).
     // -----------------------------------------------------------------------
     try {
+      // [STAK-403] Snapshot + clear override flag before the async fetch so any early
+      // exit (network error, etc.) does not leave the flag stale across calls.
+      var _prePushOverride = _syncConflictUserOverride;
+      _syncConflictUserOverride = false;
       console.warn('[CloudSync] Pre-push check: starting metadata download from', SYNC_META_PATH);
       var prePushApiArg = JSON.stringify({ path: SYNC_META_PATH });
       var prePushResp = await fetch('https://content.dropboxapi.com/2/files/download', {
@@ -1177,7 +1184,11 @@ async function pushSyncVault() {
           console.warn('[CloudSync] Pre-push check: comparing — remote.deviceId:', prePushMeta.deviceId, 'myDeviceId:', myDeviceId, 'remote.syncId:', prePushMeta.syncId, 'lastPull:', lastPull ? lastPull.syncId : 'null');
 
           // If a DIFFERENT device pushed AND we haven't pulled this syncId yet
-          if (prePushMeta.deviceId !== myDeviceId &&
+          if (_prePushOverride) {
+            console.warn('[CloudSync] Pre-push check: BYPASS — user explicitly resolved conflict, overwriting remote');
+            logCloudSyncActivity('auto_sync_push', 'info', 'Pre-push conflict check bypassed — user resolved conflict');
+            // fall through to push
+          } else if (prePushMeta.deviceId !== myDeviceId &&
               (!lastPull || lastPull.syncId !== prePushMeta.syncId)) {
             console.warn('[CloudSync] Pre-push check: BLOCKING — remote change from device', prePushMeta.deviceId.slice(0, 8), '— routing to handleRemoteChange');
             logCloudSyncActivity('auto_sync_push', 'deferred', 'Remote change detected from device ' + prePushMeta.deviceId.slice(0, 8) + ' — showing diff');
@@ -1756,6 +1767,7 @@ async function handleRemoteChange(remoteMeta) {
       if (choice === 'push') {
         // User chose to assert local data as authoritative — push over remote
         console.warn('[CloudSync] handleRemoteChange: user chose Push My Data');
+        _syncConflictUserOverride = true;
         pushSyncVault().catch(function(e) { console.error('[CloudSync] Push My Data failed:', e); });
         return;
       }
@@ -1946,7 +1958,7 @@ function showSyncConflictModal(opts) {
         'Keep YOUR local version? (Cancel to keep the remote version)';
       if (typeof appConfirm === 'function') {
         appConfirm(msg, 'Sync Conflict').then(function (keepMine) {
-          if (keepMine) pushSyncVault();
+          if (keepMine) { _syncConflictUserOverride = true; pushSyncVault(); }
           else pullWithPreview(opts.remoteMeta).catch(function (err) {
             debugLog('[CloudSync] pullWithPreview failed in conflict fallback:', err);
             updateSyncStatusIndicator('error', 'Pull failed — ' + err.message);
@@ -1986,6 +1998,7 @@ function showSyncConflictModal(opts) {
     if (keepMineBtn) {
       keepMineBtn.onclick = function () {
         closeModal();
+        _syncConflictUserOverride = true;
         pushSyncVault();
         resolve();
       };

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1958,7 +1958,7 @@ function showSyncConflictModal(opts) {
         'Keep YOUR local version? (Cancel to keep the remote version)';
       if (typeof appConfirm === 'function') {
         appConfirm(msg, 'Sync Conflict').then(function (keepMine) {
-          if (keepMine) { _syncConflictUserOverride = true; pushSyncVault(); }
+          if (keepMine) { _syncConflictUserOverride = true; pushSyncVault().catch(function(e) { console.error('[CloudSync] Keep Mine (fallback) push failed:', e); }); }
           else pullWithPreview(opts.remoteMeta).catch(function (err) {
             debugLog('[CloudSync] pullWithPreview failed in conflict fallback:', err);
             updateSyncStatusIndicator('error', 'Pull failed — ' + err.message);
@@ -1999,7 +1999,7 @@ function showSyncConflictModal(opts) {
       keepMineBtn.onclick = function () {
         closeModal();
         _syncConflictUserOverride = true;
-        pushSyncVault();
+        pushSyncVault().catch(function(e) { console.error('[CloudSync] Keep Mine push failed:', e); });
         resolve();
       };
     }

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.31";
+const APP_VERSION = "3.33.32";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.31-b1772564096';
+const CACHE_NAME = 'staktrakr-v3.33.32-b1772567506';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.32-b1772567506';
+const CACHE_NAME = 'staktrakr-v3.33.32-b1772569185';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.31",
+  "version": "3.33.32",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,7 +2,7 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.30
+lastUpdated: v3.33.32
 date: 2026-03-03
 sourceFiles:
   - js/cloud-sync.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.33.30 — 2026-03-03
+> **Last updated:** v3.33.32 — 2026-03-03
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -235,10 +235,13 @@ handleRemoteChange(remoteMeta)
   ├─ scheduleSyncPush.cancel()   ← CRITICAL: prevents vault overwrite race
   ├─ syncHasLocalChanges()?
   │    No  → showSyncUpdateModal() → user accepts → pullWithPreview()
+  │                                  user chooses "Push My Data"
+  │                                    → _syncConflictUserOverride = true → pushSyncVault()
   │    Yes → showSyncConflictModal()
-  │             ├─ Keep Mine  → pushSyncVault()
+  │             ├─ Keep Mine  → _syncConflictUserOverride = true → pushSyncVault()
   │             ├─ Keep Theirs → pullWithPreview(remoteMeta)
   │             └─ Skip → close modal
+  │             (appConfirm fallback: keepMine → _syncConflictUserOverride = true → pushSyncVault())
 ```
 
 ### Pull (Dropbox → inventory)
@@ -309,6 +312,39 @@ Choices:
 - **Skip** → close modal, no action (remote change will reappear on next poll)
 
 The override backup (`syncSaveOverrideBackup`) is written before any pull, enabling "Restore This Snapshot" in the Sync History section.
+
+### Keep Mine / Push My Data — conflict bypass flag (STAK-403, v3.33.32)
+
+**Problem:** Choosing "Keep Mine" in the conflict modal or "Push My Data" in the update modal triggered `pushSyncVault()`, which immediately re-ran the Layer 0 pre-push remote check. That check detected the same unacknowledged remote change the user had just explicitly dismissed and re-routed back to `handleRemoteChange()` — creating an infinite conflict-resolution loop.
+
+**Fix:** A module-level one-shot flag `_syncConflictUserOverride` (initialized `false`, line 36 of `cloud-sync.js`) is set `true` at three call sites immediately before `pushSyncVault()` is invoked:
+
+1. `keepMineBtn.onclick` in `showSyncConflictModal`
+2. `showSyncUpdateModal` "Push My Data" branch inside `handleRemoteChange`
+3. `appConfirm` fallback branch in `showSyncConflictModal`
+
+At the start of the Layer 0 pre-push try block, the flag is snapshot-and-cleared atomically:
+
+```js
+var _prePushOverride = _syncConflictUserOverride;
+_syncConflictUserOverride = false;
+```
+
+Clearing before the async fetch ensures the flag cannot survive a network error or early return and affect a subsequent push call.
+
+After the remote metadata is decrypted and the device/syncId comparison runs, the bypass branch is evaluated first:
+
+```js
+if (_prePushOverride) {
+  console.warn('[CloudSync] Pre-push check: BYPASS — user explicitly resolved conflict, overwriting remote');
+  logCloudSyncActivity('auto_sync_push', 'info', 'Pre-push conflict check bypassed — user resolved conflict');
+  // fall through to push
+} else if (prePushMeta.deviceId !== myDeviceId && (!lastPull || lastPull.syncId !== prePushMeta.syncId)) {
+  // normal conflict routing
+}
+```
+
+The flag is purely one-shot: it is consumed (cleared) at the top of the next `pushSyncVault()` call regardless of outcome, so no permanent bypass accumulates.
 
 ---
 
@@ -444,6 +480,16 @@ scheduleSyncPush(); // for inventory changes
 **Fix (v3.32.24):** `handleRemoteChange()` calls `scheduleSyncPush.cancel()` as its first substantive action — before any modal is shown.
 
 **Both devices must be on v3.32.24+.** A device on v3.32.23 will still exhibit the bug on its own debounced push, even if the other device is updated.
+
+---
+
+## Keep Mine Conflict Resolution Infinite Loop (fixed v3.33.32, STAK-403)
+
+**Symptom:** Choosing "Keep Mine" in the conflict modal (or "Push My Data" in the update modal) caused the conflict modal to reappear immediately after every push, preventing the user from ever overwriting the remote vault.
+
+**Root cause:** The Layer 0 pre-push check (added in STAK-398) downloads and inspects remote metadata before every push. When the user chose "Keep Mine", the resulting `pushSyncVault()` call hit Layer 0, detected the same unacknowledged remote change the user had just dismissed, and re-routed to `handleRemoteChange()` — triggering the conflict modal again in a loop.
+
+**Fix (v3.33.32):** A module-level one-shot flag `_syncConflictUserOverride` is set `true` at the three call sites that represent explicit user intent to overwrite (Keep Mine button, Push My Data branch, appConfirm fallback). At the start of the Layer 0 try block the flag is snapshot-and-cleared; if the snapshot is `true` the conflict check is bypassed and the push proceeds. See the "Keep Mine / Push My Data — conflict bypass flag" section under Conflict Resolution for full details.
 
 ---
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: `keepMineBtn.onclick` sets `_syncConflictUserOverride = true` before calling `pushSyncVault()` — pre-push Layer 0 check bypasses conflict re-detection exactly once, push completes instead of looping
- **Fixed**: "Push My Data" path in `showSyncUpdateModal` also sets the override flag
- **Fixed**: `appConfirm` fallback conflict path sets the override flag (modal-less case)
- **Mechanism**: Snapshot-and-clear pattern — `var _prePushOverride = _syncConflictUserOverride; _syncConflictUserOverride = false;` at Layer 0 entry; bypass branch inserted before existing `handleRemoteChange` routing

## Linear Issues

- [STAK-403: Fix Keep Mine conflict resolution loops infinitely — push blocked by pre-push check](https://linear.app/lbruton/issue/STAK-403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)