### PR TITLE
v3.33.54 — STAK-448: Dateless items sort as oldest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.54] - 2026-03-05
+
+### Fixed — STAK-448: Dateless Items Sort as Oldest
+
+- **Fixed**: Dateless items (blank/unknown purchase date) now sort as "infinitely old" — top when oldest-first, bottom when newest-first, instead of always pinned to bottom regardless of direction (STAK-448)
+
+---
+
 ## [3.33.53] - 2026-03-05
 
 ### Fixed — STAK-431: Numista N# Search Image URL + Metal Auto-Population

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -5,6 +5,8 @@
 - **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
 - **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
 - **Spot Health Dot UX, 7-Day Trend, Timezone Formatting (v3.33.50)**: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281).
+- **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
+- **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings included in selectedChanges. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 
 ## Development Roadmap
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **Dateless Items Sort as Oldest (v3.33.54)**: Items with no purchase date now sort as "infinitely old" — top when oldest-first, bottom when newest-first (STAK-448).
 - **Numista N# Search Image URL + Metal Auto-Population (v3.33.53)**: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431).
 - **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
 - **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
 - **Spot Health Dot UX, 7-Day Trend, Timezone Formatting (v3.33.50)**: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281).
-- **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
-- **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings included in selectedChanges. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.54 &ndash; Dateless Items Sort as Oldest</strong>: Items with no purchase date now sort as &ldquo;infinitely old&rdquo; &mdash; top when oldest-first, bottom when newest-first (STAK-448)</li>
     <li><strong>v3.33.53 &ndash; Numista N# Search Image URL + Metal Auto-Population</strong>: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431)</li>
     <li><strong>v3.33.52 &ndash; Market Controls Mobile Fix + Metal Filter Buttons</strong>: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434)</li>
     <li><strong>v3.33.51 &ndash; Pre-ship Security Hardening</strong>: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430)</li>
     <li><strong>v3.33.50 &ndash; Spot Health Dot UX, 7-Day Trend, Timezone Formatting</strong>: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281)</li>
-    <li><strong>v3.33.49 &ndash; Import/Restore Completeness &amp; Cloud Backup Photos</strong>: Manual cloud backup now has an optional &ldquo;Include photos&rdquo; checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.53";
+const APP_VERSION = "3.33.54";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -69,13 +69,13 @@ const sortInventory = (data = inventory) => {
     const valA = aWrapper.val;
     const valB = bWrapper.val;
 
-    // Special handling for date: empty/unknown dates should always sort to the bottom
+    // Special handling for date: empty/unknown dates sort as "infinitely old"
     if (sortColumn === 0) {
       // Simple numeric comparison for pre-calculated timestamps
-      // Handle Infinity (Empty)
+      // Dateless items = oldest: top when asc, bottom when desc
       if (valA === Infinity && valB === Infinity) return 0;
-      if (valA === Infinity) return 1; // Empty always at bottom
-      if (valB === Infinity) return -1; // Empty always at bottom
+      if (valA === Infinity) return sortDirection === 'asc' ? -1 : 1;
+      if (valB === Infinity) return sortDirection === 'asc' ? 1 : -1;
 
       return sortDirection === 'asc' ? valA - valB : valB - valA;
     }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.53-b1772746037';
+const CACHE_NAME = 'staktrakr-v3.33.54-b1772751294';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.53",
+  "version": "3.33.54",
   "releaseDate": "2026-03-05",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Dateless items (blank/unknown purchase date) now sort as "infinitely old" — top when oldest-first, bottom when newest-first, instead of always pinned to bottom regardless of direction (STAK-448)

## Fix

`js/sorting.js` — the date comparator used `Infinity` as sentinel for dateless items and always returned `1` (bottom). Now respects `sortDirection`: `asc` → dateless first, `desc` → dateless last.

## Linear Issues

- [STAK-448: Dateless items always sort to bottom — should sort as oldest](https://linear.app/lbruton/issue/STAK-448)

🤖 Generated with [Claude Code](https://claude.com/claude-code)