### PR TITLE
docs(wiki): update nightwatch log with retail-modal sync inaccuracy

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 6,
+  "nextIndex": 7,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -35,6 +35,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "Claims 'TTL is 30 minutes per claim' but devops/version-lock-protocol.md defines three tiers: Hotfix = 30min, Spec implementation = 4h, Pre-assigned queued slot = 4h.",
+      "verified": []
+    },
+    {
+      "date": "2026-03-03",
+      "page": "retail-modal.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "Page claims initRetailPrices() in retail.js loads all cached data from localStorage, then calls syncRetailPrices({ ui: false }) in the background. However, initRetailPrices does not call syncRetailPrices; background syncing is actually triggered by startRetailBackgroundSync().",
       "verified": []
     }
   ]


### PR DESCRIPTION
This pull request addresses an inaccuracy in the `wiki/retail-modal.md` page regarding the initialization flow for the background syncing of retail prices. The Nightwatch log (`wiki/.nightwatch-log.json`) has been updated to reflect the findings.

The wiki claimed that `initRetailPrices()` was responsible for triggering background sync. In reality, `startRetailBackgroundSync()` (called from `init.js`) owns the auto-sync interval logic and initial call to `syncRetailPrices({ ui: false })`. 

Changes:
* Incremented `nextIndex` to progress the Wiki rotation logic.
* Logged the finding and the relevant mismatch between the markdown documentation and `js/retail.js` in `.nightwatch-log.json`.
* Ensured `history` arrays max size cap is respected.

---
*PR created automatically by Jules for task [17284442785493954033](https://jules.google.com/task/17284442785493954033) started by @lbruton*