### PR TITLE
v3.33.38 — STAK-414/415: Fix sync poll local-newer detection + DiffModal Apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.38] - 2026-03-03
+
+### Fixed — Sync Poll Local-Newer Detection + DiffModal Apply (STAK-414, STAK-415)
+
+- **Fixed**: Sync poll no longer triggers a pull when local inventory is newer than the remote vault — now compares `lastLocalModified` timestamp (set on every inventory save) against `remoteMeta.timestamp` and triggers a push instead, preventing the user's newly added items from appearing as deletions in the DiffModal (STAK-414)
+- **Fixed**: DiffModal Apply button stays enabled when settings changes are pending even if all item checkboxes are unchecked — previously the button disabled with zero item selections, blocking settings-only apply (STAK-415)
+
+---
+
 ## [3.33.37] - 2026-03-03
 
 ### Changed — Remove Redundant Sync Update Dialog (STAK-413)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync Poll + Apply Fixes (v3.33.38)**: Sync poll now detects when local inventory is newer than remote and pushes instead of pulling — prevents newly added items from appearing as deletions. DiffModal Apply button stays enabled for settings-only apply when all item checkboxes are unchecked (STAK-414, STAK-415).
 - **Sync Dialog Cleanup (v3.33.37)**: Removed the redundant "Sync Update Available" dialog — remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413).
 - **Sync Pull Root Cause Fix (v3.33.36)**: Vault-first pull now correctly extracts inventory from the encrypted payload — was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412).
 - **Sync Apply & Dialog Fixes (v3.33.35)**: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff — falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411).
 - **Sync Pull Race Fix (v3.33.34)**: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open — the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406).
-- **Cloud Button Always Visible (v3.33.33)**: Cloud header button and Settings Cloud tab are now always shown — removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.38 &ndash; Sync Poll + Apply Fixes</strong>: Sync poll now detects when local inventory is newer than remote and pushes instead of pulling &mdash; prevents newly added items from appearing as deletions. DiffModal Apply button stays enabled for settings-only apply when all item checkboxes are unchecked (STAK-414, STAK-415)</li>
     <li><strong>v3.33.37 &ndash; Sync Dialog Cleanup</strong>: Removed the redundant &ldquo;Sync Update Available&rdquo; dialog &mdash; remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413)</li>
     <li><strong>v3.33.36 &ndash; Sync Pull Root Cause Fix</strong>: Vault-first pull now correctly extracts inventory from the encrypted payload &mdash; was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412)</li>
     <li><strong>v3.33.35 &ndash; Sync Apply &amp; Dialog Fixes</strong>: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff &mdash; falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411)</li>
     <li><strong>v3.33.34 &ndash; Sync Pull Race Fix</strong>: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open &mdash; the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406)</li>
-    <li><strong>v3.33.33 &ndash; Cloud Button Always Visible</strong>: Cloud header button and Settings Cloud tab are now always shown &mdash; removed hide-when-disconnected logic that blocked access to cloud setup for new users (STAK-405)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1646,6 +1646,22 @@ async function pollForRemoteChanges() {
       }
     }
 
+    // STAK-414: Before pulling, check if local inventory was modified more
+    // recently than the remote vault. If so, the hash mismatch is because WE
+    // changed — not the remote. Trigger a push instead of a pull to avoid
+    // showing the user's own new items as deletions.
+    var localModStr = localStorage.getItem('cloud_sync_local_modified');
+    if (localModStr && remoteMeta.timestamp) {
+      var localModTime = new Date(localModStr).getTime();
+      var remoteTime = new Date(remoteMeta.timestamp).getTime();
+      if (localModTime > remoteTime) {
+        console.warn('[CloudSync] Poll: local inventory is NEWER than remote (' + localModStr + ' > ' + remoteMeta.timestamp + ') — triggering push instead of pull');
+        logCloudSyncActivity('auto_sync_poll', 'success', 'Local newer than remote — pushing');
+        if (typeof scheduleSyncPush === 'function') scheduleSyncPush();
+        return;
+      }
+    }
+
     console.warn('[CloudSync] Poll: REMOTE CHANGE DETECTED — calling handleRemoteChange. syncId:', remoteMeta.syncId, 'itemCount:', remoteMeta.itemCount);
     logCloudSyncActivity('auto_sync_poll', 'success', 'Remote change detected: ' + remoteMeta.itemCount + ' items');
     await handleRemoteChange(remoteMeta);

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.37";
+const APP_VERSION = "3.33.38";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -919,6 +919,7 @@ const ALLOWED_STORAGE_KEYS = [
   "headerAboutBtnVisible",                             // boolean string: "true"/"false" — about button visibility (STAK-320)
   "tagBlacklist",                                      // JSON array: tags excluded from auto-tagging
   "numista_tags_auto",                                 // boolean string: "true"/"false" — auto-tag from Numista data
+  "cloud_sync_local_modified",                           // ISO string: timestamp of last local metalInventory save (STAK-414)
   "cloud_sync_migrated",                               // string: "v2" — cloud folder migration flag (flat → /sync/ + /backups/)
   "cloud_backup_history_depth",                        // string: "3"|"5"|"10"|"20" — max cloud backups to retain
   "manifestPruningThreshold",                          // number string: max sync cycles to retain in manifest before pruning older entries (STAK-184)

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -281,15 +281,16 @@
     }
 
     // Apply button count
-    // Only disable when there ARE selectable items but none are checked.
-    // When the diff is empty (no items at all), Apply should be enabled so the
-    // user can acknowledge "no changes" and let onApply record the pull timestamp.
+    // Only disable when there ARE selectable items but none are checked AND
+    // there are no pending settings changes. Settings are always included when
+    // Apply is clicked, so the button should stay enabled for settings-only apply.
     if (applyBtn) {
       var count = _checkedCount();
       var hasSelectableItems = Object.keys(_checkedItems).length > 0;
+      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
-      applyBtn.disabled = hasSelectableItems && count === 0;
-      applyBtn.style.opacity = (hasSelectableItems && count === 0) ? '0.4' : '';
+      applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
+      applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
     }
 
     // Count row (backup import flow only)
@@ -420,9 +421,10 @@
     if (applyBtn) {
       var count = _checkedCount();
       var hasSelectableItems = Object.keys(_checkedItems).length > 0;
+      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
-      applyBtn.disabled = hasSelectableItems && count === 0;
-      applyBtn.style.opacity = (hasSelectableItems && count === 0) ? '0.4' : '';
+      applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
+      applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
     }
     _updateCountRow();
   }

--- a/js/utils.js
+++ b/js/utils.js
@@ -998,6 +998,12 @@ const saveData = async (key, data) => {
     const raw = JSON.stringify(data);
     const out = __compressIfNeeded(raw);
     localStorage.setItem(key, out);
+    // STAK-414: Track when inventory was last modified locally so the sync
+    // poller can detect that local data is newer than the remote vault and
+    // trigger a push instead of a pull.
+    if (key === 'metalInventory') {
+      localStorage.setItem('cloud_sync_local_modified', new Date().toISOString());
+    }
   } catch(e) {
     console.error('saveData failed', e);
   }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.37-b1772577074';
+const CACHE_NAME = 'staktrakr-v3.33.38-b1772578297';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.37",
+  "version": "3.33.38",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **STAK-414**: Sync poll now tracks `lastLocalModified` timestamp (set on every `saveData('metalInventory')`) and compares it against `remoteMeta.timestamp` — if local is newer, triggers push instead of pull. Prevents newly added items from appearing as deletions in the DiffModal.
- **STAK-415**: DiffModal Apply button stays enabled when settings changes are pending, even if all item checkboxes are unchecked. Previously the button disabled with zero item selections, blocking settings-only apply.

## Linear Issues

- [STAK-414: Sync poll ignores local modification time](https://linear.app/lbruton/issue/STAK-414)
- [STAK-415: DiffModal Apply button disables when all items unchecked](https://linear.app/lbruton/issue/STAK-415)

🤖 Generated with [Claude Code](https://claude.com/claude-code)