### PR TITLE
fix(skills): add mandatory announcements audit to /ship and /release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -435,6 +435,21 @@ EOF
 )"
 ```
 
+### Step 3.5: Audit announcements & about.js (MANDATORY before creating PR)
+
+Over a long release cycle, `docs/announcements.md` and `js/about.js` accumulate
+stale per-patch entries. Before creating the ship PR, rewrite both to reflect
+the **full release**:
+
+1. Rewrite `## What's New` in `docs/announcements.md` with **3–5 entries**
+   covering the most significant changes (grouped by theme, not per-patch)
+2. Update `## Development Roadmap` — remove completed items, keep 3–4 forward
+3. Mirror the same entries in `js/about.js` `getEmbeddedWhatsNew()` and
+   `getEmbeddedRoadmap()` (these are the `file://` fallback)
+4. Commit and push to dev before creating the ship PR
+
+See the `/ship` skill Step 3.5 for full format details.
+
 ### Step 4: Mark ready and resolve
 
 ```bash

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -62,19 +62,7 @@ files to reflect the **full release** being shipped.
    changes in this release (grouped by theme, not per-patch). Use the version
    tags from Step 2 as source material. Format:
    ```markdown
-   - **Title (vX.X.X)**: Summary sentence. Additional detail sentence (STAK-XX).
-   ```
-3. Update `## Development Roadmap` — remove items completed in this release,
-   keep 3–4 forward-looking items.
-
-### about.js — getEmbeddedWhatsNew() + getEmbeddedRoadmap()
-
-These are the `file://` fallback and **MUST mirror announcements.md exactly**.
-
-1. Read `js/about.js` and find `getEmbeddedWhatsNew()` and `getEmbeddedRoadmap()`
-2. Replace their contents with HTML `<li>` versions of the same entries from
-   announcements.md
-3. Each entry: `<li><strong>vVERSION &ndash; TITLE</strong>: Summary</li>`
+   - **vX.X.X &ndash; Title**: Summary sentence. Additional detail sentence (STAK-XX).
 
 ### Sync check
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -48,6 +48,51 @@ For each `STAK-###` reference found across tag names and commit messages,
 call `mcp__claude_ai_Linear__get_issue` to get the current title and URL.
 This ensures the PR description is accurate, not just copy-pasted from commits.
 
+## Step 3.5: Audit announcements & about.js (MANDATORY)
+
+The `/release patch` skill updates `docs/announcements.md` and `js/about.js`
+per-patch, but over a long release cycle (many patches) the entries drift and
+accumulate stale content. Before creating the ship PR, audit and rewrite both
+files to reflect the **full release** being shipped.
+
+### announcements.md
+
+1. Read `docs/announcements.md`
+2. Rewrite `## What's New` with **3–5 entries** covering the most significant
+   changes in this release (grouped by theme, not per-patch). Use the version
+   tags from Step 2 as source material. Format:
+   ```markdown
+   - **Title (vX.X.X)**: Summary sentence. Additional detail sentence (STAK-XX).
+   ```
+3. Update `## Development Roadmap` — remove items completed in this release,
+   keep 3–4 forward-looking items.
+
+### about.js — getEmbeddedWhatsNew() + getEmbeddedRoadmap()
+
+These are the `file://` fallback and **MUST mirror announcements.md exactly**.
+
+1. Read `js/about.js` and find `getEmbeddedWhatsNew()` and `getEmbeddedRoadmap()`
+2. Replace their contents with HTML `<li>` versions of the same entries from
+   announcements.md
+3. Each entry: `<li><strong>vVERSION &ndash; TITLE</strong>: Summary</li>`
+
+### Sync check
+
+After updating both files, verify the entries match in count and content.
+Flag any drift before proceeding.
+
+### Commit the update
+
+```bash
+git add docs/announcements.md js/about.js
+git commit -m "docs: update announcements and about.js for vLATEST release"
+git push origin dev
+```
+
+> **Why here?** Individual patches update announcements incrementally, but the
+> ship step is the last chance to ensure the "What's New" modal shows a coherent
+> release summary — not a stale list from 30 patches ago.
+
 ## Step 4: Create the `dev → main` PR
 
 Build a comprehensive title from the version tags:


### PR DESCRIPTION
## Summary

- Add Step 3.5 to `/ship` skill — mandatory announcements & about.js audit before creating dev→main PR
- Add Step 3.5 cross-reference to `/release` skill Phase 4.5
- Prevents stale "What's New" modal on production after long release cycles

## Context

The v3.33.51 ship showed 25-patch-old announcements in production because neither skill enforced rewriting announcements at ship time. Individual `/release patch` runs update incrementally, but over 50 patches the entries drifted.

## Test plan

- [ ] Instruction files only — no runtime code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)