### PR TITLE
v3.33.47 — STAK-426: Sync Scope & Serialization

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.47] - 2026-03-04
+
+### Changed — Sync Scope & Serialization (STAK-426)
+
+- **Changed**: Expanded cloud sync scope from 8 to 44 keys — all user preferences, header button config, feature toggles, Numista/PCGS settings, provider order, and API credentials now sync across devices (STAK-426)
+- **Fixed**: Manifest-first pull now compares and applies settings changes via DiffEngine, showing them in the DiffModal instead of silently skipping them (STAK-426)
+- **Fixed**: Manifest-first pull now downloads and restores the image vault when the hash differs, instead of silently skipping photo sync (STAK-426)
+- **Added**: Image deletion propagation — deleting all photos locally now removes the remote image vault so other devices don't restore deleted photos (STAK-426)
+
+---
+
 ## [3.33.46] - 2026-03-04
 
 ### Fixed — Cloud Storage API Hardening (STAK-425)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Sync Scope & Serialization (v3.33.47)**: Cloud sync now syncs 44 keys across devices (up from 8) — all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426).
 - **Cloud Storage API Hardening (v3.33.46)**: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425).
 - **FAQ Cloudflare Cookie Disclosure (v3.33.45)**: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block — does not affect the app (STAK-428).
 - **Data Portability Quickfixes (v3.33.44)**: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424).
 - **Cloud Sync Storage Fix (v3.33.43)**: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421).
-- **Full Backup for Sync Snapshots (v3.33.42)**: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.47 &ndash; Sync Scope &amp; Serialization</strong>: Cloud sync now syncs 44 keys across devices (up from 8) &mdash; all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426)</li>
     <li><strong>v3.33.46 &ndash; Cloud Storage API Hardening</strong>: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425)</li>
     <li><strong>v3.33.45 &ndash; FAQ Cloudflare Cookie Disclosure</strong>: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block &mdash; does not affect the app (STAK-428)</li>
     <li><strong>v3.33.44 &ndash; Data Portability Quickfixes</strong>: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424)</li>
     <li><strong>v3.33.43 &ndash; Cloud Sync Storage Fix</strong>: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421)</li>
-    <li><strong>v3.33.42 &ndash; Full Backup for Sync Snapshots</strong>: Pre-sync snapshots now contain the full encrypted backup instead of partial sync-scoped data. Restore list shows all backups (manual + sync) in one sorted list. Fixes ghost items caused by restoring partial sync snapshots (STAK-419)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -959,13 +959,16 @@ async function buildAndUploadManifest(token, password, syncId) {
   };
 
   // 4b. STAK-426: Embed settings snapshot so manifest-first pulls can compare
-  // settings without downloading the full vault
+  // settings without downloading the full vault.
+  // Use raw localStorage.getItem() so scalar string preferences (appTheme, appTimeZone,
+  // cardViewStyle, sort columns, etc.) stored via localStorage.setItem are captured —
+  // loadDataSync() JSON-parses and would return null for those raw-string values.
   var settingsSnapshot = {};
-  if (typeof SYNC_SCOPE_KEYS !== 'undefined') {
+  if (typeof SYNC_SCOPE_KEYS !== 'undefined' && typeof localStorage !== 'undefined') {
     for (var s = 0; s < SYNC_SCOPE_KEYS.length; s++) {
       if (SYNC_SCOPE_KEYS[s] === 'metalInventory') continue;
-      var sv = loadDataSync(SYNC_SCOPE_KEYS[s], null);
-      if (sv !== null && sv !== undefined) settingsSnapshot[SYNC_SCOPE_KEYS[s]] = sv;
+      var sv = localStorage.getItem(SYNC_SCOPE_KEYS[s]);
+      if (sv !== null) settingsSnapshot[SYNC_SCOPE_KEYS[s]] = sv;
     }
   }
   manifestPayload.settings = settingsSnapshot;
@@ -2109,12 +2112,16 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
     inventory = newInventory;
   }
 
-  // 3. Apply settings changes
+  // 3. Apply settings changes.
+  // remoteVal is a raw localStorage string (from vault payload.data or manifest.settings
+  // snapshot). Use localStorage.setItem directly so scalar string preferences
+  // (appTheme, appTimeZone, etc.) are written without JSON-encoding, matching the
+  // format expected by readers like theme.js and settings-listeners.js.
   if (settingsChanges && Array.isArray(settingsChanges)) {
     for (var i = 0; i < settingsChanges.length; i++) {
       var sc = settingsChanges[i];
-      if (sc && sc.key && typeof saveDataSync === 'function') {
-        saveDataSync(sc.key, sc.remoteVal);
+      if (sc && sc.key && sc.remoteVal !== null && sc.remoteVal !== undefined && typeof localStorage !== 'undefined') {
+        localStorage.setItem(sc.key, sc.remoteVal);
       }
     }
   }
@@ -2383,14 +2390,19 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
           debugLog('[CloudSync] Selective apply would empty vault but remote has', remoteItems.length, 'items — falling back to full overwrite');
           // fall through to full-overwrite path below
         } else {
-          // STAK-426: Extract settings from vault payload and compare
+          // STAK-426: Extract settings from vault payload and compare.
+          // Use raw localStorage.getItem() for local settings so scalar string
+          // preferences (appTheme, appTimeZone, etc.) are included — loadDataSync()
+          // JSON-parses and returns null for those raw-string values. payload.data
+          // also contains raw localStorage strings, so both sides use the same
+          // serialization format and the comparison is stable.
           var _dvSettingsChanges = null;
           if (payload.data && typeof SYNC_SCOPE_KEYS !== 'undefined' && typeof DiffEngine !== 'undefined' && DiffEngine.compareSettings) {
             var _dvLocalSettings = {};
             var _dvRemoteSettings = {};
             for (var _dvs = 0; _dvs < SYNC_SCOPE_KEYS.length; _dvs++) {
               if (SYNC_SCOPE_KEYS[_dvs] === 'metalInventory') continue;
-              var _dvlv = loadDataSync(SYNC_SCOPE_KEYS[_dvs], null);
+              var _dvlv = typeof localStorage !== 'undefined' ? localStorage.getItem(SYNC_SCOPE_KEYS[_dvs]) : null;
               if (_dvlv !== null) _dvLocalSettings[SYNC_SCOPE_KEYS[_dvs]] = _dvlv;
               if (payload.data[SYNC_SCOPE_KEYS[_dvs]] !== undefined) {
                 _dvRemoteSettings[SYNC_SCOPE_KEYS[_dvs]] = payload.data[SYNC_SCOPE_KEYS[_dvs]];
@@ -2513,15 +2525,18 @@ async function pullWithPreview(remoteMeta) {
           // Build diff-like result from manifest data
           var manifestDiff = _buildDiffFromManifest(manifest);
 
-          // STAK-426: Compare settings from manifest snapshot (if present)
+          // STAK-426: Compare settings from manifest snapshot (if present).
+          // Use raw localStorage.getItem() to match the manifest snapshot format —
+          // the snapshot is also built from raw localStorage strings (scalar string
+          // prefs like appTheme would not be found by loadDataSync() which JSON-parses).
           var manifestSettingsDiff = null;
           if (manifest.settings && typeof DiffEngine !== 'undefined' && DiffEngine.compareSettings) {
             var _mLocalSettings = {};
-            if (typeof SYNC_SCOPE_KEYS !== 'undefined') {
+            if (typeof SYNC_SCOPE_KEYS !== 'undefined' && typeof localStorage !== 'undefined') {
               for (var ms = 0; ms < SYNC_SCOPE_KEYS.length; ms++) {
                 if (SYNC_SCOPE_KEYS[ms] === 'metalInventory') continue;
-                var msv = loadDataSync(SYNC_SCOPE_KEYS[ms], null);
-                if (msv !== null && msv !== undefined) _mLocalSettings[SYNC_SCOPE_KEYS[ms]] = msv;
+                var msv = localStorage.getItem(SYNC_SCOPE_KEYS[ms]);
+                if (msv !== null) _mLocalSettings[SYNC_SCOPE_KEYS[ms]] = msv;
               }
             }
             manifestSettingsDiff = DiffEngine.compareSettings(_mLocalSettings, manifest.settings);

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -958,6 +958,18 @@ async function buildAndUploadManifest(token, password, syncId) {
     summary: summary,
   };
 
+  // 4b. STAK-426: Embed settings snapshot so manifest-first pulls can compare
+  // settings without downloading the full vault
+  var settingsSnapshot = {};
+  if (typeof SYNC_SCOPE_KEYS !== 'undefined') {
+    for (var s = 0; s < SYNC_SCOPE_KEYS.length; s++) {
+      if (SYNC_SCOPE_KEYS[s] === 'metalInventory') continue;
+      var sv = loadDataSync(SYNC_SCOPE_KEYS[s], null);
+      if (sv !== null && sv !== undefined) settingsSnapshot[SYNC_SCOPE_KEYS[s]] = sv;
+    }
+  }
+  manifestPayload.settings = settingsSnapshot;
+
   // 5. Encrypt the manifest
   if (typeof encryptManifest !== 'function') {
     throw new Error('encryptManifest not available — cannot build manifest');
@@ -1376,9 +1388,9 @@ async function pushSyncVault() {
     try {
       if (typeof collectAndHashImageVault === 'function') {
         var imgData = await collectAndHashImageVault();
+        var lastPush = syncGetLastPush();
+        var lastImageHash = lastPush ? lastPush.imageHash : null;
         if (imgData) {
-          var lastPush = syncGetLastPush();
-          var lastImageHash = lastPush ? lastPush.imageHash : null;
           if (imgData.hash !== lastImageHash) {
             debugLog('[CloudSync] Image vault changed — uploading', imgData.imageCount, 'photos');
             var imageBytes = await vaultEncryptImageVault(password, imgData.payload);
@@ -1396,6 +1408,27 @@ async function pushSyncVault() {
             imageVaultMeta = lastImageHash ? { imageCount: imgData.imageCount, hash: imgData.hash } : null;
             debugLog('[CloudSync] Image vault unchanged — skipping upload');
           }
+        } else if (lastImageHash) {
+          // STAK-426: All local photos deleted — propagate deletion to remote
+          try {
+            var delArg = JSON.stringify({ path: SYNC_IMAGES_PATH });
+            var delResp = await fetch('https://api.dropboxapi.com/2/files/delete_v2', {
+              method: 'POST',
+              headers: {
+                Authorization: 'Bearer ' + token,
+                'Content-Type': 'application/json',
+              },
+              body: delArg,
+            });
+            if (delResp.ok || delResp.status === 409) {
+              debugLog('[CloudSync] Remote image vault deleted (all local photos removed)');
+            } else {
+              debugLog('[CloudSync] Image vault deletion returned status:', delResp.status);
+            }
+          } catch (delErr) {
+            debugLog('[CloudSync] Image vault deletion failed (non-blocking):', delErr.message);
+          }
+          // imageVaultMeta stays null → imageHash cleared in pushMeta
         }
       }
     } catch (imgErr) {
@@ -2350,11 +2383,53 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
           debugLog('[CloudSync] Selective apply would empty vault but remote has', remoteItems.length, 'items — falling back to full overwrite');
           // fall through to full-overwrite path below
         } else {
-          // Manifest-first selective apply intentionally applies inventory only.
-          // Sync-scoped settings are not restored via this path (null settingsChanges);
-          // they update only during vault-first pulls which have full payload access.
-          _applyAndFinalize(newInv, selectedChanges, null, remoteMeta, { source: 'sync' });
-          debugLog('[CloudSync] Deferred vault restore complete (selective apply)');
+          // STAK-426: Extract settings from vault payload and compare
+          var _dvSettingsChanges = null;
+          if (payload.data && typeof SYNC_SCOPE_KEYS !== 'undefined' && typeof DiffEngine !== 'undefined' && DiffEngine.compareSettings) {
+            var _dvLocalSettings = {};
+            var _dvRemoteSettings = {};
+            for (var _dvs = 0; _dvs < SYNC_SCOPE_KEYS.length; _dvs++) {
+              if (SYNC_SCOPE_KEYS[_dvs] === 'metalInventory') continue;
+              var _dvlv = loadDataSync(SYNC_SCOPE_KEYS[_dvs], null);
+              if (_dvlv !== null) _dvLocalSettings[SYNC_SCOPE_KEYS[_dvs]] = _dvlv;
+              if (payload.data[SYNC_SCOPE_KEYS[_dvs]] !== undefined) {
+                _dvRemoteSettings[SYNC_SCOPE_KEYS[_dvs]] = payload.data[SYNC_SCOPE_KEYS[_dvs]];
+              }
+            }
+            var _dvsDiff = DiffEngine.compareSettings(_dvLocalSettings, _dvRemoteSettings);
+            if (_dvsDiff && _dvsDiff.changed && _dvsDiff.changed.length > 0) {
+              _dvSettingsChanges = _dvsDiff.changed;
+            }
+          }
+          _applyAndFinalize(newInv, selectedChanges, _dvSettingsChanges, remoteMeta, { source: 'sync' });
+          debugLog('[CloudSync] Deferred vault restore complete (selective apply, settings:', _dvSettingsChanges ? _dvSettingsChanges.length + ' changes' : 'none', ')');
+
+          // STAK-426: Restore image vault on manifest-first path (previously skipped)
+          try {
+            if (remoteMeta && remoteMeta.imageVault && typeof vaultDecryptAndRestoreImages === 'function') {
+              var _dvLastPull = syncGetLastPull();
+              var _dvLocalImageHash = _dvLastPull ? _dvLastPull.imageHash : null;
+              if (remoteMeta.imageVault.hash !== _dvLocalImageHash) {
+                debugLog('[CloudSync] Manifest-path: image vault changed — pulling', remoteMeta.imageVault.imageCount, 'photos');
+                var _dvImgArg = JSON.stringify({ path: SYNC_IMAGES_PATH });
+                var _dvImgResp = await fetch('https://content.dropboxapi.com/2/files/download', {
+                  method: 'POST',
+                  headers: {
+                    Authorization: 'Bearer ' + token,
+                    'Dropbox-API-Arg': _dvImgArg,
+                  },
+                });
+                if (_dvImgResp.ok) {
+                  var _dvImgBytes = new Uint8Array(await _dvImgResp.arrayBuffer());
+                  await vaultDecryptAndRestoreImages(_dvImgBytes, password);
+                  debugLog('[CloudSync] Manifest-path: image vault restored');
+                }
+              }
+            }
+          } catch (_dvImgErr) {
+            debugLog('[CloudSync] Manifest-path image restore failed (non-blocking):', _dvImgErr.message);
+          }
+
           return;
         }
       }
@@ -2438,15 +2513,29 @@ async function pullWithPreview(remoteMeta) {
           // Build diff-like result from manifest data
           var manifestDiff = _buildDiffFromManifest(manifest);
 
-          // STAK-417: If manifest has no item changes, fall through to vault-first
-          // which can also check settings. The manifest path doesn't compare settings,
-          // so an empty manifest diff might hide a settings-only change.
+          // STAK-426: Compare settings from manifest snapshot (if present)
+          var manifestSettingsDiff = null;
+          if (manifest.settings && typeof DiffEngine !== 'undefined' && DiffEngine.compareSettings) {
+            var _mLocalSettings = {};
+            if (typeof SYNC_SCOPE_KEYS !== 'undefined') {
+              for (var ms = 0; ms < SYNC_SCOPE_KEYS.length; ms++) {
+                if (SYNC_SCOPE_KEYS[ms] === 'metalInventory') continue;
+                var msv = loadDataSync(SYNC_SCOPE_KEYS[ms], null);
+                if (msv !== null && msv !== undefined) _mLocalSettings[SYNC_SCOPE_KEYS[ms]] = msv;
+              }
+            }
+            manifestSettingsDiff = DiffEngine.compareSettings(_mLocalSettings, manifest.settings);
+          }
+
+          // STAK-417 + STAK-426: If manifest has no item changes AND no settings
+          // changes, fall through to vault-first for a full comparison.
           var _mNoChanges = (manifestDiff.added || []).length === 0
             && (manifestDiff.deleted || []).length === 0
             && (manifestDiff.modified || []).length === 0;
-          if (_mNoChanges) {
-            console.warn('[CloudSync] Manifest has no item changes — falling through to vault-first (may have settings changes)');
-            throw new Error('Manifest empty: falling through to vault-first for settings check');
+          var _mNoSettingsChanges = !manifestSettingsDiff || !manifestSettingsDiff.changed || manifestSettingsDiff.changed.length === 0;
+          if (_mNoChanges && _mNoSettingsChanges) {
+            console.warn('[CloudSync] Manifest has no item or settings changes — falling through to vault-first');
+            throw new Error('Manifest empty: falling through to vault-first for full check');
           }
 
           // STAK-402 + STAK-412: Verify the manifest diff is complete by checking
@@ -2529,6 +2618,7 @@ async function pullWithPreview(remoteMeta) {
             DiffModal.show({
               source: { type: 'sync', label: _syncProvider || 'Cloud' },
               diff: manifestDiff,
+              settingsDiff: manifestSettingsDiff || null,
               conflicts: manifestConflicts || null,
               meta: {
                 deviceId: manifest.deviceId || (remoteMeta ? remoteMeta.deviceId : null),

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.46";
+const APP_VERSION = "3.33.47";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -794,18 +794,75 @@ const MANUAL_BACKUP_PREFIX = 'staktrakr-backup-';
 const SYNC_BACKUP_PREFIX = 'pre-sync-';
 
 /**
- * Keys included in a sync vault (excludes API keys, tokens, spot history).
- * Only inventory data + display preferences that are meaningful across devices.
+ * Keys included in a sync vault — inventory data + all user preferences that are
+ * meaningful across devices. Expanded in STAK-426 from 8 → ~36 keys.
+ * Excludes: OAuth tokens, transient caches, server-sourced data, device-local state.
  */
 const SYNC_SCOPE_KEYS = [
-  'metalInventory',   // LS_KEY — inventory items
-  'itemTags',         // ITEM_TAGS_KEY — per-item tags
-  'displayCurrency',  // DISPLAY_CURRENCY_KEY — active display currency
-  'appTheme',         // THEME_KEY — light/dark/sepia/system theme
-  'inlineChipConfig', // inline chip config (grade, year, etc.)
-  'filterChipCategoryConfig', // filter chip category config
-  'viewModalSectionConfig',   // view modal section visibility
-  'chipMinCount',     // minimum count for filter chips
+  // ── Core data ──
+  'metalInventory',            // LS_KEY — inventory items
+  'itemTags',                  // ITEM_TAGS_KEY — per-item tags
+
+  // ── Display preferences ──
+  'displayCurrency',           // DISPLAY_CURRENCY_KEY — active display currency
+  'appTheme',                  // THEME_KEY — light/dark/sepia/system theme
+  'cardViewStyle',             // CARD_STYLE_KEY
+  'desktopCardView',           // DESKTOP_CARD_VIEW_KEY
+  'defaultSortColumn',         // DEFAULT_SORT_COL_KEY
+  'defaultSortDir',            // DEFAULT_SORT_DIR_KEY
+  'showRealizedGainLoss',      // SHOW_REALIZED_KEY
+  'metalOrderConfig',          // METAL_ORDER_KEY
+  'settingsItemsPerPage',      // ITEMS_PER_PAGE_KEY
+  'appTimeZone',               // TIMEZONE_KEY
+
+  // ── Chip & filter config ──
+  'inlineChipConfig',          // inline chip config (grade, year, etc.)
+  'filterChipCategoryConfig',  // filter chip category config
+  'viewModalSectionConfig',    // view modal section visibility
+  'chipMinCount',              // minimum count for filter chips
+  'chipMaxCount',              // maximum count for filter chips
+  'chipCustomGroups',          // custom chip groupings
+  'chipBlacklist',             // hidden chips
+  'chipSortOrder',             // chip sort preference
+
+  // ── Layout & table ──
+  'layoutSectionConfig',       // section layout config
+  'tableImagesEnabled',        // show images in table
+  'tableImageSides',           // which image sides to show
+
+  // ── Tag config ──
+  'tagBlacklist',              // hidden tags
+
+  // ── Header button preferences ──
+  'headerThemeBtnVisible',     // theme toggle button
+  'headerCurrencyBtnVisible',  // currency toggle button
+  'headerTrendBtnVisible',     // HEADER_TREND_BTN_KEY
+  'headerSyncBtnVisible',      // HEADER_SYNC_BTN_KEY
+  'headerMarketBtnVisible',    // HEADER_MARKET_BTN_KEY
+  'headerVaultBtnVisible',     // HEADER_VAULT_BTN_KEY
+  'headerRestoreBtnVisible',   // HEADER_RESTORE_BTN_KEY
+  'headerCloudSyncBtnVisible', // HEADER_CLOUD_SYNC_BTN_KEY
+  'headerBtnShowText',         // HEADER_BTN_SHOW_TEXT_KEY
+  'headerBtnOrder',            // button ordering
+  'headerAboutBtnVisible',     // about button
+
+  // ── Feature toggles ──
+  'goldback-enabled',          // GOLDBACK_ENABLED_KEY
+  'goldback-estimate-enabled', // GOLDBACK_ESTIMATE_ENABLED_KEY
+  'goldback-estimate-modifier', // GB_ESTIMATE_MODIFIER_KEY
+
+  // ── Numista config ──
+  'numista_tags_auto',         // auto-tag on Numista lookup
+  'numistaLookupRules',        // lookup rule config
+  'numistaViewFields',         // view modal field config
+
+  // ── Seed & provider config ──
+  'enabledSeedRules',          // seed data rules
+  'apiProviderOrder',          // spot provider order
+  'providerPriority',          // provider priority config
+
+  // ── API credentials ──
+  'metalApiConfig',            // API_KEY_STORAGE_KEY — Numista/PCGS/spot provider keys
 ];
 
 const ALLOWED_STORAGE_KEYS = [

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.46-b1772633538';
+const CACHE_NAME = 'staktrakr-v3.33.47-b1772640712';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.47-b1772640712';
+const CACHE_NAME = 'staktrakr-v3.33.47-b1772642724';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.46",
+  "version": "3.33.47",
   "releaseDate": "2026-03-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Expanded sync scope** from 8 to 44 keys — all user preferences, header buttons, feature toggles, Numista/PCGS config, provider order, and API credentials now sync across devices
- **Manifest-first settings sync** — settings snapshot embedded in manifest push; pull path compares and applies settings via DiffEngine instead of silently skipping
- **Manifest-first image sync** — image vault download on manifest-first pull path (previously skipped)
- **Image deletion propagation** — deleting all photos locally now removes the remote image vault

## Linear Issues

- [STAK-426: Sync Scope & Serialization](https://linear.app/lbruton/issue/STAK-426) — Epic STAK-423, Spec 3 of 4

## Files Changed

- `js/constants.js` — SYNC_SCOPE_KEYS expanded (8→44)
- `js/cloud-sync.js` — manifest settings embed, manifest-first settings/image pull, image deletion propagation
- 5 version bump files (constants, changelog, announcements, about, version.json, sw.js auto-stamped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)