### PR TITLE
v3.33.42 — STAK-419: Full backup for sync snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.42] - 2026-03-03
+
+### Fixed — Full Backup for Sync Snapshots (STAK-419)
+
+- **Fixed**: Pre-sync snapshots now contain the FULL encrypted backup (all localStorage keys) instead of a partial sync-scoped copy — previously only contained 8 keys (inventory + display prefs), causing ghost items and data corruption when restored (STAK-419)
+- **Fixed**: Restore list now shows all backups (manual + sync) in a single flat list sorted newest first, each labeled "Manual" or "Sync" — previously showed partial sync files in a separate collapsible section (STAK-419)
+- **Fixed**: Backup count badge shows total backup count instead of manual-only count (STAK-419)
+
+---
+
 ## [3.33.41] - 2026-03-03
 
 ### Fixed — Cloud Backup Manual vs Sync Separation (STAK-419)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Full Backup for Sync Snapshots (v3.33.42)**: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419).
 - **Cloud Backup/Restore Fix (v3.33.41)**: Manual backups and sync snapshots now separated — auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419).
 - **Simplify Market Price Display (v3.33.40)**: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404).
 - **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.42 &ndash; Full Backup for Sync Snapshots</strong>: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419)</li>
     <li><strong>v3.33.41 &ndash; Cloud Backup/Restore Fix</strong>: Manual backups and sync snapshots now separated &mdash; auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419)</li>
     <li><strong>v3.33.40 &ndash; Simplify Market Price Display</strong>: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404)</li>
     <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1295,33 +1295,40 @@ async function pushSyncVault() {
     debugLog('[CloudSync] Encrypted:', fileBytes.byteLength, 'bytes');
 
     // -----------------------------------------------------------------------
-    // Layer 2 — Cloud-side backup-before-overwrite (REQ-2)
-    // Copy the existing cloud vault to /backups/ before overwriting.
-    // Non-blocking: if copy fails (first push, no existing file), log and continue.
+    // Layer 2 — Full backup-before-overwrite (STAK-419)
+    // Create a FULL encrypted backup (all localStorage keys) and upload to
+    // /backups/ before overwriting the sync vault. This ensures every pre-sync
+    // snapshot is a complete restore point, not a partial sync-scoped copy.
+    // Non-blocking: if backup fails (first push, encryption error), log and continue.
     // -----------------------------------------------------------------------
     try {
       var backupTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      var backupPath = SYNC_BACKUP_FOLDER + '/pre-sync-' + backupTimestamp + '.stvault';
-      debugLog('[CloudSync] Backup-before-overwrite: copying vault to', backupPath);
-      var backupResp = await fetch('https://api.dropboxapi.com/2/files/copy_v2', {
+      var backupPath = SYNC_BACKUP_FOLDER + '/' + SYNC_BACKUP_PREFIX + backupTimestamp + '.stvault';
+      debugLog('[CloudSync] Full backup-before-overwrite: encrypting…');
+      var fullBackupBytes = await vaultEncryptToBytes(password);
+      debugLog('[CloudSync] Full backup-before-overwrite: uploading', fullBackupBytes.byteLength, 'bytes to', backupPath);
+      var backupArg = JSON.stringify({
+        path: backupPath,
+        mode: 'add',
+        autorename: true,
+        mute: true,
+      });
+      var backupResp = await fetch('https://content.dropboxapi.com/2/files/upload', {
         method: 'POST',
         headers: {
           Authorization: 'Bearer ' + token,
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/octet-stream',
+          'Dropbox-API-Arg': backupArg,
         },
-        body: JSON.stringify({
-          from_path: SYNC_FILE_PATH,
-          to_path: backupPath,
-        }),
+        body: fullBackupBytes,
       });
       if (backupResp.ok) {
-        debugLog('[CloudSync] Backup-before-overwrite: created', backupPath);
+        debugLog('[CloudSync] Full backup-before-overwrite: created', backupPath);
       } else {
-        var backupStatus = backupResp.status;
-        debugLog('[CloudSync] Backup-before-overwrite: copy returned', backupStatus, '(expected on first push)');
+        debugLog('[CloudSync] Full backup-before-overwrite: upload returned', backupResp.status);
       }
     } catch (backupErr) {
-      debugLog('[CloudSync] Backup-before-overwrite: failed (non-blocking):', backupErr.message);
+      debugLog('[CloudSync] Full backup-before-overwrite: failed (non-blocking):', backupErr.message);
     }
 
     var syncId = typeof generateUUID === 'function' ? generateUUID() : _syncFallbackUUID();

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.41";
+const APP_VERSION = "3.33.42";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1018,27 +1018,28 @@ const renderCloudBackupList = (provider, backups) => {
 
   listEl.style.display = '';
 
-  // Build manual backups section
+  // Single flat list — manual + sync merged, sorted newest first
   var html = '';
   if (!backups || backups.length === 0) {
-    html += '<div class="cloud-backup-empty">No manual backups</div>';
+    html += '<div class="cloud-backup-empty">No backups found</div>';
   } else {
-    html += '<div class="cloud-backup-section-header" style="font-size:0.7rem;color:var(--text-secondary);margin-bottom:0.3rem;font-weight:600">Manual Backups</div>';
     html += backups.map(function (b) {
-      const d = new Date(b.server_modified);
-      const dateStr = d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
+      var d = new Date(b.server_modified);
+      var dateStr = d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
         ' ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-      const sizeStr = b.size < 1024 ? b.size + ' B' :
+      var sizeStr = b.size < 1024 ? b.size + ' B' :
         b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
           (b.size / 1048576).toFixed(1) + ' MB';
-      const safeProvider = sanitizeHtml(provider);
-      const safeFilename = sanitizeHtml(b.name);
+      var isManual = b.name.indexOf(MANUAL_BACKUP_PREFIX) === 0;
+      var typeLabel = isManual ? 'Manual' : 'Sync';
+      var safeProvider = sanitizeHtml(provider);
+      var safeFilename = sanitizeHtml(b.name);
       return '<div class="cloud-backup-row">' +
         '<button class="cloud-backup-entry" data-provider="' + safeProvider +
           '" data-filename="' + safeFilename + '" data-size="' + b.size + '">' +
+          '<span class="cloud-backup-type" style="min-width:3rem">' + typeLabel + '</span>' +
           '<span class="cloud-backup-name" title="' + safeFilename + '">' + sanitizeHtml(dateStr) + '</span>' +
           '<span class="cloud-backup-size">' + sanitizeHtml(sizeStr) + '</span>' +
-          '<span class="cloud-backup-type">Manual backup</span>' +
         '</button>' +
         '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
           '" data-filename="' + safeFilename + '" title="Delete this backup from cloud storage" aria-label="Delete ' + safeFilename + '">' +
@@ -1048,76 +1049,8 @@ const renderCloudBackupList = (provider, backups) => {
     }).join('');
   }
 
-  // Add collapsible sync snapshots section
-  html += '<button type="button" class="cloud-backup-sync-toggle" role="button" aria-expanded="false" aria-controls="cloudSyncList_' + sanitizeHtml(provider) + '" style="background:none;border:none;cursor:pointer;margin-top:0.5rem;padding:0.3rem 0;font-size:0.7rem;color:var(--text-secondary);user-select:none;width:100%;text-align:left" data-provider="' + sanitizeHtml(provider) + '">' +
-    '<span class="cloud-backup-sync-arrow" style="display:inline-block;transition:transform 0.2s;margin-right:0.3rem">&#9654;</span>Sync Snapshots' +
-  '</button>' +
-  '<div class="cloud-backup-sync-list" id="cloudSyncList_' + sanitizeHtml(provider) + '" data-provider="' + sanitizeHtml(provider) + '" style="display:none"></div>';
-
   // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
   listEl.innerHTML = html;
-
-  // Wire up sync snapshots toggle
-  var syncToggle = listEl.querySelector('.cloud-backup-sync-toggle');
-  if (syncToggle) {
-    syncToggle.addEventListener('click', async function () {
-      var syncList = listEl.querySelector('.cloud-backup-sync-list');
-      var arrow = syncToggle.querySelector('.cloud-backup-sync-arrow');
-      if (!syncList) return;
-
-      if (syncList.style.display !== 'none') {
-        syncList.style.display = 'none';
-        if (arrow) arrow.style.transform = '';
-        syncToggle.setAttribute('aria-expanded', 'false');
-        return;
-      }
-
-      syncList.style.display = '';
-      if (arrow) arrow.style.transform = 'rotate(90deg)';
-      syncToggle.setAttribute('aria-expanded', 'true');
-
-      // Lazy-load sync snapshots
-      if (!syncList.dataset.loaded) {
-        // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
-        syncList.innerHTML = '<div class="cloud-backup-empty" style="font-size:0.72rem">Loading…</div>';
-        try {
-          var syncBackups = await cloudListBackups(provider, 'sync');
-          if (!syncBackups || syncBackups.length === 0) {
-            // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
-            syncList.innerHTML = '<div class="cloud-backup-empty" style="font-size:0.72rem">No sync snapshots</div>';
-          } else {
-            // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
-            syncList.innerHTML = syncBackups.map(function (b) {
-              var d = new Date(b.server_modified);
-              var dateStr = d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
-                ' ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-              var sizeStr = b.size < 1024 ? b.size + ' B' :
-                b.size < 1048576 ? (b.size / 1024).toFixed(0) + ' KB' :
-                  (b.size / 1048576).toFixed(1) + ' MB';
-              var safeProvider = sanitizeHtml(provider);
-              var safeFilename = sanitizeHtml(b.name);
-              return '<div class="cloud-backup-row">' +
-                '<button class="cloud-backup-entry" data-provider="' + safeProvider +
-                  '" data-filename="' + safeFilename + '" data-size="' + b.size + '">' +
-                  '<span class="cloud-backup-name" title="' + safeFilename + '">' + sanitizeHtml(dateStr) + '</span>' +
-                  '<span class="cloud-backup-size">' + sanitizeHtml(sizeStr) + '</span>' +
-                  '<span class="cloud-backup-type">Sync snapshot</span>' +
-                '</button>' +
-                '<button class="cloud-backup-delete-btn" data-provider="' + safeProvider +
-                  '" data-filename="' + safeFilename + '" title="Delete this snapshot from cloud storage" aria-label="Delete ' + safeFilename + '">' +
-                  '&times;' +
-                '</button>' +
-              '</div>';
-            }).join('');
-          }
-          syncList.dataset.loaded = 'true';
-        } catch (err) {
-          // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
-          syncList.innerHTML = '<div class="cloud-backup-empty" style="font-size:0.72rem;color:var(--danger)">Failed to load sync snapshots</div>';
-        }
-      }
-    });
-  }
 };
 
 /**
@@ -1196,9 +1129,9 @@ const cloudUpdateBackupCount = async (provider) => {
   const el = safeGetElement('cloudBackupCount_' + provider);
   if (!(el instanceof HTMLElement)) return;
   try {
-    const backups = await cloudListBackups(provider, 'manual');
+    const backups = await cloudListBackups(provider);
     const count = Array.isArray(backups) ? backups.length : 0;
-    el.textContent = count + ' manual backup' + (count !== 1 ? 's' : '');
+    el.textContent = count + ' backup' + (count !== 1 ? 's' : '');
   } catch {
     el.textContent = '\u2014';
   }
@@ -1264,7 +1197,7 @@ const bindCloudStorageListeners = () => {
         return;
       }
       await _cloudBtnAction(btn, 'Loading\u2026', async () => {
-        var backups = await cloudListBackups(provider, 'manual');
+        var backups = await cloudListBackups(provider);
         renderCloudBackupList(provider, backups);
       }, 'Failed to list backups: ');
 
@@ -1293,7 +1226,7 @@ const bindCloudStorageListeners = () => {
       }, 'Download failed: ', async () => {
         var parentList = btn.closest('.cloud-backup-list');
         if (parentList) {
-          var refreshed = await cloudListBackups(provider, 'manual');
+          var refreshed = await cloudListBackups(provider);
           renderCloudBackupList(provider, refreshed);
         }
       });
@@ -1307,7 +1240,7 @@ const bindCloudStorageListeners = () => {
       }, 'Delete failed: ', async () => {
         var parentList = btn.closest('.cloud-backup-list');
         if (parentList) {
-          var refreshed = await cloudListBackups(provider, 'manual');
+          var refreshed = await cloudListBackups(provider);
           renderCloudBackupList(provider, refreshed);
         }
       });

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.41-b1772592261';
+const CACHE_NAME = 'staktrakr-v3.33.42-b1772593568';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.41",
+  "version": "3.33.42",
   "releaseDate": "2026-03-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Pre-sync snapshots now use `vaultEncryptToBytes()` (full backup)** instead of `copy_v2` of the partial sync vault — every sync snapshot is now ~1.5MB with the complete dataset, not 137KB of 8 sync-scoped keys
- **Restore list shows all backups in one flat list** sorted newest first, each labeled "Manual" or "Sync" — no more confusing collapsible section
- **Backup count badge** shows total count instead of manual-only

## Root Cause

`pushSyncVault()` created pre-sync backups by copying the remote `staktrakr-sync.stvault` (built with `vaultEncryptToBytesScoped()` — only 8 keys). Restoring one of these partial files only wrote inventory + display prefs, creating ghost items from stale inventory state without supporting data.

## Linear Issues

- STAK-419: Cloud backup manual vs sync separation (follow-up fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)