### PR TITLE
v3.33.41 — STAK-419: Separate manual backups from sync snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.41] - 2026-03-03
+
+### Fixed — Cloud Backup Manual vs Sync Separation (STAK-419)
+
+- **Fixed**: Auto-prune now only deletes sync snapshots (`pre-sync-*`), never user manual backups (`staktrakr-backup-*`) — previously pruned all backups indiscriminately causing data loss (STAK-419)
+- **Fixed**: Restore list now shows only manual backups by default with sync snapshots in a collapsible section — previously flooded with identical sync metadata copies (STAK-419)
+- **Fixed**: "Backup history" dropdown renamed to "Sync history" and now controls only sync snapshot retention, not total backup count (STAK-419)
+- **Fixed**: Manual Backup button now always prompts for password via vault modal — previously silently reused the sync password cache (STAK-419)
+- **Fixed**: Manual backups no longer update `cloud_last_backup` sync tracking state or cache the password for auto-sync use (STAK-419)
+- **Added**: `MANUAL_BACKUP_PREFIX` and `SYNC_BACKUP_PREFIX` constants for filename-based backup type discrimination (STAK-419)
+
+---
+
 ## [3.33.40] - 2026-03-03
 
 ### Changed — Simplify Market Price Display (STAK-404)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Cloud Backup/Restore Fix (v3.33.41)**: Manual backups and sync snapshots now separated — auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419).
 - **Simplify Market Price Display (v3.33.40)**: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404).
 - **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).
 - **Sync Poll, Settings Sync, DiffModal Fixes (v3.33.38)**: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices — poll compares both inventory and settings hashes. "No changes detected" popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417).

--- a/index.html
+++ b/index.html
@@ -3464,7 +3464,7 @@
 
                     <!-- Backup history depth -->
                     <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.6rem;border-top:1px solid var(--border);padding-top:0.6rem">
-                      <span class="cloud-status-label" style="flex:1"><strong>Backup history</strong></span>
+                      <span class="cloud-status-label" style="flex:1" title="Number of automatic sync snapshots to retain"><strong>Sync history</strong></span>
                       <select id="cloudBackupHistoryDepth" style="width:auto;min-width:60px;font-size:0.82rem;padding:0.25rem 0.4rem">
                         <option value="3">3</option>
                         <option value="5" selected>5</option>

--- a/js/about.js
+++ b/js/about.js
@@ -283,10 +283,10 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.41 &ndash; Cloud Backup/Restore Fix</strong>: Manual backups and sync snapshots now separated &mdash; auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419)</li>
     <li><strong>v3.33.40 &ndash; Simplify Market Price Display</strong>: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404)</li>
     <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>
     <li><strong>v3.33.38 &ndash; Sync Poll, Settings Sync, DiffModal Fixes</strong>: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices &mdash; poll compares both inventory and settings hashes. &ldquo;No changes detected&rdquo; popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417)</li>
-    <li><strong>v3.33.37 &ndash; Sync Dialog Cleanup</strong>: Removed the redundant &ldquo;Sync Update Available&rdquo; dialog &mdash; remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413)</li>
   `;
 };
 

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -687,29 +687,31 @@ async function cloudUploadVault(provider, fileBytes, opts) {
       body: fileBytes,
     });
 
-    // Upload latest.json pointer
-    var latestData = {
-      filename: filename,
-      timestamp: now,
-      appVersion: cloudSafeAppVersion(),
-      itemCount: cloudSafeItemCount(),
-    };
-    var latestBytes = new TextEncoder().encode(JSON.stringify(latestData));
-    var latestArg = JSON.stringify({
-      path: config.folder + '/backups/' + CLOUD_LATEST_FILENAME,
-      mode: 'overwrite',
-      autorename: false,
-      mute: true,
-    });
-    await fetch('https://content.dropboxapi.com/2/files/upload', {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer ' + token,
-        'Content-Type': 'application/octet-stream',
-        'Dropbox-API-Arg': latestArg,
-      },
-      body: latestBytes,
-    });
+    // Upload latest.json pointer (skip for manual backups — STAK-419)
+    if (!(opts && opts.skipLatestUpdate)) {
+      var latestData = {
+        filename: filename,
+        timestamp: now,
+        appVersion: cloudSafeAppVersion(),
+        itemCount: cloudSafeItemCount(),
+      };
+      var latestBytes = new TextEncoder().encode(JSON.stringify(latestData));
+      var latestArg = JSON.stringify({
+        path: config.folder + '/backups/' + CLOUD_LATEST_FILENAME,
+        mode: 'overwrite',
+        autorename: false,
+        mute: true,
+      });
+      await fetch('https://content.dropboxapi.com/2/files/upload', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'Content-Type': 'application/octet-stream',
+          'Dropbox-API-Arg': latestArg,
+        },
+        body: latestBytes,
+      });
+    }
   } else if (provider === 'pcloud') {
     var formData = new FormData();
     formData.append('file', new Blob([fileBytes]), filename);

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -638,7 +638,7 @@ function cloudSafeAppVersion() {
 // Upload vault to cloud (accepts pre-built fileBytes)
 // ---------------------------------------------------------------------------
 
-async function cloudUploadVault(provider, fileBytes) {
+async function cloudUploadVault(provider, fileBytes, opts) {
   var uploadStart = Date.now();
   var token = await cloudGetToken(provider);
   if (!token) throw new Error('Not connected to ' + CLOUD_PROVIDERS[provider].name);
@@ -739,7 +739,9 @@ async function cloudUploadVault(provider, fileBytes) {
     appVersion: cloudSafeAppVersion(),
     itemCount: safeCount,
   };
-  localStorage.setItem('cloud_last_backup', JSON.stringify(backupMeta));
+  if (!(opts && opts.skipLatestUpdate)) {
+    localStorage.setItem('cloud_last_backup', JSON.stringify(backupMeta));
+  }
 
   recordCloudActivity({ action: 'backup', provider: provider, result: 'success', detail: filename + ' (' + safeCount + ' items)', duration: Date.now() - uploadStart });
 
@@ -795,7 +797,7 @@ async function cloudGetRemoteLatest(provider) {
 // List backups in cloud folder
 // ---------------------------------------------------------------------------
 
-async function cloudListBackups(provider) {
+async function cloudListBackups(provider, type) {
   var listStart = Date.now();
   var token = await cloudGetToken(provider);
   if (!token) throw new Error('Not connected to ' + CLOUD_PROVIDERS[provider].name);
@@ -835,6 +837,13 @@ async function cloudListBackups(provider) {
   backups.sort(function (a, b) {
     return new Date(b.server_modified) - new Date(a.server_modified);
   });
+
+  // Filter by backup type if requested (STAK-419)
+  if (type === 'manual') {
+    backups = backups.filter(function (b) { return b.name.indexOf(MANUAL_BACKUP_PREFIX) === 0; });
+  } else if (type === 'sync') {
+    backups = backups.filter(function (b) { return b.name.indexOf(SYNC_BACKUP_PREFIX) === 0; });
+  }
 
   recordCloudActivity({ action: 'list', provider: provider, result: 'success', detail: backups.length + ' backups found', duration: Date.now() - listStart });
 
@@ -1327,9 +1336,10 @@ async function cloudMigrateToV2(provider) {
 // Prune old backups — keeps only the newest `maxKeep` backups
 // ---------------------------------------------------------------------------
 
-async function cloudPruneBackups(provider, maxKeep) {
+async function cloudPruneBackups(provider, maxKeep, type) {
   try {
-    var backups = await cloudListBackups(provider);
+    var effectiveType = type || 'sync';
+    var backups = await cloudListBackups(provider, effectiveType);
     if (!backups || backups.length <= maxKeep) return;
 
     // cloudListBackups returns newest-first; delete from the end (oldest)

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1478,7 +1478,7 @@ async function pushSyncVault() {
     // Auto-prune old backups (fire-and-forget)
     if (typeof cloudPruneBackups === 'function') {
       var pruneMax = parseInt(loadDataSync(CLOUD_BACKUP_HISTORY_KEY, String(CLOUD_BACKUP_HISTORY_DEFAULT)), 10);
-      cloudPruneBackups(_syncProvider, pruneMax).catch(function (e) {
+      cloudPruneBackups(_syncProvider, pruneMax, 'sync').catch(function (e) {
         debugLog('[CloudSync] Prune error (non-blocking):', e.message);
       });
     }

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.40";
+const APP_VERSION = "3.33.41";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -792,6 +792,12 @@ const CLOUD_LATEST_FILENAME = 'staktrakr-latest.json';
 const CLOUD_BACKUP_HISTORY_KEY = 'cloud_backup_history_depth';
 const CLOUD_BACKUP_HISTORY_DEFAULT = 5;
 const CLOUD_BACKUP_HISTORY_OPTIONS = [3, 5, 10, 20];
+
+/** Filename prefix for user-initiated manual backups */
+const MANUAL_BACKUP_PREFIX = 'staktrakr-backup-';
+
+/** Filename prefix for auto-sync pre-push snapshot backups */
+const SYNC_BACKUP_PREFIX = 'pre-sync-';
 
 /**
  * Keys included in a sync vault (excludes API keys, tokens, spot history).
@@ -1735,6 +1741,8 @@ if (typeof window !== "undefined") {
   window.SYNC_MANIFEST_PATH = SYNC_MANIFEST_PATH;
   window.SYNC_MANIFEST_PATH_LEGACY = SYNC_MANIFEST_PATH_LEGACY;
   window.SYNC_BACKUP_FOLDER = SYNC_BACKUP_FOLDER;
+  window.MANUAL_BACKUP_PREFIX = MANUAL_BACKUP_PREFIX;
+  window.SYNC_BACKUP_PREFIX = SYNC_BACKUP_PREFIX;
   window.CLOUD_LATEST_FILENAME = CLOUD_LATEST_FILENAME;
   window.CLOUD_BACKUP_HISTORY_KEY = CLOUD_BACKUP_HISTORY_KEY;
   window.CLOUD_BACKUP_HISTORY_DEFAULT = CLOUD_BACKUP_HISTORY_DEFAULT;

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1016,37 +1016,106 @@ const renderCloudBackupList = (provider, backups) => {
   const listEl = document.getElementById('cloudBackupList_' + provider);
   if (!listEl) return;
 
+  listEl.style.display = '';
+
+  // Build manual backups section
+  var html = '';
   if (!backups || backups.length === 0) {
-    listEl.style.display = '';
-    listEl.innerHTML = '<div class="cloud-backup-empty">No backups found</div>';
-    return;
+    html += '<div class="cloud-backup-empty">No manual backups</div>';
+  } else {
+    html += '<div class="cloud-backup-section-header" style="font-size:0.7rem;color:var(--text-secondary);margin-bottom:0.3rem;font-weight:600">Manual Backups</div>';
+    html += backups.map(function (b) {
+      const d = new Date(b.server_modified);
+      const dateStr = d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
+        ' ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      const sizeStr = b.size < 1024 ? b.size + ' B' :
+        b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
+          (b.size / 1048576).toFixed(1) + ' MB';
+      const safeProvider = sanitizeHtml(provider);
+      const safeFilename = sanitizeHtml(b.name);
+      return '<div class="cloud-backup-row">' +
+        '<button class="cloud-backup-entry" data-provider="' + safeProvider +
+          '" data-filename="' + safeFilename + '" data-size="' + b.size + '">' +
+          '<span class="cloud-backup-name" title="' + safeFilename + '">' + sanitizeHtml(dateStr) + '</span>' +
+          '<span class="cloud-backup-size">' + sanitizeHtml(sizeStr) + '</span>' +
+          '<span class="cloud-backup-type">Manual backup</span>' +
+        '</button>' +
+        '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
+          '" data-filename="' + safeFilename + '" title="Delete this backup from Dropbox" aria-label="Delete ' + safeFilename + '">' +
+          '&times;' +
+        '</button>' +
+      '</div>';
+    }).join('');
   }
 
-  listEl.style.display = '';
+  // Add collapsible sync snapshots section
+  html += '<div class="cloud-backup-sync-toggle" style="cursor:pointer;margin-top:0.5rem;padding:0.3rem 0;font-size:0.7rem;color:var(--text-secondary);user-select:none" data-provider="' + sanitizeHtml(provider) + '">' +
+    '<span class="cloud-backup-sync-arrow" style="display:inline-block;transition:transform 0.2s;margin-right:0.3rem">&#9654;</span>Sync Snapshots' +
+  '</div>' +
+  '<div class="cloud-backup-sync-list" data-provider="' + sanitizeHtml(provider) + '" style="display:none"></div>';
+
   // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
-  listEl.innerHTML = backups.map(function (b) {
-    const d = new Date(b.server_modified);
-    const dateStr = d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
-      ' ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-    const sizeStr = b.size < 1024 ? b.size + ' B' :
-      b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
-        (b.size / 1048576).toFixed(1) + ' MB';
-    const label = b.name.includes(VAULT_IMAGE_FILE_SUFFIX) ? 'Image backup' : 'Inventory backup';
-    const safeProvider = sanitizeHtml(provider);
-    const safeFilename = sanitizeHtml(b.name);
-    return '<div class="cloud-backup-row">' +
-      '<button class="cloud-backup-entry" data-provider="' + safeProvider +
-        '" data-filename="' + safeFilename + '" data-size="' + b.size + '">' +
-        '<span class="cloud-backup-name" title="' + safeFilename + '">' + sanitizeHtml(dateStr) + '</span>' +
-        '<span class="cloud-backup-size">' + sanitizeHtml(sizeStr) + '</span>' +
-        '<span class="cloud-backup-type">' + label + '</span>' +
-      '</button>' +
-      '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
-        '" data-filename="' + safeFilename + '" title="Delete this backup from Dropbox" aria-label="Delete ' + safeFilename + '">' +
-        '&times;' +
-      '</button>' +
-    '</div>';
-  }).join('');
+  listEl.innerHTML = html;
+
+  // Wire up sync snapshots toggle
+  var syncToggle = listEl.querySelector('.cloud-backup-sync-toggle');
+  if (syncToggle) {
+    syncToggle.addEventListener('click', async function () {
+      var syncList = listEl.querySelector('.cloud-backup-sync-list');
+      var arrow = syncToggle.querySelector('.cloud-backup-sync-arrow');
+      if (!syncList) return;
+
+      if (syncList.style.display !== 'none') {
+        syncList.style.display = 'none';
+        if (arrow) arrow.style.transform = '';
+        return;
+      }
+
+      syncList.style.display = '';
+      if (arrow) arrow.style.transform = 'rotate(90deg)';
+
+      // Lazy-load sync snapshots
+      if (!syncList.dataset.loaded) {
+        // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
+        syncList.innerHTML = '<div class="cloud-backup-empty" style="font-size:0.72rem">Loading…</div>';
+        try {
+          var syncBackups = await cloudListBackups(provider, 'sync');
+          if (!syncBackups || syncBackups.length === 0) {
+            // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
+            syncList.innerHTML = '<div class="cloud-backup-empty" style="font-size:0.72rem">No sync snapshots</div>';
+          } else {
+            // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
+            syncList.innerHTML = syncBackups.map(function (b) {
+              var d = new Date(b.server_modified);
+              var dateStr = d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
+                ' ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+              var sizeStr = b.size < 1024 ? b.size + ' B' :
+                b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
+                  (b.size / 1048576).toFixed(1) + ' MB';
+              var safeProvider = sanitizeHtml(provider);
+              var safeFilename = sanitizeHtml(b.name);
+              return '<div class="cloud-backup-row">' +
+                '<button class="cloud-backup-entry" data-provider="' + safeProvider +
+                  '" data-filename="' + safeFilename + '" data-size="' + b.size + '">' +
+                  '<span class="cloud-backup-name" title="' + safeFilename + '">' + sanitizeHtml(dateStr) + '</span>' +
+                  '<span class="cloud-backup-size">' + sanitizeHtml(sizeStr) + '</span>' +
+                  '<span class="cloud-backup-type">Sync snapshot</span>' +
+                '</button>' +
+                '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
+                  '" data-filename="' + safeFilename + '" title="Delete this snapshot from Dropbox" aria-label="Delete ' + safeFilename + '">' +
+                  '&times;' +
+                '</button>' +
+              '</div>';
+            }).join('');
+          }
+          syncList.dataset.loaded = 'true';
+        } catch (err) {
+          // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
+          syncList.innerHTML = '<div class="cloud-backup-empty" style="font-size:0.72rem;color:var(--danger)">Failed to load sync snapshots</div>';
+        }
+      }
+    });
+  }
 };
 
 /**
@@ -1125,9 +1194,9 @@ const cloudUpdateBackupCount = async (provider) => {
   const el = safeGetElement('cloudBackupCount_' + provider);
   if (!(el instanceof HTMLElement)) return;
   try {
-    const backups = await cloudListBackups(provider);
+    const backups = await cloudListBackups(provider, 'manual');
     const count = Array.isArray(backups) ? backups.length : 0;
-    el.textContent = count + ' backup' + (count !== 1 ? 's' : '');
+    el.textContent = count + ' manual backup' + (count !== 1 ? 's' : '');
   } catch {
     el.textContent = '\u2014';
   }
@@ -1182,16 +1251,7 @@ const bindCloudStorageListeners = () => {
             return;
           }
         }
-        // Prefer session cache (hot path), fall back to localStorage so Backup
-        // works after a page reload without re-prompting when password is already stored.
-        var cachedPw = typeof cloudGetCachedPassword === 'function' ? cloudGetCachedPassword(provider) : null;
-        if (!cachedPw) cachedPw = localStorage.getItem('cloud_vault_password') || null;
-        if (cachedPw) {
-          await _cloudBackupWithCachedPw(provider, cachedPw, btn);
-          return;
-        }
-        openVaultModal('cloud-export', { provider: provider });
-        if (typeof showKrakenToastIfFirst === 'function') showKrakenToastIfFirst();
+        openVaultModal('cloud-export', { provider: provider, isManualBackup: true });
       }, 'Conflict check failed: ');
 
     } else if (btn.classList.contains('cloud-restore-btn')) {
@@ -1202,7 +1262,7 @@ const bindCloudStorageListeners = () => {
         return;
       }
       await _cloudBtnAction(btn, 'Loading\u2026', async () => {
-        var backups = await cloudListBackups(provider);
+        var backups = await cloudListBackups(provider, 'manual');
         renderCloudBackupList(provider, backups);
       }, 'Failed to list backups: ');
 

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1013,8 +1013,8 @@ const bindImageSettingsListeners = () => {
  * Render the backup list for a cloud provider.
  */
 const renderCloudBackupList = (provider, backups) => {
-  const listEl = document.getElementById('cloudBackupList_' + provider);
-  if (!listEl) return;
+  const listEl = safeGetElement('cloudBackupList_' + provider);
+  if (!(listEl instanceof HTMLElement)) return;
 
   listEl.style.display = '';
 
@@ -1041,7 +1041,7 @@ const renderCloudBackupList = (provider, backups) => {
           '<span class="cloud-backup-type">Manual backup</span>' +
         '</button>' +
         '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
-          '" data-filename="' + safeFilename + '" title="Delete this backup from Dropbox" aria-label="Delete ' + safeFilename + '">' +
+          '" data-filename="' + safeFilename + '" title="Delete this backup from cloud storage" aria-label="Delete ' + safeFilename + '">' +
           '&times;' +
         '</button>' +
       '</div>';
@@ -1049,10 +1049,10 @@ const renderCloudBackupList = (provider, backups) => {
   }
 
   // Add collapsible sync snapshots section
-  html += '<div class="cloud-backup-sync-toggle" style="cursor:pointer;margin-top:0.5rem;padding:0.3rem 0;font-size:0.7rem;color:var(--text-secondary);user-select:none" data-provider="' + sanitizeHtml(provider) + '">' +
+  html += '<button type="button" class="cloud-backup-sync-toggle" role="button" aria-expanded="false" aria-controls="cloudSyncList_' + sanitizeHtml(provider) + '" style="background:none;border:none;cursor:pointer;margin-top:0.5rem;padding:0.3rem 0;font-size:0.7rem;color:var(--text-secondary);user-select:none;width:100%;text-align:left" data-provider="' + sanitizeHtml(provider) + '">' +
     '<span class="cloud-backup-sync-arrow" style="display:inline-block;transition:transform 0.2s;margin-right:0.3rem">&#9654;</span>Sync Snapshots' +
-  '</div>' +
-  '<div class="cloud-backup-sync-list" data-provider="' + sanitizeHtml(provider) + '" style="display:none"></div>';
+  '</button>' +
+  '<div class="cloud-backup-sync-list" id="cloudSyncList_' + sanitizeHtml(provider) + '" data-provider="' + sanitizeHtml(provider) + '" style="display:none"></div>';
 
   // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
   listEl.innerHTML = html;
@@ -1068,11 +1068,13 @@ const renderCloudBackupList = (provider, backups) => {
       if (syncList.style.display !== 'none') {
         syncList.style.display = 'none';
         if (arrow) arrow.style.transform = '';
+        syncToggle.setAttribute('aria-expanded', 'false');
         return;
       }
 
       syncList.style.display = '';
       if (arrow) arrow.style.transform = 'rotate(90deg)';
+      syncToggle.setAttribute('aria-expanded', 'true');
 
       // Lazy-load sync snapshots
       if (!syncList.dataset.loaded) {
@@ -1102,7 +1104,7 @@ const renderCloudBackupList = (provider, backups) => {
                   '<span class="cloud-backup-type">Sync snapshot</span>' +
                 '</button>' +
                 '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
-                  '" data-filename="' + safeFilename + '" title="Delete this snapshot from Dropbox" aria-label="Delete ' + safeFilename + '">' +
+                  '" data-filename="' + safeFilename + '" title="Delete this snapshot from cloud storage" aria-label="Delete ' + safeFilename + '">' +
                   '&times;' +
                 '</button>' +
               '</div>';
@@ -1291,7 +1293,7 @@ const bindCloudStorageListeners = () => {
       }, 'Download failed: ', async () => {
         var parentList = btn.closest('.cloud-backup-list');
         if (parentList) {
-          var refreshed = await cloudListBackups(provider);
+          var refreshed = await cloudListBackups(provider, 'manual');
           renderCloudBackupList(provider, refreshed);
         }
       });
@@ -1305,7 +1307,7 @@ const bindCloudStorageListeners = () => {
       }, 'Delete failed: ', async () => {
         var parentList = btn.closest('.cloud-backup-list');
         if (parentList) {
-          var refreshed = await cloudListBackups(provider);
+          var refreshed = await cloudListBackups(provider, 'manual');
           renderCloudBackupList(provider, refreshed);
         }
       });

--- a/js/vault.js
+++ b/js/vault.js
@@ -1154,10 +1154,10 @@ async function handleVaultAction() {
         // Cloud export: encrypt then upload
         var fileBytes = await vaultEncryptToBytes(password);
         showVaultStatus("info", "Uploading\u2026");
-        await cloudUploadVault(_cloudContext.provider, fileBytes);
+        await cloudUploadVault(_cloudContext.provider, fileBytes, _cloudContext.isManualBackup ? { skipLatestUpdate: true } : undefined);
         showVaultStatus("success", "Backup uploaded successfully.");
         // Cache password for this browser session
-        if (typeof cloudCachePassword === 'function') {
+        if (typeof cloudCachePassword === 'function' && !(_cloudContext && _cloudContext.isManualBackup)) {
           cloudCachePassword(_cloudContext.provider, password);
         }
         if (typeof showKrakenToastIfFirst === 'function') showKrakenToastIfFirst();

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.41-b1772583651';
+const CACHE_NAME = 'staktrakr-v3.33.41-b1772592261';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.40-b1772581550';
+const CACHE_NAME = 'staktrakr-v3.33.41-b1772583651';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.40",
+  "version": "3.33.41",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,7 +2,7 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.34
+lastUpdated: v3.33.41
 date: 2026-03-03
 sourceFiles:
   - js/cloud-storage.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.34 — 2026-03-03
+> **Last updated:** v3.33.41 — 2026-03-03
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`
 
 ## Overview
@@ -65,12 +65,14 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 - Cloud activity log: all transactions recorded to `cloud_activity_log` (capped at 500 entries, max 180 days)
 - UI state management via `syncCloudUI()`
 
-**Manual cloud backup flow:**
+**Manual cloud backup flow (updated STAK-419, v3.33.41):**
 
-1. `vaultEncryptToBytes(password)` encrypts all `ALLOWED_STORAGE_KEYS` into a binary `.stvault`
-2. `cloudUploadVault(provider, fileBytes)` uploads the vault as `staktrakr-backup-YYYYMMDD-HHmmss.stvault` to the provider folder
-3. Also writes `staktrakr-latest.json` (pointer with `filename`, `timestamp`, `appVersion`, `itemCount`)
-4. Records `cloud_last_backup` in localStorage
+1. User clicks "Backup" → vault modal opens (always prompts for password; no cached password reuse for manual backups)
+2. `vaultEncryptToBytes(password)` encrypts all `ALLOWED_STORAGE_KEYS` into a binary `.stvault`
+3. `cloudUploadVault(provider, fileBytes, { skipLatestUpdate: true })` uploads the vault as `staktrakr-backup-YYYYMMDD-HHmmss.stvault` to the `/backups/` subfolder
+4. `staktrakr-latest.json` pointer is NOT updated (manual backups do not affect sync state)
+5. `cloud_last_backup` is NOT written (manual backups are independent of sync tracking)
+6. Password is NOT cached to `sessionStorage` (each manual backup requires re-entry)
 
 ### cloud-sync.js Role
 
@@ -93,9 +95,12 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 | Image vault | `/StakTrakr/sync/staktrakr-images.stvault` | `userImages` IDB blobs (base64) |
 | Metadata pointer | `/StakTrakr/sync/staktrakr-sync.json` | `rev`, `itemCount`, `syncId`, `deviceId`, `imageVault` hash |
 | Manifest | `/StakTrakr/sync/staktrakr-manifest.stvault` | Encrypted field-level change log for diff-merge |
-| Pre-push backups | `/StakTrakr/backups/pre-sync-TIMESTAMP.stvault` | Auto-backups before each vault overwrite |
+| Pre-push backups | `/StakTrakr/backups/pre-sync-TIMESTAMP.stvault` | Auto-backups before each vault overwrite (prefix: `SYNC_BACKUP_PREFIX`) |
+| Manual backups | `/StakTrakr/backups/staktrakr-backup-YYYYMMDD-HHmmss.stvault` | User-initiated vault backups (prefix: `MANUAL_BACKUP_PREFIX`) |
 
 > **Legacy paths:** Flat-root paths (`/StakTrakr/staktrakr-sync.*`) are retained as `*_LEGACY` constants in `js/constants.js` for migration only. Active sync uses `/StakTrakr/sync/`. Migration runs once on first push (`cloudMigrateToV2`).
+>
+> **Backup isolation (STAK-419, v3.33.41):** Manual backups and sync snapshots share the `/StakTrakr/backups/` folder but are distinguished by filename prefix. `cloudListBackups(provider, type)` filters by prefix; `cloudPruneBackups` defaults to pruning only sync snapshots. Manual backups are never automatically deleted.
 
 ### utils.js Role
 
@@ -280,7 +285,7 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 1. Empty-vault guard: if local inventory is empty and remote has items, block push and prompt to pull instead
 2. Migration check: run `cloudMigrateToV2()` if not yet migrated (once per device)
 3. `vaultEncryptToBytesScoped(password)` — encrypt sync-scope vault
-4. Cloud-side backup-before-overwrite: copy existing cloud vault to `/StakTrakr/backups/pre-sync-TIMESTAMP.stvault` (non-blocking)
+4. Cloud-side backup-before-overwrite: copy existing cloud vault to `/StakTrakr/backups/pre-sync-TIMESTAMP.stvault` (non-blocking; uses `SYNC_BACKUP_PREFIX`)
 5. Upload inventory vault to `/StakTrakr/sync/staktrakr-sync.stvault` (overwrite)
 6. `collectAndHashImageVault()` — compute image hash; if changed, encrypt and upload image vault (non-fatal on failure)
 7. Upload `staktrakr-sync.json` metadata pointer (`rev`, `itemCount`, `syncId`, `deviceId`, `imageVault`)
@@ -294,16 +299,17 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
-| `cloudUploadVault` | `async (provider, fileBytes)` | Upload a pre-built `.stvault` to cloud; writes versioned file + `latest.json` pointer |
+| `cloudUploadVault` | `async (provider, fileBytes, opts?)` | Upload a pre-built `.stvault` to cloud; writes versioned file + `latest.json` pointer (unless `opts.skipLatestUpdate` is true — used for manual backups) |
 | `cloudDownloadVaultByName` | `async (provider, filename)` | Download a named `.stvault` from cloud; returns `Uint8Array` |
 | `cloudDownloadVault` | `async (provider)` | Download the latest vault (reads `latest.json` pointer first, falls back to newest in folder) |
-| `cloudListBackups` | `async (provider)` | List all `.stvault` files in cloud folder; returns array sorted newest-first |
+| `cloudListBackups` | `async (provider, type?)` | List `.stvault` files in the cloud backups folder; optional `type` filters by prefix: `'manual'`, `'sync'`, or `undefined` (all). Returns array sorted newest-first |
 | `cloudDeleteBackup` | `async (provider, filename)` | Delete a named vault file; clears `cloud_last_backup` if matched |
 | `cloudCheckConflict` | `async (provider)` | Compare remote `latest.json` timestamp vs `cloud_last_backup`; returns conflict info object |
 | `cloudGetToken` | `async (provider)` | Get OAuth access token; auto-refreshes if expired; clears token on refresh failure |
 | `cloudIsConnected` | `(provider)` | Returns `true` if a stored token exists for the provider |
 | `cloudAuthStart` | `(provider)` | Opens OAuth popup; initiates PKCE flow for Dropbox |
 | `cloudExchangeCode` | `async (code, state)` | Exchanges OAuth auth code for access token; stores in localStorage |
+| `cloudPruneBackups` | `async (provider, maxKeep, type?)` | Prune old backups, keeping newest `maxKeep`. Defaults to `type='sync'` — manual backups are never auto-pruned |
 | `cloudDisconnect` | `(provider)` | Clears token and `cloud_last_backup` |
 | `recordCloudActivity` | `(entry)` | Appends to `cloud_activity_log` (max 500 entries, 180-day rolling window) |
 | `syncCloudUI` | `()` | Refreshes cloud card UI state (connected badge, backup status, button states) |
@@ -356,6 +362,15 @@ Conflict detection is driven by `syncHasLocalChanges()`, which checks whether bo
 
 **Override backup guard:** `syncRestoreOverrideBackup()` only clears scope keys if the snapshot is non-empty — an empty snapshot is treated as corruption and does not wipe localStorage.
 
+### Cloud restore list UI (STAK-419, v3.33.41)
+
+The cloud restore picker in Settings shows a two-tier list:
+
+1. **Manual backups** (top section) — shown by default, listed newest-first. These are user-initiated backups with the `staktrakr-backup-` prefix.
+2. **Sync snapshots** (collapsible section) — collapsed by default. These are automatic `pre-sync-` backups created by the sync system.
+
+The backup count badge on the restore button shows the count of **manual backups only**, not total backups. This gives the user a clear signal of how many deliberate restore points exist.
+
 ### Merge strategy during import
 
 All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
@@ -374,8 +389,12 @@ All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
 | Trigger | User clicks "Backup" button | Debounced on every inventory change |
 | Vault scope | Full (`ALLOWED_STORAGE_KEYS`) | Sync-scope (`SYNC_SCOPE_KEYS`) only |
 | What's included | All localStorage keys including API keys and spot history | Inventory + display prefs only |
-| Filename | Versioned: `staktrakr-backup-YYYYMMDD-HHmmss.stvault` | Fixed: `staktrakr-sync.stvault` |
-| Pointer file | `staktrakr-latest.json` | `staktrakr-sync.json` (rev + hash + syncId) |
+| Filename prefix | `MANUAL_BACKUP_PREFIX` (`staktrakr-backup-`) | `SYNC_BACKUP_PREFIX` (`pre-sync-`) for pre-push snapshots |
+| Filename | Versioned: `staktrakr-backup-YYYYMMDD-HHmmss.stvault` | Fixed: `staktrakr-sync.stvault` (live); `pre-sync-TIMESTAMP.stvault` (snapshots) |
+| Pointer file | None (manual backups skip `staktrakr-latest.json` update) | `staktrakr-sync.json` (rev + hash + syncId) |
+| `cloud_last_backup` | Not written (`skipLatestUpdate: true`) | Written on each sync push |
+| Password caching | Disabled — always prompts for password | Cached in `sessionStorage` via `cloudCachePassword` |
+| Auto-pruning | Never auto-pruned | Pruned by `cloudPruneBackups(provider, max, 'sync')` |
 | Image vault | Not part of manual backup | Pushed when `userImages` hash changes |
 | Conflict check | `cloudCheckConflict()` on manual download | `syncHasLocalChanges()` on pull |
 | Pre-restore snapshot | No | Yes: `syncSaveOverrideBackup()` before every pull |

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -2,8 +2,8 @@
 title: Data Model
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.41
+date: 2026-03-03
 sourceFiles:
   - js/constants.js
   - js/utils.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Data Model
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.41 — 2026-03-03
 > **Source files:** `js/constants.js`, `js/utils.js`, `js/types.js`
 
 ## Overview
@@ -362,7 +362,7 @@ All keys currently registered in `js/constants.js`. `cleanupStorage()` enforces 
 | `cloud_token_dropbox` | JSON | Dropbox OAuth token data |
 | `cloud_token_pcloud` | JSON | pCloud OAuth token data |
 | `cloud_token_box` | JSON | Box OAuth token data |
-| `cloud_last_backup` | JSON | `{ provider, timestamp }` last backup info |
+| `cloud_last_backup` | JSON | `{ provider, timestamp }` last backup info — only written by sync operations (manual backups with `skipLatestUpdate` skip this key) |
 | `cloud_kraken_seen` | Boolean string | Easter egg seen flag |
 | `staktrakr_oauth_result` | JSON | Transient OAuth callback relay (cleared after read) |
 | `cloud_activity_log` | JSON | Cloud sync activity log entries |
@@ -379,6 +379,15 @@ All keys currently registered in `js/constants.js`. `cleanupStorage()` enforces 
 | `cloud_sync_migrated` | String | Cloud folder migration flag — `"v2"` indicates flat-to-subfolder migration complete |
 | `cloud_backup_history_depth` | String | Max cloud backups to retain (`"3"`, `"5"`, `"10"`, or `"20"`) |
 | `manifestPruningThreshold` | Number string | Max sync cycles retained in manifest before pruning older entries (STAK-184) |
+
+**Cloud backup filename constants** (not localStorage keys — defined in `js/constants.js`, STAK-419):
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `MANUAL_BACKUP_PREFIX` | `'staktrakr-backup-'` | Filename prefix for user-initiated manual backups |
+| `SYNC_BACKUP_PREFIX` | `'pre-sync-'` | Filename prefix for automatic sync pre-push snapshots |
+
+These prefixes are used by `cloudListBackups(provider, type)` to filter backups by type and by `cloudPruneBackups(provider, maxKeep, type)` to ensure auto-pruning only targets sync snapshots (manual backups are never auto-pruned).
 
 **One-time migrations:**
 

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -2,8 +2,8 @@
 title: Storage Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.41
+date: 2026-03-03
 sourceFiles:
   - js/utils.js
   - js/constants.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Storage Patterns
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.41 — 2026-03-03
 > **Source files:** `js/utils.js`, `js/constants.js`
 
 ## Overview
@@ -269,7 +269,7 @@ All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. A
 | `"cloud_token_dropbox"` | JSON | Dropbox OAuth token data |
 | `"cloud_token_pcloud"` | JSON | pCloud OAuth token data |
 | `"cloud_token_box"` | JSON | Box OAuth token data |
-| `"cloud_last_backup"` | JSON | `{ provider, timestamp }` last cloud backup |
+| `"cloud_last_backup"` | JSON | `{ provider, timestamp }` last cloud backup — only written by sync operations (manual backups with `skipLatestUpdate` skip this key) |
 | `"cloud_activity_log"` | JSON array | Cloud sync activity log |
 | `"cloud_sync_enabled"` | boolean string | Master auto-sync toggle |
 | `"cloud_sync_last_push"` | JSON | `{ syncId, timestamp, rev, itemCount }` |

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,7 +2,7 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.34
+lastUpdated: v3.33.41
 date: 2026-03-03
 sourceFiles:
   - js/cloud-sync.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.33.34 — 2026-03-03
+> **Last updated:** v3.33.41 — 2026-03-03
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -168,10 +168,10 @@ getSyncPasswordSilent()
 | `cloudStoreToken(provider, tokenData)` | `(string, object) → void` | Persist token to localStorage under `cloud_token_<provider>`. |
 | `cloudClearToken(provider)` | `(string) → void` | Remove stored token. |
 | `cloudDisconnect(provider)` | `(string) → void` | Clear token + account ID + last backup; update UI. |
-| `cloudUploadVault(provider, fileBytes)` | `(string, ArrayBuffer) → Promise<void>` | Manual backup upload. Writes versioned `.stvault` file + `staktrakr-latest.json` pointer. Records to activity log. |
+| `cloudUploadVault(provider, fileBytes, opts)` | `(string, ArrayBuffer, object?) → Promise<void>` | Manual backup upload. Writes versioned `.stvault` file + `staktrakr-latest.json` pointer (unless `opts.skipLatestUpdate` is true). Records to activity log. |
 | `cloudDownloadVault(provider)` | `(string) → Promise<Uint8Array>` | Download latest backup by pointer, or by listing if no pointer. |
 | `cloudDownloadVaultByName(provider, filename)` | `(string, string) → Promise<Uint8Array>` | Download a specific named backup file. |
-| `cloudListBackups(provider)` | `(string) → Promise<object[]>` | List `.stvault` files in the provider folder, sorted newest-first. |
+| `cloudListBackups(provider, type)` | `(string, string?) → Promise<object[]>` | List `.stvault` files in the provider's backups folder, sorted newest-first. Optional `type` param filters by prefix: `'manual'` (matches `MANUAL_BACKUP_PREFIX`), `'sync'` (matches `SYNC_BACKUP_PREFIX`), or `undefined` (all backups). |
 | `cloudDeleteBackup(provider, filename)` | `(string, string) → Promise<void>` | Delete a specific backup file; clears `cloud_last_backup` if it matches. |
 | `cloudCheckConflict(provider)` | `(string) → Promise<object>` | Compare remote `staktrakr-latest.json` timestamp against local last-backup record. Returns `{conflict: bool, ...}`. |
 | `recordCloudActivity(entry)` | `(object) → void` | Append an entry to the cloud activity log (capped at 500 entries, purges >180 days old). |
@@ -181,6 +181,7 @@ getSyncPasswordSilent()
 | `cloudCachePassword(provider, password)` | `(string, string) → void` | XOR-obfuscated session-only password cache (sessionStorage). Starts idle lock timer. |
 | `cloudGetCachedPassword(provider)` | `(string) → string\|null` | Retrieve session-cached password. |
 | `cloudClearCachedPassword()` | `() → void` | Clear session cache and stop idle lock timer. |
+| `cloudPruneBackups(provider, maxKeep, type)` | `(string, number, string?) → Promise<void>` | Prune old backups, keeping only the newest `maxKeep`. Defaults to `type='sync'` so manual backups are never auto-pruned. |
 | `showCloudToast(message, durationMs?)` | `(string, number?) → void` | Display a transient toast notification. |
 
 ---
@@ -205,7 +206,7 @@ saveInventory()
             ├─ Upload: /sync/staktrakr-sync.json (metadata pointer, includes inventoryHash, settingsHash)
             ├─ buildAndUploadManifest() — field-level changelog (non-fatal)
             ├─ syncSetLastPush() + syncSetCursor()
-            ├─ Auto-prune old backups (fire-and-forget)
+            ├─ Auto-prune old sync backups: cloudPruneBackups(provider, max, 'sync') (fire-and-forget)
             └─ Broadcast sync-push-complete to other tabs
 ```
 
@@ -358,14 +359,28 @@ The flag is purely one-shot: it is consumed (cleared) at the top of the next `pu
 
 ## Backup/Restore Relationship
 
-Cloud sync and manual backups are parallel systems:
+Cloud sync and manual backups are parallel systems with distinct file prefixes and independent lifecycles (STAK-419, v3.33.41):
 
-| Operation | File location | Who calls |
-|---|---|---|
-| Auto-sync push | `/StakTrakr/sync/staktrakr-sync.stvault` | `pushSyncVault()` — triggered by `saveInventory()` debounce |
-| Backup-before-overwrite | `/StakTrakr/backups/pre-sync-<ts>.stvault` | Inside `pushSyncVault()`, each push cycle |
-| Manual backup | `/StakTrakr/staktrakr-backup-<ts>.stvault` + `staktrakr-latest.json` | `cloudUploadVault()` — user-initiated |
-| Override backup (pre-pull snapshot) | `cloud_sync_override_backup` localStorage key | `syncSaveOverrideBackup()` — before every pull |
+| Operation | File location | Prefix | Who calls |
+|---|---|---|---|
+| Auto-sync push | `/StakTrakr/sync/staktrakr-sync.stvault` | — | `pushSyncVault()` — triggered by `saveInventory()` debounce |
+| Backup-before-overwrite | `/StakTrakr/backups/pre-sync-<ts>.stvault` | `SYNC_BACKUP_PREFIX` | Inside `pushSyncVault()`, each push cycle |
+| Manual backup | `/StakTrakr/backups/staktrakr-backup-<ts>.stvault` | `MANUAL_BACKUP_PREFIX` | `cloudUploadVault()` — user-initiated |
+| Override backup (pre-pull snapshot) | `cloud_sync_override_backup` localStorage key | — | `syncSaveOverrideBackup()` — before every pull |
+
+### Two-tier backup isolation (STAK-419, v3.33.41)
+
+Manual backups and sync snapshots are separated by filename prefix and treated independently:
+
+- **`MANUAL_BACKUP_PREFIX` (`staktrakr-backup-`)** — user-initiated backups via the "Backup" button. These are never auto-pruned by the sync system. The user must delete them explicitly.
+- **`SYNC_BACKUP_PREFIX` (`pre-sync-`)** — automatic pre-push snapshots created by `pushSyncVault()`. These are pruned by `cloudPruneBackups()` which defaults to `type='sync'`.
+
+**Key behavioral changes:**
+
+- `cloudListBackups(provider, type)` accepts an optional `type` parameter (`'manual'` | `'sync'` | `undefined`) for client-side prefix filtering.
+- `cloudPruneBackups(provider, maxKeep, type)` defaults to `type='sync'`, so auto-pruning only touches sync snapshots. Manual backups are preserved regardless of the backup history depth setting.
+- `cloudUploadVault(provider, fileBytes, opts)` accepts an `opts` parameter. When `opts.skipLatestUpdate` is true, the `cloud_last_backup` pointer is not updated — this prevents manual backups from interfering with sync state tracking.
+- The vault modal password is not cached for manual backups (password caching via `cloudCachePassword` is skipped for `isManualBackup: true` contexts). Each manual backup requires the user to re-enter their vault password.
 
 The override backup is the safety net for "Keep Theirs" conflicts or unwanted sync pulls. It restores raw localStorage strings (not Dropbox files) directly back to the pre-pull state.
 
@@ -386,7 +401,7 @@ The override backup is the safety net for "Keep Theirs" conflicts or unwanted sy
 | `cloud_sync_override_backup` | JSON snapshot of `SYNC_SCOPE_KEYS` taken before a pull |
 | `cloud_sync_migrated` | `'v2'` when flat-layout migration is complete |
 | `cloud_token_<provider>` | JSON: `{access_token, refresh_token, expires_at}` |
-| `cloud_last_backup` | JSON: last manual backup metadata (for manual backup UI) |
+| `cloud_last_backup` | JSON: last backup metadata (only written by sync operations; manual backups with `skipLatestUpdate` do not update this key) |
 | `cloud_activity_log` | JSON array: cloud activity entries (max 500, 180-day TTL) |
 | `cloud_kraken_seen` | `'true'` after first successful backup (suppresses easter-egg toast) |
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Auto-prune now only deletes `pre-sync-*` sync snapshots, never `staktrakr-backup-*` manual backups — prevents data loss
- **Fixed**: Restore list shows manual backups only by default, with sync snapshots in a collapsible section
- **Fixed**: "Backup history" dropdown renamed to "Sync history" — controls only sync snapshot retention
- **Fixed**: Manual Backup button always prompts for password via vault modal — no longer silently reuses sync password cache
- **Fixed**: Manual backups don't update `cloud_last_backup` sync state or cache password for auto-sync
- **Added**: `MANUAL_BACKUP_PREFIX` and `SYNC_BACKUP_PREFIX` constants for filename-based type discrimination

## Files Changed (6 implementation + 5 version)

- `js/constants.js` — New prefix constants + version bump
- `js/cloud-storage.js` — `type` filter on `cloudListBackups()`, `cloudPruneBackups()`, `cloudUploadVault()` opts
- `js/cloud-sync.js` — Explicit `'sync'` type passed to prune call
- `js/settings-listeners.js` — Decoupled manual backup flow, filtered restore list, updated badge count
- `js/vault.js` — `isManualBackup` guard on password caching and latest update
- `index.html` — "Backup history" → "Sync history" label

## Linear Issues

- [STAK-419: Cloud backup/restore: manual vs sync backups not separated — prune destroys manual backups](https://linear.app/lbruton/issue/STAK-419)

🤖 Generated with [Claude Code](https://claude.com/claude-code)