### PR TITLE
v3.33.43 — STAK-421: Fix cloud sync storage blowout, import sync race, QuotaExceeded toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.43] - 2026-03-04
+
+### Fixed — Cloud Sync Storage Blowout and Import Race (STAK-421)
+
+- **Fixed**: `restoreVaultData()` now compresses data before writing to localStorage — previously wrote raw vault payloads, causing metalSpotHistory (9 MB) to blow out localStorage quota on every sync pull (STAK-421)
+- **Fixed**: Override imports (CSV/JSON) now cancel the debounced sync push — previously `saveInventory()` would trigger a push that overwrote remote vault with freshly imported local data (STAK-421)
+- **Fixed**: `QuotaExceededError` in `saveData()` now shows a toast notification instead of silently logging to console (STAK-421)
+
+---
+
 ## [3.33.42] - 2026-03-03
 
 ### Fixed — Full Backup for Sync Snapshots (STAK-419)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **Cloud Sync Storage Fix (v3.33.43)**: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421).
 - **Full Backup for Sync Snapshots (v3.33.42)**: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419).
 - **Cloud Backup/Restore Fix (v3.33.41)**: Manual backups and sync snapshots now separated — auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419).
 - **Simplify Market Price Display (v3.33.40)**: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404).
 - **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).
-- **Sync Poll, Settings Sync, DiffModal Fixes (v3.33.38)**: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices — poll compares both inventory and settings hashes. "No changes detected" popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417).
-- **Sync Dialog Cleanup (v3.33.37)**: Removed the redundant "Sync Update Available" dialog — remote changes now go directly to the Review Sync Changes DiffModal for both conflict and non-conflict paths (STAK-413).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.43 &ndash; Cloud Sync Storage Fix</strong>: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421)</li>
     <li><strong>v3.33.42 &ndash; Full Backup for Sync Snapshots</strong>: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419)</li>
     <li><strong>v3.33.41 &ndash; Cloud Backup/Restore Fix</strong>: Manual backups and sync snapshots now separated &mdash; auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419)</li>
     <li><strong>v3.33.40 &ndash; Simplify Market Price Display</strong>: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404)</li>
     <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>
-    <li><strong>v3.33.38 &ndash; Sync Poll, Settings Sync, DiffModal Fixes</strong>: Sync poll detects local-newer inventory and pushes instead of pulling. Settings changes (theme, etc.) now sync between devices &mdash; poll compares both inventory and settings hashes. &ldquo;No changes detected&rdquo; popup eliminated. DiffModal Apply stays enabled for settings-only apply (STAK-414, STAK-415, STAK-416, STAK-417)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.42";
+const APP_VERSION = "3.33.43";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -3095,6 +3095,12 @@ const importCsv = (file, override = false) => {
           }
 
           saveInventory();
+          // STAK-421: Cancel the debounced sync push that saveInventory() just
+          // scheduled — override imports replace all local data, so pushing
+          // immediately would overwrite the remote vault before the user can review.
+          if (typeof scheduleSyncPush === 'function' && typeof scheduleSyncPush.cancel === 'function') {
+            scheduleSyncPush.cancel();
+          }
           renderTable();
           if (typeof renderActiveFilters === 'function') {
             renderActiveFilters();
@@ -3334,6 +3340,10 @@ const importNumistaCsv = (file, override = false) => {
             inventory = catalogManager.syncInventory(inventory);
           }
           saveInventory();
+          // STAK-421: Cancel debounced sync push after override import
+          if (typeof scheduleSyncPush === 'function' && typeof scheduleSyncPush.cancel === 'function') {
+            scheduleSyncPush.cancel();
+          }
           renderTable();
           if (typeof renderActiveFilters === 'function') renderActiveFilters();
           if (typeof updateStorageStats === 'function') updateStorageStats();
@@ -3760,6 +3770,11 @@ const importJson = (file, override = false) => {
           inventory = catalogManager.syncInventory(inventory);
         }
         saveInventory();
+        // STAK-421: Cancel debounced sync push — override import replaces all
+        // local data; pushing now would overwrite remote before user can review.
+        if (typeof scheduleSyncPush === 'function' && typeof scheduleSyncPush.cancel === 'function') {
+          scheduleSyncPush.cancel();
+        }
         renderTable();
         if (typeof renderActiveFilters === 'function') renderActiveFilters();
         if (typeof updateStorageStats === 'function') updateStorageStats();

--- a/js/tags.js
+++ b/js/tags.js
@@ -13,7 +13,20 @@
  */
 const loadItemTags = () => {
   try {
-    itemTags = loadDataSync(ITEM_TAGS_KEY, {});
+    var loaded = loadDataSync(ITEM_TAGS_KEY, {});
+    // STAK-421: Repair cascading JSON.stringify corruption — if the stored
+    // value was stringified multiple times, loadDataSync returns a string
+    // instead of an object. Unwind parse layers until we get an object.
+    var repairs = 0;
+    while (typeof loaded === 'string' && repairs < 20) {
+      try { loaded = JSON.parse(loaded); repairs++; } catch (_) { break; }
+    }
+    if (repairs > 0) {
+      console.warn('[Tags] Repaired', repairs, 'layers of stringify corruption');
+    }
+    itemTags = (typeof loaded === 'object' && loaded !== null && !Array.isArray(loaded)) ? loaded : {};
+    // Persist the repaired value so the corruption doesn't recur on next sync
+    if (repairs > 0) saveItemTags();
   } catch (e) {
     console.error('Failed to load item tags:', e);
     itemTags = {};
@@ -25,6 +38,12 @@ const loadItemTags = () => {
  */
 const saveItemTags = () => {
   try {
+    // STAK-421: Guard against saving corrupted non-object value — this is the
+    // entry point for the cascading stringify corruption (string gets re-stringified).
+    if (typeof itemTags !== 'object' || itemTags === null || Array.isArray(itemTags)) {
+      console.warn('[Tags] saveItemTags blocked — itemTags is not an object:', typeof itemTags);
+      itemTags = {};
+    }
     saveDataSync(ITEM_TAGS_KEY, itemTags);
     if (typeof scheduleSyncPush === 'function') scheduleSyncPush();
   } catch (e) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -1032,7 +1032,19 @@ const loadData = async (key, defaultValue = []) => {
 };
 
 // Synchronous versions for backward compatibility where async isn't supported
-const saveDataSync = (key, data) => { try { const raw = JSON.stringify(data); const out = __compressIfNeeded(raw); localStorage.setItem(key, out); } catch(e) { console.error('saveDataSync failed', e); if (e && e.name === 'QuotaExceededError' && typeof showToast === 'function') { showToast('Storage is full — some data could not be saved.', 'error'); } throw e; } };
+const saveDataSync = (key, data) => {
+  try {
+    const raw = JSON.stringify(data);
+    const out = __compressIfNeeded(raw);
+    localStorage.setItem(key, out);
+  } catch (e) {
+    console.error('saveDataSync failed', e);
+    if (e && e.name === 'QuotaExceededError' && typeof showToast === 'function') {
+      showToast('Storage is full — some data could not be saved. Try clearing unused spot history or image cache.', 'error');
+    }
+    throw e;
+  }
+};
 const loadDataSync = (key, defaultValue = []) => { try { const raw = localStorage.getItem(key); if(raw == null) return defaultValue; const str = __decompressIfNeeded(raw); return JSON.parse(str); } catch(e) { return defaultValue; } };
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -1006,6 +1006,10 @@ const saveData = async (key, data) => {
     }
   } catch(e) {
     console.error('saveData failed', e);
+    // STAK-421: Surface QuotaExceededError so users know storage is full
+    if (e && e.name === 'QuotaExceededError' && typeof showToast === 'function') {
+      showToast('Storage is full — some data could not be saved. Try clearing unused spot history or image cache.', 'error');
+    }
   }
 };
 
@@ -1028,7 +1032,7 @@ const loadData = async (key, defaultValue = []) => {
 };
 
 // Synchronous versions for backward compatibility where async isn't supported
-const saveDataSync = (key, data) => { try { const raw = JSON.stringify(data); const out = __compressIfNeeded(raw); localStorage.setItem(key, out); } catch(e) { console.error('saveDataSync failed', e); throw e; } };
+const saveDataSync = (key, data) => { try { const raw = JSON.stringify(data); const out = __compressIfNeeded(raw); localStorage.setItem(key, out); } catch(e) { console.error('saveDataSync failed', e); if (e && e.name === 'QuotaExceededError' && typeof showToast === 'function') { showToast('Storage is full — some data could not be saved.', 'error'); } throw e; } };
 const loadDataSync = (key, defaultValue = []) => { try { const raw = localStorage.getItem(key); if(raw == null) return defaultValue; const str = __decompressIfNeeded(raw); return JSON.parse(str); } catch(e) { return defaultValue; } };
 
 /**

--- a/js/vault.js
+++ b/js/vault.js
@@ -372,7 +372,13 @@ async function restoreVaultData(payload) {
     // Only restore recognized keys
     if (ALLOWED_STORAGE_KEYS.indexOf(key) !== -1) {
       try {
-        localStorage.setItem(key, data[key]);
+        // STAK-421: Compress before writing — raw vault payloads can exceed
+        // localStorage quota (e.g. metalSpotHistory at 9 MB uncompressed).
+        var value = data[key];
+        if (typeof __compressIfNeeded === 'function') {
+          value = __compressIfNeeded(value);
+        }
+        localStorage.setItem(key, value);
       } catch (e) {
         debugLog("Vault: could not write key", key, e);
       }

--- a/js/vault.js
+++ b/js/vault.js
@@ -374,8 +374,13 @@ async function restoreVaultData(payload) {
       try {
         // STAK-421: Compress before writing — raw vault payloads can exceed
         // localStorage quota (e.g. metalSpotHistory at 9 MB uncompressed).
+        // Skip if already CMP1-compressed to avoid double-wrapping.
         var value = data[key];
-        if (typeof __compressIfNeeded === 'function') {
+        if (
+          typeof value === 'string' &&
+          typeof __compressIfNeeded === 'function' &&
+          !value.startsWith('CMP1:')
+        ) {
           value = __compressIfNeeded(value);
         }
         localStorage.setItem(key, value);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.43-b1772597393';
+const CACHE_NAME = 'staktrakr-v3.33.43-b1772597423';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.42-b1772593568';
+const CACHE_NAME = 'staktrakr-v3.33.43-b1772596184';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.43-b1772596184';
+const CACHE_NAME = 'staktrakr-v3.33.43-b1772597393';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.42",
-  "releaseDate": "2026-03-03",
+  "version": "3.33.43",
+  "releaseDate": "2026-03-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

### Cloud Sync Storage Fixes
- **Fix**: `restoreVaultData()` now compresses data via `__compressIfNeeded()` before writing to localStorage — previously wrote raw vault payloads, causing metalSpotHistory (9 MB) to blow out localStorage quota on every sync pull
- **Fix**: Override imports (CSV, JSON, Numista CSV) now cancel the debounced `scheduleSyncPush()` — previously `saveInventory()` would trigger a push that overwrote remote vault with freshly imported local data
- **Fix**: `QuotaExceededError` in `saveData()` and `saveDataSync()` now shows a toast notification — previously silently logged to console

### Tag Corruption Repair
- **Fix**: `loadItemTags()` now detects cascading JSON.stringify corruption (string returned instead of object) and unwinds parse layers to recover — 10 layers of corruption observed on beta after cloud sync cycles
- **Fix**: `saveItemTags()` now blocks saving non-object `itemTags` values, preventing the corruption cycle from restarting
- **Root cause**: `loadDataSync` returns a string when stored value was multiply-stringified; `saveDataSync` then re-stringifies the string, adding another layer each sync cycle. This also caused settings hash mismatch → infinite sync loop → Numista bulk sync lockup

## Files Changed

- `js/vault.js` — compress before `localStorage.setItem` in `restoreVaultData()`
- `js/inventory.js` — cancel `scheduleSyncPush` after override imports (3 paths: CSV, JSON, Numista)
- `js/utils.js` — surface `QuotaExceededError` via `showToast()` in `saveData()` and `saveDataSync()`
- `js/tags.js` — repair corrupt itemTags on load + guard against saving non-object values

## Linear Issues

- STAK-421: Cloud sync quick fixes — storage blowout, import race, QuotaExceeded UX, tag corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)