### PR TITLE
v3.33.44 — STAK-424: Data Portability Quickfixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 - `displayCurrency`, `exchangeRate`, `currencySymbol` -- currency settings
 - `elements` (object) -- cached DOM references
 - `itemTags` (object) -- per-item tag data
-- `cloudBackupEnabled` (boolean) -- cloud backup feature flag
+
 
 **From `js/debug-log.js`:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Key globals by source file:
 
 | File | Globals |
 |------|---------|
-| `state.js` | `inventory`, `spotPrices`, `elements`, `displayCurrency`, `exchangeRate`, `currencySymbol`, `itemTags`, `cloudBackupEnabled` |
+| `state.js` | `inventory`, `spotPrices`, `elements`, `displayCurrency`, `exchangeRate`, `currencySymbol`, `itemTags` |
 | `debug-log.js` | `debugLog()` |
 | `constants.js` | `API_PROVIDERS`, `METALS`, `ALLOWED_STORAGE_KEYS`, `APP_VERSION`, `LS_KEY`, `SPOT_HISTORY_KEY` |
 | `utils.js` | `saveData()`, `loadData()`, `saveDataSync()`, `loadDataSync()`, `sanitizeHtml()`, `formatCurrency()`, `computeMeltValue()` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.44] - 2026-03-04
+
+### Fixed — Data Portability Quickfixes (STAK-424)
+
+- **Fixed**: `chipMaxCount` added to `ALLOWED_STORAGE_KEYS` — previously silently deleted by `cleanupStorage()` on every session (STAK-424)
+- **Removed**: Dead `cloudBackupEnabled` flag, `MAX_LOCAL_FILE_SIZE` 2 MB limit, and `checkFileSize()` — import files of any size are now accepted, with QuotaExceeded toast as the safety net (STAK-424)
+- **Added**: Storage Location and Tags columns to CSV export; `tags` array to JSON export — re-imports now preserve more data (STAK-424)
+- **Fixed**: CSV import tag persistence deferred until user confirms — cancelling an import no longer leaves orphaned tags in localStorage (STAK-424)
+- **Fixed**: ZIP image import now handles reverse-only user photos — previously dropped images with no obverse (STAK-424)
+
+---
+
 ## [3.33.43] - 2026-03-04
 
 ### Fixed — Cloud Sync Storage Blowout and Import Race (STAK-421)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Data Portability Quickfixes (v3.33.44)**: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424).
 - **Cloud Sync Storage Fix (v3.33.43)**: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421).
 - **Full Backup for Sync Snapshots (v3.33.42)**: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419).
 - **Cloud Backup/Restore Fix (v3.33.41)**: Manual backups and sync snapshots now separated — auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419).
 - **Simplify Market Price Display (v3.33.40)**: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404).
-- **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.44 &ndash; Data Portability Quickfixes</strong>: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424)</li>
     <li><strong>v3.33.43 &ndash; Cloud Sync Storage Fix</strong>: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421)</li>
     <li><strong>v3.33.42 &ndash; Full Backup for Sync Snapshots</strong>: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419)</li>
     <li><strong>v3.33.41 &ndash; Cloud Backup/Restore Fix</strong>: Manual backups and sync snapshots now separated &mdash; auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419)</li>
     <li><strong>v3.33.40 &ndash; Simplify Market Price Display</strong>: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404)</li>
-    <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.43";
+const APP_VERSION = "3.33.44";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -393,12 +393,6 @@ const replaceTemplateVariables = (text) => {
     return variables[key] || match;
   });
 };
-
-/** Maximum upload size in bytes for local imports (2MB) */
-const MAX_LOCAL_FILE_SIZE = 2 * 1024 * 1024;
-
-/** Flag indicating whether cloud backup is enabled */
-let cloudBackupEnabled = false;
 
 /**
  * Inserts formatted version string into a target element
@@ -834,6 +828,7 @@ const ALLOWED_STORAGE_KEYS = [
   "spotPlatinum",
   "spotPalladium",
   "chipMinCount",
+  "chipMaxCount",
   "changeLog",
   "autocomplete_lookup_cache",
   "autocomplete_cache_timestamp",
@@ -1715,7 +1710,7 @@ if (typeof window !== "undefined") {
   window.METALS = METALS;
   window.DEBUG = DEBUG;
   window.DEFAULT_CURRENCY = DEFAULT_CURRENCY;
-  window.MAX_LOCAL_FILE_SIZE = MAX_LOCAL_FILE_SIZE;
+
   window.BRANDING_DOMAIN_OPTIONS = BRANDING_DOMAIN_OPTIONS;
   window.BRANDING_DOMAIN_OVERRIDE = BRANDING_DOMAIN_OVERRIDE;
   window.getTemplateVariables = getTemplateVariables;

--- a/js/events.js
+++ b/js/events.js
@@ -380,11 +380,7 @@ const setupFormatImport = (overrideBtn, mergeBtn, fileInput, importFn, formatNam
   optionalListener(fileInput, "change", function (e) {
     if (e.target.files.length > 0) {
       const file = e.target.files[0];
-      if (!checkFileSize(file)) {
-        appAlert("File exceeds 2MB limit. Enable cloud backup for larger uploads.");
-      } else {
-        importFn(file, isOverride);
-      }
+      importFn(file, isOverride);
     }
     this.value = "";
   }, `${formatName} import`);

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -2840,11 +2840,11 @@ const showImportDiffReview = (parsedItems, sourceInfo, options, onComplete) => {
 
       inventory = DiffEngine.applySelectedChanges(inventory, selectedChanges);
 
-      // Apply tags for added items if pendingTagsByUuid provided
+      // Apply deferred tags for accepted changes (add + modify)
       if (options.pendingTagsByUuid && typeof addItemTag === 'function') {
-        const addedItems = selectedChanges.filter(function(c) { return c.type === 'add'; });
-        for (const change of addedItems) {
-          if (change.item) {
+        const tagEligible = selectedChanges.filter(function(c) { return c.type === 'add' || c.type === 'modify'; });
+        for (const change of tagEligible) {
+          if (change.item && change.item.uuid) {
             const tags = options.pendingTagsByUuid.get(change.item.uuid);
             if (tags && tags.length) {
               tags.forEach(function(tag) { addItemTag(change.item.uuid, tag, false); });

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -2931,6 +2931,7 @@ const importCsv = (file, override = false) => {
 
         const supportedMetals = ['Silver', 'Gold', 'Platinum', 'Palladium'];
         const skippedNonPM = [];
+        const pendingTagsByUuid = new Map();
 
         for (const row of results.data) {
           processed++;
@@ -3033,19 +3034,15 @@ const importCsv = (file, override = false) => {
 
           imported.push(item);
 
-          // STAK-126: Import tags from CSV
-          if (csvTags && typeof addItemTag === 'function') {
-            csvTags.split(';').map(t => t.trim()).filter(Boolean).forEach(tag => {
-              addItemTag(item.uuid, tag, false);
-            });
+          // STAK-126 / STAK-424: Collect tags but defer persistence until import confirmed
+          if (csvTags) {
+            const tagList = csvTags.split(';').map(t => t.trim()).filter(Boolean);
+            if (tagList.length) pendingTagsByUuid.set(item.uuid, tagList);
           }
 
           importedCount++;
           updateImportProgress(processed, importedCount, totalRows);
         }
-
-        // STAK-126: Persist any imported tags
-        if (typeof saveItemTags === 'function') saveItemTags();
 
         endImportProgress();
 
@@ -3095,6 +3092,16 @@ const importCsv = (file, override = false) => {
           }
 
           saveInventory();
+          // STAK-424: Apply deferred tags after override confirmation
+          if (pendingTagsByUuid.size > 0 && typeof addItemTag === 'function') {
+            for (const item of imported) {
+              const tags = pendingTagsByUuid.get(item.uuid);
+              if (tags && tags.length) {
+                tags.forEach(tag => addItemTag(item.uuid, tag, false));
+              }
+            }
+            if (typeof saveItemTags === 'function') saveItemTags();
+          }
           // STAK-421: Cancel the debounced sync push that saveInventory() just
           // scheduled — override imports replace all local data, so pushing
           // immediately would overwrite the remote vault before the user can review.
@@ -3118,6 +3125,7 @@ const importCsv = (file, override = false) => {
         // --- Merge path: use shared DiffEngine + DiffModal helper ---
         showImportDiffReview(imported, { type: 'csv', label: file.name }, {
           validationResult: _validationResult,
+          pendingTagsByUuid: pendingTagsByUuid,
         }, function(summary) {
           debugLog('importCsv DiffEngine complete', summary.added, 'added', summary.modified, 'modified', summary.deleted, 'deleted');
         });
@@ -3474,7 +3482,7 @@ const exportCsv = () => {
   const headers = [
     "Date","Metal","Type","Name","Year","Qty","Weight(oz)","Weight Unit","Purity",
     "Purchase Price","Melt Value","Retail Price","Gain/Loss",
-    "Purchase Location","N#","PCGS #","Grade","Grading Authority","Cert #","Serial Number","Notes","UUID",
+    "Purchase Location","Storage Location","N#","PCGS #","Grade","Grading Authority","Cert #","Serial Number","Notes","Tags","UUID",
     "Obverse Image URL","Reverse Image URL",
     "Disposition Type","Disposition Date","Disposition Amount","Realized Gain/Loss"
   ];
@@ -3506,6 +3514,7 @@ const exportCsv = () => {
       formatCurrency(i.marketValue || 0),
       gainLoss !== null ? formatCurrency(gainLoss) : '—',
       i.purchaseLocation,
+      i.storageLocation || '',
       i.numistaId || '',
       i.pcgsNumber || '',
       i.grade || '',
@@ -3513,6 +3522,7 @@ const exportCsv = () => {
       i.certNumber || '',
       i.serialNumber || '',
       i.notes || '',
+      typeof getItemTags === 'function' ? getItemTags(i.uuid).join('; ') : '',
       i.uuid || '',
       i.obverseImageUrl || '',
       i.reverseImageUrl || '',
@@ -3852,6 +3862,7 @@ const exportJson = () => {
     marketValue: item.marketValue || 0,
     purchaseLocation: item.purchaseLocation,
     storageLocation: item.storageLocation,
+    tags: typeof getItemTags === 'function' ? getItemTags(item.uuid) : [],
     notes: item.notes,
     numistaId: item.numistaId,
     grade: item.grade || '',

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -2736,13 +2736,14 @@ const endImportProgress = () => {
 /**
  * Post-import cleanup — registers names, syncs catalog, saves, and re-renders.
  * @param {Array} newItems - Items that were added during import
- * @param {Map|null} pendingTagsByUuid - Optional map of uuid -> tag[] for deferred tag application
+ * @param {Map|null} pendingTagsByUuid - Optional map of itemKey -> tag[] for deferred tag application
  */
 const _postImportCleanup = (newItems, pendingTagsByUuid) => {
-  // Apply deferred tags if needed
+  // Apply deferred tags if needed (keyed by DiffEngine.computeItemKey)
   if (pendingTagsByUuid && typeof addItemTag === 'function') {
     for (const item of newItems) {
-      const tags = pendingTagsByUuid.get(item.uuid);
+      const itemKey = typeof DiffEngine !== 'undefined' ? DiffEngine.computeItemKey(item) : (item.uuid || item.serial || '');
+      const tags = pendingTagsByUuid.get(itemKey);
       if (tags && tags.length) {
         tags.forEach(tag => addItemTag(item.uuid, tag, false));
       }
@@ -2840,12 +2841,14 @@ const showImportDiffReview = (parsedItems, sourceInfo, options, onComplete) => {
 
       inventory = DiffEngine.applySelectedChanges(inventory, selectedChanges);
 
-      // Apply deferred tags for accepted changes (add + modify)
+      // Apply deferred tags for accepted changes (add + modify).
+      // Look up by DiffEngine.computeItemKey to match the key used at build time.
       if (options.pendingTagsByUuid && typeof addItemTag === 'function') {
         const tagEligible = selectedChanges.filter(function(c) { return c.type === 'add' || c.type === 'modify'; });
         for (const change of tagEligible) {
           if (change.item && change.item.uuid) {
-            const tags = options.pendingTagsByUuid.get(change.item.uuid);
+            var tagKey = typeof DiffEngine !== 'undefined' ? DiffEngine.computeItemKey(change.item) : (change.item.uuid || change.item.serial || '');
+            const tags = options.pendingTagsByUuid.get(tagKey);
             if (tags && tags.length) {
               tags.forEach(function(tag) { addItemTag(change.item.uuid, tag, false); });
             }
@@ -3034,10 +3037,15 @@ const importCsv = (file, override = false) => {
 
           imported.push(item);
 
-          // STAK-126 / STAK-424: Collect tags but defer persistence until import confirmed
+          // STAK-126 / STAK-424: Collect tags but defer persistence until import confirmed.
+          // Key by DiffEngine.computeItemKey (uuid → serial → name|date) so legacy
+          // CSV exports without UUIDs still match after serial→uuid enrichment.
           if (csvTags) {
             const tagList = csvTags.split(';').map(t => t.trim()).filter(Boolean);
-            if (tagList.length) pendingTagsByUuid.set(item.uuid, tagList);
+            if (tagList.length) {
+              const tagKey = typeof DiffEngine !== 'undefined' ? DiffEngine.computeItemKey(item) : (item.uuid || item.serial || '');
+              if (tagKey) pendingTagsByUuid.set(tagKey, tagList);
+            }
           }
 
           importedCount++;
@@ -3095,7 +3103,8 @@ const importCsv = (file, override = false) => {
           // STAK-424: Apply deferred tags after override confirmation
           if (pendingTagsByUuid.size > 0 && typeof addItemTag === 'function') {
             for (const item of imported) {
-              const tags = pendingTagsByUuid.get(item.uuid);
+              const itemKey = typeof DiffEngine !== 'undefined' ? DiffEngine.computeItemKey(item) : (item.uuid || item.serial || '');
+              const tags = pendingTagsByUuid.get(itemKey);
               if (tags && tags.length) {
                 tags.forEach(tag => addItemTag(item.uuid, tag, false));
               }

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -980,7 +980,7 @@ const bindImageImportExportListeners = () => {
           for (const [uuid, sides] of userMap) {
             const obverse = sides.obverse ? await sides.obverse.async('blob') : null;
             const reverse = sides.reverse ? await sides.reverse.async('blob') : null;
-            if (obverse) await imageCache.cacheUserImage(uuid, obverse, reverse);
+            if (obverse || reverse) await imageCache.cacheUserImage(uuid, obverse, reverse);
           }
         }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -169,17 +169,6 @@ const debounce = (func, wait) => {
 };
 
 /**
- * Checks if a file exceeds the local upload size limit
- *
- * @param {File} file - File to validate
- * @returns {boolean} True if file is within allowed size
- */
-const checkFileSize = (file) => {
-  const limit = cloudBackupEnabled ? Infinity : MAX_LOCAL_FILE_SIZE;
-  return file.size <= limit;
-};
-
-/**
  * Refreshes composition dropdown options in add/edit modals
  */
 const refreshCompositionOptions = () => {
@@ -3146,7 +3135,6 @@ if (typeof window !== 'undefined') {
   };
 
   window.cleanupStorage = cleanupStorage;
-  window.checkFileSize = checkFileSize;
   window.closeModalById = closeModalById;
   window.openModalById = openModalById;
   window.updateStorageStats = updateStorageStats;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.43-b1772597423';
+const CACHE_NAME = 'staktrakr-v3.33.44-b1772601932';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.44-b1772601932';
+const CACHE_NAME = 'staktrakr-v3.33.44-b1772605441';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.44-b1772605441';
+const CACHE_NAME = 'staktrakr-v3.33.44-b1772607738';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.43",
+  "version": "3.33.44",
   "releaseDate": "2026-03-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,7 +2,7 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.41
+lastUpdated: v3.33.44
 date: 2026-03-03
 sourceFiles:
   - js/cloud-storage.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.41 — 2026-03-03
+> **Last updated:** v3.33.44 — 2026-03-03
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`
 
 ## Overview
@@ -150,7 +150,7 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 | `user_images/` | User-uploaded photo blobs (obverse/reverse per UUID) | IDB `userImages` store |
 | `user_image_manifest.json` | UUID→filename mapping | Used during restore |
 | `pattern_images/` | Pattern rule image blobs | IDB `patternImages` store |
-| `inventory_export.csv` | Human-readable CSV | Not restored (report only) |
+| `inventory_export.csv` | Human-readable CSV (includes Tags and Storage Location columns as of v3.33.44) | Not restored (report only) |
 | `inventory_report.html` | HTML report | Not restored (report only) |
 
 What is NOT included: `coinImages` IDB store (legacy/dead, explicitly skipped), API keys, OAuth tokens, cloud sync state.
@@ -171,7 +171,7 @@ Does NOT include: `userImages`, `patternImages`, or `coinMetadata` IDB blobs.
 
 **Sync scope** (`vaultEncryptToBytesScoped`) includes only `SYNC_SCOPE_KEYS`:
 
-- `metalInventory`, `itemTags`, display preferences, `chipMinCount`, `chipMaxCount`
+- `metalInventory`, `itemTags`, display preferences, `chipMinCount`
 
 Intentionally excludes: API keys, OAuth tokens, spot price history.
 

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -2,7 +2,7 @@
 title: Data Model
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.41
+lastUpdated: v3.33.44
 date: 2026-03-03
 sourceFiles:
   - js/constants.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Data Model
 
-> **Last updated:** v3.33.41 — 2026-03-03
+> **Last updated:** v3.33.44 — 2026-03-03
 > **Source files:** `js/constants.js`, `js/utils.js`, `js/types.js`
 
 ## Overview
@@ -326,6 +326,7 @@ All keys currently registered in `js/constants.js`. `cleanupStorage()` enforces 
 | `showRealizedGainLoss` | Boolean string | Show realized G/L in summary cards (STAK-72) |
 | `tagBlacklist` | JSON array | Tags excluded from auto-tagging |
 | `chipMinCount` | Number string | Minimum item count for chip display |
+| `chipMaxCount` | Number string | Maximum item count for chip display |
 | `chipCustomGroups` | JSON array | Custom chip grouping definitions |
 | `chipBlacklist` | JSON array | Hidden chip values |
 | `inlineChipConfig` | JSON object | Inline chip display configuration |

--- a/wiki/dom-patterns.md
+++ b/wiki/dom-patterns.md
@@ -2,8 +2,8 @@
 title: DOM Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.44
+date: 2026-03-03
 sourceFiles:
   - js/utils.js
   - js/about.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # DOM Patterns
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.44 — 2026-03-03
 > **Source files:** `js/utils.js`, `js/init.js`, `js/about.js`
 
 ## Overview

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -2,8 +2,8 @@
 title: Frontend Overview
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.44
+date: 2026-03-03
 sourceFiles:
   - index.html
   - js/constants.js
@@ -17,7 +17,7 @@ relatedPages:
 ---
 # Frontend Overview
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.44 — 2026-03-03
 > **Source files:** `index.html`, `js/constants.js`, `sw.js`, `js/file-protocol-fix.js`
 
 ## Overview
@@ -71,12 +71,12 @@ index.html  (single-page app — all UI panels, modals, and sections)
 `APP_VERSION` in `js/constants.js` follows the `BRANCH.RELEASE.PATCH` format:
 
 ```text
-3   .   33   .   25
+3   .   33   .   44
 ^       ^        ^
 Branch  Release  Patch
 ```
 
-Current version: **3.33.25**
+Current version: **3.33.44**
 
 Optional state suffixes: `a` = alpha, `b` = beta, `rc` = release candidate.
 

--- a/wiki/release-workflow.md
+++ b/wiki/release-workflow.md
@@ -2,8 +2,8 @@
 title: Release Workflow
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.44
+date: 2026-03-03
 sourceFiles:
   - .claude/skills/release/SKILL.md
   - .claude/skills/ship/SKILL.md
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Release Workflow
 
-> **Last updated:** v3.33.25 — 2026-03-02
+> **Last updated:** v3.33.44 — 2026-03-03
 > **Source files:** `.claude/skills/release/SKILL.md`, `.claude/skills/ship/SKILL.md`, `devops/version.lock`, `js/constants.js`
 
 ## Overview
@@ -47,7 +47,7 @@ Defined in `js/constants.js` as `APP_VERSION`:
 
 ```
 BRANCH.RELEASE.PATCH
-  3  .  33  .  25
+  3  .  33  .  44
 ```
 
 | Component | Meaning | When it changes |
@@ -59,7 +59,7 @@ BRANCH.RELEASE.PATCH
 The current version is always the authoritative value in `js/constants.js`:
 
 ```javascript
-const APP_VERSION = "3.33.25";
+const APP_VERSION = "3.33.44";
 ```
 
 ---

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -2,7 +2,7 @@
 title: Storage Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.41
+lastUpdated: v3.33.44
 date: 2026-03-03
 sourceFiles:
   - js/utils.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Storage Patterns
 
-> **Last updated:** v3.33.41 — 2026-03-03
+> **Last updated:** v3.33.44 — 2026-03-03
 > **Source files:** `js/utils.js`, `js/constants.js`
 
 ## Overview
@@ -188,7 +188,7 @@ function __decompressIfNeeded(stored) {
 
 ## Storage Keys Registry
 
-All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. As of v3.33.25 the list contains ~90 entries. Keys are grouped by function:
+All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. As of v3.33.44 the list contains ~90 entries. Keys are grouped by function:
 
 ### Core inventory
 
@@ -243,6 +243,7 @@ All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. A
 | `"filterChipCategoryConfig"` | JSON array | Filter chip category config |
 | `"chipSortOrder"` | string | Chip sort order |
 | `"chipMinCount"` | number string | Min count for filter chips |
+| `"chipMaxCount"` | number string | Max count for filter chips |
 | `"chipCustomGroups"` | JSON object | Custom chip groupings |
 | `"chipBlacklist"` | JSON array | Chips excluded from display |
 | `"layoutSectionConfig"` | JSON array | Ordered layout section config |
@@ -325,6 +326,7 @@ All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. A
 | `ACK_DISMISSED_KEY` | _(defined in constants)_ | string | Acknowledgment dismissal state |
 | `"changeLog"` | _(raw string)_ | JSON | Changelog data |
 | `"chipMinCount"` | _(raw string)_ | number string | Minimum chip count |
+| `"chipMaxCount"` | _(raw string)_ | number string | Maximum chip count |
 | `"apiProviderOrder"` | _(raw string)_ | JSON array | API provider display order |
 | `"providerPriority"` | _(raw string)_ | JSON object | Provider priority weighting |
 | `"staktrakr.debug"` | _(raw string)_ | boolean string | Debug mode (staktrakr.com) |


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

Five independent bug fixes from the data portability audit (Gemini + Codex):

1. **chipMaxCount in ALLOWED_STORAGE_KEYS** — was silently deleted by `cleanupStorage()` every session
2. **Remove dead 2 MB import limit** — `cloudBackupEnabled`, `MAX_LOCAL_FILE_SIZE`, `checkFileSize()` all removed. IDB storage engine handles multi-GB data; QuotaExceeded toast is the safety net
3. **CSV/JSON export completeness** — added Storage Location + Tags columns to CSV, `tags` array to JSON export
4. **Deferred tag persistence** — CSV import tags now collected in a `pendingTagsByUuid` Map and only persisted after user confirms (override or merge). Uses existing `showImportDiffReview` infrastructure
5. **Reverse-only image import** — changed `if (obverse)` to `if (obverse || reverse)` in ZIP image import. `cacheUserImage()` already handles null obverse

## Files Changed

- `js/constants.js` — added `chipMaxCount` to allowlist, removed dead `MAX_LOCAL_FILE_SIZE` + `cloudBackupEnabled`
- `js/utils.js` — removed `checkFileSize()` function and window export
- `js/events.js` — removed file size gate on import
- `js/inventory.js` — added export columns/fields, deferred tag persistence via pendingTagsByUuid
- `js/settings-listeners.js` — fixed reverse-only image import guard
- `AGENTS.md`, `.github/copilot-instructions.md` — removed `cloudBackupEnabled` references
- Version bump files (constants, changelog, announcements, about, version.json, sw.js)

## Linear Issues

- [STAK-424: Data Portability Quickfixes](https://linear.app/lbruton/issue/STAK-424)
- Parent epic: [STAK-423: Data Portability Overhaul](https://linear.app/lbruton/issue/STAK-423)

🤖 Generated with [Claude Code](https://claude.com/claude-code)