### PR TITLE
v3.33.45 — STAK-428: FAQ Cloudflare cookie disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.45] - 2026-03-04
+
+### Fixed — FAQ Cloudflare Cookie Disclosure (STAK-428)
+
+- **Fixed**: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie (e.g. `__cf_bm`) for bot protection on the hosted site — previously claimed "No cookies" without distinguishing app code from CDN infrastructure (STAK-428)
+- **Fixed**: FAQ technical detail section updated from "Does not: set cookies" to explicitly note the infrastructure cookie is safe to block (STAK-428)
+
+---
+
 ## [3.33.43] - 2026-03-04
 
 ### Fixed — Cloud Sync Storage Blowout and Import Race (STAK-421)

--- a/about/FAQ.md
+++ b/about/FAQ.md
@@ -27,9 +27,14 @@ No. There is no server-side component, no database, and no analytics that transm
 
 **Does this app use cookies or tracking?**
 
-**No cookies. No advertising SDKs. No tracking pixels.** The app uses browser localStorage and IndexedDB solely to store your inventory and preferences on your own device.
+**StakTrakr itself sets no cookies.** No advertising SDKs. No tracking pixels. The app uses browser localStorage and IndexedDB solely to store your inventory and preferences on your own device.
 
-When you use the hosted version at staktrakr.com (served via Cloudflare Pages), Cloudflare Web Analytics is active at the network edge. It collects aggregated, anonymous page-view metrics — visit counts, countries, browser types — without cookies and without building individual user profiles. No inventory data is ever included. If you download and run the app locally from a ZIP file, no analytics run at all.
+When you use the hosted version at staktrakr.com (served via Cloudflare Pages), two things happen at the infrastructure level:
+
+- **Cloudflare Web Analytics** — collects aggregated, anonymous page-view metrics (visit counts, countries, browser types) without cookies and without building individual user profiles.
+- **Cloudflare infrastructure cookie** — Cloudflare may set a temporary cookie (e.g. `__cf_bm`) for bot protection. This is set by Cloudflare's CDN, not by StakTrakr. It contains no inventory data, is not used for tracking, and **can be safely blocked** without affecting the app.
+
+No inventory data is ever included in any of the above. If you download and run the app locally from a ZIP file, none of this applies — no analytics, no cookies, nothing.
 
 ---
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **FAQ Cloudflare Cookie Disclosure (v3.33.45)**: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block — does not affect the app (STAK-428).
 - **Cloud Sync Storage Fix (v3.33.43)**: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421).
 - **Full Backup for Sync Snapshots (v3.33.42)**: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419).
 - **Cloud Backup/Restore Fix (v3.33.41)**: Manual backups and sync snapshots now separated — auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419).
 - **Simplify Market Price Display (v3.33.40)**: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404).
-- **Summary Bar Items + Weight (v3.33.39)**: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L — shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -4003,12 +4003,16 @@
                 <details class="faq-item">
                   <summary class="faq-question">Does this app use cookies or tracking?</summary>
                   <div class="faq-answer">
-                    <p><strong>No cookies. No advertising SDKs. No tracking pixels.</strong> The app itself uses browser localStorage and IndexedDB solely to store your inventory and preferences on your own device.</p>
-                    <p>However, when you use the <strong>hosted version</strong> at staktrakr.com (served via Cloudflare Pages), <a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener">Cloudflare Web Analytics</a> is active at the network edge. It collects aggregated, anonymous page view metrics — things like visit counts, countries, and browser types — to help the developer understand usage. Cloudflare does this without cookies and without building individual user profiles.</p>
-                    <p>No inventory data is ever included. If you download and run the app locally from a ZIP file, no analytics run at all.</p>
+                    <p><strong>StakTrakr itself sets no cookies.</strong> No advertising SDKs. No tracking pixels. The app uses browser localStorage and IndexedDB solely to store your inventory and preferences on your own device.</p>
+                    <p>However, when you use the <strong>hosted version</strong> at staktrakr.com (served via Cloudflare Pages), two things happen at the infrastructure level:</p>
+                    <ul>
+                      <li><strong>Cloudflare Web Analytics</strong> — collects aggregated, anonymous page view metrics (visit counts, countries, browser types) without cookies and without building individual user profiles. <a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener">Learn more</a>.</li>
+                      <li><strong>Cloudflare infrastructure cookie</strong> — Cloudflare may set a temporary cookie (e.g. <code>__cf_bm</code>) for bot protection. This is set by Cloudflare's CDN, not by StakTrakr. It contains no inventory data, is not used for tracking, and <strong>can be safely blocked</strong> without affecting the app.</li>
+                    </ul>
+                    <p>No inventory data is ever included in any of the above. If you download and run the app locally from a ZIP file, none of this applies — no analytics, no cookies, nothing.</p>
                     <details class="faq-technical">
-                      <summary>What Cloudflare Web Analytics does and does not do</summary>
-                      <p><strong>Does not:</strong> set cookies · use localStorage · fingerprint individuals · share data with advertisers · track you across sites<br><strong>Does:</strong> log page views at the network edge · process IP addresses server-side (not stored individually) · report aggregated metrics to the site owner only</p>
+                      <summary>What Cloudflare does and does not do on the hosted site</summary>
+                      <p><strong>Does not:</strong> use localStorage · fingerprint individuals · share data with advertisers · track you across sites · access your inventory<br><strong>Does:</strong> log page views at the network edge · process IP addresses server-side (not stored individually) · report aggregated metrics to the site owner only · may set a temporary infrastructure cookie for bot protection (safe to block)</p>
                     </details>
                   </div>
                 </details>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.45 &ndash; FAQ Cloudflare Cookie Disclosure</strong>: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block &mdash; does not affect the app (STAK-428)</li>
     <li><strong>v3.33.43 &ndash; Cloud Sync Storage Fix</strong>: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421)</li>
     <li><strong>v3.33.42 &ndash; Full Backup for Sync Snapshots</strong>: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419)</li>
     <li><strong>v3.33.41 &ndash; Cloud Backup/Restore Fix</strong>: Manual backups and sync snapshots now separated &mdash; auto-prune only deletes sync snapshots, restore list shows manual backups by default, Backup button always prompts for password. Prevents accidental deletion of user manual backups (STAK-419)</li>
     <li><strong>v3.33.40 &ndash; Simplify Market Price Display</strong>: Removed confidence score badges and out-of-stock styling from market vendor chips. Vendors with valid prices display equally. Anomalous prices silently filtered via 40% median deviation threshold. Monument Metals false OOS fixed (STAK-404)</li>
-    <li><strong>v3.33.39 &ndash; Summary Bar Items + Weight</strong>: Item count and total weight now display in the portfolio summary bar alongside Buy/Melt/Market/G/L &mdash; shows filtered/total format when filters active, total weight in troy ounces. Bottom footer item count removed (STAK-418)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.43";
+const APP_VERSION = "3.33.45";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.43-b1772597423';
+const CACHE_NAME = 'staktrakr-v3.33.45-b1772606376';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.43",
+  "version": "3.33.45",
   "releaseDate": "2026-03-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie (e.g. `__cf_bm`) for bot protection on the hosted site
- Previously claimed "No cookies" without distinguishing app code from CDN infrastructure
- Updated `index.html` FAQ, `about/FAQ.md`, and the Cloudflare technical detail section
- Cookie is safe to block — noted explicitly in FAQ

## Linear Issues

- STAK-428: FAQ Cloudflare cookie disclosure

## Source

Reddit feedback from u/PumpkinCrouton (2026-03-04)

🤖 Generated with [Claude Code](https://claude.com/claude-code)