### PR TITLE
v3.33.48 — STAK-387: DiffModal Settings Fix & Empty-Diff Silent Pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.48] - 2026-03-04
+
+### Fixed — DiffModal Settings Fix & Empty-Diff Silent Pull (STAK-387)
+
+- **Fixed**: DiffModal Apply button now correctly detects pending settings changes — was checking `.length` on an object instead of `.changed.length` (STAK-401, STAK-415)
+- **Fixed**: DiffModal Apply handler now includes settings entries in selectedChanges, preventing settings from being silently dropped on restore (STAK-387)
+- **Fixed**: Manifest-first pull returns silently when both item diff and settings diff are empty — no unnecessary vault download or DiffModal (STAK-417)
+
+---
+
 ## [3.33.47] - 2026-03-04
 
 ### Changed — Sync Scope & Serialization (STAK-426)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 - **Sync Scope & Serialization (v3.33.47)**: Cloud sync now syncs 44 keys across devices (up from 8) — all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426).
 - **Cloud Storage API Hardening (v3.33.46)**: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425).
 - **FAQ Cloudflare Cookie Disclosure (v3.33.45)**: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block — does not affect the app (STAK-428).
 - **Data Portability Quickfixes (v3.33.44)**: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424).
-- **Cloud Sync Storage Fix (v3.33.43)**: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.48 &ndash; DiffModal Settings Fix &amp; Empty-Diff Silent Pull</strong>: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417)</li>
     <li><strong>v3.33.47 &ndash; Sync Scope &amp; Serialization</strong>: Cloud sync now syncs 44 keys across devices (up from 8) &mdash; all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426)</li>
     <li><strong>v3.33.46 &ndash; Cloud Storage API Hardening</strong>: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425)</li>
     <li><strong>v3.33.45 &ndash; FAQ Cloudflare Cookie Disclosure</strong>: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block &mdash; does not affect the app (STAK-428)</li>
     <li><strong>v3.33.44 &ndash; Data Portability Quickfixes</strong>: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424)</li>
-    <li><strong>v3.33.43 &ndash; Cloud Sync Storage Fix</strong>: Vault restore now compresses data before writing to localStorage, preventing storage blowout from 9 MB metalSpotHistory. Override imports cancel debounced sync push to prevent overwriting remote data. QuotaExceededError now shows a toast instead of failing silently (STAK-421)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2245,14 +2245,23 @@ function showRestorePreviewModal(diffResult, settingsDiff, remotePayload, remote
             // Apply only the user-selected changes via DiffEngine
             var newInv = DiffEngine.applySelectedChanges(inventory, selectedChanges);
 
-            // Build settings changes from settingsDiff
+            // Build settings changes from selectedChanges (DiffModal includes them as type:'setting')
             var settingsChanges = null;
-            if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
+            if (selectedChanges) {
+              var extracted = [];
+              for (var i = 0; i < selectedChanges.length; i++) {
+                if (selectedChanges[i].type === 'setting') {
+                  extracted.push({ key: selectedChanges[i].key, remoteVal: selectedChanges[i].value });
+                }
+              }
+              if (extracted.length > 0) settingsChanges = extracted;
+            } else if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
+              // Fallback for null selectedChanges (full overwrite / empty diff case)
               settingsChanges = [];
-              for (var i = 0; i < settingsDiff.changed.length; i++) {
+              for (var j = 0; j < settingsDiff.changed.length; j++) {
                 settingsChanges.push({
-                  key: settingsDiff.changed[i].key,
-                  remoteVal: settingsDiff.changed[i].remoteVal
+                  key: settingsDiff.changed[j].key,
+                  remoteVal: settingsDiff.changed[j].remoteVal
                 });
               }
             }
@@ -2549,8 +2558,15 @@ async function pullWithPreview(remoteMeta) {
             && (manifestDiff.modified || []).length === 0;
           var _mNoSettingsChanges = !manifestSettingsDiff || !manifestSettingsDiff.changed || manifestSettingsDiff.changed.length === 0;
           if (_mNoChanges && _mNoSettingsChanges) {
-            console.warn('[CloudSync] Manifest has no item or settings changes — falling through to vault-first');
-            throw new Error('Manifest empty: falling through to vault-first for full check');
+            // STAK-387: Silent return — no vault download needed when manifest confirms no changes
+            syncSetLastPull({
+              syncId: remoteMeta ? remoteMeta.syncId : null,
+              timestamp: remoteMeta ? remoteMeta.timestamp : Date.now(),
+              rev: remoteMeta ? remoteMeta.rev : null,
+            });
+            logCloudSyncActivity('auto_sync_pull', 'success', 'No changes — pull recorded silently (manifest)');
+            updateSyncStatusIndicator('idle', 'just now');
+            return;
           }
 
           // STAK-402 + STAK-412: Verify the manifest diff is complete by checking

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.47";
+const APP_VERSION = "3.33.48";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -287,7 +287,7 @@
     if (applyBtn) {
       var count = _checkedCount();
       var hasSelectableItems = Object.keys(_checkedItems).length > 0;
-      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.length > 0;
+      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.changed && _options.settingsDiff.changed.length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
       applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
       applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
@@ -421,7 +421,7 @@
     if (applyBtn) {
       var count = _checkedCount();
       var hasSelectableItems = Object.keys(_checkedItems).length > 0;
-      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.length > 0;
+      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.changed && _options.settingsDiff.changed.length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
       applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
       applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
@@ -514,6 +514,14 @@
       if (_checkedItems['deleted-' + d] !== false) {
         result.push({ type: 'delete', itemKey: _itemKey(deleted[d]) });
       }
+    }
+
+    // Settings changes — always included (no per-setting checkboxes)
+    var settingsDiff = _options.settingsDiff || {};
+    var changedSettings = settingsDiff.changed || [];
+    for (var s = 0; s < changedSettings.length; s++) {
+      var setting = changedSettings[s];
+      result.push({ type: 'setting', key: setting.key, value: setting.remoteVal });
     }
 
     return result;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.47-b1772642724';
+const CACHE_NAME = 'staktrakr-v3.33.48-b1772660766';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.47",
+  "version": "3.33.48",
   "releaseDate": "2026-03-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: DiffModal Apply button now correctly detects pending settings changes — was checking `.length` on an object instead of `.changed.length` (STAK-401, STAK-415)
- **Fixed**: DiffModal Apply handler now includes settings entries in `selectedChanges`, preventing settings from being silently dropped on restore (STAK-387)
- **Fixed**: Manifest-first pull returns silently when both item diff and settings diff are empty — no unnecessary vault download or DiffModal (STAK-417)

## Linear Issues

- [STAK-387](https://linear.app/lbruton/issue/STAK-387): DiffModal settings diff — Apply handler for settings changes
- [STAK-401](https://linear.app/lbruton/issue/STAK-401): Apply button broken for settings
- [STAK-415](https://linear.app/lbruton/issue/STAK-415): hasSettings type bug
- [STAK-417](https://linear.app/lbruton/issue/STAK-417): Empty diff still downloads vault

## Spec

`STAK-387-diffmodal-settings-diff-apply-handler-for-settings-changes` — 3/3 tasks complete

## QA Notes

- Cloud sync must be tested at beta.staktrakr.com after merge (OAuth redirect only registered for beta, not PR preview)
- Test: sync with settings changes → DiffModal shows, Apply works
- Test: sync with no changes → silent return, no DiffModal

🤖 Generated with [Claude Code](https://claude.com/claude-code)