### PR TITLE
v3.33.34 — STAK-406: Fix cloud sync push racing with DiffModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.34] - 2026-03-03
+
+### Fixed — Cloud Sync Push Race with DiffModal (STAK-406)
+
+- **Fixed**: `pullWithPreview()` now awaits the user's DiffModal decision (Apply or Cancel) before returning — previously it returned immediately after showing the modal, clearing `_syncRemoteChangeActive` while the user was still reading the diff, allowing a concurrent `pushSyncVault()` call to overwrite Dropbox with stale local data before the pull was applied
+- **Fixed**: `showRestorePreviewModal()` (vault-first path) now returns a Promise that resolves after the user completes the modal, so the vault-first pull is also fully awaited
+- **Fixed**: `_deferredVaultRestore()` is now awaited in the manifest-first `onApply` callback before the modal Promise resolves, ensuring the full vault download and apply completes before any push can proceed
+
+---
+
 ## [3.33.33] - 2026-03-03
 
 ### Fixed — Cloud Button and Settings Tab Always Visible (STAK-405)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync Pull Race Fix (v3.33.34)**: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open — the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406).
 - **Cloud Button Always Visible (v3.33.33)**: Cloud header button and Settings Cloud tab are now always shown — removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405).
 - **Keep Mine Conflict Fix (v3.33.32)**: Pressing Keep Mine or Push My Data now completes the push — a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403).
 - **Sync Diff Preview Fix (v3.33.31)**: Pull preview now shows real item differences instead of "No changes detected" when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402).
 - **Bi-Directional Sync Fix (v3.33.30)**: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398).
-- **Cloud Backup/Restore Pipeline Fix (v3.33.29)**: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.34 &ndash; Sync Pull Race Fix</strong>: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open &mdash; the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406)</li>
     <li><strong>v3.33.33 &ndash; Cloud Button Always Visible</strong>: Cloud header button and Settings Cloud tab are now always shown &mdash; removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405)</li>
     <li><strong>v3.33.32 &ndash; Keep Mine Conflict Fix</strong>: Pressing Keep Mine or Push My Data now completes the push &mdash; a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403)</li>
     <li><strong>v3.33.31 &ndash; Sync Diff Preview Fix</strong>: Pull preview now shows real item differences instead of &ldquo;No changes detected&rdquo; when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402)</li>
     <li><strong>v3.33.30 &ndash; Bi-Directional Sync Fix</strong>: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398)</li>
-    <li><strong>v3.33.29 &ndash; Cloud Backup/Restore Pipeline Fix</strong>: Fixed backup path functions, async/sync bugs in settings and migration checks, encrypted sync metadata with AES-256-GCM, restructured cloud card UI with backup count badge (STAK-398, STAK-382)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2144,75 +2144,81 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
  * @param {object} remoteMeta - Remote sync metadata
  */
 function showRestorePreviewModal(diffResult, settingsDiff, remotePayload, remoteMeta, conflicts) {
-  // Delegate to DiffModal (STAK-184) — falls back to false if unavailable
+  // Delegate to DiffModal (STAK-184) — falls back to null if unavailable.
+  // Returns a Promise that resolves when the user completes their modal action
+  // (Apply or Cancel), so callers can await the full pull before clearing
+  // _syncRemoteChangeActive. Returns null when DiffModal is unavailable.
   if (typeof DiffModal === 'undefined' || !DiffModal.show) {
     debugLog('[CloudSync] DiffModal not available — falling back');
-    return false;
+    return null;
   }
 
   var addedCount = diffResult.added ? diffResult.added.length : 0;
   var removedCount = diffResult.deleted ? diffResult.deleted.length : 0;
   var modifiedCount = diffResult.modified ? diffResult.modified.length : 0;
 
-  DiffModal.show({
-    source: { type: 'sync', label: _syncProvider || 'Cloud' },
-    diff: diffResult,
-    settingsDiff: settingsDiff || null,
-    conflicts: conflicts || null,
-    meta: {
-      deviceId: remoteMeta.deviceId,
-      timestamp: remoteMeta.timestamp,
-      itemCount: remoteMeta.itemCount,
-      appVersion: remoteMeta.appVersion
-    },
-    onApply: function (selectedChanges) {
-      try {
-        // Guard: fall back to full overwrite if DiffEngine unavailable
-        if (typeof DiffEngine === 'undefined' || !DiffEngine.applySelectedChanges) {
-          debugLog('[CloudSync] DiffEngine not available — falling back to full overwrite');
-          syncSaveOverrideBackup();
-          restoreVaultData(remotePayload).then(function () {
-            updateSyncStatusIndicator('idle', 'just now');
-            if (typeof refreshSyncUI === 'function') refreshSyncUI();
-            debugLog('[CloudSync] Full overwrite restore completed via fallback');
-          }).catch(function (restoreErr) {
-            debugLog('[CloudSync] Full overwrite restore failed:', restoreErr);
-            updateSyncStatusIndicator('error', 'Restore failed');
-            if (typeof showCloudToast === 'function') {
-              showCloudToast('Restore failed: ' + (restoreErr.message || 'Unknown error'));
-            }
-          });
-          return;
-        }
-
-        // Apply only the user-selected changes via DiffEngine
-        var newInv = DiffEngine.applySelectedChanges(inventory, selectedChanges);
-
-        // Build settings changes from settingsDiff
-        var settingsChanges = null;
-        if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
-          settingsChanges = [];
-          for (var i = 0; i < settingsDiff.changed.length; i++) {
-            settingsChanges.push({
-              key: settingsDiff.changed[i].key,
-              remoteVal: settingsDiff.changed[i].remoteVal
+  return new Promise(function (resolve) {
+    DiffModal.show({
+      source: { type: 'sync', label: _syncProvider || 'Cloud' },
+      diff: diffResult,
+      settingsDiff: settingsDiff || null,
+      conflicts: conflicts || null,
+      meta: {
+        deviceId: remoteMeta.deviceId,
+        timestamp: remoteMeta.timestamp,
+        itemCount: remoteMeta.itemCount,
+        appVersion: remoteMeta.appVersion
+      },
+      onApply: function (selectedChanges) {
+        var p;
+        try {
+          // Guard: fall back to full overwrite if DiffEngine unavailable
+          if (typeof DiffEngine === 'undefined' || !DiffEngine.applySelectedChanges) {
+            debugLog('[CloudSync] DiffEngine not available — falling back to full overwrite');
+            syncSaveOverrideBackup();
+            p = restoreVaultData(remotePayload).then(function () {
+              updateSyncStatusIndicator('idle', 'just now');
+              if (typeof refreshSyncUI === 'function') refreshSyncUI();
+              debugLog('[CloudSync] Full overwrite restore completed via fallback');
+            }).catch(function (restoreErr) {
+              debugLog('[CloudSync] Full overwrite restore failed:', restoreErr);
+              updateSyncStatusIndicator('error', 'Restore failed');
+              if (typeof showCloudToast === 'function') {
+                showCloudToast('Restore failed: ' + (restoreErr.message || 'Unknown error'));
+              }
             });
+          } else {
+            // Apply only the user-selected changes via DiffEngine
+            var newInv = DiffEngine.applySelectedChanges(inventory, selectedChanges);
+
+            // Build settings changes from settingsDiff
+            var settingsChanges = null;
+            if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
+              settingsChanges = [];
+              for (var i = 0; i < settingsDiff.changed.length; i++) {
+                settingsChanges.push({
+                  key: settingsDiff.changed[i].key,
+                  remoteVal: settingsDiff.changed[i].remoteVal
+                });
+              }
+            }
+
+            // Delegate everything to _applyAndFinalize (backup, save, render, toast, status, broadcast)
+            _applyAndFinalize(newInv, selectedChanges, settingsChanges, remoteMeta, { source: 'sync' });
+            debugLog('[CloudSync] Restore preview: applied selected changes via DiffEngine');
+            p = Promise.resolve();
           }
+        } catch (applyErr) {
+          debugLog('[CloudSync] Restore preview: apply failed:', applyErr);
+          updateSyncStatusIndicator('error', 'Restore failed');
+          if (typeof showCloudToast === 'function') showCloudToast('Restore failed: ' + applyErr.message);
+          p = Promise.resolve();
         }
-
-        // Delegate everything to _applyAndFinalize (backup, save, render, toast, status, broadcast)
-        _applyAndFinalize(newInv, selectedChanges, settingsChanges, remoteMeta, { source: 'sync' });
-        debugLog('[CloudSync] Restore preview: applied selected changes via DiffEngine');
-      } catch (applyErr) {
-        debugLog('[CloudSync] Restore preview: apply failed:', applyErr);
-        updateSyncStatusIndicator('error', 'Restore failed');
-        if (typeof showCloudToast === 'function') showCloudToast('Restore failed: ' + applyErr.message);
-      }
-    },
-    onCancel: function () { /* no-op */ }
+        p.then(resolve).catch(resolve);
+      },
+      onCancel: function () { resolve(); }
+    });
   });
-
-  return true;
 }
 
 /**
@@ -2479,24 +2485,32 @@ async function pullWithPreview(remoteMeta) {
             manifestConflicts = null;
           }
 
-          // Show DiffModal with manifest preview — vault download deferred to onApply
-          DiffModal.show({
-            source: { type: 'sync', label: _syncProvider || 'Cloud' },
-            diff: manifestDiff,
-            conflicts: manifestConflicts || null,
-            meta: {
-              deviceId: manifest.deviceId || (remoteMeta ? remoteMeta.deviceId : null),
-              timestamp: remoteMeta ? remoteMeta.timestamp : null,
-              itemCount: remoteMeta ? remoteMeta.itemCount : null,
-              appVersion: remoteMeta ? remoteMeta.appVersion : null,
-            },
-            onApply: function (selectedChanges) {
-              // Deferred: download full vault, decrypt, selective apply
-              _deferredVaultRestore(token, password, remoteMeta, selectedChanges);
-            },
-            onCancel: function () {
-              debugLog('[CloudSync] Manifest preview cancelled — no vault download');
-            }
+          // STAK-406: Await user decision in DiffModal before returning.
+          // This keeps _syncRemoteChangeActive=true (set by handleRemoteChange)
+          // until the full pull is applied, preventing a concurrent push from
+          // racing and overwriting the remote vault with stale local data.
+          await new Promise(function (resolveModal) {
+            DiffModal.show({
+              source: { type: 'sync', label: _syncProvider || 'Cloud' },
+              diff: manifestDiff,
+              conflicts: manifestConflicts || null,
+              meta: {
+                deviceId: manifest.deviceId || (remoteMeta ? remoteMeta.deviceId : null),
+                timestamp: remoteMeta ? remoteMeta.timestamp : null,
+                itemCount: remoteMeta ? remoteMeta.itemCount : null,
+                appVersion: remoteMeta ? remoteMeta.appVersion : null,
+              },
+              onApply: function (selectedChanges) {
+                // Deferred: download full vault, decrypt, selective apply.
+                // Resolve after _deferredVaultRestore completes so the caller
+                // keeps _syncRemoteChangeActive=true until pull is fully applied.
+                _deferredVaultRestore(token, password, remoteMeta, selectedChanges).finally(resolveModal);
+              },
+              onCancel: function () {
+                debugLog('[CloudSync] Manifest preview cancelled — no vault download');
+                resolveModal();
+              }
+            });
           });
           updateSyncStatusIndicator('idle', 'just now');
           return; // manifest path succeeded — skip vault-first path
@@ -2603,8 +2617,10 @@ async function pullWithPreview(remoteMeta) {
         conflicts = null;
       }
 
-      var shown = showRestorePreviewModal(diffResult, settingsDiff, remotePayload, remoteMeta, conflicts);
-      if (!shown) {
+      // STAK-406: shownPromise resolves only after user completes Apply/Cancel,
+      // keeping _syncRemoteChangeActive=true until the pull is fully applied.
+      var shownPromise = showRestorePreviewModal(diffResult, settingsDiff, remotePayload, remoteMeta, conflicts);
+      if (!shownPromise) {
         // Modal not in DOM — fall back to direct restore (try all key variants)
         debugLog('[CloudSync] Preview modal unavailable — falling back to direct restore');
         syncSaveOverrideBackup();
@@ -2612,6 +2628,8 @@ async function pullWithPreview(remoteMeta) {
         await restoreVaultData(fbPayload2);
         syncSetLastPull(_previewPullMeta);
         _previewPullMeta = null;
+      } else {
+        await shownPromise;
       }
 
     } catch (decryptErr) {

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.33";
+const APP_VERSION = "3.33.34";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.33-b1772570107';
+const CACHE_NAME = 'staktrakr-v3.33.34-b1772571435';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.33",
+  "version": "3.33.34",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,7 +2,7 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.30
+lastUpdated: v3.33.34
 date: 2026-03-03
 sourceFiles:
   - js/cloud-storage.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.30 — 2026-03-03
+> **Last updated:** v3.33.34 — 2026-03-03
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`
 
 ## Overview
@@ -313,7 +313,7 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 | Function | Signature | Purpose |
 |----------|-----------|---------|
 | `pushSyncVault` | `async ()` | Encrypt and push sync-scoped vault to Dropbox; includes empty-vault guard, image vault, and manifest |
-| `pullWithPreview` | `async ()` — (calls `pullSyncVault`) | Download and decrypt sync vault; saves override backup before applying |
+| `pullWithPreview` | `async (remoteMeta)` | Primary pull path. Shows DiffModal (manifest-first or vault-first) and awaits user action (Apply or Cancel) before returning. Keeps `_syncRemoteChangeActive=true` for the full duration, blocking concurrent pushes while the user reviews the diff. |
 | `syncSaveOverrideBackup` | `()` | Snapshot all `SYNC_SCOPE_KEYS` raw strings to `cloud_sync_override_backup` |
 | `syncRestoreOverrideBackup` | `async ()` | Restore pre-pull snapshot with confirmation; clears scope keys then rewrites from snapshot |
 | `getSyncPassword` | `()` → `Promise<string\|null>` | Interactively prompt for vault password; stores in localStorage; returns composite key |

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,7 +2,7 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.32
+lastUpdated: v3.33.34
 date: 2026-03-03
 sourceFiles:
   - js/cloud-sync.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.33.32 — 2026-03-03
+> **Last updated:** v3.33.34 — 2026-03-03
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -46,7 +46,7 @@ A separate image vault lives at:
 
 1. **Never bypass `getSyncPasswordSilent()`** — do not add your own `localStorage.getItem('cloud_vault_password')` reads inline. All key derivation logic (Simple mode migration, Unified mode construction) is encapsulated there.
 2. **`.catch()` on `pushSyncVault()` is optional** — it catches internally and all guard conditions return silently. **`.catch()` on `pullSyncVault()` is required** — the token check at the top fires before the internal try/catch, so callers must handle rejection.
-3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before opening any modal. If you add a new pull path, replicate this cancel guard or the vault overwrite race will reopen.
+3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before opening any modal. If you add a new pull path, replicate this cancel guard or the vault overwrite race will reopen. `handleRemoteChange()` also sets `_syncRemoteChangeActive = true` for the entire duration of the pull (including while the DiffModal is open, awaiting user action), which blocks concurrent `pushSyncVault()` calls. Both guards are required: the cancel prevents the queued debounce from firing, and the `_syncRemoteChangeActive` flag blocks any new push triggered while the user is reviewing the diff.
 4. **Do not duplicate `getSyncPassword()` logic** — the fast-path check at the top delegates to `getSyncPasswordSilent()`, which handles both modes and the migration edge case. Adding a second localStorage read before it breaks Simple-mode migration.
 5. **Only the leader tab pushes and polls** — `_syncIsLeader` guards both `pushSyncVault()` and `pollForRemoteChanges()`. Do not call the underlying network operations directly from UI code without this guard, or multi-tab races occur.
 6. **`cloud_dropbox_account_id` is required on every pull/poll path** — `pollForRemoteChanges()`, `pullSyncVault()`, and `pullWithPreview()` all check for a present `cloud_dropbox_account_id` before attempting any decrypt. Missing accountId yields an early-return with a "setup incomplete" toast instead of a misleading "Wrong Vault Password" error.
@@ -136,7 +136,7 @@ getSyncPasswordSilent()
 | `pushSyncVault()` | `() → Promise<void>` | Encrypt and upload inventory to Dropbox. Includes empty-vault guard, backup-before-overwrite, image vault upload, manifest upload, metadata pointer write. |
 | `scheduleSyncPush` | `debounced fn` | Debounced wrapper around `pushSyncVault` (2000ms delay). Exposed on `window` so `saveInventory()` can call it. |
 | `pullSyncVault(remoteMeta)` | `(object) → Promise<void>` | Download, decrypt, and restore vault. Throws if no token — callers must `.catch()`. |
-| `pullWithPreview(remoteMeta)` | `(object) → Promise<void>` | Primary pull path. Manifest-first: downloads `.stmanifest`, builds diff, shows `DiffModal`. Falls back to vault-first if manifest unavailable. |
+| `pullWithPreview(remoteMeta)` | `(object) → Promise<void>` | Primary pull path. Manifest-first: downloads `.stmanifest`, builds diff, shows `DiffModal` and awaits user action before returning. Falls back to vault-first if manifest unavailable; vault-first path also awaits user action. Does not return until Apply or Cancel is selected. |
 | `pollForRemoteChanges()` | `() → Promise<void>` | Download `staktrakr-sync.json`, compare `syncId` with last pull, call `handleRemoteChange()` on change. Only runs if leader tab + visible. |
 | `handleRemoteChange(remoteMeta)` | `(object) → Promise<void>` | Route a detected remote change: cancel debounced push, then show update modal (no local changes) or conflict modal (both sides changed). |
 | `showSyncConflictModal(opts)` | `({local, remote, remoteMeta}) → void` | Display conflict modal with Keep Mine / Keep Theirs / Skip. |
@@ -232,9 +232,11 @@ pollForRemoteChanges()
 ```
 handleRemoteChange(remoteMeta)
   ├─ Defer if password prompt is active
+  ├─ _syncRemoteChangeActive = true   ← blocks concurrent pushes for the full duration
   ├─ scheduleSyncPush.cancel()   ← CRITICAL: prevents vault overwrite race
   ├─ syncHasLocalChanges()?
-  │    No  → showSyncUpdateModal() → user accepts → pullWithPreview()
+  │    No  → showSyncUpdateModal() → user accepts → await pullWithPreview()
+  │                                                  (returns only after Apply/Cancel)
   │                                  user chooses "Push My Data"
   │                                    → _syncConflictUserOverride = true → pushSyncVault()
   │    Yes → showSyncConflictModal()
@@ -242,6 +244,7 @@ handleRemoteChange(remoteMeta)
   │             ├─ Keep Theirs → pullWithPreview(remoteMeta)
   │             └─ Skip → close modal
   │             (appConfirm fallback: keepMine → _syncConflictUserOverride = true → pushSyncVault())
+  └─ finally: _syncRemoteChangeActive = false   ← clears only after pull is fully applied
 ```
 
 ### Pull (Dropbox → inventory)
@@ -256,16 +259,21 @@ pullWithPreview(remoteMeta)
   ├─ Manifest-first path (preferred):
   │    ├─ Download /sync/staktrakr-sync.stmanifest
   │    ├─ decryptManifest() → build diff from changelog entries
-  │    ├─ DiffModal.show() with manifest diff
-  │    │    └─ onApply: _deferredVaultRestore() — download full vault only now
-  │    └─ return (vault download deferred until user confirms)
+  │    ├─ await new Promise(resolveModal):
+  │    │    DiffModal.show() with manifest diff
+  │    │    └─ onApply: _deferredVaultRestore().finally(resolveModal)
+  │    │         — download full vault, decrypt, selective apply
+  │    │    └─ onCancel: resolveModal() — no vault downloaded
+  │    └─ returns only after user selects Apply or Cancel
   │
   └─ Vault-first fallback (if manifest unavailable or DiffModal missing):
        ├─ Download /sync/staktrakr-sync.stvault
        ├─ vaultDecryptToData() → DiffEngine.compareItems() + compareSettings()
-       ├─ showRestorePreviewModal(diffResult, settingsDiff, ...)
-       │    └─ onApply: _applyAndFinalize()
-       └─ fallback: direct pullSyncVault() if modal unavailable
+       ├─ await showRestorePreviewModal(diffResult, settingsDiff, ...)
+       │    ├─ returns Promise<void> — resolves on Apply or Cancel
+       │    └─ onApply: _applyAndFinalize() → resolve()
+       │    (returns null if DiffModal unavailable → falls back below)
+       └─ null fallback: direct pullSyncVault() if modal unavailable
 ```
 
 `pullSyncVault()` is the lower-level restore function (full overwrite, no preview):
@@ -388,7 +396,7 @@ The override backup is the safety net for "Keep Theirs" conflicts or unwanted sy
 
 - **`pushSyncVault()`** — all errors caught internally; sets status indicator to `'error'`; returns silently. No caller catch required.
 - **`pullSyncVault()`** — token guard THROWS before the internal try/catch. All callers must `.catch()` or wrap in try/catch.
-- **`pullWithPreview()`** — catches internally; falls back to `pullSyncVault()` on outer error; sets status indicator to `'error'`.
+- **`pullWithPreview()`** — catches internally; falls back to `pullSyncVault()` on outer error; sets status indicator to `'error'`. Awaits the DiffModal user action (Apply or Cancel) before returning, so `_syncRemoteChangeActive` stays `true` until the pull is fully applied.
 - **Missing `cloud_dropbox_account_id`** — `pollForRemoteChanges()`, `pullSyncVault()`, and `pullWithPreview()` all guard against a missing accountId. Each fires a `console.warn('[CloudSync] … cloud_dropbox_account_id missing')` and a `showCloudToast('Cloud sync setup is incomplete on this device. Please reconnect Dropbox…')` then returns early. No decrypt is attempted.
 - **`getSyncPassword()` missing accountId at confirm time** — the onConfirm handler re-reads `cloud_dropbox_account_id`; if absent, it injects an error message into the modal's error element and returns without closing (modal stays open for the user to cancel and reconnect). The `appPrompt` fallback path resolves `null` when accountId is missing.
 - **`buildAndUploadManifest()`** — must be called inside try/catch; failure is intentionally non-blocking relative to the vault push.
@@ -471,15 +479,17 @@ scheduleSyncPush(); // for inventory changes
 
 ---
 
-## Vault Overwrite Race (fixed v3.32.24)
+## Vault Overwrite Race (fixed v3.32.24, extended v3.33.34)
 
 **Symptom:** On two-device setups, choosing "Keep Theirs" in the conflict modal silently discarded the remote device's changes.
 
 **Root cause:** `initSyncModule()` builds `scheduleSyncPush` with a 2000ms debounce. If the poller detected a remote change within that 2-second window, the debounced push fired during or after the conflict modal, overwriting the remote vault before the pull could complete.
 
-**Fix (v3.32.24):** `handleRemoteChange()` calls `scheduleSyncPush.cancel()` as its first substantive action — before any modal is shown.
+**Fix (v3.32.24):** `handleRemoteChange()` calls `scheduleSyncPush.cancel()` as its first substantive action — before any modal is shown. This prevents the *queued debounce* from firing.
 
-**Both devices must be on v3.32.24+.** A device on v3.32.23 will still exhibit the bug on its own debounced push, even if the other device is updated.
+**Extended fix (v3.33.34, STAK-406):** A second race path remained: `pullWithPreview()` previously returned as soon as it handed off to `DiffModal.show()`, clearing `_syncRemoteChangeActive` before the user had applied or cancelled. A new push triggered while the DiffModal was open (e.g., from another tab broadcast or user action) would not be blocked. The fix makes `pullWithPreview()` await the DiffModal user action in both the manifest-first and vault-first paths before returning, so `_syncRemoteChangeActive` stays `true` until the pull is fully applied. Similarly, `showRestorePreviewModal()` now returns a `Promise<void>` (resolved on Apply or Cancel) instead of a boolean, enabling callers to await it. It returns `null` only when DiffModal is unavailable.
+
+**Both devices must be on v3.32.24+.** A device on v3.32.23 will still exhibit the original debounce-race bug on its own debounced push, even if the other device is updated.
 
 ---
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

- **Fixed**: `pullWithPreview()` now awaits the user's DiffModal decision (Apply or Cancel) before returning — previously cleared `_syncRemoteChangeActive` prematurely while modal was open, allowing concurrent `pushSyncVault()` to overwrite Dropbox with stale local data
- **Fixed**: Manifest-first path wraps `DiffModal.show()` in a Promise that resolves after `_deferredVaultRestore()` completes on Apply, or immediately on Cancel
- **Fixed**: `showRestorePreviewModal()` (vault-first path) now returns a Promise instead of boolean so `pullWithPreview()` can `await` the full user interaction
- **Fixed**: Both paths now keep `_syncRemoteChangeActive=true` for the entire duration of the pull, blocking `enableCloudSync`/`syncNow` from pushing during the DiffModal session

## Root Cause

`DiffModal.show()` uses `onApply`/`onCancel` callbacks but the calling functions returned immediately after showing it — before the user clicked anything. This meant the `finally: _syncRemoteChangeActive = false` in `handleRemoteChange()` fired while the diff was still open, and `enableCloudSync()` then called `pushSyncVault()` which overwrote the remote vault with the local device's stale data before the user could click OK to pull.

## Linear Issues

- [STAK-406: Fix cloud sync push racing with DiffModal](https://linear.app/lbruton/issue/STAK-406)

🤖 Generated with [Claude Code](https://claude.com/claude-code)