### PR TITLE
v3.33.37 — STAK-413: Remove redundant Sync Update Available dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.37] - 2026-03-03
+
+### Changed — Remove Redundant Sync Update Dialog (STAK-413)
+
+- **Changed**: Removed the "Sync Update Available" intermediate dialog (Accept Update / Push My Data / Not Now) — remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths, completing the UX simplification started in STAK-412
+
+---
+
 ## [3.33.36] - 2026-03-03
 
 ### Fixed — Cloud Sync Pull Root Cause + UX Cleanup (STAK-412)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync Dialog Cleanup (v3.33.37)**: Removed the redundant "Sync Update Available" dialog — remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413).
 - **Sync Pull Root Cause Fix (v3.33.36)**: Vault-first pull now correctly extracts inventory from the encrypted payload — was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412).
 - **Sync Apply & Dialog Fixes (v3.33.35)**: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff — falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411).
 - **Sync Pull Race Fix (v3.33.34)**: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open — the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406).
 - **Cloud Button Always Visible (v3.33.33)**: Cloud header button and Settings Cloud tab are now always shown — removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405).
-- **Keep Mine Conflict Fix (v3.33.32)**: Pressing Keep Mine or Push My Data now completes the push — a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.37 &ndash; Sync Dialog Cleanup</strong>: Removed the redundant &ldquo;Sync Update Available&rdquo; dialog &mdash; remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413)</li>
     <li><strong>v3.33.36 &ndash; Sync Pull Root Cause Fix</strong>: Vault-first pull now correctly extracts inventory from the encrypted payload &mdash; was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412)</li>
     <li><strong>v3.33.35 &ndash; Sync Apply &amp; Dialog Fixes</strong>: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff &mdash; falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411)</li>
     <li><strong>v3.33.34 &ndash; Sync Pull Race Fix</strong>: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open &mdash; the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406)</li>
     <li><strong>v3.33.33 &ndash; Cloud Button Always Visible</strong>: Cloud header button and Settings Cloud tab are now always shown &mdash; removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405)</li>
-    <li><strong>v3.33.32 &ndash; Keep Mine Conflict Fix</strong>: Pressing Keep Mine or Push My Data now completes the push &mdash; a one-shot override flag prevents the pre-push check from re-detecting the resolved conflict and looping (STAK-403)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1755,34 +1755,11 @@ async function handleRemoteChange(remoteMeta) {
   }
 
   try {
-    var hasLocal = syncHasLocalChanges();
-    console.warn('[CloudSync] handleRemoteChange: hasLocalChanges:', hasLocal);
-
-    if (!hasLocal) {
-      // Show the update-available modal — let user decide before password prompt
-      console.warn('[CloudSync] handleRemoteChange: showing update modal');
-      var choice = await showSyncUpdateModal(remoteMeta);
-      if (choice === 'push') {
-        // User chose to assert local data as authoritative — push over remote
-        console.warn('[CloudSync] handleRemoteChange: user chose Push My Data');
-        _syncConflictUserOverride = true;
-        pushSyncVault().catch(function(e) { console.error('[CloudSync] Push My Data failed:', e); });
-        return;
-      }
-      if (!choice || choice === 'dismiss') {
-        console.warn('[CloudSync] handleRemoteChange: user dismissed update — will retry next poll');
-        return;
-      }
-      // choice === 'accept' — Layer 5: show restore preview instead of direct pull (REQ-5)
-      await pullWithPreview(remoteMeta);
-      return;
-    }
-
-    // STAK-412: Skip the redundant Sync Conflict dialog (Keep Mine / Keep Theirs)
-    // and go directly to the DiffModal (Review Sync Changes) which shows the full
-    // item-level diff. The conflict dialog was an extra layer that confused users
-    // without adding information the DiffModal doesn't already provide.
-    console.warn('[CloudSync] handleRemoteChange: CONFLICT — going directly to pull preview');
+    // STAK-413: Go directly to the DiffModal (Review Sync Changes) for ALL
+    // remote changes — both conflict and non-conflict. The intermediate dialogs
+    // (Sync Update Available, Sync Conflict) were redundant layers that confused
+    // users without adding information the DiffModal doesn't already provide.
+    console.warn('[CloudSync] handleRemoteChange: going directly to pull preview');
     await pullWithPreview(remoteMeta);
   } finally {
     _syncRemoteChangeActive = false;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.36";
+const APP_VERSION = "3.33.37";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.36-b1772576204';
+const CACHE_NAME = 'staktrakr-v3.33.37-b1772577074';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.36",
+  "version": "3.33.37",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- Removed the "Sync Update Available" intermediate dialog (Accept Update / Push My Data / Not Now)
- Remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths
- Completes the UX simplification started in STAK-412

## Linear Issues

- STAK-413: Remove redundant Sync Update Available dialog — go directly to DiffModal

🤖 Generated with [Claude Code](https://claude.com/claude-code)