### PR TITLE
v3.33.49 — STAK-427: Import/Restore Completeness & Cloud Backup Photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.49] - 2026-03-04
+
+### Fixed — Import/Restore Completeness & Cloud Backup Photos (STAK-427)
+
+- **Added**: "Include photos" checkbox in manual cloud backup — uploads encrypted image vault alongside inventory when checked; failure is non-fatal (STAK-427)
+- **Added**: `window.CloudSync.isSyncActive()` read-only accessor for restore isolation guards (STAK-427)
+- **Fixed**: ZIP restore and vault restore now blocked while cloud sync pull is active — shows warning toast instead of corrupting mid-sync state (STAK-427)
+- **Docs**: Wiki updated with Snapshot Terminology table, ZIP restore destructiveness warning, and manual backup image gap callout (STAK-427)
+
+---
+
 ## [3.33.48] - 2026-03-04
 
 ### Fixed — DiffModal Settings Fix & Empty-Diff Silent Pull (STAK-387)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
 - **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 - **Sync Scope & Serialization (v3.33.47)**: Cloud sync now syncs 44 keys across devices (up from 8) — all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426).
 - **Cloud Storage API Hardening (v3.33.46)**: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425).
 - **FAQ Cloudflare Cookie Disclosure (v3.33.45)**: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block — does not affect the app (STAK-428).
-- **Data Portability Quickfixes (v3.33.44)**: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.49 &ndash; Import/Restore Completeness &amp; Cloud Backup Photos</strong>: Manual cloud backup now has an optional &ldquo;Include photos&rdquo; checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427)</li>
     <li><strong>v3.33.48 &ndash; DiffModal Settings Fix &amp; Empty-Diff Silent Pull</strong>: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417)</li>
     <li><strong>v3.33.47 &ndash; Sync Scope &amp; Serialization</strong>: Cloud sync now syncs 44 keys across devices (up from 8) &mdash; all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426)</li>
     <li><strong>v3.33.46 &ndash; Cloud Storage API Hardening</strong>: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425)</li>
     <li><strong>v3.33.45 &ndash; FAQ Cloudflare Cookie Disclosure</strong>: FAQ now accurately discloses that Cloudflare may set a temporary infrastructure cookie for bot protection on the hosted site. Safe to block &mdash; does not affect the app (STAK-428)</li>
-    <li><strong>v3.33.44 &ndash; Data Portability Quickfixes</strong>: Added chipMaxCount to storage allowlist, removed dead 2 MB import limit, added Storage Location and Tags to CSV/JSON exports, deferred CSV import tags until confirmation, fixed reverse-only image import from ZIP (STAK-424)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -3127,6 +3127,11 @@ window.showSyncUpdateModal = showSyncUpdateModal;
 window.showRestorePreviewModal = showRestorePreviewModal;
 window.pullWithPreview = pullWithPreview;
 window.computeInventoryHash = computeInventoryHash;
+
+// STAK-427: Read-only sync state accessor for restore isolation guards
+function isSyncActive() { return _syncRemoteChangeActive; }
+window.CloudSync = window.CloudSync || {};
+window.CloudSync.isSyncActive = isSyncActive;
 window.summarizeMetals = summarizeMetals;
 window.computeTotalWeight = computeTotalWeight;
 window.computeSettingsHash = computeSettingsHash;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.48";
+const APP_VERSION = "3.33.49";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -340,6 +340,11 @@ const createBackupZip = async () => {
  * @param {File} file - ZIP file created by createBackupZip
  */
 const restoreBackupZip = async (file) => {
+  // STAK-427: Block restore while cloud sync is applying remote changes
+  if (window.CloudSync && window.CloudSync.isSyncActive()) {
+    showToast('Cloud sync is in progress — please wait a moment and try again.', 'warning');
+    return;
+  }
   try {
     const zip = await JSZip.loadAsync(file);
 

--- a/js/vault.js
+++ b/js/vault.js
@@ -497,6 +497,11 @@ async function vaultEncryptToBytesScoped(password) {
  * @returns {Promise<void>}
  */
 async function vaultDecryptAndRestore(fileBytes, password) {
+  // STAK-427: Block restore while cloud sync is applying remote changes
+  if (window.CloudSync && window.CloudSync.isSyncActive()) {
+    showToast('Cloud sync is in progress — please wait a moment and try again.', 'warning');
+    return;
+  }
   var payload = await vaultDecryptToData(fileBytes, password);
   await restoreVaultData(payload);
 }
@@ -1027,7 +1032,10 @@ function openVaultModal(mode, fileOrOpts) {
 
   if (mode === 'cloud-export') {
     effectiveMode = 'export';
-    _cloudContext = { provider: fileOrOpts && fileOrOpts.provider ? fileOrOpts.provider : 'dropbox' };
+    _cloudContext = {
+      provider: fileOrOpts && fileOrOpts.provider ? fileOrOpts.provider : 'dropbox',
+      isManualBackup: fileOrOpts && fileOrOpts.isManualBackup ? true : false,
+    };
   } else if (mode === 'cloud-import') {
     effectiveMode = 'import';
     if (fileOrOpts && fileOrOpts.fileBytes) {
@@ -1065,6 +1073,40 @@ function openVaultModal(mode, fileOrOpts) {
       actionBtn.className = "btn";
     }
     _vaultPendingFile = null;
+
+    // STAK-427: "Include photos" checkbox for manual cloud backup
+    var existingPhotoRow = safeGetElement("vaultIncludePhotosRow");
+    if (existingPhotoRow) existingPhotoRow.remove();
+    if (_cloudContext && _cloudContext.isManualBackup) {
+      // Async check for user photos — inject checkbox if any exist
+      (function () {
+        try {
+          var req = indexedDB.open('StakTrakrImages', 1);
+          req.onsuccess = function (ev) {
+            var db = ev.target.result;
+            if (!db.objectStoreNames.contains('userImages')) { db.close(); return; }
+            var tx = db.transaction('userImages', 'readonly');
+            var countReq = tx.objectStore('userImages').count();
+            countReq.onsuccess = function () {
+              db.close();
+              if (countReq.result > 0) {
+                var row = document.createElement('div');
+                row.id = 'vaultIncludePhotosRow';
+                row.style.cssText = 'margin:8px 0;display:flex;align-items:center;gap:8px;';
+                row.innerHTML = '<label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:0.9em;">' +
+                  '<input type="checkbox" id="vaultIncludePhotos"> Include photos (' + countReq.result + ' image' + (countReq.result === 1 ? '' : 's') + ')</label>';
+                // Insert before action button row
+                var actionsEl = actionBtn ? actionBtn.parentElement : null;
+                if (actionsEl && actionsEl.parentElement) {
+                  actionsEl.parentElement.insertBefore(row, actionsEl);
+                }
+              }
+            };
+          };
+          req.onerror = function () {}; // IDB unavailable — skip checkbox
+        } catch (_) {}
+      })();
+    }
   } else {
     var importTitle = _cloudContext ? "Cloud Restore — Enter Password" : "Import Encrypted Backup";
     if (titleEl) titleEl.textContent = importTitle;
@@ -1121,6 +1163,9 @@ function closeVaultModal() {
   _vaultPendingFile = null;
   _vaultPendingImageFile = null;
   _cloudContext = null;
+  // STAK-427: Remove dynamic photo checkbox
+  var photoRow = document.getElementById('vaultIncludePhotosRow');
+  if (photoRow) photoRow.remove();
   closeModalById("vaultModal");
 }
 
@@ -1177,7 +1222,43 @@ async function handleVaultAction() {
         var fileBytes = await vaultEncryptToBytes(password);
         showVaultStatus("info", "Uploading\u2026");
         await cloudUploadVault(_cloudContext.provider, fileBytes, _cloudContext.isManualBackup ? { skipLatestUpdate: true } : undefined);
-        showVaultStatus("success", "Backup uploaded successfully.");
+
+        // STAK-427: Upload image vault if "Include photos" checkbox is checked
+        var includePhotos = false;
+        var photoCheckbox = document.getElementById('vaultIncludePhotos');
+        if (photoCheckbox && photoCheckbox.checked) includePhotos = true;
+        var photoMsg = '';
+        if (includePhotos) {
+          try {
+            showVaultStatus("info", "Uploading photos\u2026");
+            var imgData = typeof collectAndHashImageVault === 'function' ? await collectAndHashImageVault() : null;
+            if (imgData && imgData.payload) {
+              var imageBytes = await vaultEncryptImageVault(password, imgData.payload);
+              var token = typeof cloudGetToken === 'function' ? await cloudGetToken(_cloudContext.provider) : null;
+              if (token && typeof SYNC_IMAGES_PATH !== 'undefined') {
+                var imgArg = JSON.stringify({ path: SYNC_IMAGES_PATH, mode: 'overwrite', autorename: false, mute: true });
+                var imgResp = await fetch('https://content.dropboxapi.com/2/files/upload', {
+                  method: 'POST',
+                  headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'application/octet-stream', 'Dropbox-API-Arg': imgArg },
+                  body: imageBytes,
+                });
+                if (imgResp.ok) {
+                  photoMsg = ' (with ' + imgData.imageCount + ' photo' + (imgData.imageCount === 1 ? '' : 's') + ')';
+                } else {
+                  throw new Error('Image upload returned ' + imgResp.status);
+                }
+              }
+            }
+          } catch (imgErr) {
+            console.warn('[Vault] Image vault upload failed (non-fatal):', imgErr.message || imgErr);
+            photoMsg = '';
+            if (typeof showToast === 'function') {
+              showToast('Backup saved, but photos could not be uploaded. Use ZIP backup for full photo coverage.', 'warning');
+            }
+          }
+        }
+
+        showVaultStatus("success", "Backup uploaded successfully" + photoMsg + ".");
         // Cache password for this browser session
         if (typeof cloudCachePassword === 'function' && !(_cloudContext && _cloudContext.isManualBackup)) {
           cloudCachePassword(_cloudContext.provider, password);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.48-b1772660766';
+const CACHE_NAME = 'staktrakr-v3.33.49-b1772663243';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.48",
+  "version": "3.33.49",
   "releaseDate": "2026-03-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,7 +2,7 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.46
+lastUpdated: v3.33.49
 date: 2026-03-04
 sourceFiles:
   - js/cloud-storage.js
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.46 — 2026-03-04
+> **Last updated:** v3.33.49 — 2026-03-04
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`, `js/vault.js`
 
 ## Overview
@@ -35,6 +35,17 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 | Encrypted Vault | `.stvault` | Yes (AES-256-GCM) | Settings → Vault → "Export Vault" |
 | Image Vault | `.stvault` | Yes (AES-256-GCM) | Cloud auto-sync (automatic) |
 | Cloud Sync | Dropbox | Yes (vault-wrapped) | Settings → Cloud → Auto-sync toggle |
+
+---
+
+## Snapshot Terminology
+
+| Term | Description |
+|------|-------------|
+| **Override backup** | Pre-pull localStorage snapshot saved before applying remote changes. Used for rollback if a pull goes wrong. Stored in IDB as `cloud_sync_override_backup`. |
+| **Pre-push backup** | Full encrypted vault uploaded to `/backups/pre-sync-TIMESTAMP.stvault` before each push. Provides disaster recovery if a push corrupts remote state. |
+| **Image vault** | Companion file to the sync vault containing user-uploaded coin photos (`userImages` IDB). Uploaded alongside inventory during auto-sync push (conditional). |
+| **Manual vault** | Encrypted backup created on-demand from the Settings → Cloud → Backup button. Covers all localStorage keys except credentials. Optional "Include photos" checkbox uploads the image vault alongside the manual backup (STAK-427). |
 
 ---
 
@@ -74,6 +85,8 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 4. `staktrakr-latest.json` pointer is NOT updated (manual backups do not affect sync state)
 5. `cloud_last_backup` is NOT written (manual backups are independent of sync tracking)
 6. Password is NOT cached to `sessionStorage` (each manual backup requires re-entry)
+
+> **Photos optional (STAK-427):** When the `userImages` IDB store has entries, the vault modal shows an "Include photos" checkbox. If checked, `collectAndHashImageVault()` + `vaultEncryptImageVault()` uploads the image vault to `/StakTrakr/sync/staktrakr-images.stvault` after the inventory vault succeeds. Image upload failure shows a warning toast but does not fail the overall backup. Without checking this box, user-uploaded coin photos (`userImages`), pattern rule images (`patternImages`), and Numista metadata (`coinMetadata`) are NOT included — use ZIP backup for full coverage.
 
 ### cloud-sync.js Role
 
@@ -246,6 +259,8 @@ The backup/export panel shows a `<small class="format-desc">` beneath each optio
 
 ### ZIP Restore (`restoreBackupZip`)
 
+> **Destructive restore:** ZIP restore replaces all data — all localStorage keys are overwritten with backup values, and all IDB image stores (`userImages`, `patternImages`, `coinMetadata`) are replaced. There is no merge option. If cloud sync is active when you initiate a ZIP restore, the restore will be blocked until sync completes (STAK-427).
+
 1. Unzip all files
 2. Restore localStorage keys from `inventory_data.json`, `settings.json`, `spot_price_history.json`, etc.
 3. Restore `userImages` IDB from `user_images/` using `user_image_manifest.json`; falls back to filename parsing for old ZIPs pre-STAK-226
@@ -397,7 +412,7 @@ All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
 | `cloud_last_backup` | Not written (`skipLatestUpdate: true`) | Written on each sync push |
 | Password caching | Disabled — always prompts for password | Cached in `sessionStorage` via `cloudCachePassword` |
 | Auto-pruning | Never auto-pruned | Pruned by `cloudPruneBackups(provider, max, 'sync')` |
-| Image vault | Not part of manual backup | Pushed when `userImages` hash changes |
+| Image vault | Optional via "Include photos" checkbox (STAK-427) | Pushed when `userImages` hash changes |
 | Conflict check | `cloudCheckConflict()` on manual download | `syncHasLocalChanges()` on pull |
 | Pre-restore snapshot | No | Yes: `syncSaveOverrideBackup()` before every pull |
 | Provider support | Dropbox, pCloud, Box | Dropbox only |


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Added**: "Include photos" checkbox in manual cloud backup — uploads encrypted image vault alongside inventory when checked; failure is non-fatal (warning toast only)
- **Added**: `window.CloudSync.isSyncActive()` read-only accessor for restore isolation guards
- **Fixed**: ZIP restore (`restoreBackupZip`) and vault restore (`vaultDecryptAndRestore`) now blocked while cloud sync pull is active — shows warning toast instead of corrupting mid-sync state
- **Fixed**: `_cloudContext.isManualBackup` now correctly preserved from `openVaultModal` options (was previously lost)
- **Docs**: Wiki `backup-restore.md` updated with Snapshot Terminology table, ZIP restore destructiveness warning, manual backup image gap callout, and comparison table update

## Linear Issues

- [STAK-427](https://linear.app/lbruton/issue/STAK-427): Import/Restore Completeness — Cloud Backup Images + Authoritative ZIP
- Parent epic: [STAK-423](https://linear.app/lbruton/issue/STAK-423) — Data Portability Overhaul (Spec 4 of 4)

## Spec

`STAK-427-importrestore-completeness-cloud-backup-images-authoritative-zip` — 4/4 tasks complete

## QA Notes

- Cloud sync features must be tested at beta.staktrakr.com after merge (OAuth redirect only registered for beta, not PR preview)
- Test: manual cloud backup with "Include photos" checked → both vault + image vault uploaded
- Test: manual cloud backup with checkbox unchecked → only vault uploaded (no regression)
- Test: attempt ZIP restore while sync pull is active → warning toast, restore blocked
- Note: Task 3 spec said edit `cloud-storage.js` but actual implementation is in `vault.js` where the backup modal and handler live

🤖 Generated with [Claude Code](https://claude.com/claude-code)