### PR TITLE
v3.33.36 — STAK-412: Fix cloud sync pull root cause + remove redundant conflict dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.36] - 2026-03-03
+
+### Fixed — Cloud Sync Pull Root Cause + UX Cleanup (STAK-412)
+
+- **Fixed**: Vault-first pull path now correctly extracts inventory from `remotePayload.data.metalInventory` (compressed dict of localStorage keys) instead of treating the payload dict as an inventory array — this was the root cause of DiffModal showing only deletions and zero additions, leading to empty inventory on Apply (STAK-412)
+- **Fixed**: Remote settings extraction in vault-first path now reads sync-scoped keys from `remotePayload.data` (excluding metalInventory) instead of the empty `remotePayload.settings` field
+- **Changed**: Removed redundant Sync Conflict dialog (Keep Mine / Keep Theirs / Skip) — remote changes now go directly to the Review Sync Changes DiffModal which shows the full item-level diff
+- **Fixed**: Manifest-first count check now verifies `local + added - deleted == remote` instead of only checking for zero changes — catches incomplete diffs where the manifest changelog misses remote-only additions
+
+---
+
 ## [3.33.35] - 2026-03-03
 
 ### Fixed — Sync DiffModal Apply Data Loss + Empty-Vault Dialog (STAK-409, STAK-410, STAK-411)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync Pull Root Cause Fix (v3.33.36)**: Vault-first pull now correctly extracts inventory from the encrypted payload — was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412).
 - **Sync Apply & Dialog Fixes (v3.33.35)**: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff — falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411).
 - **Sync Pull Race Fix (v3.33.34)**: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open — the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406).
 - **Cloud Button Always Visible (v3.33.33)**: Cloud header button and Settings Cloud tab are now always shown — removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405).
 - **Keep Mine Conflict Fix (v3.33.32)**: Pressing Keep Mine or Push My Data now completes the push — a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403).
-- **Sync Diff Preview Fix (v3.33.31)**: Pull preview now shows real item differences instead of "No changes detected" when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.36 &ndash; Sync Pull Root Cause Fix</strong>: Vault-first pull now correctly extracts inventory from the encrypted payload &mdash; was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412)</li>
     <li><strong>v3.33.35 &ndash; Sync Apply &amp; Dialog Fixes</strong>: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff &mdash; falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411)</li>
     <li><strong>v3.33.34 &ndash; Sync Pull Race Fix</strong>: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open &mdash; the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406)</li>
     <li><strong>v3.33.33 &ndash; Cloud Button Always Visible</strong>: Cloud header button and Settings Cloud tab are now always shown &mdash; removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405)</li>
     <li><strong>v3.33.32 &ndash; Keep Mine Conflict Fix</strong>: Pressing Keep Mine or Push My Data now completes the push &mdash; a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403)</li>
-    <li><strong>v3.33.31 &ndash; Sync Diff Preview Fix</strong>: Pull preview now shows real item differences instead of &ldquo;No changes detected&rdquo; when seeded/imported items have no changeLog history. Empty-diff Accept correctly does a full restore (STAK-402)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1778,23 +1778,12 @@ async function handleRemoteChange(remoteMeta) {
       return;
     }
 
-    // Conflict: both sides have changes
-    console.warn('[CloudSync] handleRemoteChange: CONFLICT — showing conflict modal');
-    var lastPush = syncGetLastPush();
-    await showSyncConflictModal({
-      local: {
-        itemCount: typeof inventory !== 'undefined' ? inventory.length : 0,
-        timestamp: lastPush ? lastPush.timestamp : null,
-        appVersion: typeof APP_VERSION !== 'undefined' ? APP_VERSION : 'unknown',
-      },
-      remote: {
-        itemCount: remoteMeta.itemCount || 0,
-        timestamp: remoteMeta.timestamp || null,
-        appVersion: remoteMeta.appVersion || 'unknown',
-        deviceId: remoteMeta.deviceId || '',
-      },
-      remoteMeta: remoteMeta,
-    });
+    // STAK-412: Skip the redundant Sync Conflict dialog (Keep Mine / Keep Theirs)
+    // and go directly to the DiffModal (Review Sync Changes) which shows the full
+    // item-level diff. The conflict dialog was an extra layer that confused users
+    // without adding information the DiffModal doesn't already provide.
+    console.warn('[CloudSync] handleRemoteChange: CONFLICT — going directly to pull preview');
+    await pullWithPreview(remoteMeta);
   } finally {
     _syncRemoteChangeActive = false;
   }
@@ -2428,16 +2417,18 @@ async function pullWithPreview(remoteMeta) {
           // Build diff-like result from manifest data
           var manifestDiff = _buildDiffFromManifest(manifest);
 
-          // STAK-402: If the manifest shows zero changes but the remote item count
-          // differs from the local inventory, the manifest was built from an empty
-          // changeLog (seeded/imported items have no changeLog entries). Fall through
-          // to the vault-first path which does a full DiffEngine.compareItems comparison.
-          var _mChanges = manifestDiff.added.length + manifestDiff.modified.length + manifestDiff.deleted.length;
+          // STAK-402 + STAK-412: Verify the manifest diff is complete by checking
+          // whether the expected post-apply count matches the remote item count.
+          // The manifest changelog only records changes the pushing device made — it
+          // cannot enumerate items the local device has never seen. If the math
+          // doesn't add up, fall through to vault-first which does a full
+          // DiffEngine.compareItems comparison with the actual inventory arrays.
           var _mRemoteCount = remoteMeta ? (remoteMeta.itemCount || 0) : 0;
           var _mLocalCount = (typeof inventory !== 'undefined' && inventory) ? inventory.length : 0;
-          if (_mChanges === 0 && _mRemoteCount !== _mLocalCount) {
-            debugLog('[CloudSync] Manifest diff empty but item counts differ (' + _mRemoteCount + ' remote vs ' + _mLocalCount + ' local) — using vault-first');
-            throw new Error('Manifest stale: empty diff with count mismatch');
+          var _mExpectedAfterApply = _mLocalCount + manifestDiff.added.length - manifestDiff.deleted.length;
+          if (_mExpectedAfterApply !== _mRemoteCount) {
+            debugLog('[CloudSync] Manifest diff incomplete: expected ' + _mExpectedAfterApply + ' items after apply but remote has ' + _mRemoteCount + ' (' + _mLocalCount + ' local + ' + manifestDiff.added.length + ' added - ' + manifestDiff.deleted.length + ' deleted) — using vault-first');
+            throw new Error('Manifest stale: post-apply count mismatch');
           }
 
           // Stash pull metadata
@@ -2550,16 +2541,37 @@ async function pullWithPreview(remoteMeta) {
     // Attempt to decrypt and preview
     try {
       var remotePayload = await _tryDecryptVault(bytes, 'stvault');
-      var remoteItems = remotePayload.data || [];
+      // STAK-412: remotePayload.data is a dict of localStorage keys (e.g.
+      // {metalInventory: "CMP1:...", itemTags: "...", ...}), NOT an inventory
+      // array. Extract and decompress metalInventory to get the actual items.
+      var remoteItems = [];
+      try {
+        var _vfRaw = remotePayload.data && remotePayload.data.metalInventory
+          ? remotePayload.data.metalInventory : '[]';
+        var _vfDecompressed = typeof __decompressIfNeeded === 'function'
+          ? __decompressIfNeeded(_vfRaw) : _vfRaw;
+        remoteItems = JSON.parse(_vfDecompressed);
+      } catch (_vfErr) {
+        debugLog('[CloudSync] Vault-first: could not parse metalInventory:', _vfErr.message);
+      }
       var localItems = typeof inventory !== 'undefined' ? inventory : [];
 
       var diffResult = typeof DiffEngine !== 'undefined'
         ? DiffEngine.compareItems(localItems, remoteItems)
         : { added: [], deleted: [], modified: [], unchanged: [] };
 
-      // Compare settings
+      // Compare settings — settings are stored inside remotePayload.data as
+      // individual localStorage keys (everything except metalInventory).
       var localSettings = {};
-      var remoteSettings = remotePayload.settings || {};
+      var remoteSettings = {};
+      if (remotePayload.data) {
+        var _rsKeys = Object.keys(remotePayload.data);
+        for (var rs = 0; rs < _rsKeys.length; rs++) {
+          if (_rsKeys[rs] !== 'metalInventory') {
+            remoteSettings[_rsKeys[rs]] = remotePayload.data[_rsKeys[rs]];
+          }
+        }
+      }
       if (typeof SYNC_SCOPE_KEYS !== 'undefined') {
         for (var i = 0; i < SYNC_SCOPE_KEYS.length; i++) {
           if (SYNC_SCOPE_KEYS[i] === 'metalInventory') continue;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.35";
+const APP_VERSION = "3.33.36";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.35-b1772574370';
+const CACHE_NAME = 'staktrakr-v3.33.36-b1772576204';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.35",
+  "version": "3.33.36",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Root cause fix**: Vault-first pull path now extracts inventory from `remotePayload.data.metalInventory` (CMP1-compressed) instead of treating the localStorage dict as an inventory array — this was why DiffModal showed only deletions and zero additions
- **UX cleanup**: Removed redundant Sync Conflict dialog (Keep Mine / Keep Theirs / Skip) — remote changes now go directly to Review Sync Changes DiffModal
- **Settings fix**: Vault-first remote settings extraction reads from `remotePayload.data` keys instead of empty `remotePayload.settings`
- **Count check**: Manifest-first STAK-402 check now verifies `local + added - deleted == remote` instead of only `changes == 0`

## Linear Issues

- STAK-412: Cloud sync pull shows wrong diff — vault-first path treats payload.data dict as inventory array

🤖 Generated with [Claude Code](https://claude.com/claude-code)