### PR TITLE
v3.33.40 — STAK-404: Simplify market price display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.40] - 2026-03-03
+
+### Changed — Simplify Market Price Display (STAK-404)
+
+- **Removed**: Confidence score badges (e.g., "70%") from vendor chips on market cards and expanded card vendor rows — all vendors now display equally (STAK-404)
+- **Removed**: Out-of-stock vendor styling — no more grayed-out rows, strikethrough prices, or "OOS" badges; vendors with valid prices display normally regardless of stock flag (STAK-404)
+- **Added**: Median anomaly filter for market list vendor chips — vendors with prices deviating more than 40% from the median are silently excluded instead of shown with warnings (STAK-404)
+- **Fixed**: Monument Metals false OOS detection — page nav "PRE-ORDER" text no longer triggers out-of-stock flag (STAK-404, StakTrakrApi)
+
+---
+
 ## [3.33.39] - 2026-03-03
 
 ### Changed — Summary Bar Items + Weight (STAK-418)

--- a/css/styles.css
+++ b/css/styles.css
@@ -11885,36 +11885,6 @@ th {
   font-weight: 600;
 }
 
-/* Out-of-stock vendor styling */
-.retail-vendor-row--out-of-stock {
-  opacity: 0.6;
-  background-color: var(--bs-gray-100);
-}
-
-.retail-vendor-row--out-of-stock .retail-vendor-name {
-  color: var(--bs-gray-600);
-}
-
-.retail-vendor-row--out-of-stock .retail-vendor-price del {
-  text-decoration: line-through;
-  color: var(--bs-gray-500);
-}
-
-/* Confidence percentage chip — uses Bootstrap 5.3 semantic emphasis vars that adapt per theme */
-.retail-conf-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.15rem 0.4rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  border-radius: 999px;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-.retail-conf-chip--low  { background: color-mix(in srgb, var(--danger)  12%, transparent); color: var(--danger); }
-.retail-conf-chip--mid  { background: color-mix(in srgb, var(--warning) 12%, transparent); color: var(--warning); }
-.retail-conf-chip--high { background: color-mix(in srgb, var(--success) 12%, transparent); color: var(--success); }
-
 .retail-vendor-details { margin-top: 0.25rem; }
 
 /* STAK-217: Loading skeleton shimmer */
@@ -12629,22 +12599,6 @@ th {
 .vendor-medal--1 { background: rgba(245,158,11,0.2); color: #f59e0b; }
 .vendor-medal--2 { background: rgba(148,163,184,0.2); color: #94a3b8; }
 .vendor-medal--3 { background: rgba(217,119,6,0.15); color: #d97706; }
-.vendor-chip .vendor-confidence {
-  font-size: 9px;
-  color: var(--text-muted, #6c757d);
-  opacity: 0.7;
-}
-.vendor-chip.oos .vendor-name {
-  color: var(--text-muted, #6c757d) !important;
-  text-decoration: line-through;
-}
-.vendor-chip.oos .vendor-price {
-  color: var(--text-muted, #6c757d);
-  text-decoration: line-through;
-  font-size: 11px;
-}
-.vendor-chip.low-conf .vendor-price { opacity: 0.6; }
-
 /* Trend badge */
 .market-card-trend {
   display: flex;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,9 @@
 ## What's New
 
+- **Simplify Market Price Display (v3.33.40)**: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404).
 - **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).
 - **Sync Poll, Settings Sync, DiffModal Fixes (v3.33.38)**: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices — poll compares both inventory and settings hashes. "No changes detected" popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417).
 - **Sync Dialog Cleanup (v3.33.37)**: Removed the redundant "Sync Update Available" dialog — remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413).
-- **Sync Pull Root Cause Fix (v3.33.36)**: Vault-first pull now correctly extracts inventory from the encrypted payload — was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412).
-- **Sync Apply & Dialog Fixes (v3.33.35)**: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff — falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.40 &ndash; Simplify Market Price Display</strong>: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404)</li>
     <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>
     <li><strong>v3.33.38 &ndash; Sync Poll, Settings Sync, DiffModal Fixes</strong>: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices &mdash; poll compares both inventory and settings hashes. &ldquo;No changes detected&rdquo; popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417)</li>
     <li><strong>v3.33.37 &ndash; Sync Dialog Cleanup</strong>: Removed the redundant &ldquo;Sync Update Available&rdquo; dialog &mdash; remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413)</li>
-    <li><strong>v3.33.36 &ndash; Sync Pull Root Cause Fix</strong>: Vault-first pull now correctly extracts inventory from the encrypted payload &mdash; was treating the localStorage dict as an array, showing zero additions. Removed redundant Sync Conflict dialog; remote changes go directly to Review Sync Changes DiffModal. Manifest count check expanded to catch incomplete diffs (STAK-412)</li>
-    <li><strong>v3.33.35 &ndash; Sync Apply &amp; Dialog Fixes</strong>: DiffModal Apply no longer empties the vault when remote-only additions are missed by the manifest diff &mdash; falls back to full overwrite. Empty-vault guard dialog OK button now correctly triggers a pull. Double conflict modal prevented (STAK-409, STAK-410, STAK-411)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.39";
+const APP_VERSION = "3.33.40";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -90,9 +90,11 @@ const _buildVendorLegend = (slug) => {
       || (typeof RETAIL_VENDOR_URLS !== "undefined" && RETAIL_VENDOR_URLS[vendorId])
       || null;
 
+    // Skip vendors with no price
+    if (price == null) return;
+
     const item = document.createElement(vendorUrl ? "a" : "span");
     item.className = "retail-legend-item";
-    if (isOOS) item.style.opacity = "0.5";
     if (vendorUrl) {
       item.href = "#";
       item.addEventListener("click", (e) => {
@@ -113,25 +115,7 @@ const _buildVendorLegend = (slug) => {
 
     const priceEl = document.createElement("span");
     priceEl.className = "retail-legend-price";
-
-    if (isOOS) {
-      const lkpMap = typeof retailLastKnownPrices !== 'undefined' && retailLastKnownPrices;
-      const ladMap = typeof retailLastAvailableDates !== 'undefined' && retailLastAvailableDates;
-      const lkp = lkpMap && lkpMap[slug] && lkpMap[slug][vendorId];
-      const lad = ladMap && ladMap[slug] && ladMap[slug][vendorId];
-      const priceText = document.createElement("del");
-      priceText.textContent = lkp != null ? `$${Number(lkp).toFixed(2)}` : '\u2014';
-      priceEl.appendChild(priceText);
-      const badge = document.createElement("small");
-      badge.className = "text-danger ms-1";
-      badge.textContent = "OOS";
-      priceEl.appendChild(badge);
-      item.title = lad
-        ? `Out of stock (last seen: ${priceText.textContent} on ${lad})`
-        : "Out of stock";
-    } else {
-      priceEl.textContent = `$${Number(price).toFixed(2)}`;
-    }
+    priceEl.textContent = `$${Number(price).toFixed(2)}`;
 
     item.appendChild(swatch);
     item.appendChild(nameEl);

--- a/js/retail.js
+++ b/js/retail.js
@@ -837,36 +837,13 @@ const _buildRetailCard = (slug, meta, priceData) => {
         const label = getVendorDisplay(key).name;
         return { key, label, price, score, isAvailable };
       })
-      .filter(({ price, isAvailable }) => price != null || !isAvailable) // show if has price OR is OOS
-      .sort((a, b) => {
-        // OOS vendors always go last
-        if (!a.isAvailable && b.isAvailable) return 1;
-        if (a.isAvailable && !b.isAvailable) return -1;
-        if (!a.isAvailable && !b.isAvailable) return 0; // both OOS, maintain order
-        // Both in-stock: sort by confidence and price
-        const aHigh = a.score != null && a.score >= 60;
-        const bHigh = b.score != null && b.score >= 60;
-        if (aHigh && bHigh) return a.price - b.price;
-        if (aHigh) return -1;
-        if (bHigh) return 1;
-        return 0;
-      });
+      .filter(({ price }) => price != null) // show only vendors with a price
+      .sort((a, b) => a.price - b.price); // sort by price ascending
 
-    // Award medals to top 3 high-confidence (≥60%) in-stock vendors by price
-    const qualifyingVendors = sortedVendorEntries
-      .filter(({ isAvailable, score }) => isAvailable && score != null && score >= 60);
-    const top3 = qualifyingVendors.slice(0, 3).map(({ key }) => key);
-    const medals = { 0: "🥇", 1: "🥈", 2: "🥉" };
+    // Award medals to top 3 vendors by price
+    const top3 = sortedVendorEntries.slice(0, 3).map(({ key }) => key);
 
-    sortedVendorEntries.forEach(({ key, label, price, score, isAvailable }) => {
-      if (!isAvailable) {
-        // Render out-of-stock vendor
-        const oosRow = _buildOOSVendorRow(key, lastKnownPrices[key], lastKnownDates[key], slug);
-        vendors.appendChild(oosRow);
-        return;
-      }
-
-      // Render in-stock vendor (existing logic)
+    sortedVendorEntries.forEach(({ key, label, price }) => {
       const row = document.createElement("div");
       row.className = "retail-vendor-row";
       const medalIndex = top3.indexOf(key);
@@ -902,11 +879,8 @@ const _buildRetailCard = (slug, meta, priceData) => {
       priceEl.className = "retail-vendor-price";
       priceEl.textContent = _fmtRetailPrice(price);
 
-      const scoreEl = _buildConfidenceBar(score);
-
       row.appendChild(nameEl);
       row.appendChild(priceEl);
-      row.appendChild(scoreEl);
       vendors.appendChild(row);
     });
 
@@ -948,83 +922,6 @@ const _buildRetailCard = (slug, meta, priceData) => {
   card.appendChild(btnRow);
 
   return card;
-};
-
-/**
- * Builds a compact confidence percentage chip.
- * @param {number|null} score - 0 to 100
- * @returns {HTMLElement}
- */
-const _buildConfidenceBar = (score) => {
-  const chip = document.createElement("span");
-  const tier = (score == null) ? "low" : score >= 60 ? "high" : score >= 40 ? "mid" : "low";
-  chip.className = `retail-conf-chip retail-conf-chip--${tier}`;
-  chip.textContent = score != null ? `${Math.round(score)}%` : "?";
-  chip.title = `Confidence: ${score != null ? `${Math.round(score)}/100` : "unknown"}`;
-  return chip;
-};
-
-/**
- * Builds a grayed-out vendor row for out-of-stock items.
- * @param {string} vendorId - Vendor key (e.g., "apmex")
- * @param {number|null} lastKnownPrice - Last known price before going OOS
- * @param {string|null} lastAvailableDate - Last date item was in stock (YYYY-MM-DD)
- * @param {string} [slug] - Product slug for product-page link lookup
- * @returns {HTMLElement}
- */
-const _buildOOSVendorRow = (vendorId, lastKnownPrice, lastAvailableDate, slug) => {
-  const row = document.createElement("div");
-  row.className = "retail-vendor-row retail-vendor-row--out-of-stock";
-
-  const nameEl = document.createElement("span");
-  nameEl.className = "retail-vendor-name text-muted";
-  const _vd = getVendorDisplay(vendorId);
-  const vendorLabel = _vd.name;
-  // Add vendor link (same pattern as in-stock rows)
-  const vendorUrl = (slug && retailProviders && retailProviders[slug] && retailProviders[slug][vendorId])
-    || _vd.url;
-  if (vendorUrl) {
-    const link = document.createElement("a");
-    link.href = "#";
-    link.textContent = vendorLabel;
-    link.className = "retail-vendor-link text-muted";
-    link.addEventListener("click", (e) => {
-      e.preventDefault();
-      const popup = window.open(vendorUrl, `retail_vendor_${vendorId}`, "width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no");
-      if (!popup) window.open(vendorUrl, "_blank");
-    });
-    nameEl.appendChild(link);
-  } else {
-    nameEl.textContent = vendorLabel;
-  }
-
-  const priceEl = document.createElement("span");
-  priceEl.className = "retail-vendor-price";
-
-  const priceText = document.createElement("del");
-  priceText.textContent = lastKnownPrice ? _fmtRetailPrice(lastKnownPrice) : "\u2014";
-  priceEl.appendChild(priceText);
-
-  const oosLabel = document.createElement("small");
-  oosLabel.className = "text-danger ms-1";
-  oosLabel.textContent = "OOS";
-  oosLabel.title = "Out of stock";
-  priceEl.appendChild(oosLabel);
-
-  const badgeEl = document.createElement("span");
-  badgeEl.className = "retail-conf-chip badge-muted";
-  badgeEl.textContent = "\u2014";
-
-  const tooltipText = lastAvailableDate
-    ? `Out of stock (last seen: ${priceText.textContent} on ${lastAvailableDate})`
-    : "Out of stock";
-  row.title = tooltipText;
-
-  row.appendChild(nameEl);
-  row.appendChild(priceEl);
-  row.appendChild(badgeEl);
-
-  return row;
 };
 
 // ---------------------------------------------------------------------------
@@ -1207,71 +1104,57 @@ const _buildMarketListCard = (slug, meta, priceData, historyData) => {
       gbPriceEl.textContent = _fmtRetailPrice(gbPrice.price) + (gbPrice.isStale ? " (stale)" : "");
       gbChip.appendChild(gbPriceEl);
       const gbSrc = document.createElement("span");
-      gbSrc.className = "vendor-confidence";
+      gbSrc.className = "vendor-source";
       gbSrc.textContent = "goldback.com";
       gbSrc.style.fontSize = "0.65rem";
+      gbSrc.style.color = "var(--text-muted, #6c757d)";
+      gbSrc.style.opacity = "0.7";
       gbChip.appendChild(gbSrc);
       vendorRow.appendChild(gbChip);
     }
   }
   if (priceData) {
     const vendorMap = priceData.vendors || {};
-    const avail = retailAvailability[slug] || {};
-    const allVendorKeys = new Set([...Object.keys(vendorMap), ...Object.keys(avail)]);
-    const sortedVendors = Array.from(allVendorKeys)
+    const sortedVendors = Object.keys(vendorMap)
       .map((key) => {
         const vd = vendorMap[key];
-        const isAvailable = avail[key] !== false;
         const price = vd ? vd.price : null;
-        const score = vd ? vd.confidence : null;
-        return { key, price, score, isAvailable };
+        return { key, price };
       })
-      .filter(({ price, isAvailable }) => price != null || !isAvailable)
-      .sort((a, b) => {
-        if (!a.isAvailable && b.isAvailable) return 1;
-        if (a.isAvailable && !b.isAvailable) return -1;
-        if (!a.isAvailable && !b.isAvailable) return 0;
-        const aHigh = a.score != null && a.score >= 60;
-        const bHigh = b.score != null && b.score >= 60;
-        if (aHigh && bHigh) return a.price - b.price;
-        if (aHigh) return -1;
-        if (bHigh) return 1;
-        return 0;
-      });
-    const qualVendors = sortedVendors.filter(({ isAvailable, price }) => isAvailable && price != null);
-    const top3Keys = qualVendors.slice(0, 3).map(({ key }) => key);
-    sortedVendors.forEach(({ key, price, score, isAvailable }) => {
+      .filter(({ price }) => price != null && price > 0)
+      .sort((a, b) => a.price - b.price);
+
+    // Median anomaly filter: suppress vendors >40% from median (3+ vendors required)
+    let displayVendors = sortedVendors;
+    if (sortedVendors.length >= 3) {
+      const prices = sortedVendors.map(({ price }) => price);
+      const mid = Math.floor(prices.length / 2);
+      const median = prices.length % 2 ? prices[mid] : (prices[mid - 1] + prices[mid]) / 2;
+      const threshold = typeof RETAIL_ANOMALY_THRESHOLD !== "undefined" ? RETAIL_ANOMALY_THRESHOLD : 0.40;
+      const filtered = sortedVendors.filter(({ price }) => Math.abs(price - median) / median <= threshold);
+      // Guard: if all would be filtered, show all
+      if (filtered.length > 0) displayVendors = filtered;
+    }
+
+    const top3Keys = displayVendors.slice(0, 3).map(({ key }) => key);
+    displayVendors.forEach(({ key, price }) => {
       const chip = document.createElement("span");
       chip.className = "vendor-chip";
-      if (!isAvailable) chip.classList.add("oos");
-      else if (score != null && score < 60) chip.classList.add("low-conf");
 
-      if (isAvailable) {
-        const medalIdx = top3Keys.indexOf(key);
-        if (medalIdx !== -1) {
-          const medal = document.createElement("span");
-          medal.className = `vendor-medal ${_MARKET_MEDAL_CLASSES[medalIdx]}`;
-          medal.textContent = _MARKET_MEDALS[medalIdx];
-          chip.appendChild(medal);
-        }
+      const medalIdx = top3Keys.indexOf(key);
+      if (medalIdx !== -1) {
+        const medal = document.createElement("span");
+        medal.className = `vendor-medal ${_MARKET_MEDAL_CLASSES[medalIdx]}`;
+        medal.textContent = _MARKET_MEDALS[medalIdx];
+        chip.appendChild(medal);
       }
       const nameLink = _buildMarketVendorLink(key, slug);
       nameLink.className = "vendor-name";
-      if (!isAvailable) {
-        nameLink.style.color = "";
-      }
       chip.appendChild(nameLink);
       const priceEl = document.createElement("span");
       priceEl.className = "vendor-price";
-      priceEl.textContent = isAvailable ? _fmtRetailPrice(price) : "OOS";
+      priceEl.textContent = _fmtRetailPrice(price);
       chip.appendChild(priceEl);
-      // Confidence score badge (playground shows "95%", "80%" etc.)
-      if (isAvailable && score != null) {
-        const confEl = document.createElement("span");
-        confEl.className = "vendor-confidence";
-        confEl.textContent = `${Math.round(score)}%`;
-        chip.appendChild(confEl);
-      }
       vendorRow.appendChild(chip);
     });
   }
@@ -2001,7 +1884,6 @@ if (typeof window !== "undefined") {
   window.RETAIL_VENDOR_NAMES = RETAIL_VENDOR_NAMES;
   window.RETAIL_VENDOR_URLS = RETAIL_VENDOR_URLS;
   window.RETAIL_VENDOR_COLORS = RETAIL_VENDOR_COLORS;
-  window._buildConfidenceBar = _buildConfidenceBar;
   window.retailAvailability = retailAvailability;
   window.retailLastKnownPrices = retailLastKnownPrices;
   window.retailLastAvailableDates = retailLastAvailableDates;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.39-b1772580139';
+const CACHE_NAME = 'staktrakr-v3.33.40-b1772580637';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.39",
+  "version": "3.33.40",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Removed** confidence score badges ("70%") from vendor chips on market cards and expanded card vendor rows
- **Removed** out-of-stock vendor styling — no more grayed-out rows, strikethrough prices, or "OOS" badges
- **Added** median anomaly filter for market list vendor chips — vendors deviating >40% from median silently excluded
- **Fixed** Monument Metals false OOS detection (backend fix in StakTrakrApi PR #35)
- **Deleted** ~170 lines of dead CSS and JS (OOS/confidence rendering paths)

## Linear Issues

- [STAK-404: Simplify market price display](https://linear.app/lbruton/issue/STAK-404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)