### PR TITLE
v3.33.35 — STAK-409/410/411: Fix DiffModal Apply data loss, empty-vault dialog, double conflict modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.35] - 2026-03-03
+
+### Fixed — Sync DiffModal Apply Data Loss + Empty-Vault Dialog (STAK-409, STAK-410, STAK-411)
+
+- **Fixed**: DiffModal Apply no longer empties the vault when the manifest-first diff shows only deletions — `_deferredVaultRestore` now falls back to full overwrite when selective apply would produce an empty result but the remote has items, preventing silent data loss when remote-only additions are missed by the local manifest (STAK-409)
+- **Fixed**: Empty-vault push guard dialog now correctly calls `pullWithPreview()` on OK — the `showAppConfirm` call was using an old callback-style API, passing the callback as the `title` argument, causing the dialog heading to display `function () { pullWithPreview(); }` and OK to do nothing (STAK-410)
+- **Fixed**: Double conflict modal prevented — pre-push check now sets `_syncRemoteChangeActive = true` before `await handleRemoteChange()` so a concurrent auto-poll that fires between the routing decision and the flag being set inside `handleRemoteChange` sees the flag and skips its own modal (STAK-411)
+
+---
+
 ## [3.33.34] - 2026-03-03
 
 ### Fixed — Cloud Sync Push Race with DiffModal (STAK-406)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync Apply & Dialog Fixes (v3.33.35)**: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff — falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411).
 - **Sync Pull Race Fix (v3.33.34)**: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open — the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406).
 - **Cloud Button Always Visible (v3.33.33)**: Cloud header button and Settings Cloud tab are now always shown — removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405).
 - **Keep Mine Conflict Fix (v3.33.32)**: Pressing Keep Mine or Push My Data now completes the push — a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403).
 - **Sync Diff Preview Fix (v3.33.31)**: Pull preview now shows real item differences instead of "No changes detected" when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402).
-- **Bi-Directional Sync Fix (v3.33.30)**: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.35 &ndash; Sync Apply &amp; Dialog Fixes</strong>: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff &mdash; falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411)</li>
     <li><strong>v3.33.34 &ndash; Sync Pull Race Fix</strong>: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open &mdash; the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406)</li>
     <li><strong>v3.33.33 &ndash; Cloud Button Always Visible</strong>: Cloud header button and Settings Cloud tab are now always shown &mdash; removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405)</li>
     <li><strong>v3.33.32 &ndash; Keep Mine Conflict Fix</strong>: Pressing Keep Mine or Push My Data now completes the push &mdash; a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403)</li>
     <li><strong>v3.33.31 &ndash; Sync Diff Preview Fix</strong>: Pull preview now shows real item differences instead of &ldquo;No changes detected&rdquo; when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402)</li>
-    <li><strong>v3.33.30 &ndash; Bi-Directional Sync Fix</strong>: Pre-push remote check prevents blind overwrite when another device has pushed. Sync Now polls before pushing. Settings hash and diff preview use synchronous storage reads. 5 bugs fixed (STAK-398)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1188,6 +1188,9 @@ async function pushSyncVault() {
             logCloudSyncActivity('auto_sync_push', 'deferred', 'Remote change detected from device ' + prePushMeta.deviceId.slice(0, 8) + ' — showing diff');
             _syncPushInFlight = false;
             updateSyncStatusIndicator('idle');
+            // STAK-411: Set flag before await so concurrent poll sees it and skips
+            // its own handleRemoteChange call, preventing a double conflict modal.
+            _syncRemoteChangeActive = true;
             await handleRemoteChange(prePushMeta);
             return; // Do NOT push — let the user decide via the update/conflict modal
           } else {
@@ -1253,14 +1256,15 @@ async function pushSyncVault() {
             updateSyncStatusIndicator('error', 'Empty vault — pull first');
             guardBlocked = true;
             _syncPushInFlight = false;
+            // STAK-410: showAppConfirm is Promise-based (message, title) — use .then()
+            // instead of passing the callback as arg 2 (old callback-style API).
             showAppConfirm(
               'Your local vault is empty but the cloud has ' + guardMeta.itemCount + ' items. ' +
               'Push cancelled to prevent data loss. Pull from cloud instead?',
-              function () { pullWithPreview(); },
-              null,
-              'Pull from Cloud',
-              'Cancel'
-            );
+              'Sync Update'
+            ).then(function (confirmed) {
+              if (confirmed) pullWithPreview();
+            });
             return;
           } else {
             debugLog('[CloudSync] Empty-vault guard: remote is also empty — allowing');
@@ -2328,12 +2332,21 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
 
         var localItems = typeof inventory !== 'undefined' ? inventory : [];
         var newInv = DiffEngine.applySelectedChanges(localItems, selectedChanges);
-        // Manifest-first selective apply intentionally applies inventory only.
-        // Sync-scoped settings are not restored via this path (null settingsChanges);
-        // they update only during vault-first pulls which have full payload access.
-        _applyAndFinalize(newInv, selectedChanges, null, remoteMeta, { source: 'sync' });
-        debugLog('[CloudSync] Deferred vault restore complete (selective apply)');
-        return;
+        // STAK-409: Safety guard — if selective apply would empty the vault but the
+        // remote has items, the manifest-first diff missed remote-only additions
+        // (items the local device has never seen). Fall through to full overwrite
+        // to prevent silent data loss.
+        if (newInv.length === 0 && remoteItems.length > 0) {
+          debugLog('[CloudSync] Selective apply would empty vault but remote has', remoteItems.length, 'items — falling back to full overwrite');
+          // fall through to full-overwrite path below
+        } else {
+          // Manifest-first selective apply intentionally applies inventory only.
+          // Sync-scoped settings are not restored via this path (null settingsChanges);
+          // they update only during vault-first pulls which have full payload access.
+          _applyAndFinalize(newInv, selectedChanges, null, remoteMeta, { source: 'sync' });
+          debugLog('[CloudSync] Deferred vault restore complete (selective apply)');
+          return;
+        }
       }
       // payload missing or corrupt — fall through to full overwrite
       debugLog('[CloudSync] Selective apply failed (bad payload) — falling back to full overwrite');

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.34";
+const APP_VERSION = "3.33.35";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.34-b1772571435';
+const CACHE_NAME = 'staktrakr-v3.33.35-b1772574370';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.34",
+  "version": "3.33.35",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **STAK-409 (Urgent)**: DiffModal Apply no longer empties vault when manifest-first diff shows only deletions — `_deferredVaultRestore` now falls back to full overwrite when selective apply result is empty but remote has items (remote-only additions were missed by local manifest)
- **STAK-410 (High)**: Empty-vault push guard dialog now correctly calls `pullWithPreview()` on OK — was using old callback-style API passing function as `title` arg to Promise-based `showAppConfirm()`, causing dialog heading to display function source and OK to do nothing
- **STAK-411 (Medium)**: Double conflict modal prevented — pre-push check now sets `_syncRemoteChangeActive = true` before `await handleRemoteChange()` so concurrent auto-poll that fires before the flag is set inside `handleRemoteChange` skips its own modal

## Linear Issues

- [STAK-409: DiffModal Apply empties vault — selective apply drops remote-only additions](https://linear.app/lbruton/issue/STAK-409)
- [STAK-410: showAppConfirm API mismatch in empty-vault guard — callback passed as title, OK does nothing](https://linear.app/lbruton/issue/STAK-410)
- [STAK-411: Double conflict modal — pre-push check and auto-poll both call handleRemoteChange simultaneously](https://linear.app/lbruton/issue/STAK-411)

🤖 Generated with [Claude Code](https://claude.com/claude-code)