### PR TITLE
v3.33.53 — STAK-431: Numista N# search image URL + metal auto-population

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -312,13 +312,22 @@ Commit message format: `vNEW_VERSION — TITLE`
 
 If there are other uncommitted changes beyond the 5 version files, ask the user whether to include them in this commit or leave them staged separately.
 
-**After a successful commit, dispatch a background wiki update:**
+**After a successful commit, run wiki update (BLOCKING — must complete before PR):**
 
-Invoke the `wiki-update` skill (Skill tool) as a background Task agent. It identifies
-which wiki pages were affected by this patch and updates in-repo `wiki/`.
-Do not wait for it — proceed to Phase 4 immediately.
+Invoke the `wiki-update` skill (Skill tool). It identifies which wiki pages were
+affected by this patch and updates in-repo `wiki/`. **This is a blocking step.**
+Wiki changes MUST be committed to the patch branch BEFORE proceeding to Phase 4.
+Do NOT push or create a PR until wiki updates are committed.
 
-**After a successful commit, push the patch branch and open a PR to dev** (Phase 4 covers this).
+If wiki-update produces changes, commit them on the same patch branch:
+```bash
+git add wiki/
+git commit -m "docs: update wiki pages for vVERSION"
+```
+
+If wiki-update finds no affected pages, it exits with a no-op message — proceed to Phase 4.
+
+**After wiki is committed, push the patch branch and open a PR to dev** (Phase 4 covers this).
 **After the PR is merged to dev — tag the patch commit on dev and run worktree cleanup:**
 
 ```bash
@@ -347,6 +356,22 @@ git push origin --delete patch/VERSION
 
 > **⚠️ PR target reminder:** `patch/VERSION` → **`dev`** (QA preview). `dev` → `main` only via Phase 4.5, only when user says ready. Never create a patch PR targeting main.
 
+### Pre-flight check (HARD GATE)
+
+Before pushing, verify the branch is complete:
+
+```bash
+# 1. Wiki must be committed — no orphaned wiki changes
+git diff --name-only wiki/ | grep -c . && echo "FAIL: uncommitted wiki changes" || echo "OK: wiki clean"
+
+# 2. All version files present in commit history
+git log --oneline --name-only HEAD~3..HEAD | grep -E '(wiki/|js/constants|CHANGELOG)' || echo "WARNING: check commit contents"
+```
+
+If uncommitted wiki changes exist, commit them before pushing. **Do NOT create a PR with pending wiki updates.**
+
+### Step 1: Push and create PR
+
 1. Push the patch branch:
    ```bash
    git push origin patch/VERSION
@@ -373,6 +398,20 @@ git push origin --delete patch/VERSION
    ```
 
 3. (Optional — requires Linear MCP) If Linear issues are referenced, update status to **In Progress** (not Done — that happens at merge time).
+
+### Step 2: PR Resolution & Scan Monitoring (MANDATORY)
+
+After the PR is created, **do not walk away**. Complete these steps:
+
+1. **Wait for CI/Codacy scans** to start (usually 30-60 seconds after push)
+2. **Run `/pr-resolve`** to monitor and resolve review threads as they appear
+3. **Check scan results**: `gh pr checks <PR_NUMBER>` — wait for all checks to complete
+4. **Address any Codacy/Copilot findings** — fix issues, push follow-up commits, re-run `/pr-resolve`
+5. **Confirm the PR is clean** — all checks passing, no unresolved threads
+
+The PR should be ready for the user to merge with a single click. Do not leave unresolved threads or failing checks for the user to clean up.
+
+> **The PR is not "done" until it's clean.** A draft PR with failing scans and unresolved threads is incomplete work.
 
 > **No `dev → main` PR here.** The patch branch PRs to `dev` only. The `dev → main` PR is created at Phase 4.5, using version tags on `dev` as the changelog source. Do not create or touch any PR targeting `main` during Phase 4.
 

--- a/.claude/skills/wiki-update/SKILL.md
+++ b/.claude/skills/wiki-update/SKILL.md
@@ -10,7 +10,9 @@ Called automatically from `/release patch` Phase 3 after the version bump commit
 Identifies which wiki pages are affected by this patch's diff, rewrites only those
 pages, and commits the changes with the same patch branch. No separate PR needed.
 
-Runs as a background Task agent — Phase 4 (PR creation) does not wait.
+**BLOCKING step** — Phase 4 (push & PR creation) MUST wait for wiki updates to
+complete and be committed before proceeding. Wiki changes that land after the PR
+is created are orphaned and never make it into the PR.
 
 ---
 
@@ -193,8 +195,10 @@ Wiki update: no relevant files changed — skipping.
 
 This skill is invoked after the version bump commit in Phase 3 of `/release patch`:
 
-> After committing the version bump, invoke the `wiki-update` skill via the Skill
-> tool as a background Task agent. Do not wait for it before proceeding to Phase 4.
+> After committing the version bump, invoke the `wiki-update` skill. This is a
+> **blocking step** — wiki changes MUST be committed to the patch branch before
+> Phase 4 (push & PR creation). Do NOT proceed to Phase 4 until wiki updates
+> are committed or confirmed as a no-op.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.53] - 2026-03-05
+
+### Fixed — STAK-431: Numista N# Search Image URL + Metal Auto-Population
+
+- **Fixed**: Numista N# search now auto-populates obverse and reverse image URLs into inventory items — images appear immediately in table and card views without manual re-download (STAK-431)
+- **Fixed**: Metal type is now auto-detected from Numista composition data and pre-selected in the form dropdown for gold, silver, platinum, and palladium items (STAK-431)
+- **Added**: Field picker now shows Obverse Image, Reverse Image, and Metal checkboxes — users can opt out of any field before filling (STAK-431)
+
+---
+
 ## [3.33.52] - 2026-03-05
 
 ### Fixed/Added — STAK-433/STAK-434: Market Controls Mobile Fix + Metal Filter Buttons

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Works on `file://` and HTTP. Runtime artifact: zero build step, zero install. Se
 
 ## Wiki — Project Technical Documentation
 
-`wiki/` (in-repo) is the **only** technical documentation for this project. There are no other doc sources. **After every code change, update the relevant wiki page(s) in the same PR.** Use `/wiki-update` to auto-detect affected pages via frontmatter `sourceFiles`. For widespread changes, use `/wiki-sweep`.
+`wiki/` (in-repo) is the **only** technical documentation for this project. There are no other doc sources. **Wiki updates MUST be committed to the branch BEFORE pushing or creating a PR.** This is a blocking step — wiki changes after PR creation are orphaned. Use `/wiki-update` (blocking) to auto-detect affected pages via frontmatter `sourceFiles`. For widespread changes, use `/wiki-sweep`.
 
 If a wiki page would become inaccurate after your change, updating it is not optional — treat it as part of the PR diff.
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,11 @@
 ## What's New
 
+- **Numista N# Search Image URL + Metal Auto-Population (v3.33.53)**: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431).
 - **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
 - **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
 - **Spot Health Dot UX, 7-Day Trend, Timezone Formatting (v3.33.50)**: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281).
 - **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
-- **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
+- **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings included in selectedChanges. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.53 &ndash; Numista N# Search Image URL + Metal Auto-Population</strong>: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431)</li>
     <li><strong>v3.33.52 &ndash; Market Controls Mobile Fix + Metal Filter Buttons</strong>: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434)</li>
     <li><strong>v3.33.51 &ndash; Pre-ship Security Hardening</strong>: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430)</li>
     <li><strong>v3.33.50 &ndash; Spot Health Dot UX, 7-Day Trend, Timezone Formatting</strong>: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281)</li>
     <li><strong>v3.33.49 &ndash; Import/Restore Completeness &amp; Cloud Backup Photos</strong>: Manual cloud backup now has an optional &ldquo;Include photos&rdquo; checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427)</li>
-    <li><strong>v3.33.48 &ndash; DiffModal Settings Fix &amp; Empty-Diff Silent Pull</strong>: DiffModal Apply button now correctly detects pending settings changes. Settings are included in selectedChanges instead of being silently dropped. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417)</li>
   `;
 };
 

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1307,6 +1307,7 @@ const renderNumistaFieldCheckboxes = (result) => {
   if (!container) return;
 
   const typeValid = result.type && isValidSelectOption('itemType', result.type);
+  const metalValid = result.metal && result.metal !== 'Alloy/Other' && isValidSelectOption('itemMetal', result.metal);
 
   // Fields ordered: primary (checked by default) first, then optional (unchecked)
   const fields = [
@@ -1321,6 +1322,9 @@ const renderNumistaFieldCheckboxes = (result) => {
       warn: result.type && !typeValid ? `"${result.type}" — not in form options` : ''
     },
     { key: 'weight', label: 'Weight (g)', value: result.weight ? String(result.weight) : '', available: result.weight > 0, defaultOn: result.weight > 0 },
+    { key: 'obverseImage', label: 'Obverse Image', value: result.imageUrl || '', available: !!result.imageUrl, defaultOn: true },
+    { key: 'reverseImage', label: 'Reverse Image', value: result.reverseImageUrl || '', available: !!result.reverseImageUrl, defaultOn: true },
+    { key: 'metal', label: 'Metal', value: result.metal || '', available: metalValid, defaultOn: metalValid, warn: result.metal && !metalValid ? `"${result.metal}" — not in form options` : '' },
   ];
 
   // Keep the heading, rebuild field rows
@@ -1342,6 +1346,9 @@ const renderNumistaFieldCheckboxes = (result) => {
     year: (elements.itemYear || document.getElementById('itemYear'))?.value?.trim() || '',
     type: (elements.itemType || document.getElementById('itemType'))?.value || '',
     weight: (elements.itemWeight || document.getElementById('itemWeight'))?.value?.trim() || '',
+    obverseImage: (elements.itemObverseImageUrl || document.getElementById('itemObverseImageUrl'))?.value?.trim() || '',
+    reverseImage: (elements.itemReverseImageUrl || document.getElementById('itemReverseImageUrl'))?.value?.trim() || '',
+    metal: (elements.itemMetal || document.getElementById('itemMetal'))?.value || '',
   };
 
   fields.forEach(f => {
@@ -1633,6 +1640,24 @@ const fillFormFromNumistaResult = () => {
       case 'catalog': {
         const el = elements.itemCatalog || document.getElementById('itemCatalog');
         if (el) el.value = val;
+        break;
+      }
+      case 'obverseImage': {
+        const el = elements.itemObverseImageUrl || document.getElementById('itemObverseImageUrl');
+        if (el && !el.value.trim()) el.value = val;
+        break;
+      }
+      case 'reverseImage': {
+        const el = elements.itemReverseImageUrl || document.getElementById('itemReverseImageUrl');
+        if (el && !el.value.trim()) el.value = val;
+        break;
+      }
+      case 'metal': {
+        const el = elements.itemMetal || document.getElementById('itemMetal');
+        if (el) {
+          const valid = Array.from(el.options).map(o => o.value);
+          if (valid.includes(val)) el.value = val;
+        }
         break;
       }
     }

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.52";
+const APP_VERSION = "3.33.53";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.52-b1772698948';
+const CACHE_NAME = 'staktrakr-v3.33.53-b1772746037';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.52",
+  "version": "3.33.53",
   "releaseDate": "2026-03-05",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -2,8 +2,8 @@
 title: Frontend Overview
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.44
-date: 2026-03-03
+lastUpdated: v3.33.52
+date: 2026-03-05
 sourceFiles:
   - index.html
   - js/constants.js
@@ -17,7 +17,7 @@ relatedPages:
 ---
 # Frontend Overview
 
-> **Last updated:** v3.33.44 — 2026-03-03
+> **Last updated:** v3.33.52 — 2026-03-05
 > **Source files:** `index.html`, `js/constants.js`, `sw.js`, `js/file-protocol-fix.js`
 
 ## Overview
@@ -76,7 +76,7 @@ index.html  (single-page app — all UI panels, modals, and sections)
 Branch  Release  Patch
 ```
 
-Current version: **3.33.44**
+Current version: **3.33.52**
 
 Optional state suffixes: `a` = alpha, `b` = beta, `rc` = release candidate.
 

--- a/wiki/retail-modal.md
+++ b/wiki/retail-modal.md
@@ -2,8 +2,8 @@
 title: Retail Modal
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.50
-date: 2026-03-04
+lastUpdated: v3.33.52
+date: 2026-03-05
 sourceFiles:
   - js/retail-view-modal.js
   - js/retail.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Retail Modal
 
-> **Last updated:** v3.33.50 — 2026-03-04
+> **Last updated:** v3.33.52 — 2026-03-05
 > **Source files:** `js/retail-view-modal.js`, `js/retail.js`
 
 ## Overview
@@ -54,6 +54,8 @@ On open, the modal displays cached data from localStorage immediately, then fire
 - Manifest-driven slug/metadata resolution: `getActiveRetailSlugs`, `getRetailCoinMeta`, `getVendorDisplay`.
 - The sync log, sync-in-progress flags, and error state. The sync log Time column uses timezone-aware formatting via `TIMEZONE_KEY` from localStorage, matching the `_fmtIntradayTime` pattern in `retail-view-modal.js`. Falls back gracefully if the stored timezone is invalid.
 - Rendering of all card/list views (grid view, market list view, sparklines).
+- Metal filter pill state (`_marketMetalFilter`) and filtering logic in `_getFilteredSortedSlugs()` — filters slugs by `getRetailCoinMeta(slug).metal` when a pill other than "All" is active.
+- Expand/Collapse button text reset — `_renderMarketListView()` resets `marketExpandAllBtn` to "Expand All" on every re-render (search, filter change), since newly rendered cards are always collapsed.
 - Card-level trend indicators via `_computeRetailTrend(slug)`, which sorts history by date descending before comparing the two most recent entries to determine trend direction.
 
 **`retail-view-modal.js`** owns:
@@ -79,6 +81,13 @@ Declared in `retail.js`. All three maps must be updated together when adding a n
 | `bullionexchanges` | BullionX | `#f472b6` bright pink |
 | `summitmetals` | Summit | `#22d3ee` bright cyan |
 | `goldback` | Goldback | `#d4a017` deep gold |
+
+### Module-Level State (retail.js — market list view)
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `_marketMetalFilter` | `string` | Active metal filter pill value: `"all"`, `"silver"`, `"gold"`, `"goldback"`, `"platinum"`, or `"palladium"` |
+| `_marketSearchTimer` | `number \| null` | Search input debounce timer |
 
 ### Module-Level State (retail-view-modal.js)
 

--- a/wiki/vendor-quirks.md
+++ b/wiki/vendor-quirks.md
@@ -2,8 +2,8 @@
 title: Vendor Quirks
 category: infrastructure
 owner: staktrakr
-lastUpdated: v3.33.50
-date: 2026-03-04
+lastUpdated: v3.33.52
+date: 2026-03-05
 sourceFiles:
   - js/retail.js
   - js/api.js


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Numista N# search now auto-populates obverse and reverse image URLs into inventory items — images appear immediately in table and card views without manual re-download
- **Fixed**: Metal type auto-detected from Numista composition data and pre-selected in form dropdown for gold, silver, platinum, and palladium items
- **Added**: Field picker shows Obverse Image, Reverse Image, and Metal checkboxes with opt-out control
- Existing user-provided URLs are not overwritten (empty guard)
- Alloy/Other metals are excluded from auto-fill (avoids false classification)

## Files Changed

- `js/catalog-api.js` — extended `renderNumistaFieldCheckboxes()` (+3 fields) and `fillFormFromNumistaResult()` (+3 switch cases)
- Version bump files (constants.js, CHANGELOG.md, announcements.md, about.js, version.json, sw.js)

## Linear Issues

- [STAK-431: Numista N# search does not auto-populate image URLs into inventory items](https://linear.app/lbruton/issue/STAK-431)

🤖 Generated with [Claude Code](https://claude.com/claude-code)