### PR TITLE
docs(wiki): update nightwatch log for retail-modal

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 6,
+  "nextIndex": 7,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -35,6 +35,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "Claims 'TTL is 30 minutes per claim' but devops/version-lock-protocol.md defines three tiers: Hotfix = 30min, Spec implementation = 4h, Pre-assigned queued slot = 4h.",
+      "verified": []
+    },
+    {
+      "date": "2026-03-04",
+      "page": "retail-modal.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "`initRetailPrices()` does not call `syncRetailPrices({ ui: false })` in the background. That is handled by `startRetailBackgroundSync()`.",
       "verified": []
     }
   ]


### PR DESCRIPTION
Updates the nightwatch tracker file `wiki/.nightwatch-log.json` with an inaccuracy finding found in `wiki/retail-modal.md`. The wiki incorrectly claimed that `initRetailPrices()` called `syncRetailPrices()` in the background, but the actual code shows this logic resides in `startRetailBackgroundSync()`. Added finding to history and incremented `nextIndex`.

---
*PR created automatically by Jules for task [11599074863064835287](https://jules.google.com/task/11599074863064835287) started by @lbruton*