### PR TITLE
v3.33.52 — STAK-433/STAK-434: Market Controls Mobile Fix + Metal Filter Buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.52] - 2026-03-05
+
+### Fixed/Added — STAK-433/STAK-434: Market Controls Mobile Fix + Metal Filter Buttons
+
+- **Fixed**: Mobile market view search bar crushed to 2 characters — added `flex-wrap` to controls row at mobile breakpoint (STAK-433)
+- **Fixed**: Expand/Collapse button text flipped when typing in search — now resets to "Expand All" on every re-render (STAK-433)
+- **Added**: Metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) in market list view header — filter by metal type with color-coded pills matching existing badge palette (STAK-434)
+- **Added**: Mobile responsive pill layout with wrapping and touch-friendly sizing (STAK-434)
+
+---
+
 ## [3.33.51] - 2026-03-05
 
 ### Fixed — STAK-430: Pre-ship Security Hardening

--- a/css/styles.css
+++ b/css/styles.css
@@ -12391,6 +12391,59 @@ th {
 .market-sort-label {
   pointer-events: none;
 }
+/* Metal filter pills */
+.market-filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.market-filter-pill {
+  background: transparent;
+  border: 1px solid var(--border, var(--bs-border-color));
+  border-radius: 14px;
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  color: var(--text-muted, #6c757d);
+}
+.market-filter-pill:hover {
+  border-color: var(--border-hover, #475569);
+  color: var(--text-primary, var(--bs-body-color));
+}
+.market-filter-pill.active[data-metal="all"] {
+  background: var(--bs-primary, #3b82f6);
+  color: #fff;
+  border-color: var(--bs-primary, #3b82f6);
+}
+.market-filter-pill.active[data-metal="gold"] {
+  background: rgba(245,158,11,0.15);
+  color: #f59e0b;
+  border-color: #f59e0b;
+}
+.market-filter-pill.active[data-metal="silver"] {
+  background: rgba(139,147,166,0.15);
+  color: var(--bs-secondary-color, #6c757d);
+  border-color: #6c757d;
+}
+.market-filter-pill.active[data-metal="platinum"] {
+  background: rgba(6,182,212,0.15);
+  color: #06b6d4;
+  border-color: #06b6d4;
+}
+.market-filter-pill.active[data-metal="goldback"] {
+  background: rgba(212,160,23,0.15);
+  color: #d4a017;
+  border-color: #d4a017;
+}
+.market-filter-pill.active[data-metal="palladium"] {
+  background: rgba(148,163,184,0.15);
+  color: #94a3b8;
+  border-color: #94a3b8;
+}
 /* Sync button — status-aware: green=current, amber=stale */
 .market-sync-btn {
   background: transparent;
@@ -12720,6 +12773,8 @@ th {
   .market-header-row { flex-wrap: wrap; gap: 8px; }
   .market-search { width: 100%; flex: unset; min-width: 0; }
   .market-header-controls-right { width: 100%; justify-content: flex-end; }
+  .market-filter-pills { width: 100%; }
+  .market-filter-pill { min-height: 32px; padding: 6px 12px; }
   .market-footer-row { flex-direction: column; align-items: flex-start; gap: 8px; }
   .market-list-card {
     grid-template-columns: 70px 1fr;

--- a/css/styles.css
+++ b/css/styles.css
@@ -12716,6 +12716,7 @@ th {
   .market-card-trend { display: none; }
 }
 @media (max-width: 767px) {
+  .market-header-controls-row { flex-wrap: wrap; }
   .market-header-row { flex-wrap: wrap; gap: 8px; }
   .market-search { width: 100%; flex: unset; min-width: 0; }
   .market-header-controls-right { width: 100%; justify-content: flex-end; }

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
 - **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
 - **Spot Health Dot UX, 7-Day Trend, Timezone Formatting (v3.33.50)**: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281).
 - **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
 - **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
-- **Sync Scope & Serialization (v3.33.47)**: Cloud sync now syncs 44 keys across devices (up from 8) — all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -3719,12 +3719,12 @@
                            placeholder="Search items, metals, vendors..." autocomplete="off"
                            aria-label="Search market items">
                     <div class="market-filter-pills" id="marketFilterPills">
-                      <button class="market-filter-pill active" data-metal="all" type="button">All</button>
-                      <button class="market-filter-pill" data-metal="silver" type="button">Silver</button>
-                      <button class="market-filter-pill" data-metal="gold" type="button">Gold</button>
-                      <button class="market-filter-pill" data-metal="goldback" type="button">Goldback</button>
-                      <button class="market-filter-pill" data-metal="platinum" type="button">Platinum</button>
-                      <button class="market-filter-pill" data-metal="palladium" type="button">Palladium</button>
+                      <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>
+                      <button class="market-filter-pill" data-metal="silver" type="button" aria-pressed="false">Silver</button>
+                      <button class="market-filter-pill" data-metal="gold" type="button" aria-pressed="false">Gold</button>
+                      <button class="market-filter-pill" data-metal="goldback" type="button" aria-pressed="false">Goldback</button>
+                      <button class="market-filter-pill" data-metal="platinum" type="button" aria-pressed="false">Platinum</button>
+                      <button class="market-filter-pill" data-metal="palladium" type="button" aria-pressed="false">Palladium</button>
                     </div>
                     <div class="market-header-controls-right">
                       <div class="market-sort-wrap">

--- a/index.html
+++ b/index.html
@@ -3718,6 +3718,14 @@
                     <input type="search" id="marketSearchInput" class="market-search"
                            placeholder="Search items, metals, vendors..." autocomplete="off"
                            aria-label="Search market items">
+                    <div class="market-filter-pills" id="marketFilterPills">
+                      <button class="market-filter-pill active" data-metal="all" type="button">All</button>
+                      <button class="market-filter-pill" data-metal="silver" type="button">Silver</button>
+                      <button class="market-filter-pill" data-metal="gold" type="button">Gold</button>
+                      <button class="market-filter-pill" data-metal="goldback" type="button">Goldback</button>
+                      <button class="market-filter-pill" data-metal="platinum" type="button">Platinum</button>
+                      <button class="market-filter-pill" data-metal="palladium" type="button">Palladium</button>
+                    </div>
                     <div class="market-header-controls-right">
                       <div class="market-sort-wrap">
                         <span class="market-header-btn market-sort-label">Sort: Name <span class="btn-chevron">&#9662;</span></span>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.52 &ndash; Market Controls Mobile Fix + Metal Filter Buttons</strong>: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434)</li>
     <li><strong>v3.33.51 &ndash; Pre-ship Security Hardening</strong>: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430)</li>
     <li><strong>v3.33.50 &ndash; Spot Health Dot UX, 7-Day Trend, Timezone Formatting</strong>: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281)</li>
     <li><strong>v3.33.49 &ndash; Import/Restore Completeness &amp; Cloud Backup Photos</strong>: Manual cloud backup now has an optional &ldquo;Include photos&rdquo; checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427)</li>
     <li><strong>v3.33.48 &ndash; DiffModal Settings Fix &amp; Empty-Diff Silent Pull</strong>: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417)</li>
-    <li><strong>v3.33.47 &ndash; Sync Scope &amp; Serialization</strong>: Cloud sync now syncs 44 keys across devices (up from 8) &mdash; all preferences, header buttons, feature toggles, and API credentials. Manifest-first pulls now compare and apply settings changes. Photos sync on all pull paths. Deleting all photos propagates deletion to remote (STAK-426)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.51";
+const APP_VERSION = "3.33.52";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -1580,6 +1580,8 @@ const _renderMarketListView = () => {
   footerRow.appendChild(sponsorBadge);
   footer.appendChild(footerRow);
   grid.appendChild(footer);
+  const expandBtn = safeGetElement("marketExpandAllBtn");
+  if (expandBtn) expandBtn.textContent = "Expand All";
 };
 
 /** Debounced search handler for market list view. */

--- a/js/retail.js
+++ b/js/retail.js
@@ -938,6 +938,7 @@ const _marketChartInstances = new Map();
 
 /** Search debounce timer */
 let _marketSearchTimer = null;
+let _marketMetalFilter = "all";
 
 /**
  * Builds a compact vendor link element for the market list card.
@@ -1444,6 +1445,12 @@ const _initMarketCardChart = (slug, detailsEl) => {
  */
 const _getFilteredSortedSlugs = (query, sortKey) => {
   let slugs = [...getActiveRetailSlugs()];
+  if (_marketMetalFilter !== "all") {
+    slugs = slugs.filter((slug) => {
+      const meta = getRetailCoinMeta(slug);
+      return meta.metal === _marketMetalFilter;
+    });
+  }
   if (query && query.trim()) {
     const q = query.trim().toLowerCase();
     slugs = slugs.filter((slug) => {
@@ -1626,6 +1633,18 @@ const _initMarketListViewListeners = () => {
     });
     expandBtn.textContent = allOpen ? "Expand All" : "Collapse All";
   });
+
+  const pillContainer = safeGetElement("marketFilterPills");
+  if (pillContainer) {
+    pillContainer.addEventListener("click", (e) => {
+      const pill = e.target.closest(".market-filter-pill");
+      if (!pill) return;
+      _marketMetalFilter = pill.dataset.metal;
+      pillContainer.querySelectorAll(".market-filter-pill").forEach((p) => p.classList.remove("active"));
+      pill.classList.add("active");
+      _renderMarketListView();
+    });
+  }
 };
 
 // ---------------------------------------------------------------------------

--- a/js/retail.js
+++ b/js/retail.js
@@ -1533,6 +1533,10 @@ const _renderMarketListView = () => {
   // Hide inline disclaimer in list view — disclaimer text lives in the footer instead
   disclaimer.style.display = "none";
 
+  // Reset expand button before any early-return path
+  const expandBtn = safeGetElement("marketExpandAllBtn");
+  if (expandBtn) expandBtn.textContent = "Expand All";
+
   if (_retailSyncInProgress) {
     emptyState.style.display = "none";
     getActiveRetailSlugs().forEach(() => grid.appendChild(_buildSkeletonCard()));
@@ -1587,8 +1591,6 @@ const _renderMarketListView = () => {
   footerRow.appendChild(sponsorBadge);
   footer.appendChild(footerRow);
   grid.appendChild(footer);
-  const expandBtn = safeGetElement("marketExpandAllBtn");
-  if (expandBtn) expandBtn.textContent = "Expand All";
 };
 
 /** Debounced search handler for market list view. */
@@ -1640,8 +1642,12 @@ const _initMarketListViewListeners = () => {
       const pill = e.target.closest(".market-filter-pill");
       if (!pill) return;
       _marketMetalFilter = pill.dataset.metal;
-      pillContainer.querySelectorAll(".market-filter-pill").forEach((p) => p.classList.remove("active"));
+      pillContainer.querySelectorAll(".market-filter-pill").forEach((p) => {
+        p.classList.remove("active");
+        p.setAttribute("aria-pressed", "false");
+      });
       pill.classList.add("active");
+      pill.setAttribute("aria-pressed", "true");
       _renderMarketListView();
     });
   }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.51-b1772694702';
+const CACHE_NAME = 'staktrakr-v3.33.52-b1772694810';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.51-b1772694616';
+const CACHE_NAME = 'staktrakr-v3.33.51-b1772694702';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.51-b1772694502';
+const CACHE_NAME = 'staktrakr-v3.33.51-b1772694616';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.51-b1772694493';
+const CACHE_NAME = 'staktrakr-v3.33.51-b1772694502';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.51-b1772683154';
+const CACHE_NAME = 'staktrakr-v3.33.51-b1772694493';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.52-b1772694810';
+const CACHE_NAME = 'staktrakr-v3.33.52-b1772698948';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.51",
+  "version": "3.33.52",
   "releaseDate": "2026-03-05",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Mobile market view search bar crushed to ~2 chars and sort/expand buttons pushed off-screen — added `flex-wrap: wrap` to controls row at 767px breakpoint (STAK-433)
- **Fixed**: Expand/Collapse button text incorrectly showing "Collapse All" after search re-renders cards — now resets to "Expand All" on every re-render (STAK-433)
- **Added**: Metal filter pill buttons (All / Silver / Gold / Goldback / Platinum / Palladium) in market list view header — click to filter by metal type, works in combination with text search (STAK-434)
- **Added**: Pill colors reuse existing `retail-metal-badge` palette; mobile responsive with wrapping and 32px touch targets (STAK-434)
- **Version**: 3.33.52

## Linear Issues

- [STAK-433](https://linear.app/lbruton/issue/STAK-433): Bug — Mobile market view search bar crushed, controls overflow, expand text flips
- [STAK-434](https://linear.app/lbruton/issue/STAK-434): Enhancement — Metal filter buttons for market view

## Spec

- `.spec-workflow/specs/STAK-433-434-market-controls-mobile-fix-metal-filters/`
- Requirements ✅ → Design ✅ → Tasks ✅ → Implementation (4/4 tasks complete)

## Files Changed

| File | Changes |
|------|---------|
| `css/styles.css` | Mobile `flex-wrap` fix + pill button styles |
| `js/retail.js` | Expand text reset + `_marketMetalFilter` state + filter logic + pill listeners |
| `index.html` | 6 pill buttons in market header |
| `js/constants.js` | Version bump to 3.33.52 |
| `js/about.js` | What's New entry |
| `CHANGELOG.md` | v3.33.52 section |
| `docs/announcements.md` | v3.33.52 entry |
| `version.json` | Version bump |

🤖 Generated with [Claude Code](https://claude.com/claude-code)