### PR TITLE
v3.33.39 — STAK-418: Summary bar items + weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.39] - 2026-03-03
+
+### Changed — Summary Bar Items + Weight (STAK-418)
+
+- **Changed**: Item count and total weight now display in the portfolio summary bar (ITEMS/WEIGHT alongside Buy/Melt/Market/G/L) instead of a separate bottom footer — shows filtered/total format when filters active (e.g., 172/189), total weight in troy ounces for currently visible items (STAK-418)
+
+---
+
 ## [3.33.38] - 2026-03-03
 
 ### Fixed — Sync Poll, Settings Sync, DiffModal (STAK-414, STAK-415, STAK-416, STAK-417)

--- a/css/styles.css
+++ b/css/styles.css
@@ -4126,19 +4126,9 @@ table {
   height: auto;
 }
 
-  .table-item-count {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    background: var(--bg-tertiary);
-    padding: 0.125rem 0.375rem;
-    border-radius: var(--radius);
-    display: inline-block;
-  }
-
   .table-footer-controls {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     margin-top: 0.25rem;
     width: 100%;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).
 - **Sync Poll, Settings Sync, DiffModal Fixes (v3.33.38)**: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices — poll compares both inventory and settings hashes. "No changes detected" popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417).
 - **Sync Dialog Cleanup (v3.33.37)**: Removed the redundant "Sync Update Available" dialog — remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413).
 - **Sync Pull Root Cause Fix (v3.33.36)**: Vault-first pull now correctly extracts inventory from the encrypted payload — was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412).
 - **Sync Apply & Dialog Fixes (v3.33.35)**: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff — falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411).
-- **Sync Pull Race Fix (v3.33.34)**: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open — the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -1149,7 +1149,6 @@
           </table>
           </div>
           <div class="table-footer-controls">
-            <div class="table-item-count"><strong id="itemCount"></strong></div>
             <select id="itemsPerPage" class="control-select" title="Visible rows">
               <option value="3">3</option>
               <option value="6">6</option>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>
     <li><strong>v3.33.38 &ndash; Sync Poll, Settings Sync, DiffModal Fixes</strong>: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices &mdash; poll compares both inventory and settings hashes. &ldquo;No changes detected&rdquo; popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417)</li>
     <li><strong>v3.33.37 &ndash; Sync Dialog Cleanup</strong>: Removed the redundant &ldquo;Sync Update Available&rdquo; dialog &mdash; remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413)</li>
     <li><strong>v3.33.36 &ndash; Sync Pull Root Cause Fix</strong>: Vault-first pull now correctly extracts inventory from the encrypted payload &mdash; was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412)</li>
     <li><strong>v3.33.35 &ndash; Sync Apply &amp; Dialog Fixes</strong>: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff &mdash; falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411)</li>
-    <li><strong>v3.33.34 &ndash; Sync Pull Race Fix</strong>: Cloud sync no longer overwrites Dropbox with stale local data while the diff preview modal is open &mdash; the pull now fully blocks concurrent pushes until the user clicks Apply and the vault restore completes (STAK-406)</li>
   `;
 };
 

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -18,11 +18,13 @@ function isCardViewActive() {
 
 /**
  * Computes portfolio summary totals for currently filtered items.
- * @returns {{ purchase: number, melt: number, retail: number, gainLoss: number, count: number }}
+ * @returns {{ purchase: number, melt: number, retail: number, gainLoss: number, filteredCount: number, totalCount: number, totalWeight: number }}
  */
 function _computePortfolioSummary() {
   const items = (typeof filterInventory === 'function') ? filterInventory() : (inventory || []);
-  let purchase = 0, melt = 0, retail = 0, count = 0;
+  const totalCount = (typeof inventory !== 'undefined' && Array.isArray(inventory)) ? inventory.length : items.length;
+  let purchase = 0, melt = 0, retail = 0, totalWeight = 0;
+  const gbToOzt = (typeof GB_TO_OZT !== 'undefined') ? GB_TO_OZT : 1 / 50;
   items.forEach(item => {
     const spot = (typeof spotPrices !== 'undefined' ? spotPrices[(item.metal || '').toLowerCase()] : 0) || 0;
     const valuation = (typeof computeItemValuation === 'function')
@@ -40,9 +42,12 @@ function _computePortfolioSummary() {
     purchase += valuation.purchaseTotal || 0;
     melt += valuation.meltValue || 0;
     retail += valuation.retailTotal || 0;
-    count++;
+    const qty = Number(item.qty) || 1;
+    const w = parseFloat(item.weight) || 0;
+    const wOz = (item.weightUnit === 'gb') ? w * gbToOzt : w;
+    totalWeight += qty * wOz;
   });
-  return { purchase, melt, retail, gainLoss: retail - purchase, count };
+  return { purchase, melt, retail, gainLoss: retail - purchase, filteredCount: items.length, totalCount, totalWeight };
 }
 
 /**
@@ -258,7 +263,15 @@ function _renderSortBarSummary() {
   const gl = s.gainLoss;
   const glClass = gl >= 0 ? 'summary-positive' : 'summary-negative';
   const glSign = gl >= 0 ? '+' : '';
+  const itemsText = s.filteredCount === s.totalCount
+    ? `${s.totalCount}`
+    : `${s.filteredCount}/${s.totalCount}`;
+  const weightText = `${s.totalWeight.toFixed(1)}oz`;
   el.innerHTML =
+    `<span class="summary-item"><span class="summary-label">Items</span><span class="summary-val">${itemsText}</span></span>` +
+    `<span class="summary-sep">·</span>` +
+    `<span class="summary-item"><span class="summary-label">Weight</span><span class="summary-val">${weightText}</span></span>` +
+    `<span class="summary-sep">·</span>` +
     `<span class="summary-item"><span class="summary-label">Buy</span><span class="summary-val">${fmt(s.purchase)}</span></span>` +
     `<span class="summary-sep">·</span>` +
     `<span class="summary-item"><span class="summary-label">Melt</span><span class="summary-val">${fmt(s.melt)}</span></span>` +

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.38";
+const APP_VERSION = "3.33.39";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/init.js
+++ b/js/init.js
@@ -263,7 +263,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Pagination elements
     debugLog("Phase 5: Initializing pagination elements...");
     elements.itemsPerPage = safeGetElement("itemsPerPage");
-    elements.itemCount = safeGetElement("itemCount");
 
       elements.changeLogBtn = safeGetElement("changeLogBtn");
       elements.backupReminder = safeGetElement("backupReminder");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1089,18 +1089,10 @@ const persistInventoryAndRefresh = () => {
 };
 
 /**
- * Updates the displayed inventory item count based on active filters
- *
- * @param {number} filteredCount - Items matching current filters
- * @param {number} totalCount - Total items in inventory
+ * Updates the displayed inventory item count — now handled by the summary bar
+ * in card-view.js (_renderSortBarSummary). Kept as no-op for call-site compat.
  */
-const updateItemCount = (filteredCount, totalCount) => {
-  if (!elements.itemCount) return;
-  elements.itemCount.textContent =
-    filteredCount === totalCount
-      ? `${totalCount} items`
-      : `${filteredCount} of ${totalCount} items`;
-};
+const updateItemCount = () => {};
 
 /**
  * Enhanced validation for inline edits with comprehensive field support

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.38-b1772579072';
+const CACHE_NAME = 'staktrakr-v3.33.39-b1772580139';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.38",
+  "version": "3.33.39",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **STAK-418**: Item count and total weight now display in the portfolio summary bar (ITEMS · WEIGHT · Buy · Melt · Market · G/L)
- ITEMS shows `filtered/total` format when filters active (e.g., `172/189`), just `189` when unfiltered
- WEIGHT shows total troy ounces of currently filtered items
- Bottom footer `table-item-count` div removed (per-page selector stays)
- `updateItemCount()` converted to no-op; `elements.itemCount` init removed
- CSS: `.table-item-count` rules removed, `.table-footer-controls` changed to `justify-content: flex-end`

## Linear Issues

- [STAK-418: Move item count + weight to summary bar, remove bottom footer](https://linear.app/lbruton/issue/STAK-418)

🤖 Generated with [Claude Code](https://claude.com/claude-code)