### PR TITLE
v3.33.51 — STAK-430: Pre-ship Security Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.51] - 2026-03-05
+
+### Fixed — STAK-430: Pre-ship Security Hardening
+
+- **Fixed**: XSS vulnerability in settings pattern rule display — user-controlled item names now sanitized via `sanitizeHtml()` (STAK-430)
+- **Fixed**: OAuth CSRF protection on localStorage relay path — state parameter validated before processing (STAK-430)
+- **Fixed**: Sync flag leak — `_syncRemoteChangeActive` no longer gets stuck true when password prompt interrupts (STAK-430)
+- **Changed**: Password-change overwrite confirmation now uses styled `appConfirm` modal instead of blocking `window.confirm` (STAK-430)
+- **Changed**: Console output sanitized — removed cryptographic metadata (key lengths, password lengths, partial account IDs) from production logs (STAK-430)
+- **Removed**: Dead sync modal code (~206 lines) — `showSyncUpdateModal` and `showSyncConflictModal` replaced by DiffModal in STAK-413 (STAK-430)
+- **Fixed**: `package.json` version synced from stale `3.32.01` to match `APP_VERSION` (STAK-430)
+
+---
+
 ## [3.33.50] - 2026-03-04
 
 ### Fixed — Spot Health Dot UX, 7-Day Trend, Timezone Formatting (STAK-429)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
 - **Spot Health Dot UX, 7-Day Trend, Timezone Formatting (v3.33.50)**: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281).
 - **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
 - **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 - **Sync Scope & Serialization (v3.33.47)**: Cloud sync now syncs 44 keys across devices (up from 8) — all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426).
-- **Cloud Storage API Hardening (v3.33.46)**: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -4427,66 +4427,6 @@
       </div>
     </div>
 
-    <!-- STAK-149: Cloud Auto-Sync Conflict Modal -->
-    <div class="modal" id="cloudSyncConflictModal" style="display: none">
-      <div class="modal-content" style="max-width: 520px">
-        <div class="modal-header">
-          <h2>Sync Conflict</h2>
-          <button aria-label="Close modal" class="modal-close" id="syncConflictSkip">&times;</button>
-        </div>
-        <div class="modal-body">
-          <p class="settings-subtext" style="margin-bottom:1rem">Both this device and another device have changes since the last sync. Choose which version to keep.</p>
-          <div class="cloud-conflict-grid">
-            <div class="cloud-conflict-col">
-              <div class="cloud-conflict-col-label">This Device</div>
-              <div class="cloud-conflict-row"><span>Items</span><strong id="syncConflictLocalItems">&mdash;</strong></div>
-              <div class="cloud-conflict-row"><span>Changed</span><strong id="syncConflictLocalTime">&mdash;</strong></div>
-              <div class="cloud-conflict-row"><span>Version</span><strong id="syncConflictLocalVersion">&mdash;</strong></div>
-            </div>
-            <div class="cloud-conflict-divider">vs</div>
-            <div class="cloud-conflict-col">
-              <div class="cloud-conflict-col-label">Remote (another device)</div>
-              <div class="cloud-conflict-row"><span>Items</span><strong id="syncConflictRemoteItems">&mdash;</strong></div>
-              <div class="cloud-conflict-row"><span>Changed</span><strong id="syncConflictRemoteTime">&mdash;</strong></div>
-              <div class="cloud-conflict-row"><span>Version</span><strong id="syncConflictRemoteVersion">&mdash;</strong></div>
-              <div class="cloud-conflict-row"><span>Device</span><strong id="syncConflictRemoteDevice">&mdash;</strong></div>
-            </div>
-          </div>
-          <div class="encryption-warning" style="margin-top:1rem">
-            <strong>Note:</strong> The losing version will be overwritten and cannot be recovered.
-          </div>
-          <div class="encryption-actions" style="margin-top:1rem;gap:0.5rem;flex-wrap:wrap">
-            <button class="btn success" id="syncConflictKeepMine">Keep Mine (push local)</button>
-            <button class="btn info" id="syncConflictKeepTheirs">Keep Theirs (pull remote)</button>
-            <button class="btn" id="syncConflictSkipBtn" onclick="document.getElementById('cloudSyncConflictModal').style.display='none'">Skip for now</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- STAK-149: Cloud Auto-Sync Update Available Modal -->
-    <div class="modal" id="cloudSyncUpdateModal" style="display: none">
-      <div class="modal-content" style="max-width: 420px">
-        <div class="modal-header">
-          <h2>Sync Update Available</h2>
-          <button aria-label="Close modal" class="modal-close" id="syncUpdateDismissX">&times;</button>
-        </div>
-        <div class="modal-body">
-          <p class="settings-subtext" style="margin-bottom:1rem">Another device has pushed a newer version of your inventory. Would you like to update now?</p>
-          <div class="cloud-sync-update-meta">
-            <div class="cloud-sync-update-row"><span>Items</span><strong id="syncUpdateItemCount">&mdash;</strong></div>
-            <div class="cloud-sync-update-row"><span>Updated</span><strong id="syncUpdateTimestamp">&mdash;</strong></div>
-            <div class="cloud-sync-update-row"><span>Device</span><strong id="syncUpdateDevice">&mdash;</strong></div>
-          </div>
-          <div class="encryption-actions" style="margin-top:1.2rem;gap:0.5rem;flex-wrap:wrap">
-            <button class="btn success" id="syncUpdateAcceptBtn">Accept Update</button>
-            <button class="btn warning" id="syncUpdatePushBtn">Push My Data</button>
-            <button class="btn" id="syncUpdateDismissBtn">Not Now</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- STAK-186: Restore Preview Modal (Layer 5 — DiffEngine preview before sync restore) -->
     <div class="modal" id="restorePreviewModal" style="display: none">
       <div class="modal-content" style="max-width: 600px">

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.51 &ndash; Pre-ship Security Hardening</strong>: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430)</li>
     <li><strong>v3.33.50 &ndash; Spot Health Dot UX, 7-Day Trend, Timezone Formatting</strong>: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281)</li>
     <li><strong>v3.33.49 &ndash; Import/Restore Completeness &amp; Cloud Backup Photos</strong>: Manual cloud backup now has an optional &ldquo;Include photos&rdquo; checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427)</li>
     <li><strong>v3.33.48 &ndash; DiffModal Settings Fix &amp; Empty-Diff Silent Pull</strong>: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417)</li>
     <li><strong>v3.33.47 &ndash; Sync Scope &amp; Serialization</strong>: Cloud sync now syncs 44 keys across devices (up from 8) &mdash; all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426)</li>
-    <li><strong>v3.33.46 &ndash; Cloud Storage API Hardening</strong>: Upload validation catches failed Dropbox/pCloud/Box uploads. Backup list fetches all pages. Disconnect removes all cloud state. Delete-latest updates remote pointer. Full vault exports exclude OAuth tokens and credentials (STAK-425)</li>
   `;
 };
 

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -539,6 +539,11 @@ function cloudCheckOAuthRelay() {
     localStorage.removeItem('staktrakr_oauth_result');
     var data = JSON.parse(raw);
     if (data.code && data.state) {
+      var savedState = sessionStorage.getItem('cloud_oauth_state');
+      if (!savedState || savedState !== data.state) {
+        console.warn('[CloudStorage] OAuth relay: state mismatch — possible CSRF, rejecting');
+        return;
+      }
       cloudExchangeCode(data.code, data.state);
     }
   } catch (e) { /* ignore */ }

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -485,8 +485,7 @@ async function cloudExchangeCode(code, state) {
       if (data.account_id) {
         localStorage.setItem('cloud_dropbox_account_id', data.account_id);
         // STAK-398 diagnostic: MUST use console.warn (not debugWarn) so it's always visible
-        console.warn('[CloudStorage] Stored Dropbox account_id from token exchange:',
-          data.account_id.slice(0, 8) + '… (' + data.account_id.length + ' chars)');
+        console.warn('[CloudStorage] Stored Dropbox account_id from token exchange: present');
       } else {
         // Fallback: fetch account ID from API — awaited so syncCloudUI runs after account_id is stored
         console.warn('[CloudStorage] Token exchange did NOT include account_id — fetching from API');
@@ -502,10 +501,9 @@ async function cloudExchangeCode(code, state) {
           var info = acctResp.ok ? await acctResp.json() : null;
           if (info && info.account_id) {
             localStorage.setItem('cloud_dropbox_account_id', info.account_id);
-            console.warn('[CloudStorage] Stored Dropbox account_id from API fallback:',
-              info.account_id.slice(0, 8) + '… (' + info.account_id.length + ' chars)');
+            console.warn('[CloudStorage] Stored Dropbox account_id from API fallback: present');
           } else {
-            console.warn('[CloudStorage] API fallback FAILED to get account_id — response:', acctResp.status);
+            console.warn('[CloudStorage] API fallback FAILED to get account_id');
           }
         } catch (e) { console.warn('[CloudStorage] Failed to fetch Dropbox account ID:', e.message); }
       }

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -505,7 +505,7 @@ async function cloudExchangeCode(code, state) {
           } else {
             console.warn('[CloudStorage] API fallback FAILED to get account_id');
           }
-        } catch (e) { console.warn('[CloudStorage] Failed to fetch Dropbox account ID:', e.message); }
+        } catch (e) { console.warn('[CloudStorage] Failed to fetch Dropbox account ID.'); }
       }
     }
     sessionStorage.removeItem('cloud_oauth_state');
@@ -537,9 +537,9 @@ function cloudCheckOAuthRelay() {
     localStorage.removeItem('staktrakr_oauth_result');
     var data = JSON.parse(raw);
     if (data.code && data.state) {
-      var savedState = sessionStorage.getItem('cloud_oauth_state');
+      const savedState = sessionStorage.getItem('cloud_oauth_state');
       if (!savedState || savedState !== data.state) {
-        console.warn('[CloudStorage] OAuth relay: state mismatch — possible CSRF, rejecting');
+        console.warn('[CloudStorage] OAuth relay: state mismatch (likely another tab) — skipping');
         return;
       }
       cloudExchangeCode(data.code, data.state);

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1879,7 +1879,6 @@ async function pullSyncVault(remoteMeta) {
             pulledImageHash = remoteMeta.imageVault.hash;
             debugLog('[CloudSync] Image vault not found on remote (404) — skipping');
           } else {
-            var imgErrBody = await imgPullResp.text().catch(function () { return ''; });
             console.warn('[CloudSync] Image vault download failed:', imgPullResp.status);
             logCloudSyncActivity('image_vault_pull', 'fail', 'HTTP ' + imgPullResp.status);
           }

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -647,7 +647,7 @@ function _logDecryptAttempt(artifact, candidates) {
   console.warn('[CloudSync] decrypt attempt:',
     'artifact=' + artifact,
     'vaultPw:', _diagPw,
-    'accountId:', _diagAid ? _diagAid.slice(0, 8) + '… (' + _diagAid.length + ' chars)' : 'MISSING',
+    'accountId:', _diagAid ? 'present' : 'MISSING',
     'candidates:', candidates.length);
 }
 
@@ -723,7 +723,7 @@ async function _tryDecryptMetadata(parsed) {
       console.warn('[CloudSync] Metadata decrypted with', candidates[i].label, 'key (attempt', i + 1 + '/' + candidates.length + ')');
       return { meta: meta, keyUsed: candidates[i].label };
     } catch (_) {
-      console.warn('[CloudSync] Decrypt attempt', i + 1, 'failed (' + candidates[i].label + ', key length:', candidates[i].key.length + ')');
+      console.warn('[CloudSync] Decrypt attempt', i + 1, 'failed (' + candidates[i].label + ')');
     }
   }
   throw new Error('All ' + candidates.length + ' key variants failed to decrypt metadata');
@@ -740,11 +740,10 @@ function getSyncPasswordSilent() {
   var vaultPw = localStorage.getItem('cloud_vault_password');
   var accountId = localStorage.getItem('cloud_dropbox_account_id');
 
-  // STAK-398 diagnostic: log key component shapes (not values) — MUST use console.warn, not debugLog
-  console.warn('[CloudSync] getSyncPasswordSilent:',
-    'vaultPw:', vaultPw ? vaultPw.length + ' chars' : 'NULL',
-    '| accountId:', accountId ? accountId.slice(0, 8) + '… (' + accountId.length + ' chars)' : 'NULL',
-    '| compositeKey:', (vaultPw && accountId) ? (vaultPw + ':' + accountId).length + ' chars' : 'N/A');
+  debugLog('[CloudSync] getSyncPasswordSilent:',
+    'vaultPw:', vaultPw ? 'present' : 'NULL',
+    '| accountId:', accountId ? 'present' : 'NULL',
+    '| compositeKey:', (vaultPw && accountId) ? 'present' : 'N/A');
 
   // Unified mode: both required
   if (vaultPw && accountId) {
@@ -1113,7 +1112,7 @@ async function pushSyncVault() {
         var prePushMeta = null;
         var prePushBuffer = await prePushResp.arrayBuffer();
         var prePushBytes = new Uint8Array(prePushBuffer);
-        console.warn('[CloudSync] Pre-push check: metadata downloaded,', prePushBytes.length, 'bytes');
+        debugLog('[CloudSync] Pre-push check: metadata downloaded,', prePushBytes.length, 'bytes');
 
         // First, try to interpret the metadata as an encrypted .stvault file
         var prePushParsed = null;
@@ -1471,8 +1470,7 @@ async function pushSyncVault() {
 
     // Encrypt metadata before upload (same AES-256-GCM as vault files)
     // STAK-398 diagnostic: log the key used for metadata encryption (for cross-device comparison)
-    console.warn('[CloudSync] Metadata ENCRYPT: password length:', password.length,
-      '| iterations:', VAULT_PBKDF2_ITERATIONS);
+    debugLog('[CloudSync] Metadata ENCRYPT: using', password.indexOf(':') !== -1 ? 'composite key' : 'password-only');
     var metaJson = JSON.stringify(metaPayload);
     var metaSalt = vaultRandomBytes(32);
     var metaIv = vaultRandomBytes(12);
@@ -1623,7 +1621,7 @@ async function pollForRemoteChanges() {
     try {
       metaBuffer = await resp.arrayBuffer();
       var metaBytes = new Uint8Array(metaBuffer);
-      console.warn('[CloudSync] Poll: metadata downloaded,', metaBytes.length, 'bytes');
+      debugLog('[CloudSync] Poll: metadata downloaded,', metaBytes.length, 'bytes');
       var metaParsed = parseVaultFile(metaBytes);
       // Check we have at least a password before trying decrypt
       if (!localStorage.getItem('cloud_vault_password')) {
@@ -1693,7 +1691,7 @@ async function pollForRemoteChanges() {
         }
 
         console.warn('[CloudSync] Poll: hash comparison — inv:', invMatch, 'settings:', settingsMatch,
-          '| local:', localHash, '(' + localInv.length + ' items) vs remote:', remoteMeta.inventoryHash, '(' + remoteMeta.itemCount + ' items)');
+          '| local:', localInv.length, 'items vs remote:', remoteMeta.itemCount, 'items');
 
         if (invMatch && settingsMatch) {
           console.warn('[CloudSync] Poll: inventory + settings hashes MATCH — silently recording pull');
@@ -1935,7 +1933,7 @@ async function pullSyncVault(remoteMeta) {
             debugLog('[CloudSync] Image vault not found on remote (404) — skipping');
           } else {
             var imgErrBody = await imgPullResp.text().catch(function () { return ''; });
-            console.warn('[CloudSync] Image vault download failed:', imgPullResp.status, imgErrBody.slice(0, 120));
+            console.warn('[CloudSync] Image vault download failed:', imgPullResp.status);
             logCloudSyncActivity('image_vault_pull', 'fail', 'HTTP ' + imgPullResp.status);
           }
         } else {

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1751,59 +1751,6 @@ function syncHasLocalChanges() {
 }
 
 /**
- * Show the "Update available" modal and return a Promise that resolves with the
- * user's choice: 'accept', 'push', or 'dismiss'. Resolves null if the modal is not in the DOM.
- * @param {object} remoteMeta - The parsed staktrakr-sync.json content
- * @returns {Promise<'accept'|'push'|'dismiss'|null>}
- */
-function showSyncUpdateModal(remoteMeta) {
-  return new Promise(function (resolve) {
-    var modal = safeGetElement('cloudSyncUpdateModal');
-    if (!modal) { resolve(false); return; } // fallback: decline if no modal in DOM
-
-    // Populate metadata fields
-    var itemCountEl = safeGetElement('syncUpdateItemCount');
-    var timestampEl = safeGetElement('syncUpdateTimestamp');
-    var deviceEl    = safeGetElement('syncUpdateDevice');
-
-    if (itemCountEl) itemCountEl.textContent = remoteMeta.itemCount != null ? String(remoteMeta.itemCount) : '—';
-    if (timestampEl) {
-      var ts = remoteMeta.timestamp ? new Date(remoteMeta.timestamp) : null;
-      timestampEl.textContent = ts ? ts.toLocaleString() : '—';
-    }
-    if (deviceEl) {
-      var devId = remoteMeta.deviceId || '';
-      deviceEl.textContent = devId ? devId.slice(0, 8) + '\u2026' : 'unknown';
-    }
-
-    modal.style.display = 'flex';
-
-    var acceptBtn  = safeGetElement('syncUpdateAcceptBtn');
-    var pushBtn    = safeGetElement('syncUpdatePushBtn');
-    var dismissBtn = safeGetElement('syncUpdateDismissBtn');
-    var dismissX   = safeGetElement('syncUpdateDismissX');
-
-    function cleanup(result) {
-      modal.style.display = 'none';
-      if (acceptBtn)  acceptBtn.removeEventListener('click', onAccept);
-      if (pushBtn)    pushBtn.removeEventListener('click', onPush);
-      if (dismissBtn) dismissBtn.removeEventListener('click', onDismiss);
-      if (dismissX)   dismissX.removeEventListener('click', onDismiss);
-      resolve(result);
-    }
-
-    function onAccept()  { cleanup('accept'); }
-    function onPush()    { cleanup('push'); }
-    function onDismiss() { cleanup('dismiss'); }
-
-    if (acceptBtn)  acceptBtn.addEventListener('click', onAccept);
-    if (pushBtn)    pushBtn.addEventListener('click', onPush);
-    if (dismissBtn) dismissBtn.addEventListener('click', onDismiss);
-    if (dismissX)   dismissX.addEventListener('click', onDismiss);
-  });
-}
-
-/**
  * Handle a detected remote change.
  * If no local changes → show update-available modal, then pull on Accept.
  * If both sides changed → show conflict modal.
@@ -1978,95 +1925,6 @@ async function pullSyncVault(remoteMeta) {
     updateSyncStatusIndicator('error', errMsg.slice(0, 60));
     if (typeof showCloudToast === 'function') showCloudToast('Auto-sync pull failed: ' + errMsg);
   }
-}
-
-// ---------------------------------------------------------------------------
-// Conflict modal
-// ---------------------------------------------------------------------------
-
-/**
- * Show the sync conflict modal with local vs. remote comparison.
- * @param {{local: object, remote: object, remoteMeta: object}} opts
- */
-function showSyncConflictModal(opts) {
-  return new Promise(function (resolve) {
-    var modal = safeGetElement('cloudSyncConflictModal');
-    if (!modal) {
-      var msg = 'Sync conflict detected.\n\n' +
-        'Local:  ' + opts.local.itemCount + ' items\n' +
-        'Remote: ' + opts.remote.itemCount + ' items\n\n' +
-        'Keep YOUR local version? (Cancel to keep the remote version)';
-      if (typeof appConfirm === 'function') {
-        appConfirm(msg, 'Sync Conflict').then(function (keepMine) {
-          if (keepMine) { _syncConflictUserOverride = true; pushSyncVault().catch(function(e) { console.error('[CloudSync] Keep Mine (fallback) push failed:', e); }); }
-          else pullWithPreview(opts.remoteMeta).catch(function (err) {
-            debugLog('[CloudSync] pullWithPreview failed in conflict fallback:', err);
-            updateSyncStatusIndicator('error', 'Pull failed — ' + err.message);
-          });
-          resolve();
-        });
-      } else {
-        resolve();
-      }
-      return;
-    }
-
-    // Populate modal fields
-    var setEl = function (id, text) {
-      var el = safeGetElement(id);
-      if (el) el.textContent = text || '\u2014';
-    };
-
-    setEl('syncConflictLocalItems', opts.local.itemCount + ' items');
-    setEl('syncConflictLocalTime', opts.local.timestamp ? _syncRelativeTime(opts.local.timestamp) : 'Unknown');
-    setEl('syncConflictLocalVersion', 'v' + opts.local.appVersion);
-    setEl('syncConflictRemoteItems', opts.remote.itemCount + ' items');
-    setEl('syncConflictRemoteTime', opts.remote.timestamp ? _syncRelativeTime(opts.remote.timestamp) : 'Unknown');
-    setEl('syncConflictRemoteVersion', 'v' + opts.remote.appVersion);
-    setEl('syncConflictRemoteDevice', opts.remote.deviceId ? opts.remote.deviceId.slice(0, 8) + '\u2026' : 'Another device');
-
-    // Wire buttons
-    var keepMineBtn = safeGetElement('syncConflictKeepMine');
-    var keepTheirsBtn = safeGetElement('syncConflictKeepTheirs');
-    var skipBtn = safeGetElement('syncConflictSkip');
-
-    var closeModal = function () {
-      modal.style.display = 'none';
-      if (typeof closeModalById === 'function') closeModalById('cloudSyncConflictModal');
-    };
-
-    if (keepMineBtn) {
-      keepMineBtn.onclick = function () {
-        closeModal();
-        _syncConflictUserOverride = true;
-        pushSyncVault().catch(function(e) { console.error('[CloudSync] Keep Mine push failed:', e); });
-        resolve();
-      };
-    }
-    if (keepTheirsBtn) {
-      keepTheirsBtn.onclick = function () {
-        closeModal();
-        // Layer 5 — Show restore preview instead of direct pull (REQ-5)
-        pullWithPreview(opts.remoteMeta).catch(function (err) {
-          debugLog('[CloudSync] pullWithPreview failed on Keep Theirs:', err);
-          updateSyncStatusIndicator('error', 'Pull failed — ' + err.message);
-        });
-        resolve();
-      };
-    }
-    if (skipBtn) {
-      skipBtn.onclick = function () {
-        closeModal();
-        resolve();
-      };
-    }
-
-    if (typeof openModalById === 'function') {
-      openModalById('cloudSyncConflictModal');
-    } else {
-      modal.style.display = 'flex';
-    }
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -3118,8 +2976,6 @@ window.syncNow = syncNow;
 window.pushSyncVault = pushSyncVault;
 window.pullSyncVault = pullSyncVault;
 window.pollForRemoteChanges = pollForRemoteChanges;
-window.showSyncConflictModal = showSyncConflictModal;
-window.showSyncUpdateModal = showSyncUpdateModal;
 window.showRestorePreviewModal = showRestorePreviewModal;
 window.pullWithPreview = pullWithPreview;
 window.computeInventoryHash = computeInventoryHash;

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1142,11 +1142,12 @@ async function pushSyncVault() {
           // OLD password. In that case we cannot reliably decrypt with the NEW password.
           if (_syncPasswordJustChanged) {
             console.warn('[CloudSync] Pre-push check: password just changed — remote metadata likely encrypted with old password');
-            var confirmBlindOverwrite = window.confirm(
+            var confirmBlindOverwrite = await appConfirm(
               'Your sync password was just changed.\n\n' +
               'StakTrakr cannot verify whether the cloud copy of your vault is newer than this device. ' +
               'Continuing may overwrite newer remote data.\n\n' +
-              'Do you want to overwrite the cloud copy with the data from this device now?'
+              'Do you want to overwrite the cloud copy with the data from this device now?',
+              'Cloud Sync'
             );
             if (!confirmBlindOverwrite) {
               console.warn('[CloudSync] Pre-push check: user cancelled blind overwrite after password change');
@@ -1203,9 +1204,6 @@ async function pushSyncVault() {
             logCloudSyncActivity('auto_sync_push', 'deferred', 'Remote change detected from device ' + prePushMeta.deviceId.slice(0, 8) + ' — showing diff');
             _syncPushInFlight = false;
             updateSyncStatusIndicator('idle');
-            // STAK-411: Set flag before await so concurrent poll sees it and skips
-            // its own handleRemoteChange call, preventing a double conflict modal.
-            _syncRemoteChangeActive = true;
             await handleRemoteChange(prePushMeta);
             return; // Do NOT push — let the user decide via the update/conflict modal
           } else {

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.50";
+const APP_VERSION = "3.33.51";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/init.js
+++ b/js/init.js
@@ -203,7 +203,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     elements.apiHistoryModal = safeGetElement("apiHistoryModal");
     elements.goldbackHistoryModal = safeGetElement("goldbackHistoryModal");
     elements.cloudSyncModal = safeGetElement("cloudSyncModal");
-    elements.cloudSyncConflictModal = safeGetElement("cloudSyncConflictModal");
     elements.vaultModal = safeGetElement("vaultModal");
     elements.apiQuotaModal = safeGetElement("apiQuotaModal");
     elements.aboutModal = safeGetElement("aboutModal");

--- a/js/settings.js
+++ b/js/settings.js
@@ -1874,7 +1874,7 @@ const renderUserImageGrid = async () => {
 
     const info = document.createElement('div');
     info.className = 'pattern-rule-info';
-    info.innerHTML = `<div class="rule-replacement">${name}</div>`;
+    info.innerHTML = '<div class="rule-replacement">' + sanitizeHtml(name) + '</div>';
     row.appendChild(info);
 
     // Actions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.33.50",
+  "version": "3.33.51",
   "type": "module",
   "description": "Precious metals inventory tracker",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.32.01",
+  "version": "3.33.50",
   "type": "module",
   "description": "Precious metals inventory tracker",
   "scripts": {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.51-b1772681102';
+const CACHE_NAME = 'staktrakr-v3.33.51-b1772683154';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.50-b1772679775';
+const CACHE_NAME = 'staktrakr-v3.33.51-b1772681102';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.50-b1772670174';
+const CACHE_NAME = 'staktrakr-v3.33.50-b1772679321';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.50-b1772679338';
+const CACHE_NAME = 'staktrakr-v3.33.50-b1772679617';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.50-b1772679321';
+const CACHE_NAME = 'staktrakr-v3.33.50-b1772679330';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.50-b1772679330';
+const CACHE_NAME = 'staktrakr-v3.33.50-b1772679338';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.50-b1772679617';
+const CACHE_NAME = 'staktrakr-v3.33.50-b1772679775';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.50",
-  "releaseDate": "2026-03-04",
+  "version": "3.33.51",
+  "releaseDate": "2026-03-05",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,7 +2,7 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.49
+lastUpdated: 2026-03-05
 date: 2026-03-04
 sourceFiles:
   - js/cloud-storage.js
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.49 — 2026-03-04
+> **Last updated:** v3.33.51 — 2026-03-05
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`, `js/vault.js`
 
 ## Overview
@@ -76,6 +76,7 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 - Conflict detection via `cloudCheckConflict()` comparing remote `latest.json` timestamp against `cloud_last_backup` in localStorage
 - Cloud activity log: all transactions recorded to `cloud_activity_log` (capped at 500 entries, max 180 days)
 - UI state management via `syncCloudUI()`
+- OAuth state validation in the localStorage relay path (`cloudCheckOAuthRelay`) — rejects relayed OAuth codes whose `state` does not match `cloud_oauth_state` in `sessionStorage`, guarding against CSRF
 
 **Manual cloud backup flow (updated STAK-419, v3.33.41):**
 
@@ -100,6 +101,13 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 - Multi-tab coordination via `BroadcastChannel('staktrakr-sync')` — push/pull events broadcast to all tabs
 - Password management (`getSyncPassword`, `getSyncPasswordSilent`, `changeVaultPassword`)
 - Empty-vault push guard: blocks push when local is empty but remote has items
+- All user confirmation dialogs use `await appConfirm()` — no `window.confirm` calls
+
+**Remote change flow (STAK-413):**
+
+All remote changes (both sync updates and conflicts) flow directly into `handleRemoteChange()`, which routes to `pullWithPreview()` showing the DiffModal. The former intermediate dialogs `showSyncUpdateModal()` and `showSyncConflictModal()` have been removed — DiffModal is the sole review UI.
+
+`_syncRemoteChangeActive` is managed exclusively by `handleRemoteChange()` via `try/finally`, guaranteeing the flag is always cleared even if `pullWithPreview()` throws.
 
 **Auto-sync file layout on Dropbox:**
 
@@ -322,6 +330,7 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 | `cloudListBackups` | `async (provider, type?)` | List `.stvault` files in the cloud backups folder; paginates via `files/list_folder/continue` when Dropbox returns `has_more` (STAK-425). Optional `type` filters by prefix: `'manual'`, `'sync'`, or `undefined` (all). Returns array sorted newest-first |
 | `cloudDeleteBackup` | `async (provider, filename)` | Delete a named vault file. If the deleted file was the `cloud_last_backup` pointer target, updates remote `staktrakr-latest.json` to point to the next most recent backup, or deletes the pointer if no backups remain (STAK-425). |
 | `cloudCheckConflict` | `async (provider)` | Compare remote `latest.json` timestamp vs `cloud_last_backup`; returns conflict info object |
+| `cloudCheckOAuthRelay` | `()` | Reads `staktrakr_oauth_result` from localStorage (relay path when popup loses `window.opener`); validates `state` against `sessionStorage` before calling `cloudExchangeCode`. Rejects with a warning on state mismatch (CSRF guard). |
 | `cloudGetToken` | `async (provider)` | Get OAuth access token; auto-refreshes if expired; clears token on refresh failure |
 | `cloudIsConnected` | `(provider)` | Returns `true` if a stored token exists for the provider |
 | `cloudAuthStart` | `(provider)` | Opens OAuth popup; initiates PKCE flow for Dropbox |
@@ -336,12 +345,13 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 | Function | Signature | Purpose |
 |----------|-----------|---------|
 | `pushSyncVault` | `async ()` | Encrypt and push sync-scoped vault to Dropbox; includes empty-vault guard, image vault, and manifest |
-| `pullWithPreview` | `async (remoteMeta)` | Primary pull path. Shows DiffModal (manifest-first or vault-first) and awaits user action (Apply or Cancel) before returning. Keeps `_syncRemoteChangeActive=true` for the full duration, blocking concurrent pushes while the user reviews the diff. |
+| `handleRemoteChange` | `async (remoteMeta)` | Entry point for all remote change events (both sync updates and conflicts). Sets `_syncRemoteChangeActive = true`, cancels any queued push, then calls `pullWithPreview()`. Uses `try/finally` to guarantee `_syncRemoteChangeActive` is cleared on exit, including on error. |
+| `pullWithPreview` | `async (remoteMeta)` | Primary pull path. Shows DiffModal (manifest-first or vault-first) and awaits user action (Apply or Cancel) before returning. Runs within `handleRemoteChange`'s `_syncRemoteChangeActive` scope, blocking concurrent pushes while the user reviews the diff. |
 | `syncSaveOverrideBackup` | `()` | Snapshot all `SYNC_SCOPE_KEYS` raw strings to `cloud_sync_override_backup` |
 | `syncRestoreOverrideBackup` | `async ()` | Restore pre-pull snapshot with confirmation; clears scope keys then rewrites from snapshot |
 | `getSyncPassword` | `()` → `Promise<string\|null>` | Interactively prompt for vault password; stores in localStorage; returns composite key |
 | `getSyncPasswordSilent` | `()` → `string\|null` | Return composite key (`password:accountId`) without UI; returns `null` if either missing |
-| `changeVaultPassword` | `async (newPassword)` → `boolean` | Store new password; triggers debounced push to re-encrypt vault |
+| `changeVaultPassword` | `async (newPassword)` → `boolean` | Store new password; triggers debounced push to re-encrypt vault. Password-change overwrites require `appConfirm()` confirmation before blind-overwriting remote. |
 | `syncIsEnabled` | `()` → `boolean` | Returns `true` when `cloud_sync_enabled === 'true'` in localStorage |
 | `syncGetLastPush` | `()` → `object\|null` | Read `cloud_sync_last_push` from localStorage |
 | `syncSetLastPush` | `(meta)` | Write `cloud_sync_last_push` to localStorage |
@@ -374,6 +384,8 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 ### Auto-sync conflict
 
 Conflict detection is driven by `syncHasLocalChanges()`, which checks whether both local and remote have diverged (last push timestamp is more recent than last pull timestamp). When both sides have diverged, the conflict modal appears. It is not triggered by item-count differences alone.
+
+All remote changes — both routine updates and conflicts — are routed through `handleRemoteChange()`, which calls `pullWithPreview()` (DiffModal). The former intermediate dialogs (`showSyncUpdateModal`, `showSyncConflictModal`) were removed in STAK-413. DiffModal is the sole review UI for all remote sync changes.
 
 `syncSaveOverrideBackup()` stores a pre-pull snapshot enabling the "Restore Override Backup" button in the sync history section. If the user accepts a conflicting pull and wants to revert, `syncRestoreOverrideBackup()` writes the pre-pull snapshot back.
 
@@ -473,12 +485,13 @@ All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
 | "Pattern images disappeared after restore" | Only the ZIP backup includes `pattern_images/`. Cloud sync and the image vault do not cover this store. | Restore from ZIP backup to recover pattern images. |
 | "Numista images came back immediately after vault restore" | Expected behavior. Numista CDN URLs (`obverseImageUrl`, `reverseImageUrl`) are stored on the inventory items in localStorage, so they survive any vault restore without touching IDB. | No action needed — this is correct. |
 | "Image vault upload failed during cloud push" | Image vault upload is non-fatal — the inventory vault still succeeds. | Check Dropbox token validity. The next successful push will retry the image vault if the hash changed. |
-| "Conflict prompt appeared after cloud pull" | Both local and remote have diverged — last push is more recent than last pull, meaning both sides have independent changes. | Review the conflict UI and choose which version to keep. |
+| "Conflict prompt appeared after cloud pull" | Both local and remote have diverged — last push is more recent than last pull, meaning both sides have independent changes. | Review the DiffModal and choose which version to keep. |
 | "DiffModal shows fewer items than I expected" | Pre-validation in `buildImportValidationResult()` filters out invalid items before DiffModal opens. The count header shows backup count (including skipped) vs. projected count. | Check the pre-validation warning toast for the number of skipped items and their reasons. The post-import summary banner also lists skip reasons. |
 | "I see a yellow cross-domain warning on import" | The file's `exportOrigin` (e.g., `https://beta.staktrakr.com`) differs from the current domain. | The warning is informational only. Proceed if you intentionally want to merge across environments. |
 | "The JSON file I exported doesn't look like a plain array anymore" | `exportJson()` now wraps items in an object with `items` and `exportMeta` fields. | Both the wrapped format and the legacy plain-array format are supported on import. Old files still import correctly. |
 | "Import shows a banner but also a toast" | If `safeGetElement()` cannot find the inventory table container, `showImportSummaryBanner()` falls back to `showToast()`. | Verify the inventory container element id is present in the DOM at import time. |
 | "Push was blocked with 'Empty vault — pull first'" | Empty-vault guard in `pushSyncVault()` detected remote has items but local is empty. | Pull from cloud first to restore local inventory, then push will proceed normally. |
+| "OAuth relay rejected with 'state mismatch'" | `cloudCheckOAuthRelay` validates the `state` parameter from the localStorage relay against `cloud_oauth_state` in `sessionStorage`. A mismatch means the relay entry is stale or from a different OAuth session. | Re-initiate the OAuth flow from Settings → Cloud → Connect. |
 
 > **Never modify the `coinImages` IDB store.** It is a legacy store retained only to avoid a forced migration. It is never read or written. ZIP restore explicitly skips `coinImages/` and logs: `"skipping legacy coinImages folder (store deprecated)"`.
 

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,7 +2,7 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: 2026-03-05
+lastUpdated: v3.33.51
 date: 2026-03-04
 sourceFiles:
   - js/cloud-storage.js

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,7 +2,7 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: 2026-03-05
+lastUpdated: v3.33.51
 date: 2026-03-04
 sourceFiles:
   - js/cloud-sync.js

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,7 +2,7 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.46
+lastUpdated: 2026-03-05
 date: 2026-03-04
 sourceFiles:
   - js/cloud-sync.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.33.46 — 2026-03-04
+> **Last updated:** v3.33.51 — 2026-03-05
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -46,10 +46,11 @@ A separate image vault lives at:
 
 1. **Never bypass `getSyncPasswordSilent()`** — do not add your own `localStorage.getItem('cloud_vault_password')` reads inline. All key derivation logic (Simple mode migration, Unified mode construction) is encapsulated there.
 2. **`.catch()` on `pushSyncVault()` is optional** — it catches internally and all guard conditions return silently. **`.catch()` on `pullSyncVault()` is required** — the token check at the top fires before the internal try/catch, so callers must handle rejection.
-3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before opening any modal. If you add a new pull path, replicate this cancel guard or the vault overwrite race will reopen. `handleRemoteChange()` also sets `_syncRemoteChangeActive = true` for the entire duration of the pull (including while the DiffModal is open, awaiting user action), which blocks concurrent `pushSyncVault()` calls. Both guards are required: the cancel prevents the queued debounce from firing, and the `_syncRemoteChangeActive` flag blocks any new push triggered while the user is reviewing the diff.
+3. **Cancel the debounced push before pulling** — `handleRemoteChange()` calls `scheduleSyncPush.cancel()` before routing to `pullWithPreview()`. If you add a new pull path, replicate this cancel guard or the vault overwrite race will reopen. `handleRemoteChange()` also sets `_syncRemoteChangeActive = true` for the entire duration of the pull (including while the DiffModal is open, awaiting user action), which blocks concurrent `pushSyncVault()` calls. Both guards are required: the cancel prevents the queued debounce from firing, and the `_syncRemoteChangeActive` flag blocks any new push triggered while the user is reviewing the diff. The flag is managed solely by try/finally inside `handleRemoteChange()` — it must not be set at call sites.
 4. **Do not duplicate `getSyncPassword()` logic** — the fast-path check at the top delegates to `getSyncPasswordSilent()`, which handles both modes and the migration edge case. Adding a second localStorage read before it breaks Simple-mode migration.
 5. **Only the leader tab pushes and polls** — `_syncIsLeader` guards both `pushSyncVault()` and `pollForRemoteChanges()`. Do not call the underlying network operations directly from UI code without this guard, or multi-tab races occur.
 6. **`cloud_dropbox_account_id` is required on every pull/poll path** — `pollForRemoteChanges()`, `pullSyncVault()`, and `pullWithPreview()` all check for a present `cloud_dropbox_account_id` before attempting any decrypt. Missing accountId yields an early-return with a "setup incomplete" toast instead of a misleading "Wrong Vault Password" error.
+7. **All confirmations use `appConfirm`** — there are no `window.confirm` calls in this module. The password-change blind-overwrite confirmation at line 1144 uses `await appConfirm(..., 'Cloud Sync')`.
 
 ---
 
@@ -138,14 +139,12 @@ getSyncPasswordSilent()
 | `pullSyncVault(remoteMeta)` | `(object) → Promise<void>` | Download, decrypt, and restore vault. Throws if no token — callers must `.catch()`. |
 | `pullWithPreview(remoteMeta)` | `(object) → Promise<void>` | Primary pull path. Manifest-first: downloads `.stmanifest`, builds diff, shows `DiffModal` and awaits user action before returning. Falls back to vault-first if manifest unavailable; vault-first path also awaits user action. Does not return until Apply or Cancel is selected. |
 | `pollForRemoteChanges()` | `() → Promise<void>` | Download `staktrakr-sync.json`, compare `syncId` with last pull, call `handleRemoteChange()` on change. Only runs if leader tab + visible. |
-| `handleRemoteChange(remoteMeta)` | `(object) → Promise<void>` | Route a detected remote change: cancel debounced push, then show update modal (no local changes) or conflict modal (both sides changed). |
-| `showSyncConflictModal(opts)` | `({local, remote, remoteMeta}) → void` | Display conflict modal with Keep Mine / Keep Theirs / Skip. |
-| `showSyncUpdateModal(remoteMeta)` | `(object) → Promise<boolean>` | Display "Update available" modal, resolves true/false on user action. |
+| `handleRemoteChange(remoteMeta)` | `(object) → Promise<void>` | Route a detected remote change: cancel debounced push, then go directly to `pullWithPreview()`. Sets `_syncRemoteChangeActive = true` via try/finally for the full duration. |
 | `getSyncPasswordSilent()` | `() → string\|null` | Non-interactive key derivation — safe to call from background loops. |
 | `getSyncPassword()` | `() → Promise<string\|null>` | Interactive key prompt — opens password modal; shows in-modal error if `cloud_dropbox_account_id` is absent at confirm time. |
 | `changeVaultPassword(newPassword)` | `(string) → Promise<boolean>` | Update vault password in localStorage and trigger re-encrypt push. |
 | `syncSaveOverrideBackup()` | `() → void` | Snapshot all `SYNC_SCOPE_KEYS` from localStorage before a pull overwrites them. |
-| `syncRestoreOverrideBackup()` | `() → Promise<void>` | Restore the pre-pull snapshot (with confirmation dialog). |
+| `syncRestoreOverrideBackup()` | `() → Promise<void>` | Restore the pre-pull snapshot (with `appConfirm` dialog). |
 | `getSyncDeviceId()` | `() → string` | Get or create stable per-device UUID (persisted in `cloud_sync_device_id`). |
 | `syncHasLocalChanges()` | `() → boolean` | True if last push timestamp is newer than last pull timestamp. |
 | `buildAndUploadManifest(token, password, syncId)` | `(...) → Promise<void>` | Build and encrypt a field-level changelog from `changeLog`, upload to Dropbox. Non-blocking (failure does not prevent vault push). |
@@ -163,6 +162,7 @@ getSyncPasswordSilent()
 |---|---|---|
 | `cloudAuthStart(provider)` | `(string) → void` | Open OAuth popup (PKCE for Dropbox). Must be called from a click handler to avoid popup blockers. |
 | `cloudExchangeCode(code, state)` | `(string, string) → Promise<void>` | Exchange OAuth code for access/refresh tokens. Validates state parameter against saved session. |
+| `cloudCheckOAuthRelay()` | `() → void` | Fallback relay handler when popup loses `window.opener`. Reads `staktrakr_oauth_result` from localStorage, validates `data.state` against `sessionStorage.getItem('cloud_oauth_state')` before calling `cloudExchangeCode` — rejects with a CSRF warning on mismatch. |
 | `cloudGetToken(provider)` | `(string) → Promise<string\|null>` | Return valid access token. Attempts refresh if expired (with 60s buffer). Clears token and returns null on refresh failure. |
 | `cloudIsConnected(provider)` | `(string) → boolean` | True if a stored token exists for the provider. |
 | `cloudStoreToken(provider, tokenData)` | `(string, object) → void` | Persist token to localStorage under `cloud_token_<provider>`. |
@@ -230,23 +230,18 @@ pollForRemoteChanges()
 
 ### Remote Change Handling
 
+`handleRemoteChange()` no longer routes through intermediate update or conflict modals. All remote changes — whether or not the local device has unsaved changes — go directly to `pullWithPreview()`:
+
 ```
 handleRemoteChange(remoteMeta)
   ├─ Defer if password prompt is active
-  ├─ _syncRemoteChangeActive = true   ← blocks concurrent pushes for the full duration
+  ├─ _syncRemoteChangeActive = true   ← set here; cleared only by try/finally inside this function
   ├─ scheduleSyncPush.cancel()   ← CRITICAL: prevents vault overwrite race
-  ├─ syncHasLocalChanges()?
-  │    No  → showSyncUpdateModal() → user accepts → await pullWithPreview()
-  │                                                  (returns only after Apply/Cancel)
-  │                                  user chooses "Push My Data"
-  │                                    → _syncConflictUserOverride = true → pushSyncVault()
-  │    Yes → showSyncConflictModal()
-  │             ├─ Keep Mine  → _syncConflictUserOverride = true → pushSyncVault()
-  │             ├─ Keep Theirs → pullWithPreview(remoteMeta)
-  │             └─ Skip → close modal
-  │             (appConfirm fallback: keepMine → _syncConflictUserOverride = true → pushSyncVault())
+  ├─ await pullWithPreview(remoteMeta)   ← handles all cases (update, conflict, diff preview)
   └─ finally: _syncRemoteChangeActive = false   ← clears only after pull is fully applied
 ```
+
+> **Note:** `showSyncUpdateModal` and `showSyncConflictModal` were removed in STAK-413. The DiffModal used by `pullWithPreview()` presents all necessary conflict and update information in a single unified interface.
 
 ### Pull (Dropbox → inventory)
 
@@ -303,36 +298,17 @@ Runs as part of push and pull, non-fatally:
 
 ## Conflict Resolution
 
-**Default: remote wins** when there are no local changes (user accepts the update modal).
+**Default: DiffModal always shown** — `handleRemoteChange()` routes all remote changes directly to `pullWithPreview()`, which presents the DiffModal. The user chooses Apply or Cancel regardless of whether the local device has unsaved changes.
 
-`syncHasLocalChanges()` returns true if `lastPush.timestamp > lastPull.timestamp` — meaning the local device has pushed changes that predated the remote update, so both sides have diverged.
-
-When both sides have changes, the conflict modal displays:
-
-| Side | Fields shown |
-|---|---|
-| Local | item count, last-push timestamp (relative), app version |
-| Remote | item count, timestamp (relative), app version, device ID (first 8 chars) |
-
-Choices:
-
-- **Keep Mine** → `pushSyncVault()` — overwrites remote with local
-- **Keep Theirs** → `pullWithPreview(remoteMeta)` — shows diff preview, then applies remote
-- **Skip** → close modal, no action (remote change will reappear on next poll)
+`syncHasLocalChanges()` returns true if `lastPush.timestamp > lastPull.timestamp` — meaning the local device has pushed changes that predated the remote update, so both sides have diverged. This flag is checked internally within the pull/preview flow.
 
 The override backup (`syncSaveOverrideBackup`) is written before any pull, enabling "Restore This Snapshot" in the Sync History section.
 
 ### Keep Mine / Push My Data — conflict bypass flag (STAK-403, v3.33.32)
 
-**Problem:** Choosing "Keep Mine" in the conflict modal or "Push My Data" in the update modal triggered `pushSyncVault()`, which immediately re-ran the Layer 0 pre-push remote check. That check detected the same unacknowledged remote change the user had just explicitly dismissed and re-routed back to `handleRemoteChange()` — creating an infinite conflict-resolution loop.
+**Problem:** Choosing to overwrite the remote vault (from within the DiffModal or a conflict prompt) triggered `pushSyncVault()`, which immediately re-ran the Layer 0 pre-push remote check. That check detected the same unacknowledged remote change the user had just explicitly dismissed and re-routed back to `handleRemoteChange()` — creating an infinite conflict-resolution loop.
 
-**Fix:** A module-level one-shot flag `_syncConflictUserOverride` (initialized `false`, line 36 of `cloud-sync.js`) is set `true` at three call sites immediately before `pushSyncVault()` is invoked:
-
-1. `keepMineBtn.onclick` in `showSyncConflictModal`
-2. `showSyncUpdateModal` "Push My Data" branch inside `handleRemoteChange`
-3. `appConfirm` fallback branch in `showSyncConflictModal`
-
-At the start of the Layer 0 pre-push try block, the flag is snapshot-and-cleared atomically:
+**Fix:** A module-level one-shot flag `_syncConflictUserOverride` (initialized `false`, line 36 of `cloud-sync.js`) is set `true` at call sites that represent explicit user intent to overwrite. At the start of the Layer 0 try block, the flag is snapshot-and-cleared atomically:
 
 ```js
 var _prePushOverride = _syncConflictUserOverride;
@@ -375,14 +351,14 @@ Manual backups and sync snapshots are separated by filename prefix and treated i
 - **`MANUAL_BACKUP_PREFIX` (`staktrakr-backup-`)** — user-initiated backups via the "Backup" button. These are never auto-pruned by the sync system. The user must delete them explicitly.
 - **`SYNC_BACKUP_PREFIX` (`pre-sync-`)** — automatic pre-push snapshots created by `pushSyncVault()`. These are pruned by `cloudPruneBackups()` which defaults to `type='sync'`.
 
-**Key behavioral changes:**
+**Key behavioral notes:**
 
 - `cloudListBackups(provider, type)` accepts an optional `type` parameter (`'manual'` | `'sync'` | `undefined`) for client-side prefix filtering.
 - `cloudPruneBackups(provider, maxKeep, type)` defaults to `type='sync'`, so auto-pruning only touches sync snapshots. Manual backups are preserved regardless of the backup history depth setting.
 - `cloudUploadVault(provider, fileBytes, opts)` accepts an `opts` parameter. When `opts.skipLatestUpdate` is true, the `cloud_last_backup` pointer is not updated — this prevents manual backups from interfering with sync state tracking.
 - The vault modal password is not cached for manual backups (password caching via `cloudCachePassword` is skipped for `isManualBackup: true` contexts). Each manual backup requires the user to re-enter their vault password.
 
-The override backup is the safety net for "Keep Theirs" conflicts or unwanted sync pulls. It restores raw localStorage strings (not Dropbox files) directly back to the pre-pull state.
+The override backup is the safety net for unwanted sync pulls. It restores raw localStorage strings (not Dropbox files) directly back to the pre-pull state.
 
 ---
 
@@ -409,6 +385,35 @@ The override backup is the safety net for "Keep Theirs" conflicts or unwanted sy
 
 ---
 
+## Security Notes
+
+### Console output sanitization (STAK-430, v3.33.51)
+
+Console and debug output has been hardened to avoid leaking credential material:
+
+- **`cloud-sync.js`** — `console.warn` calls no longer emit `password.length`, `key.length`, byte counts, or hash values. Crypto-diagnostic logs are routed through `debugLog()` (suppressed in production). The pre-decrypt diagnostic (`_logDecryptAttempt`) logs only boolean presence of `cloud_vault_password` and `'present'`/`'MISSING'` for `cloud_dropbox_account_id` — never the actual value or its length.
+- **`cloud-storage.js`** — Account ID logged as `'present'` rather than a slice of the actual value. Response status codes are not included in failure log messages.
+
+### OAuth state parameter validation (STAK-430, v3.33.51)
+
+`cloudCheckOAuthRelay()` now validates the OAuth state parameter before processing relay results:
+
+```js
+var savedState = sessionStorage.getItem('cloud_oauth_state');
+if (!savedState || savedState !== data.state) {
+  console.warn('[CloudStorage] OAuth relay: state mismatch — possible CSRF, rejecting');
+  return;
+}
+```
+
+If the state stored in `sessionStorage` is missing or does not match `data.state` from the relay payload, the relay is rejected and `cloudExchangeCode` is never called. This prevents a CSRF attacker from injecting a crafted OAuth result into localStorage and having it auto-processed.
+
+### All confirmations use `appConfirm`
+
+There are no `window.confirm` calls anywhere in `cloud-sync.js` or `cloud-storage.js`. The password-change blind-overwrite prompt uses `await appConfirm(..., 'Cloud Sync')`, which renders in the app's modal system rather than the browser's native dialog (consistent with all other sync confirmations).
+
+---
+
 ## Error Handling Patterns
 
 - **`pushSyncVault()`** — all errors caught internally; sets status indicator to `'error'`; returns silently. No caller catch required.
@@ -423,17 +428,18 @@ The override backup is the safety net for "Keep Theirs" conflicts or unwanted sy
 
 ### Pre-decrypt diagnostics
 
-`_tryDecryptVault(fileBytes, artifactLabel?)` and `_tryDecryptMetadata(parsed)` each emit a structured `console.warn` **before entering the key-candidate loop**:
+`_tryDecryptVault(fileBytes, artifactLabel?)` and `_tryDecryptMetadata(parsed)` each emit a structured `console.warn` **before entering the key-candidate loop** via `_logDecryptAttempt()`:
 
 ```
-[CloudSync] decrypt attempt: artifact=stvault vaultPw: true accountId: dbid:abc1… (40 chars) candidates: 3
+[CloudSync] decrypt attempt: artifact=stvault vaultPw: true accountId: present candidates: 3
 [CloudSync] decrypt attempt: artifact=metadata vaultPw: true accountId: MISSING candidates: 0
 ```
 
 Fields logged:
+
 - `artifact` — `'stvault'` (all `_tryDecryptVault` call sites), `'metadata'` (`_tryDecryptMetadata`)
-- `vaultPw` — boolean presence of `cloud_vault_password`
-- `accountId` — first 8 chars + length if present, or `MISSING`
+- `vaultPw` — boolean presence of `cloud_vault_password` (never the value or its length)
+- `accountId` — `'present'` if set, or `'MISSING'` (never the account ID value or a slice of it)
 - `candidates` — count from `_getSyncKeyCandidates()` (0 when accountId is missing, since no valid composite key can be formed)
 
 ---
@@ -494,6 +500,10 @@ scheduleSyncPush(); // for inventory changes
 
 `pullWithPreview()` has two distinct paths: manifest-first (lightweight) and vault-first (full download). The manifest path is best-effort. Code that hooks into the pull flow must handle both paths.
 
+### Setting `_syncRemoteChangeActive` at a call site
+
+`_syncRemoteChangeActive` is managed exclusively by `handleRemoteChange()` via try/finally. Setting it to `true` before calling `handleRemoteChange()` — a pattern that previously existed — was removed in STAK-430 because it caused the flag to remain `true` if `handleRemoteChange()` threw before reaching its own try block, permanently blocking all future pushes.
+
 ---
 
 ## Vault Overwrite Race (fixed v3.32.24, extended v3.33.34)
@@ -502,7 +512,7 @@ scheduleSyncPush(); // for inventory changes
 
 **Root cause:** `initSyncModule()` builds `scheduleSyncPush` with a 2000ms debounce. If the poller detected a remote change within that 2-second window, the debounced push fired during or after the conflict modal, overwriting the remote vault before the pull could complete.
 
-**Fix (v3.32.24):** `handleRemoteChange()` calls `scheduleSyncPush.cancel()` as its first substantive action — before any modal is shown. This prevents the *queued debounce* from firing.
+**Fix (v3.32.24):** `handleRemoteChange()` calls `scheduleSyncPush.cancel()` as its first substantive action — before routing to `pullWithPreview()`. This prevents the *queued debounce* from firing.
 
 **Extended fix (v3.33.34, STAK-406):** A second race path remained: `pullWithPreview()` previously returned as soon as it handed off to `DiffModal.show()`, clearing `_syncRemoteChangeActive` before the user had applied or cancelled. A new push triggered while the DiffModal was open (e.g., from another tab broadcast or user action) would not be blocked. The fix makes `pullWithPreview()` await the DiffModal user action in both the manifest-first and vault-first paths before returning, so `_syncRemoteChangeActive` stays `true` until the pull is fully applied. Similarly, `showRestorePreviewModal()` now returns a `Promise<void>` (resolved on Apply or Cancel) instead of a boolean, enabling callers to await it. It returns `null` only when DiffModal is unavailable.
 
@@ -512,11 +522,11 @@ scheduleSyncPush(); // for inventory changes
 
 ## Keep Mine Conflict Resolution Infinite Loop (fixed v3.33.32, STAK-403)
 
-**Symptom:** Choosing "Keep Mine" in the conflict modal (or "Push My Data" in the update modal) caused the conflict modal to reappear immediately after every push, preventing the user from ever overwriting the remote vault.
+**Symptom:** Choosing to overwrite the remote vault caused the conflict resolution flow to immediately re-trigger, preventing the user from ever overwriting the remote vault.
 
-**Root cause:** The Layer 0 pre-push check (added in STAK-398) downloads and inspects remote metadata before every push. When the user chose "Keep Mine", the resulting `pushSyncVault()` call hit Layer 0, detected the same unacknowledged remote change the user had just dismissed, and re-routed to `handleRemoteChange()` — triggering the conflict modal again in a loop.
+**Root cause:** The Layer 0 pre-push check (added in STAK-398) downloads and inspects remote metadata before every push. When the user chose to overwrite, the resulting `pushSyncVault()` call hit Layer 0, detected the same unacknowledged remote change the user had just dismissed, and re-routed to `handleRemoteChange()` — triggering the conflict flow again in a loop.
 
-**Fix (v3.33.32):** A module-level one-shot flag `_syncConflictUserOverride` is set `true` at the three call sites that represent explicit user intent to overwrite (Keep Mine button, Push My Data branch, appConfirm fallback). At the start of the Layer 0 try block the flag is snapshot-and-cleared; if the snapshot is `true` the conflict check is bypassed and the push proceeds. See the "Keep Mine / Push My Data — conflict bypass flag" section under Conflict Resolution for full details.
+**Fix (v3.33.32):** A module-level one-shot flag `_syncConflictUserOverride` is set `true` at call sites that represent explicit user intent to overwrite. At the start of the Layer 0 try block the flag is snapshot-and-cleared; if the snapshot is `true` the conflict check is bypassed and the push proceeds. See the "Keep Mine / Push My Data — conflict bypass flag" section under Conflict Resolution for full details.
 
 ---
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **XSS fix**: Sanitized user-controlled item name in settings pattern rule innerHTML via `sanitizeHtml()` (REQ-1)
- **OAuth CSRF**: Added state parameter validation to localStorage relay path in `cloudCheckOAuthRelay()` (REQ-5)
- **Sync flag leak**: Removed premature `_syncRemoteChangeActive = true` at call site — flag now solely managed by try/finally in `handleRemoteChange()` (REQ-2)
- **appConfirm**: Replaced last `window.confirm` in sync flow with async `appConfirm` modal (REQ-3)
- **Console sanitization**: Stripped key lengths, password lengths, partial account IDs, byte counts from production console output (REQ-4)
- **Dead code removal**: Removed `showSyncUpdateModal` (~46 lines) and `showSyncConflictModal` (~80 lines) + DOM elements (~58 lines) — replaced by DiffModal in STAK-413 (REQ-6)
- **package.json**: Synced version from stale `3.32.01` to `3.33.51` (REQ-7)
- **Wiki**: Updated `sync-cloud.md` and `backup-restore.md` to reflect all changes

## Files Changed

- `js/settings.js` — 1 line (sanitizeHtml)
- `js/cloud-storage.js` — 8 lines (OAuth state validation + console sanitization)
- `js/cloud-sync.js` — ~150 lines net removed (flag fix, appConfirm, console cleanup, dead code)
- `index.html` — ~58 lines removed (dead modal HTML)
- `js/init.js` — 1 line removed (orphaned element cache)
- `package.json`, `version.json`, `CHANGELOG.md`, `docs/announcements.md`, `js/about.js`, `js/constants.js`, `sw.js` — version bump
- `wiki/sync-cloud.md`, `wiki/backup-restore.md` — documentation updates

## Linear Issues

- STAK-430: Pre-ship Security & Quality Hardening

## Test Results

- Playwright/browserless: 88 passed, 33 failed (all pre-existing), 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)