### PR TITLE
v3.33.33 — STAK-405: Fix cloud button and Settings Cloud tab hidden when not connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.33] - 2026-03-03
+
+### Fixed — Cloud Button and Settings Tab Always Visible (STAK-405)
+
+- **Fixed**: Cloud header button is now always visible — removed the `!connected` early-return that hid the button when no OAuth token was stored, blocking access to cloud setup
+- **Fixed**: Cloud tab in Settings is now always visible — removed the STAK-317 hide block that suppressed the nav item when no provider was connected; the gray dot state communicates "not connected" without hiding the UI entry point
+
+---
+
 ## [3.33.32] - 2026-03-03
 
 ### Fixed — Keep Mine Conflict Resolution Infinite Loop (STAK-403)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Cloud Button Always Visible (v3.33.33)**: Cloud header button and Settings Cloud tab are now always shown — removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405).
 - **Keep Mine Conflict Fix (v3.33.32)**: Pressing Keep Mine or Push My Data now completes the push — a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403).
 - **Sync Diff Preview Fix (v3.33.31)**: Pull preview now shows real item differences instead of "No changes detected" when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402).
 - **Bi-Directional Sync Fix (v3.33.30)**: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398).
 - **Cloud Backup/Restore Pipeline Fix (v3.33.29)**: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382).
-- **Documentation Accuracy Cleanup (v3.33.27)**: Full audit fix — script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved across instruction files, skills, and wiki (STAK-397).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.33 &ndash; Cloud Button Always Visible</strong>: Cloud header button and Settings Cloud tab are now always shown &mdash; removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405)</li>
     <li><strong>v3.33.32 &ndash; Keep Mine Conflict Fix</strong>: Pressing Keep Mine or Push My Data now completes the push &mdash; a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403)</li>
     <li><strong>v3.33.31 &ndash; Sync Diff Preview Fix</strong>: Pull preview now shows real item differences instead of &ldquo;No changes detected&rdquo; when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402)</li>
     <li><strong>v3.33.30 &ndash; Bi-Directional Sync Fix</strong>: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398)</li>
     <li><strong>v3.33.29 &ndash; Cloud Backup/Restore Pipeline Fix</strong>: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382)</li>
-    <li><strong>v3.33.27 &ndash; Documentation Accuracy Cleanup</strong>: Full audit fix &mdash; script counts, test section names, skill references, wiki page counts, and stale file removal. 24 issues resolved (STAK-397)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -430,14 +430,8 @@ function updateCloudSyncHeaderBtn() {
 
   var connected = typeof cloudIsConnected === 'function' ? cloudIsConnected(_syncProvider) : false;
 
-  // Show the button whenever a cloud provider is connected, regardless of
-  // cloud_sync_enabled.  The user needs the button to see cloud status and
-  // to enable/configure sync.  Hide only when no provider is connected at all.
-  if (!connected) {
-    btn.style.display = 'none';
-    return;
-  }
-
+  // Always show the Cloud button — it is the entry point for cloud setup and status.
+  // The gray dot state handles the "not connected" case visually.
   btn.style.display = '';
   if (!dot) return;
   dot.className = 'cloud-sync-dot header-cloud-dot';

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.32";
+const APP_VERSION = "3.33.33";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/settings.js
+++ b/js/settings.js
@@ -391,12 +391,6 @@ const syncSettingsUI = () => {
     switchProviderTab('NUMISTA');
   }
 
-  // Hide Cloud nav item when no provider is connected (STAK-317)
-  const cloudNavItem = document.querySelector('.settings-nav-item[data-section="cloud"]');
-  if (cloudNavItem && typeof cloudIsConnected === 'function' && typeof CLOUD_PROVIDERS !== 'undefined') {
-    const connectedCount = Object.keys(CLOUD_PROVIDERS).filter(p => cloudIsConnected(p)).length;
-    cloudNavItem.style.display = connectedCount >= 1 ? '' : 'none';
-  }
 };
 
 /**

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.32-b1772569935';
+const CACHE_NAME = 'staktrakr-v3.33.33-b1772570107';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.32-b1772569185';
+const CACHE_NAME = 'staktrakr-v3.33.32-b1772569935';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.32",
+  "version": "3.33.33",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **`cloud-sync.js`**: `updateCloudSyncHeaderBtn()` no longer hides the button when no OAuth token is stored. Gray dot state already communicates "not connected" — hiding blocked users from accessing cloud setup entirely.
- **`settings.js`**: Removed STAK-317 block that hid the Cloud nav tab when no provider was connected. Cloud tab is the only way to reach cloud setup, so hiding it was a dead end for new users.

## Linear Issues

- [STAK-405: Fix cloud header button and Settings Cloud tab hidden when not connected](https://linear.app/lbruton/issue/STAK-405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)