### PR TITLE
v3.33.55 — STAK-449: Dropbox Multi-Account UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.55] - 2026-03-06
+
+### Added — STAK-449: Dropbox Multi-Account UX
+
+- **Added**: Connected Dropbox account email and display name now shown in the Cloud settings card below the status indicator (STAK-449)
+- **Added**: "Switch Account" button disconnects the current Dropbox account and re-triggers OAuth with forced re-authentication so users can pick a different account (STAK-449)
+- **Added**: "Sign out of Dropbox" helper link opens the Dropbox logout page in a new tab for clearing browser sessions (STAK-449)
+
+---
+
 ## [3.33.54] - 2026-03-05
 
 ### Fixed — STAK-448: Dateless Items Sort as Oldest

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,12 +1,10 @@
 ## What's New
 
+- **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449).
 - **Dateless Items Sort as Oldest (v3.33.54)**: Items with no purchase date now sort as "infinitely old" — top when oldest-first, bottom when newest-first (STAK-448).
 - **Numista N# Search Image URL + Metal Auto-Population (v3.33.53)**: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431).
 - **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
 - **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
-- **Spot Health Dot UX, 7-Day Trend, Timezone Formatting (v3.33.50)**: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281).
-- **Import/Restore Completeness & Cloud Backup Photos (v3.33.49)**: Manual cloud backup now has an optional "Include photos" checkbox. ZIP and vault restore blocked during active sync. Wiki updated with snapshot terminology and restore warnings (STAK-427).
-- **DiffModal Settings Fix & Empty-Diff Silent Pull (v3.33.48)**: DiffModal Apply button now correctly detects pending settings changes. Settings included in selectedChanges. Manifest-first pull returns silently when no changes detected (STAK-387, STAK-401, STAK-415, STAK-417).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -3412,12 +3412,26 @@
                       </div>
                     </div>
 
+                    <!-- STAK-449: Account info row (visible when connected) -->
+                    <div class="cloud-status-row" id="cloudDropboxAccountInfo" style="display:none">
+                      <span class="cloud-status-label">Account</span>
+                      <span class="cloud-status-value" id="cloudDropboxAccountText"></span>
+                    </div>
+
                     <!-- Connect button (shown when disconnected) -->
                     <div class="cloud-login-area" style="margin-top:0.5rem;display:flex;gap:0.4rem;flex-wrap:wrap">
                       <button class="btn cloud-connect-btn" data-provider="dropbox" style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
                         Connect
                       </button>
+                      <button class="btn cloud-switch-account-btn" data-provider="dropbox" style="display:none;font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><polyline points="17 11 19 13 23 9"/></svg>
+                        Switch Account
+                      </button>
+                    </div>
+                    <div id="cloudDropboxSignoutLink" style="display:none;margin-top:0.3rem">
+                      <a href="https://www.dropbox.com/logout" target="_blank" rel="noopener noreferrer"
+                         style="font-size:0.72rem;color:var(--text-secondary);text-decoration:underline">Sign out of Dropbox</a>
                     </div>
 
                     <!-- Auto-sync toggle + sync status -->

--- a/index.html
+++ b/index.html
@@ -3424,7 +3424,7 @@
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
                         Connect
                       </button>
-                      <button class="btn cloud-switch-account-btn" data-provider="dropbox" style="display:none;font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
+                      <button id="cloudSwitchAccountBtn_dropbox" class="btn cloud-switch-account-btn" data-provider="dropbox" style="display:none;font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><polyline points="17 11 19 13 23 9"/></svg>
                         Switch Account
                       </button>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449)</li>
     <li><strong>v3.33.54 &ndash; Dateless Items Sort as Oldest</strong>: Items with no purchase date now sort as &ldquo;infinitely old&rdquo; &mdash; top when oldest-first, bottom when newest-first (STAK-448)</li>
     <li><strong>v3.33.53 &ndash; Numista N# Search Image URL + Metal Auto-Population</strong>: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431)</li>
     <li><strong>v3.33.52 &ndash; Market Controls Mobile Fix + Metal Filter Buttons</strong>: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434)</li>
     <li><strong>v3.33.51 &ndash; Pre-ship Security Hardening</strong>: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430)</li>
-    <li><strong>v3.33.50 &ndash; Spot Health Dot UX, 7-Day Trend, Timezone Formatting</strong>: Spot dot shows orange (syncing) instead of red on fresh installs. Dot respects cache TTL for green status. 7-day trend sorts by date for correct direction. Sync log timestamps respect timezone preference (STAK-429, STAK-408, STAK-384, STAK-399, STAK-281)</li>
   `;
 };
 

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -521,7 +521,7 @@ async function cloudExchangeCode(code, state) {
           console.warn('[CloudStorage] get_current_account returned no data');
         }
       } catch (e) {
-        console.warn('[CloudStorage] Failed to fetch Dropbox profile — connection still works.', e);
+        console.warn('[CloudStorage] Failed to fetch Dropbox profile — connection still works.');
       }
     }
     sessionStorage.removeItem('cloud_oauth_state');
@@ -1162,7 +1162,7 @@ function syncCloudUI() {
     if (key === 'dropbox') {
       const acctInfoRow = safeGetElement('cloudDropboxAccountInfo');
       const acctText = safeGetElement('cloudDropboxAccountText');
-      const switchBtn = document.querySelector('.cloud-switch-account-btn[data-provider="dropbox"]');
+      const switchBtn = safeGetElement('cloudSwitchAccountBtn_dropbox');
       const signoutDiv = safeGetElement('cloudDropboxSignoutLink');
 
       if (connected) {

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -1158,6 +1158,36 @@ function syncCloudUI() {
       if (textEl) textEl.textContent = connected ? 'Connected' : 'Not connected';
     }
 
+    // STAK-449: Display connected Dropbox account identity
+    if (key === 'dropbox') {
+      const acctInfoRow = safeGetElement('cloudDropboxAccountInfo');
+      const acctText = safeGetElement('cloudDropboxAccountText');
+      const switchBtn = document.querySelector('.cloud-switch-account-btn[data-provider="dropbox"]');
+      const signoutDiv = safeGetElement('cloudDropboxSignoutLink');
+
+      if (connected) {
+        const email = localStorage.getItem('cloud_dropbox_email');
+        const displayName = localStorage.getItem('cloud_dropbox_display_name');
+        let label = 'Unknown account';
+        if (displayName && email) {
+          label = displayName + ' (' + email + ')';
+        } else if (email) {
+          label = email;
+        } else if (displayName) {
+          label = displayName;
+        }
+        if (acctInfoRow) acctInfoRow.style.display = '';
+        if (acctText) acctText.textContent = label;
+        if (switchBtn) switchBtn.style.display = '';
+        if (signoutDiv) signoutDiv.style.display = '';
+      } else {
+        if (acctInfoRow) acctInfoRow.style.display = 'none';
+        if (acctText) acctText.textContent = '';
+        if (switchBtn) switchBtn.style.display = 'none';
+        if (signoutDiv) signoutDiv.style.display = 'none';
+      }
+    }
+
     // Update sync & item count rows
     var syncEl = card.querySelector('.cloud-status-sync');
     var itemsEl = card.querySelector('.cloud-status-items');

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -331,7 +331,7 @@ async function cloudGetToken(provider) {
 // OAuth popup flow
 // ---------------------------------------------------------------------------
 
-function cloudAuthStart(provider) {
+function cloudAuthStart(provider, options) {
   var config = CLOUD_PROVIDERS[provider];
   if (!config) return;
 
@@ -345,6 +345,11 @@ function cloudAuthStart(provider) {
     state: state,
     token_access_type: 'offline',
   });
+
+  // STAK-449: Force Dropbox to show account picker for multi-account switching
+  if (options && options.forceReauth && provider === 'dropbox') {
+    params.set('force_reauthentication', 'true');
+  }
 
   // Open popup synchronously (in click handler context) to avoid popup blockers,
   // then navigate it after the async PKCE challenge is computed.
@@ -478,34 +483,45 @@ async function cloudExchangeCode(code, state) {
     };
     cloudStoreToken(provider, tokenData);
 
-    // Store Dropbox account ID for key derivation.
+    // Store Dropbox account ID for key derivation and profile info for multi-account UX (STAK-449).
     // The token exchange response includes account_id — grab it directly (synchronous, no race).
-    // Fall back to get_current_account API only if the token response didn't include it.
+    // Always call get_current_account to fetch email + display_name (not in token response).
     if (provider === 'dropbox') {
       if (data.account_id) {
         localStorage.setItem('cloud_dropbox_account_id', data.account_id);
         // STAK-398 diagnostic: MUST use console.warn (not debugWarn) so it's always visible
         console.warn('[CloudStorage] Stored Dropbox account_id from token exchange: present');
-      } else {
-        // Fallback: fetch account ID from API — awaited so syncCloudUI runs after account_id is stored
-        console.warn('[CloudStorage] Token exchange did NOT include account_id — fetching from API');
-        try {
-          var acctResp = await fetch('https://api.dropboxapi.com/2/users/get_current_account', {
-            method: 'POST',
-            headers: {
-              Authorization: 'Bearer ' + tokenData.access_token,
-              'Content-Type': 'application/json',
-            },
-            body: 'null',
-          });
-          var info = acctResp.ok ? await acctResp.json() : null;
-          if (info && info.account_id) {
+      }
+
+      // Always fetch full profile — email and display_name are only available via this API
+      try {
+        let acctResp = await fetch('https://api.dropboxapi.com/2/users/get_current_account', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer ' + tokenData.access_token,
+            'Content-Type': 'application/json',
+          },
+          body: 'null',
+        });
+        let info = acctResp.ok ? await acctResp.json() : null;
+        if (info) {
+          if (info.account_id) {
             localStorage.setItem('cloud_dropbox_account_id', info.account_id);
-            console.warn('[CloudStorage] Stored Dropbox account_id from API fallback: present');
-          } else {
-            console.warn('[CloudStorage] API fallback FAILED to get account_id');
+            console.warn('[CloudStorage] Stored Dropbox account_id from API: present');
           }
-        } catch (e) { console.warn('[CloudStorage] Failed to fetch Dropbox account ID.'); }
+          if (info.email) {
+            localStorage.setItem('cloud_dropbox_email', info.email);
+            console.warn('[CloudStorage] Stored Dropbox email: present');
+          }
+          if (info.name && info.name.display_name) {
+            localStorage.setItem('cloud_dropbox_display_name', info.name.display_name);
+            console.warn('[CloudStorage] Stored Dropbox display_name: present');
+          }
+        } else {
+          console.warn('[CloudStorage] get_current_account returned no data');
+        }
+      } catch (e) {
+        console.warn('[CloudStorage] Failed to fetch Dropbox profile — connection still works.', e);
       }
     }
     sessionStorage.removeItem('cloud_oauth_state');
@@ -573,6 +589,8 @@ function cloudDisconnect(provider) {
   var keysToRemove = [
     'cloud_last_backup',
     'cloud_dropbox_account_id',
+    'cloud_dropbox_email',
+    'cloud_dropbox_display_name',
     'cloud_vault_password',
     'cloud_sync_enabled',
     'cloud_sync_device_id',

--- a/js/constants.js
+++ b/js/constants.js
@@ -971,6 +971,8 @@ const ALLOWED_STORAGE_KEYS = [
   CLOUD_VAULT_IDLE_TIMEOUT_KEY,                // number string: vault password idle lock timeout in minutes (15|30|60|120|0=never)
   "cloud_sync_mode",                           // DEPRECATED: kept for migration only — will be removed after v3.33
   "cloud_dropbox_account_id",                  // string: Dropbox account_id for Simple mode key derivation
+  "cloud_dropbox_email",                       // string: Dropbox account email for multi-account UX (STAK-449)
+  "cloud_dropbox_display_name",                // string: Dropbox display name for multi-account UX (STAK-449)
   "cloud_vault_password",                      // string: user vault password stored for persistent unlock
   STORAGE_PERSIST_GRANTED_KEY,                         // boolean string: "true"/"false" — storage persistence grant flag
   "headerBtnOrder",                                    // JSON array: header button card order (STAK-320)
@@ -995,6 +997,8 @@ const VAULT_EXCLUDE_KEYS = [
   'cloud_token_pcloud',
   'cloud_token_box',
   'cloud_dropbox_account_id',
+  'cloud_dropbox_email',
+  'cloud_dropbox_display_name',
   'cloud_vault_password',
   'cloud_sync_device_id',
   'cloud_sync_cursor',

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.54";
+const APP_VERSION = "3.33.55";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1163,6 +1163,10 @@ const bindCloudStorageListeners = () => {
     } else if (btn.classList.contains('cloud-disconnect-btn')) {
       if (typeof cloudDisconnect === 'function') cloudDisconnect(provider);
 
+    } else if (btn.classList.contains('cloud-switch-account-btn')) {
+      if (typeof cloudDisconnect === 'function') cloudDisconnect(provider);
+      if (typeof cloudAuthStart === 'function') cloudAuthStart(provider, { forceReauth: true });
+
     } else if (btn.classList.contains('cloud-backup-btn')) {
       await _cloudBtnAction(btn, 'Checking\u2026', async () => {
         var conflict = await cloudCheckConflict(provider);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.54-b1772763152';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772763351';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.54-b1772751294';
+const CACHE_NAME = 'staktrakr-v3.33.54-b1772762959';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.54-b1772762959';
+const CACHE_NAME = 'staktrakr-v3.33.54-b1772763152';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772763351';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772764737';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.54",
-  "releaseDate": "2026-03-05",
+  "version": "3.33.55",
+  "releaseDate": "2026-03-06",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,8 +2,8 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.51
-date: 2026-03-04
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - js/cloud-storage.js
   - js/cloud-sync.js

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -2,8 +2,8 @@
 title: Data Model
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.46
-date: 2026-03-04
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - js/constants.js
   - js/utils.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Data Model
 
-> **Last updated:** v3.33.46 — 2026-03-04
+> **Last updated:** v3.33.55 — 2026-03-06
 > **Source files:** `js/constants.js`, `js/utils.js`, `js/types.js`
 
 ## Overview
@@ -376,6 +376,8 @@ All keys currently registered in `js/constants.js`. `cleanupStorage()` enforces 
 | `cloud_vault_idle_timeout` | Number string | Vault idle lock timeout in minutes |
 | `cloud_vault_password` | String | Vault password for persistent unlock |
 | `cloud_dropbox_account_id` | String | Dropbox account_id for key derivation |
+| `cloud_dropbox_email` | String | Dropbox account email for multi-account UX (STAK-449) |
+| `cloud_dropbox_display_name` | String | Dropbox display name for multi-account UX (STAK-449) |
 | `cloud_sync_mode` | String | DEPRECATED — kept for migration only |
 | `cloud_sync_migrated` | String | Cloud folder migration flag — `"v2"` indicates flat-to-subfolder migration complete |
 | `cloud_backup_history_depth` | String | Max cloud backups to retain (`"3"`, `"5"`, `"10"`, or `"20"`) |

--- a/wiki/dom-patterns.md
+++ b/wiki/dom-patterns.md
@@ -2,8 +2,8 @@
 title: DOM Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.44
-date: 2026-03-03
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - js/utils.js
   - js/about.js

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -2,8 +2,8 @@
 title: Frontend Overview
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.52
-date: 2026-03-05
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - index.html
   - js/constants.js

--- a/wiki/release-workflow.md
+++ b/wiki/release-workflow.md
@@ -2,8 +2,8 @@
 title: Release Workflow
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.44
-date: 2026-03-03
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - .claude/skills/release/SKILL.md
   - .claude/skills/ship/SKILL.md

--- a/wiki/service-worker.md
+++ b/wiki/service-worker.md
@@ -2,8 +2,8 @@
 title: Service Worker
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.25
-date: 2026-03-02
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - sw.js
   - devops/hooks/stamp-sw-cache.sh

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -2,8 +2,8 @@
 title: Storage Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.46
-date: 2026-03-04
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - js/utils.js
   - js/constants.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Storage Patterns
 
-> **Last updated:** v3.33.46 — 2026-03-04
+> **Last updated:** v3.33.55 — 2026-03-06
 > **Source files:** `js/utils.js`, `js/constants.js`
 
 ## Overview
@@ -279,6 +279,8 @@ All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. A
 | `"cloud_sync_cursor"` | string | Dropbox rev string for change detection |
 | `"cloud_sync_override_backup"` | JSON | Pre-pull local snapshot |
 | `"cloud_dropbox_account_id"` | string | Dropbox account_id for key derivation |
+| `"cloud_dropbox_email"` | string | Dropbox account email for multi-account UX (STAK-449) |
+| `"cloud_dropbox_display_name"` | string | Dropbox display name for multi-account UX (STAK-449) |
 | `"cloud_vault_password"` | string | Vault password for persistent unlock |
 | `CLOUD_VAULT_IDLE_TIMEOUT_KEY` | number string | Vault idle lock timeout in minutes |
 | `"cloud_backup_history_depth"` | string | Max cloud backups to retain |
@@ -376,7 +378,7 @@ See [sync-cloud.md](sync-cloud.md) for the full cloud sync architecture.
 
 ### Vault Export Exclusions (STAK-425, v3.33.46)
 
-`VAULT_EXCLUDE_KEYS` in `js/constants.js` lists 14 keys that are stripped from portable full-vault exports (`collectVaultData('full')` in `js/vault.js`). These keys remain in `ALLOWED_STORAGE_KEYS` (so `cleanupStorage` does not delete them) but are excluded from `.stvault` exports to prevent shipping live OAuth tokens, vault passwords, and device-specific sync state:
+`VAULT_EXCLUDE_KEYS` in `js/constants.js` lists 16 keys that are stripped from portable full-vault exports (`collectVaultData('full')` in `js/vault.js`). These keys remain in `ALLOWED_STORAGE_KEYS` (so `cleanupStorage` does not delete them) but are excluded from `.stvault` exports to prevent shipping live OAuth tokens, vault passwords, and device-specific sync state:
 
 ```js
 const VAULT_EXCLUDE_KEYS = [
@@ -384,6 +386,8 @@ const VAULT_EXCLUDE_KEYS = [
   'cloud_token_pcloud',
   'cloud_token_box',
   'cloud_dropbox_account_id',
+  'cloud_dropbox_email',
+  'cloud_dropbox_display_name',
   'cloud_vault_password',
   'cloud_sync_device_id',
   'cloud_sync_cursor',

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,8 +2,8 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.51
-date: 2026-03-04
+lastUpdated: v3.33.55
+date: 2026-03-06
 sourceFiles:
   - js/cloud-sync.js
   - js/cloud-storage.js
@@ -160,14 +160,14 @@ getSyncPasswordSilent()
 
 | Function | Signature | Purpose |
 |---|---|---|
-| `cloudAuthStart(provider)` | `(string) → void` | Open OAuth popup (PKCE for Dropbox). Must be called from a click handler to avoid popup blockers. |
-| `cloudExchangeCode(code, state)` | `(string, string) → Promise<void>` | Exchange OAuth code for access/refresh tokens. Validates state parameter against saved session. |
+| `cloudAuthStart(provider, options?)` | `(string, object?) → void` | Open OAuth popup (PKCE for Dropbox). Must be called from a click handler to avoid popup blockers. Optional `options.forceReauth` adds `force_reauthentication=true` to the Dropbox OAuth URL, forcing the login/account-picker screen (STAK-449). |
+| `cloudExchangeCode(code, state)` | `(string, string) → Promise<void>` | Exchange OAuth code for access/refresh tokens. Validates state parameter against saved session. For Dropbox, always calls `/2/users/get_current_account` to fetch and store `email` and `display_name` in localStorage (STAK-449). |
 | `cloudCheckOAuthRelay()` | `() → void` | Fallback relay handler when popup loses `window.opener`. Reads `staktrakr_oauth_result` from localStorage, validates `data.state` against `sessionStorage.getItem('cloud_oauth_state')` before calling `cloudExchangeCode` — rejects with a CSRF warning on mismatch. |
 | `cloudGetToken(provider)` | `(string) → Promise<string\|null>` | Return valid access token. Attempts refresh if expired (with 60s buffer). Clears token and returns null on refresh failure. |
 | `cloudIsConnected(provider)` | `(string) → boolean` | True if a stored token exists for the provider. |
 | `cloudStoreToken(provider, tokenData)` | `(string, object) → void` | Persist token to localStorage under `cloud_token_<provider>`. |
 | `cloudClearToken(provider)` | `(string) → void` | Remove stored token. |
-| `cloudDisconnect(provider)` | `(string) → void` | Full disconnect: clears token, then removes all 13 cloud state keys (`cloud_last_backup`, `cloud_dropbox_account_id`, `cloud_vault_password`, `cloud_sync_enabled`, `cloud_sync_device_id`, `cloud_sync_cursor`, `cloud_sync_last_push`, `cloud_sync_last_pull`, `cloud_sync_override_backup`, `cloud_sync_mode`, `cloud_sync_local_modified`, `cloud_sync_migrated`, `staktrakr_oauth_result`). Cancels any pending `scheduleSyncPush` debounce. Updates UI. |
+| `cloudDisconnect(provider)` | `(string) → void` | Full disconnect: clears token, then removes all 15 cloud state keys (`cloud_last_backup`, `cloud_dropbox_account_id`, `cloud_dropbox_email`, `cloud_dropbox_display_name`, `cloud_vault_password`, `cloud_sync_enabled`, `cloud_sync_device_id`, `cloud_sync_cursor`, `cloud_sync_last_push`, `cloud_sync_last_pull`, `cloud_sync_override_backup`, `cloud_sync_mode`, `cloud_sync_local_modified`, `cloud_sync_migrated`, `staktrakr_oauth_result`). Cancels any pending `scheduleSyncPush` debounce. Updates UI. |
 | `cloudUploadVault(provider, fileBytes, opts)` | `(string, ArrayBuffer, object?) → Promise<void>` | Manual backup upload. Writes versioned `.stvault` file + `staktrakr-latest.json` pointer (unless `opts.skipLatestUpdate` is true). All provider upload responses are validated (`.ok` check) and throw on failure. Records to activity log. |
 | `cloudDownloadVault(provider)` | `(string) → Promise<Uint8Array>` | Download latest backup by pointer, or by listing if no pointer. |
 | `cloudDownloadVaultByName(provider, filename)` | `(string, string) → Promise<Uint8Array>` | Download a specific named backup file. |
@@ -177,7 +177,7 @@ getSyncPasswordSilent()
 | `recordCloudActivity(entry)` | `(object) → void` | Append an entry to the cloud activity log (capped at 500 entries, purges >180 days old). |
 | `renderCloudActivityTable()` | `() → void` | Render the sortable activity table in Settings → Cloud. |
 | `renderSyncHistorySection()` | `() → void` | Render the Sync History section (override backup metadata + restore button). |
-| `syncCloudUI()` | `() → void` | Refresh provider card UI (connect/disconnect buttons, status badge, backup metadata). |
+| `syncCloudUI()` | `() → void` | Refresh provider card UI (connect/disconnect buttons, status badge, backup metadata). For Dropbox, also shows/hides account identity row, Switch Account button, and Sign Out link based on connection state (STAK-449). |
 | `cloudCachePassword(provider, password)` | `(string, string) → void` | XOR-obfuscated session-only password cache (sessionStorage). Starts idle lock timer. |
 | `cloudGetCachedPassword(provider)` | `(string) → string\|null` | Retrieve session-cached password. |
 | `cloudClearCachedPassword()` | `() → void` | Clear session cache and stop idle lock timer. |
@@ -368,6 +368,8 @@ The override backup is the safety net for unwanted sync pulls. It restores raw l
 |---|---|
 | `cloud_vault_password` | User vault password (Unified mode) |
 | `cloud_dropbox_account_id` | Dropbox account ID (used in key derivation for both modes) |
+| `cloud_dropbox_email` | Dropbox account email, displayed in Cloud settings card (STAK-449). Excluded from vault backups via `VAULT_EXCLUDE_KEYS`. |
+| `cloud_dropbox_display_name` | Dropbox display name, displayed alongside email in Cloud settings card (STAK-449). Excluded from vault backups via `VAULT_EXCLUDE_KEYS`. |
 | `cloud_sync_mode` | `'simple'` — deprecated, kept for migration only, will be removed after v3.33 |
 | `cloud_sync_enabled` | `'true'` when auto-sync is active |
 | `cloud_sync_device_id` | Stable per-device UUID |
@@ -381,7 +383,15 @@ The override backup is the safety net for unwanted sync pulls. It restores raw l
 | `cloud_activity_log` | JSON array: cloud activity entries (max 500, 180-day TTL) |
 | `cloud_kraken_seen` | `'true'` after first successful backup (suppresses easter-egg toast) |
 
-**Disconnect cleanup (STAK-425, v3.33.46):** `cloudDisconnect(provider)` removes all cloud state keys except `cloud_kraken_seen`, `cloud_activity_log`, `cloud_backup_history_depth`, and `cloud_vault_idle_timeout`. It also cancels any pending `scheduleSyncPush` debounce to prevent a ghost push after disconnect.
+**Disconnect cleanup (STAK-425, v3.33.46; updated STAK-449, v3.33.55):** `cloudDisconnect(provider)` removes all cloud state keys (including `cloud_dropbox_email` and `cloud_dropbox_display_name`) except `cloud_kraken_seen`, `cloud_activity_log`, `cloud_backup_history_depth`, and `cloud_vault_idle_timeout`. It also cancels any pending `scheduleSyncPush` debounce to prevent a ghost push after disconnect.
+
+### Multi-account UX (STAK-449, v3.33.55)
+
+Users with multiple Dropbox accounts can now see which account is connected and switch between them:
+
+- **Account identity display**: `cloudExchangeCode()` always calls `/2/users/get_current_account` after token exchange to fetch `email` and `name.display_name`. These are stored in `cloud_dropbox_email` and `cloud_dropbox_display_name` and displayed in the Cloud settings card below the "Connected" status indicator.
+- **Switch Account button**: Visible when connected. Calls `cloudDisconnect(provider)` then `cloudAuthStart(provider, { forceReauth: true })`. The `force_reauthentication=true` OAuth parameter forces Dropbox to show the login/account-picker screen instead of auto-selecting the active browser session.
+- **Sign out of Dropbox link**: Opens `https://www.dropbox.com/logout` in a new tab. Does not affect StakTrakr's OAuth state — it only clears the Dropbox browser session so the next Connect or Switch Account starts fresh.
 
 ---
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Dropbox account identity display**: Connected Dropbox account email and display name now shown in Cloud settings card via `get_current_account` API call during OAuth exchange
- **Switch Account button**: Disconnects current account and re-authenticates with `force_reauthentication=true` to force Dropbox account picker
- **Sign out of Dropbox link**: Helper link opens `dropbox.com/logout` in a new tab for clearing browser sessions before switching accounts
- **2 new storage keys**: `cloud_dropbox_email` and `cloud_dropbox_display_name` registered in `ALLOWED_STORAGE_KEYS` and `VAULT_EXCLUDE_KEYS`
- **Wiki updates**: 8 wiki pages updated — `sync-cloud.md` with full content rewrite, `storage-patterns.md` and `data-model.md` with new key entries, 5 others with frontmatter bumps

## Files Changed

- `js/constants.js` — 2 new keys in ALLOWED_STORAGE_KEYS + VAULT_EXCLUDE_KEYS, version bump
- `js/cloud-storage.js` — `cloudAuthStart()` options param, `cloudExchangeCode()` profile fetch, `cloudDisconnect()` cleanup, `syncCloudUI()` identity display
- `js/settings-listeners.js` — Switch Account click handler
- `index.html` — Account info row, Switch Account button, Sign Out link in Dropbox card
- `js/about.js`, `docs/announcements.md`, `CHANGELOG.md`, `version.json` — version bump artifacts
- `wiki/*.md` — 8 pages updated

## Linear Issues

- STAK-449: Dropbox Multi-Account UX

## QA Notes

- **OAuth testing requires manual verification** at `beta.staktrakr.com` after merge to `dev` — Cloudflare preview URLs use a different origin which breaks Dropbox OAuth redirect
- Test plan: Connect Dropbox → verify email/name shown → Switch Account → verify re-auth prompt → Sign Out link opens Dropbox logout page
- Verify account info row, Switch Account button, and Sign Out link are hidden when disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)