### PR TITLE
v3.33.56 — STAK-451: DiffModal UX Overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.56] - 2026-03-06
+
+### Added — STAK-451: DiffModal UX Overhaul
+
+- **Added**: Summary dashboard with 4 clickable stat cards (Matched, Conflicts, Remote Only, Local Only) with scroll-to-section navigation (STAK-451)
+- **Added**: Progress tracker bar for sync conflict resolution showing resolved/total count (STAK-451)
+- **Added**: Per-item conflict cards with grouped field rows and click-to-pick local/remote resolution (STAK-451)
+- **Added**: Settings category cards grouping 42 settings into 7 meaningful categories with human-readable labels and per-setting click-to-pick resolution (STAK-451)
+- **Changed**: DiffModal widened from 640px to 860px desktop, full-screen on mobile/tablet (STAK-451)
+- **Changed**: API keys masked in settings diff display — never shown in plain text (STAK-451)
+
+---
+
 ## [3.33.55] - 2026-03-06
 
 ### Added — STAK-449: Dropbox Multi-Account UX

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **DiffModal UX Overhaul (v3.33.56)**: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts. Modal widened to 860px desktop, full-screen mobile (STAK-451).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449).
 - **Dateless Items Sort as Oldest (v3.33.54)**: Items with no purchase date now sort as "infinitely old" — top when oldest-first, bottom when newest-first (STAK-448).
 - **Numista N# Search Image URL + Metal Auto-Population (v3.33.53)**: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431).
 - **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
-- **Pre-ship Security Hardening (v3.33.51)**: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -4475,9 +4475,24 @@
       </div>
     </div>
 
-    <!-- Diff Review Modal — reusable change-review UI (STAK-184) -->
+    <!-- Diff Review Modal — reusable change-review UI (STAK-184, STAK-451) -->
+    <style>
+      #diffReviewModal .modal-content {
+        max-height: 90vh;
+        overflow-y: auto;
+      }
+      @media (max-width: 768px) {
+        #diffReviewModal .modal-content {
+          width: 100vw;
+          height: 100dvh;
+          max-width: none;
+          max-height: none;
+          border-radius: 0;
+        }
+      }
+    </style>
     <div class="modal" id="diffReviewModal" style="display: none">
-      <div class="modal-content" style="max-width: 640px">
+      <div class="modal-content" style="max-width: 860px">
         <div class="modal-header">
           <h2 id="diffReviewTitle">Review Changes</h2>
           <button aria-label="Close modal" class="modal-close" id="diffReviewDismissX">&times;</button>
@@ -4486,10 +4501,13 @@
           <div class="cloud-sync-update-meta" id="diffReviewSource"></div>
           <div id="diffReviewCountRow" style="display:none;margin:0.5rem 0 0.25rem;font-size:0.8rem;color:var(--text-muted,#64748b)"></div>
           <div id="diffReviewCountWarning" style="display:none;margin:0.2rem 0 0.5rem;font-size:0.78rem;color:var(--warning,#d97706)"></div>
-          <div id="diffReviewSummary" class="settings-subtext" style="margin:0.75rem 0;font-weight:600;"></div>
-          <div id="diffReviewConflicts" style="display:none;margin-bottom:1rem;"></div>
-          <div id="diffReviewList" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem;"></div>
-          <div id="diffReviewSettings" style="margin-bottom:1rem;"></div>
+          <div id="diffSummaryDashboard" style="margin:0.75rem 0"></div>
+          <div id="diffProgressTracker" style="margin:0.5rem 0"></div>
+          <div id="diffReviewSummary" class="settings-subtext" style="margin:0.75rem 0;font-weight:600"></div>
+          <div id="diffSectionConflicts" style="margin-bottom:1rem"></div>
+          <div id="diffSectionOrphans" style="margin-bottom:1rem"></div>
+          <div id="diffSectionModified" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
+          <div id="diffReviewSettings" style="margin-bottom:1rem"></div>
           <div class="encryption-actions" style="gap:0.5rem;flex-wrap:wrap">
             <button class="btn btn-sm" id="diffReviewSelectAll">Select All</button>
             <button class="btn btn-sm" id="diffReviewDeselectAll">Deselect All</button>

--- a/index.html
+++ b/index.html
@@ -4503,7 +4503,6 @@
           <div id="diffReviewCountWarning" style="display:none;margin:0.2rem 0 0.5rem;font-size:0.78rem;color:var(--warning,#d97706)"></div>
           <div id="diffSummaryDashboard" style="margin:0.75rem 0"></div>
           <div id="diffProgressTracker" style="margin:0.5rem 0"></div>
-          <div id="diffReviewSummary" class="settings-subtext" style="margin:0.75rem 0;font-weight:600"></div>
           <div id="diffSectionConflicts" style="margin-bottom:1rem"></div>
           <div id="diffSectionOrphans" style="margin-bottom:1rem"></div>
           <div id="diffSectionModified" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.56 &ndash; DiffModal UX Overhaul</strong>: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts. Modal widened to 860px desktop, full-screen mobile (STAK-451)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449)</li>
     <li><strong>v3.33.54 &ndash; Dateless Items Sort as Oldest</strong>: Items with no purchase date now sort as &ldquo;infinitely old&rdquo; &mdash; top when oldest-first, bottom when newest-first (STAK-448)</li>
     <li><strong>v3.33.53 &ndash; Numista N# Search Image URL + Metal Auto-Population</strong>: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431)</li>
     <li><strong>v3.33.52 &ndash; Market Controls Mobile Fix + Metal Filter Buttons</strong>: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434)</li>
-    <li><strong>v3.33.51 &ndash; Pre-ship Security Hardening</strong>: XSS fix in settings pattern rules. OAuth CSRF protection on relay path. Sync flag leak fix. Console output sanitized to remove cryptographic metadata. Dead sync modal code removed (~206 lines). All confirmations use appConfirm (STAK-430)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.55";
+const APP_VERSION = "3.33.56";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -258,6 +258,98 @@
 
   // ── Rendering ──
 
+  function _renderSummaryDashboard(container, diff, conflicts) {
+    if (!container) return;
+    var matched = (diff.unchanged || []).length;
+    var conflictCount = (conflicts && conflicts.conflicts || []).length;
+    var remoteOnly = (diff.added || []).length;
+    var localOnly = (diff.deleted || []).length;
+
+    var cards = [
+      { count: matched, label: 'Matched', target: 'diffSectionModified', color: '', style: 'opacity:0.5' },
+      { count: conflictCount, label: 'Conflicts', target: 'diffSectionConflicts', color: conflictCount > 0 ? 'color:#d97706' : '', style: '' },
+      { count: remoteOnly, label: 'Remote Only', target: 'diffSectionOrphans', color: '', style: '' },
+      { count: localOnly, label: 'Local Only', target: 'diffSectionOrphans', color: '', style: '' }
+    ];
+
+    var cardStyle = 'flex:1;min-width:120px;border-radius:8px;padding:0.6rem;border:1px solid var(--border-color,#ddd);cursor:pointer;text-align:center';
+    var html = '<div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin:0.75rem 0">';
+    for (var i = 0; i < cards.length; i++) {
+      var card = cards[i];
+      var numStyle = 'font-size:1.4rem;font-weight:700';
+      if (card.style) numStyle += ';' + card.style;
+      if (card.color) numStyle += ';' + card.color;
+      html += '<div data-scroll-target="' + _esc(card.target) + '" style="' + cardStyle + '">';
+      html += '<div style="' + numStyle + '">' + card.count + '</div>';
+      html += '<div style="font-size:0.7rem;opacity:0.6">' + _esc(card.label) + '</div>';
+      html += '</div>';
+    }
+    html += '</div>';
+
+    container.innerHTML = html;
+    container.onclick = function(e) {
+      var target = e.target.closest('[data-scroll-target]');
+      if (target) {
+        var el = safeGetElement(target.getAttribute('data-scroll-target'));
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    };
+  }
+
+  function _renderProgressTracker(container, conflicts, source) {
+    if (!container) return;
+    if (!source || source.type !== 'sync') {
+      container.style.display = 'none';
+      return;
+    }
+
+    var total = 0;
+    var resolved = 0;
+    for (var key in _conflictResolutions) {
+      if (_conflictResolutions.hasOwnProperty(key) && key.charAt(0) === 'c' && key.indexOf('setting-') !== 0) {
+        total++;
+        if (_conflictResolutions[key]) resolved++;
+      }
+    }
+
+    var pct = total > 0 ? Math.round((resolved / total) * 100) : 100;
+    var html = '<div style="height:6px;border-radius:3px;background:var(--border-color,#ddd);margin:0.5rem 0">';
+    html += '<div style="height:100%;border-radius:3px;background:#22c55e;width:' + pct + '%;transition:width 0.3s"></div>';
+    html += '</div>';
+    html += '<div style="font-size:0.75rem;opacity:0.6">' + resolved + ' of ' + total + ' conflicts resolved';
+    if (pct === 100 && total > 0) html += ' &#9989;';
+    html += '</div>';
+
+    container.innerHTML = html;
+    container.style.display = '';
+  }
+
+  function _updateProgress() {
+    var container = safeGetElement('diffProgressTracker');
+    if (!container) return;
+
+    var total = 0;
+    var resolved = 0;
+    for (var key in _conflictResolutions) {
+      if (_conflictResolutions.hasOwnProperty(key) && key.charAt(0) === 'c' && key.indexOf('setting-') !== 0) {
+        total++;
+        if (_conflictResolutions[key]) resolved++;
+      }
+    }
+
+    var pct = total > 0 ? Math.round((resolved / total) * 100) : 100;
+    var bar = container.querySelector('div > div');
+    if (bar) bar.style.width = pct + '%';
+
+    var children = container.children;
+    var textDiv = children.length > 1 ? children[children.length - 1] : null;
+    if (textDiv) {
+      var txt = resolved + ' of ' + total + ' conflicts resolved';
+      if (pct === 100 && total > 0) txt += ' \u2705';
+      textDiv.textContent = txt;
+    }
+  }
+
   function _render() {
     if (!_options) return;
 

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -136,6 +136,7 @@
   var _conflictResolutions = {}; // { 'c0': 'local'|'remote', ... }
   var _collapsedCategories = {}; // { added: true, ... }
   var _expandedModified = {};    // { 0: true, 1: false, ... }
+  var _expandedSettingsCategories = {}; // { 'Display & Appearance': true, ... }
   var _selectAllState = 0;  // 0=none, 1=added+modified, 2=all
 
   // ── Helpers ──
@@ -149,6 +150,13 @@
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
+  }
+
+  function _titleCase(key) {
+    return key
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, function(c) { return c.toUpperCase(); });
   }
 
   /** Derive a display key for an item */
@@ -418,6 +426,150 @@
     };
 
     container.style.display = '';
+  }
+
+  function _renderSettingsCards(container, settingsDiff) {
+    if (!container) return;
+    var changed = (settingsDiff && settingsDiff.changed) ? settingsDiff.changed : [];
+    var matched = (settingsDiff && settingsDiff.matched) ? settingsDiff.matched : [];
+    if (changed.length === 0 && matched.length === 0) {
+      container.innerHTML = '';
+      container.style.display = 'none';
+      return;
+    }
+
+    // Build category lookup for each entry
+    var catNames = Object.keys(SETTINGS_CATEGORIES);
+    function _findCategory(key) {
+      for (var ci = 0; ci < catNames.length; ci++) {
+        var cat = SETTINGS_CATEGORIES[catNames[ci]];
+        for (var ki = 0; ki < cat.keys.length; ki++) {
+          if (cat.keys[ki] === key) return catNames[ci];
+        }
+      }
+      return 'Other';
+    }
+
+    // Group changed and matched by category
+    var changedByCat = {};
+    var matchedByCat = {};
+    var i;
+    for (i = 0; i < changed.length; i++) {
+      var cCat = _findCategory(changed[i].key);
+      if (!changedByCat[cCat]) changedByCat[cCat] = [];
+      changedByCat[cCat].push(changed[i]);
+    }
+    for (i = 0; i < matched.length; i++) {
+      var mCat = _findCategory(matched[i].key);
+      if (!matchedByCat[mCat]) matchedByCat[mCat] = [];
+      matchedByCat[mCat].push(matched[i]);
+    }
+
+    // Collect all categories that have entries
+    var allCats = {};
+    var catKey;
+    for (catKey in changedByCat) {
+      if (changedByCat.hasOwnProperty(catKey)) allCats[catKey] = true;
+    }
+    for (catKey in matchedByCat) {
+      if (matchedByCat.hasOwnProperty(catKey)) allCats[catKey] = true;
+    }
+
+    var html = '';
+    var renderedCount = 0;
+
+    for (catKey in allCats) {
+      if (!allCats.hasOwnProperty(catKey)) continue;
+      var catChanged = changedByCat[catKey] || [];
+      var catMatched = matchedByCat[catKey] || [];
+      if (catChanged.length === 0 && catMatched.length === 0) continue;
+
+      var catDef = SETTINGS_CATEGORIES[catKey];
+      var catIcon = catDef ? catDef.icon : '\u2699\uFE0F';
+
+      html += '<div style="border-radius:8px;border:1px solid var(--border-color,#ddd);padding:0.75rem;margin-bottom:0.75rem">';
+
+      // Card header
+      html += '<div style="display:flex;align-items:center">';
+      html += '<span style="font-weight:600;font-size:0.85rem">' + catIcon + ' ' + _esc(catKey) + '</span>';
+      if (catChanged.length > 0) {
+        html += '<span style="display:inline-block;background:rgba(217,119,6,0.1);color:#d97706;border-radius:12px;padding:0.1rem 0.5rem;font-size:0.7rem;margin-left:0.5rem">' + catChanged.length + ' diff' + (catChanged.length !== 1 ? 's' : '') + '</span>';
+      }
+      html += '</div>';
+
+      // Changed setting rows
+      for (var ci2 = 0; ci2 < catChanged.length; ci2++) {
+        var entry = catChanged[ci2];
+        var resKey = 'setting-' + entry.key;
+        var selected = _conflictResolutions[resKey] || '';
+        var localBtnStyle = 'padding:0.25rem 0.6rem;border-radius:4px;cursor:pointer;font-size:0.8rem;';
+        var remoteBtnStyle = 'padding:0.25rem 0.6rem;border-radius:4px;cursor:pointer;font-size:0.8rem;';
+
+        if (selected === 'local') {
+          localBtnStyle += 'border:1px solid #22c55e;background:rgba(34,197,94,0.08)';
+          remoteBtnStyle += 'border:1px solid transparent';
+        } else if (selected === 'remote') {
+          localBtnStyle += 'border:1px solid transparent';
+          remoteBtnStyle += 'border:1px solid #22c55e;background:rgba(34,197,94,0.08)';
+        } else {
+          localBtnStyle += 'border:1px solid transparent';
+          remoteBtnStyle += 'border:1px solid transparent';
+        }
+
+        var label = SETTINGS_LABELS[entry.key] || _titleCase(entry.key);
+
+        html += '<div style="display:flex;align-items:center;gap:0.4rem;padding:0.3rem 0">';
+        html += '<span style="min-width:120px;font-size:0.78rem;opacity:0.6">' + _esc(label) + '</span>';
+        html += '<span data-setting-resolution="' + _esc(resKey) + '" data-side="local" style="' + localBtnStyle + '">' + _formatSettingValue(entry.key, entry.localVal) + '</span>';
+        html += '<span style="opacity:0.3;font-size:0.7rem">\u21C4</span>';
+        html += '<span data-setting-resolution="' + _esc(resKey) + '" data-side="remote" style="' + remoteBtnStyle + '">' + _formatSettingValue(entry.key, entry.remoteVal) + '</span>';
+        html += '</div>';
+      }
+
+      // Matched settings section (collapsed by default)
+      if (catMatched.length > 0) {
+        var isExpanded = _expandedSettingsCategories[catKey] || false;
+        html += '<div data-toggle-matched="' + _esc(catKey) + '" style="font-size:0.73rem;cursor:pointer;color:var(--primary,#3b82f6);margin-top:0.3rem">';
+        html += (isExpanded ? 'Hide' : 'Show') + ' ' + catMatched.length + ' matched';
+        html += '</div>';
+
+        if (isExpanded) {
+          for (var mi = 0; mi < catMatched.length; mi++) {
+            var mEntry = catMatched[mi];
+            var mLabel = SETTINGS_LABELS[mEntry.key] || _titleCase(mEntry.key);
+            html += '<div style="display:flex;align-items:center;gap:0.4rem;padding:0.2rem 0;opacity:0.6">';
+            html += '<span style="font-size:0.78rem">\u2713</span>';
+            html += '<span style="min-width:120px;font-size:0.78rem">' + _esc(mLabel) + '</span>';
+            html += '<span style="font-size:0.78rem">both: ' + _formatSettingValue(mEntry.key, mEntry.localVal) + '</span>';
+            html += '</div>';
+          }
+        }
+      }
+
+      html += '</div>';
+      renderedCount++;
+    }
+
+    container.innerHTML = html;
+    container.style.display = renderedCount > 0 ? '' : 'none';
+
+    // Event delegation
+    container.onclick = function(e) {
+      var btn = e.target.closest('[data-setting-resolution]');
+      if (btn) {
+        var key = btn.getAttribute('data-setting-resolution');
+        var side = btn.getAttribute('data-side');
+        _conflictResolutions[key] = side;
+        _renderSettingsCards(container, settingsDiff);
+        return;
+      }
+      var toggle = e.target.closest('[data-toggle-matched]');
+      if (toggle) {
+        var cat = toggle.getAttribute('data-toggle-matched');
+        _expandedSettingsCategories[cat] = !_expandedSettingsCategories[cat];
+        _renderSettingsCards(container, settingsDiff);
+      }
+    };
   }
 
   function _render() {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -350,6 +350,76 @@
     }
   }
 
+  function _renderConflictCards(container, conflicts) {
+    if (!container) return;
+    if (!conflicts || !conflicts.conflicts || conflicts.conflicts.length === 0) {
+      container.style.display = 'none';
+      return;
+    }
+
+    var grouped = _groupByItem(conflicts.conflicts);
+    var html = '';
+
+    for (var itemName in grouped) {
+      if (!grouped.hasOwnProperty(itemName)) continue;
+      var fields = grouped[itemName];
+
+      html += '<div data-conflict-card="' + _esc(itemName) + '" style="border-radius:8px;border:1px solid var(--border-color,#ddd);padding:0.75rem;margin-bottom:0.75rem">';
+
+      // Card header
+      html += '<div>';
+      html += '<span style="font-weight:600;font-size:0.85rem">' + _esc(itemName) + '</span>';
+      html += '<span style="display:inline-block;background:rgba(217,119,6,0.1);color:#d97706;border-radius:12px;padding:0.1rem 0.5rem;font-size:0.7rem;margin-left:0.5rem">' + fields.length + ' field' + (fields.length !== 1 ? 's' : '') + '</span>';
+      html += '</div>';
+
+      // Field rows
+      for (var f = 0; f < fields.length; f++) {
+        var conflict = fields[f];
+        var resKey = 'c' + conflict.idx + '-' + conflict.field;
+        var selected = _conflictResolutions[resKey] || '';
+        var localStyle = 'padding:0.25rem 0.6rem;border-radius:4px;cursor:pointer;font-size:0.8rem;';
+        var remoteStyle = 'padding:0.25rem 0.6rem;border-radius:4px;cursor:pointer;font-size:0.8rem;';
+
+        if (selected === 'local') {
+          localStyle += 'border:1px solid #22c55e;background:rgba(34,197,94,0.08)';
+          remoteStyle += 'border:1px solid transparent';
+        } else if (selected === 'remote') {
+          localStyle += 'border:1px solid transparent';
+          remoteStyle += 'border:1px solid #22c55e;background:rgba(34,197,94,0.08)';
+        } else {
+          localStyle += 'border:1px solid transparent';
+          remoteStyle += 'border:1px solid transparent';
+        }
+
+        var localDisplay = _esc(String(conflict.localVal != null ? conflict.localVal : '\u2014'));
+        var remoteDisplay = _esc(String(conflict.remoteVal != null ? conflict.remoteVal : '\u2014'));
+
+        html += '<div style="display:flex;align-items:center;gap:0.4rem;padding:0.3rem 0">';
+        html += '<span style="min-width:100px;font-size:0.78rem;opacity:0.6">' + _esc(conflict.field) + '</span>';
+        html += '<span data-resolution="' + _esc(resKey) + '" data-side="local" style="' + localStyle + '">' + localDisplay + '</span>';
+        html += '<span style="opacity:0.3;font-size:0.7rem">\u21C4</span>';
+        html += '<span data-resolution="' + _esc(resKey) + '" data-side="remote" style="' + remoteStyle + '">' + remoteDisplay + '</span>';
+        html += '</div>';
+      }
+
+      html += '</div>';
+    }
+
+    container.innerHTML = html;
+
+    container.onclick = function(e) {
+      var btn = e.target.closest('[data-resolution]');
+      if (!btn) return;
+      var key = btn.getAttribute('data-resolution');
+      var side = btn.getAttribute('data-side');
+      _conflictResolutions[key] = side;
+      _renderConflictCards(container, conflicts);
+      if (typeof _updateProgress === 'function') _updateProgress();
+    };
+
+    container.style.display = '';
+  }
+
   function _render() {
     if (!_options) return;
 

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -572,23 +572,27 @@
     };
   }
 
+  function _updateApplyButton() {
+    var applyBtn = safeGetElement('diffReviewApplyBtn');
+    if (!applyBtn) return;
+    var count = _checkedCount();
+    var hasSelectableItems = Object.keys(_checkedItems).length > 0;
+    var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.changed && _options.settingsDiff.changed.length > 0;
+    applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
+    applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
+    applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
+  }
+
   function _render() {
     if (!_options) return;
 
     var titleEl = safeGetElement('diffReviewTitle');
     var sourceEl = safeGetElement('diffReviewSource');
-    var summaryEl = safeGetElement('diffReviewSummary');
-    var conflictsEl = safeGetElement('diffReviewConflicts');
-    var listEl = safeGetElement('diffReviewList');
-    var settingsEl = safeGetElement('diffReviewSettings');
-    var applyBtn = safeGetElement('diffReviewApplyBtn');
 
     var diff = _options.diff || {};
     var added = diff.added || [];
     var modified = diff.modified || [];
     var deleted = diff.deleted || [];
-    var unchanged = diff.unchanged || [];
-    var settingsDiff = _options.settingsDiff;
     var conflicts = _options.conflicts;
     var meta = _options.meta;
     var source = _options.source || {};
@@ -617,47 +621,20 @@
       sourceEl.innerHTML = sourceHtml;
     }
 
-    // Summary chips
-    if (summaryEl) {
-      var chips = [];
-      if (added.length > 0) chips.push('<span style="display:inline-flex;align-items:center;gap:0.2rem;padding:0.2rem 0.5rem;border-radius:20px;font-size:0.73rem;font-weight:600;background:rgba(5,150,105,0.12);color:var(--success,#059669)">+' + added.length + ' added</span>');
-      if (modified.length > 0) chips.push('<span style="display:inline-flex;align-items:center;gap:0.2rem;padding:0.2rem 0.5rem;border-radius:20px;font-size:0.73rem;font-weight:600;background:rgba(217,119,6,0.12);color:var(--warning,#d97706)">&#9998; ' + modified.length + ' modified</span>');
-      if (deleted.length > 0) chips.push('<span style="display:inline-flex;align-items:center;gap:0.2rem;padding:0.2rem 0.5rem;border-radius:20px;font-size:0.73rem;font-weight:600;background:rgba(220,38,38,0.12);color:var(--danger,#dc2626)">&minus;' + deleted.length + ' deleted</span>');
-      if (unchanged.length > 0) chips.push('<span style="display:inline-flex;align-items:center;gap:0.2rem;padding:0.2rem 0.5rem;border-radius:20px;font-size:0.73rem;font-weight:600;background:rgba(107,114,128,0.1);color:#6b7280">' + unchanged.length + ' unchanged</span>');
-      if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
-        chips.push('<span style="display:inline-flex;align-items:center;gap:0.2rem;padding:0.2rem 0.5rem;border-radius:20px;font-size:0.73rem;font-weight:600;background:rgba(59,130,246,0.1);color:var(--primary,#3b82f6)">' + settingsDiff.changed.length + ' setting' + (settingsDiff.changed.length > 1 ? 's' : '') + '</span>');
-      }
-      summaryEl.innerHTML = chips.length > 0
-        ? '<div style="display:flex;flex-wrap:wrap;gap:0.35rem">' + chips.join('') + '</div>'
-        : 'No changes detected';
-    }
+    // Count row (backup import flow only)
+    _updateCountRow();
 
-    // Conflicts section
-    if (conflictsEl) {
-      if (conflicts && conflicts.conflicts && conflicts.conflicts.length > 0) {
-        var cHtml = '<div style="border-radius:8px;padding:0.75rem;background:rgba(217,119,6,0.08);border:1px solid rgba(217,119,6,0.2)">';
-        cHtml += '<div style="font-weight:600;font-size:0.85rem;margin-bottom:0.5rem;color:var(--warning,#d97706)">&#9888; ' + conflicts.conflicts.length + ' conflict' + (conflicts.conflicts.length > 1 ? 's' : '') + ' detected</div>';
-        for (var ci = 0; ci < conflicts.conflicts.length; ci++) {
-          var cf = conflicts.conflicts[ci];
-          var res = _conflictResolutions['c' + ci] || 'remote';
-          cHtml += '<div style="padding:0.5rem;border-radius:6px;margin-bottom:0.35rem;font-size:0.8rem;background:rgba(0,0,0,0.06)">';
-          cHtml += '<div style="font-weight:600">' + _esc(cf.itemName || cf.itemKey || 'Item') + '</div>';
-          cHtml += '<div style="font-size:0.73rem;opacity:0.6;margin-bottom:0.35rem">' + _esc(cf.field) + '</div>';
-          cHtml += '<div style="display:flex;gap:0.75rem">';
-          cHtml += '<label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer;font-size:0.8rem"><input type="radio" name="diffConflict' + ci + '" value="local" ' + (res === 'local' ? 'checked' : '') + ' data-conflict="' + ci + '" style="width:16px;height:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6)"> Local: <strong>' + _esc(String(cf.localVal != null ? cf.localVal : '\u2014')) + '</strong></label>';
-          cHtml += '<label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer;font-size:0.8rem"><input type="radio" name="diffConflict' + ci + '" value="remote" ' + (res === 'remote' ? 'checked' : '') + ' data-conflict="' + ci + '" style="width:16px;height:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6)"> Remote: <strong>' + _esc(String(cf.remoteVal != null ? cf.remoteVal : '\u2014')) + '</strong></label>';
-          cHtml += '</div></div>';
-        }
-        cHtml += '</div>';
-        conflictsEl.innerHTML = cHtml;
-        conflictsEl.style.display = '';
-      } else {
-        conflictsEl.innerHTML = '';
-        conflictsEl.style.display = 'none';
-      }
-    }
+    // Summary dashboard (replaces old summary chips)
+    _renderSummaryDashboard(safeGetElement('diffSummaryDashboard'), diff, conflicts);
 
-    // Change list
+    // Progress tracker (sync only)
+    _renderProgressTracker(safeGetElement('diffProgressTracker'), conflicts, source);
+
+    // Conflict cards (replaces old inline conflict rendering)
+    _renderConflictCards(safeGetElement('diffSectionConflicts'), conflicts);
+
+    // Change list — retarget to diffSectionModified container
+    var listEl = safeGetElement('diffSectionModified');
     if (listEl) {
       var totalChanges = added.length + modified.length + deleted.length;
       var lHtml = '';
@@ -676,46 +653,11 @@
       listEl.innerHTML = lHtml;
     }
 
-    // Settings diff
-    if (settingsEl) {
-      if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
-        var sHtml = '<details style="margin-top:0.25rem" open>';
-        sHtml += '<summary style="cursor:pointer;font-weight:600;font-size:0.8rem;padding:0.4rem 0;user-select:none">';
-        sHtml += settingsDiff.changed.length + ' setting change' + (settingsDiff.changed.length > 1 ? 's' : '') + '</summary>';
-        sHtml += '<div style="padding:0.4rem 0 0.25rem 0;font-size:0.8rem">';
-        for (var si = 0; si < settingsDiff.changed.length; si++) {
-          var sc = settingsDiff.changed[si];
-          sHtml += '<div style="padding:0.2rem 0;display:flex;gap:0.3rem;align-items:baseline">';
-          sHtml += '<span style="opacity:0.5;min-width:80px">' + _esc(sc.key) + '</span>';
-          sHtml += '<span style="text-decoration:line-through;opacity:0.45">' + _esc(String(sc.localVal != null ? sc.localVal : '\u2014')) + '</span>';
-          sHtml += '<span style="opacity:0.35;font-size:0.7rem">&rarr;</span>';
-          sHtml += '<span style="font-weight:500;color:var(--warning,#d97706)">' + _esc(String(sc.remoteVal != null ? sc.remoteVal : '\u2014')) + '</span>';
-          sHtml += '</div>';
-        }
-        sHtml += '</div></details>';
-        settingsEl.innerHTML = sHtml;
-        settingsEl.style.display = '';
-      } else {
-        settingsEl.innerHTML = '';
-        settingsEl.style.display = 'none';
-      }
-    }
+    // Settings cards (replaces old settings <details>)
+    _renderSettingsCards(safeGetElement('diffReviewSettings'), _options.settingsDiff);
 
-    // Apply button count
-    // Only disable when there ARE selectable items but none are checked AND
-    // there are no pending settings changes. Settings are always included when
-    // Apply is clicked, so the button should stay enabled for settings-only apply.
-    if (applyBtn) {
-      var count = _checkedCount();
-      var hasSelectableItems = Object.keys(_checkedItems).length > 0;
-      var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.changed && _options.settingsDiff.changed.length > 0;
-      applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
-      applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
-      applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
-    }
-
-    // Count row (backup import flow only)
-    _updateCountRow();
+    // Apply button
+    _updateApplyButton();
   }
 
   /** Render a meta cell for the source info row */
@@ -937,12 +879,14 @@
       }
     }
 
-    // Settings changes — always included (no per-setting checkboxes)
+    // Settings changes — resolution-aware (local/remote toggle per setting)
     var settingsDiff = _options.settingsDiff || {};
     var changedSettings = settingsDiff.changed || [];
     for (var s = 0; s < changedSettings.length; s++) {
       var setting = changedSettings[s];
-      result.push({ type: 'setting', key: setting.key, value: setting.remoteVal });
+      var resolution = _conflictResolutions['setting-' + setting.key];
+      var value = (resolution === 'local') ? setting.localVal : setting.remoteVal;
+      result.push({ type: 'setting', key: setting.key, value: value });
     }
 
     return result;
@@ -976,8 +920,7 @@
   // ── Wire buttons (called once per show) ──
 
   function _wireEvents() {
-    var listEl = safeGetElement('diffReviewList');
-    var conflictsEl = safeGetElement('diffReviewConflicts');
+    var listEl = safeGetElement('diffSectionModified');
     var selectAllBtn = safeGetElement('diffReviewSelectAll');
     var deselectAllBtn = safeGetElement('diffReviewDeselectAll');
     var selectAllToggleBtn = safeGetElement('diffReviewSelectAllToggle');
@@ -988,16 +931,10 @@
     // Determine whether we're in backup-count mode
     var hasBackupCount = _options && _options.backupCount != null;
 
-    // Event delegation on list
+    // Event delegation on item list
     if (listEl) {
       listEl.removeEventListener('click', _onListClick);
       listEl.addEventListener('click', _onListClick);
-    }
-
-    // Conflict radio delegation
-    if (conflictsEl) {
-      conflictsEl.removeEventListener('change', _onConflictsChange);
-      conflictsEl.addEventListener('change', _onConflictsChange);
     }
 
     // Pill buttons
@@ -1073,6 +1010,7 @@
       _conflictResolutions = {};
       _collapsedCategories = {};
       _expandedModified = {};
+      _expandedSettingsCategories = {};
       _selectAllState = 0;
 
       // Default all items to checked
@@ -1081,10 +1019,18 @@
       for (var m = 0; m < (diff.modified || []).length; m++) _checkedItems['modified-' + m] = true;
       for (var d = 0; d < (diff.deleted || []).length; d++) _checkedItems['deleted-' + d] = true;
 
-      // Default conflict resolutions to 'remote'
+      // Default conflict resolutions to 'remote' (per-field keys)
       if (_options.conflicts && _options.conflicts.conflicts) {
         for (var ci = 0; ci < _options.conflicts.conflicts.length; ci++) {
-          _conflictResolutions['c' + ci] = 'remote';
+          var conflict = _options.conflicts.conflicts[ci];
+          _conflictResolutions['c' + ci + '-' + conflict.field] = 'remote';
+        }
+      }
+
+      // Default settings resolutions to 'remote'
+      if (_options.settingsDiff && _options.settingsDiff.changed) {
+        for (var si = 0; si < _options.settingsDiff.changed.length; si++) {
+          _conflictResolutions['setting-' + _options.settingsDiff.changed[si].key] = 'remote';
         }
       }
 

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -106,7 +106,7 @@
     if (!conflictsArray || !conflictsArray.length) return grouped;
     for (var i = 0; i < conflictsArray.length; i++) {
       var c = conflictsArray[i];
-      var name = c.itemName || '';
+      var name = c.itemName || c.itemKey || '';
       if (!grouped[name]) grouped[name] = [];
       grouped[name].push({ field: c.field, localVal: c.localVal, remoteVal: c.remoteVal, idx: i });
     }
@@ -276,8 +276,8 @@
     var cards = [
       { count: matched, label: 'Matched', target: 'diffSectionModified', color: '', style: 'opacity:0.5' },
       { count: conflictCount, label: 'Conflicts', target: 'diffSectionConflicts', color: conflictCount > 0 ? 'color:#d97706' : '', style: '' },
-      { count: remoteOnly, label: 'Remote Only', target: 'diffSectionOrphans', color: '', style: '' },
-      { count: localOnly, label: 'Local Only', target: 'diffSectionOrphans', color: '', style: '' }
+      { count: remoteOnly, label: 'Remote Only', target: 'diffSectionModified', color: '', style: '' },
+      { count: localOnly, label: 'Local Only', target: 'diffSectionModified', color: '', style: '' }
     ];
 
     var cardStyle = 'flex:1;min-width:120px;border-radius:8px;padding:0.6rem;border:1px solid var(--border-color,#ddd);cursor:pointer;text-align:center';
@@ -299,7 +299,7 @@
       var target = e.target.closest('[data-scroll-target]');
       if (target) {
         var el = safeGetElement(target.getAttribute('data-scroll-target'));
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (el instanceof HTMLElement) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
     };
   }
@@ -324,7 +324,7 @@
     var html = '<div style="height:6px;border-radius:3px;background:var(--border-color,#ddd);margin:0.5rem 0">';
     html += '<div style="height:100%;border-radius:3px;background:#22c55e;width:' + pct + '%;transition:width 0.3s"></div>';
     html += '</div>';
-    html += '<div style="font-size:0.75rem;opacity:0.6">' + resolved + ' of ' + total + ' conflicts resolved';
+    html += '<div id="diffProgressText" style="font-size:0.75rem;opacity:0.6">' + resolved + ' of ' + total + ' conflicts resolved';
     if (pct === 100 && total > 0) html += ' &#9989;';
     html += '</div>';
 
@@ -349,8 +349,8 @@
     var bar = container.querySelector('div > div');
     if (bar) bar.style.width = pct + '%';
 
-    var children = container.children;
-    var textDiv = children.length > 1 ? children[children.length - 1] : null;
+    var textDiv = safeGetElement('diffProgressText');
+    if (!(textDiv instanceof HTMLElement)) textDiv = null;
     if (textDiv) {
       var txt = resolved + ' of ' + total + ' conflicts resolved';
       if (pct === 100 && total > 0) txt += ' \u2705';
@@ -431,7 +431,7 @@
   function _renderSettingsCards(container, settingsDiff) {
     if (!container) return;
     var changed = (settingsDiff && settingsDiff.changed) ? settingsDiff.changed : [];
-    var matched = (settingsDiff && settingsDiff.matched) ? settingsDiff.matched : [];
+    var matched = (settingsDiff && (settingsDiff.unchanged || settingsDiff.matched)) ? (settingsDiff.unchanged || settingsDiff.matched) : [];
     if (changed.length === 0 && matched.length === 0) {
       container.innerHTML = '';
       container.style.display = 'none';
@@ -879,6 +879,21 @@
       }
     }
 
+    // Item conflict resolutions — per-field local/remote picks
+    var conflictsArr = (_options.conflicts && _options.conflicts.conflicts) || [];
+    for (var ci = 0; ci < conflictsArr.length; ci++) {
+      var conf = conflictsArr[ci];
+      var resKey = 'c' + ci + '-' + conf.field;
+      var side = _conflictResolutions[resKey] || 'remote';
+      var itemKey = conf.itemKey || conf.itemName || '';
+      result.push({
+        type: 'modify',
+        itemKey: itemKey,
+        field: conf.field,
+        value: (side === 'local') ? conf.localVal : conf.remoteVal
+      });
+    }
+
     // Settings changes — resolution-aware (local/remote toggle per setting)
     var settingsDiff = _options.settingsDiff || {};
     var changedSettings = settingsDiff.changed || [];
@@ -1023,7 +1038,7 @@
       if (_options.conflicts && _options.conflicts.conflicts) {
         for (var ci = 0; ci < _options.conflicts.conflicts.length; ci++) {
           var conflict = _options.conflicts.conflicts[ci];
-          _conflictResolutions['c' + ci + '-' + conflict.field] = 'remote';
+          _conflictResolutions['c' + ci + '-' + conflict.field] = null;
         }
       }
 

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -23,6 +23,113 @@
   // ── Constants ──
   var MODAL_ID = 'diffReviewModal';
 
+  // ── Settings categories for grouped display ──
+  var SETTINGS_CATEGORIES = {
+    'Display & Appearance': {
+      icon: '\uD83C\uDFA8',
+      keys: ['displayCurrency','appTheme','cardViewStyle','desktopCardView','defaultSortColumn','defaultSortDir','showRealizedGainLoss','metalOrderConfig','settingsItemsPerPage','appTimeZone']
+    },
+    'Chips & Filters': {
+      icon: '\uD83C\uDFF7\uFE0F',
+      keys: ['inlineChipConfig','filterChipCategoryConfig','viewModalSectionConfig','chipMinCount','chipMaxCount','chipCustomGroups','chipBlacklist','chipSortOrder']
+    },
+    'Layout': {
+      icon: '\uD83D\uDCD0',
+      keys: ['layoutSectionConfig','tableImagesEnabled','tableImageSides']
+    },
+    'Tags': {
+      icon: '\uD83D\uDD16',
+      keys: ['tagBlacklist']
+    },
+    'Header Buttons': {
+      icon: '\uD83D\uDD18',
+      keys: ['headerThemeBtnVisible','headerCurrencyBtnVisible','headerTrendBtnVisible','headerSyncBtnVisible','headerMarketBtnVisible','headerVaultBtnVisible','headerRestoreBtnVisible','headerCloudSyncBtnVisible','headerBtnShowText','headerBtnOrder','headerAboutBtnVisible']
+    },
+    'Goldback & Providers': {
+      icon: '\uD83E\uDE99',
+      keys: ['goldback-enabled','goldback-estimate-enabled','goldback-estimate-modifier','enabledSeedRules','apiProviderOrder','providerPriority']
+    },
+    'Numista': {
+      icon: '\uD83D\uDCDA',
+      keys: ['numista_tags_auto','numistaLookupRules','numistaViewFields']
+    }
+  };
+
+  var SETTINGS_LABELS = {
+    'displayCurrency': 'Display Currency',
+    'appTheme': 'Theme',
+    'cardViewStyle': 'Card View Style',
+    'desktopCardView': 'Desktop Card View',
+    'defaultSortColumn': 'Default Sort Column',
+    'defaultSortDir': 'Default Sort Direction',
+    'showRealizedGainLoss': 'Show Realized Gain/Loss',
+    'metalOrderConfig': 'Metal Order',
+    'settingsItemsPerPage': 'Items Per Page',
+    'appTimeZone': 'Time Zone',
+    'inlineChipConfig': 'Inline Chips',
+    'filterChipCategoryConfig': 'Filter Chip Categories',
+    'viewModalSectionConfig': 'View Modal Sections',
+    'chipMinCount': 'Chip Min Count',
+    'chipMaxCount': 'Chip Max Count',
+    'chipCustomGroups': 'Custom Chip Groups',
+    'chipBlacklist': 'Hidden Chips',
+    'chipSortOrder': 'Chip Sort Order',
+    'layoutSectionConfig': 'Section Layout',
+    'tableImagesEnabled': 'Table Images',
+    'tableImageSides': 'Table Image Sides',
+    'tagBlacklist': 'Hidden Tags',
+    'headerThemeBtnVisible': 'Theme Button',
+    'headerCurrencyBtnVisible': 'Currency Button',
+    'headerTrendBtnVisible': 'Trend Button',
+    'headerSyncBtnVisible': 'Sync Button',
+    'headerMarketBtnVisible': 'Market Button',
+    'headerVaultBtnVisible': 'Vault Button',
+    'headerRestoreBtnVisible': 'Restore Button',
+    'headerCloudSyncBtnVisible': 'Cloud Sync Button',
+    'headerBtnShowText': 'Button Labels',
+    'headerBtnOrder': 'Button Order',
+    'headerAboutBtnVisible': 'About Button',
+    'goldback-enabled': 'Goldback Enabled',
+    'goldback-estimate-enabled': 'Goldback Estimates',
+    'goldback-estimate-modifier': 'Estimate Modifier',
+    'enabledSeedRules': 'Seed Rules',
+    'apiProviderOrder': 'Provider Order',
+    'providerPriority': 'Provider Priority',
+    'numista_tags_auto': 'Auto-Tag on Lookup',
+    'numistaLookupRules': 'Lookup Rules',
+    'numistaViewFields': 'View Fields',
+    'metalApiConfig': 'API Keys'
+  };
+
+  function _groupByItem(conflictsArray) {
+    var grouped = {};
+    if (!conflictsArray || !conflictsArray.length) return grouped;
+    for (var i = 0; i < conflictsArray.length; i++) {
+      var c = conflictsArray[i];
+      var name = c.itemName || '';
+      if (!grouped[name]) grouped[name] = [];
+      grouped[name].push({ field: c.field, localVal: c.localVal, remoteVal: c.remoteVal, idx: i });
+    }
+    return grouped;
+  }
+
+  function _formatSettingValue(key, value) {
+    if (key === 'metalApiConfig') return value ? '\u2022\u2022\u2022 configured' : 'not set';
+    if (value === null || value === undefined) return '\u2014';
+    if (typeof value === 'boolean') return value ? 'On' : 'Off';
+    if (Array.isArray(value)) {
+      var label = value.length + ' items';
+      if (value.length > 0 && typeof value[0] === 'string') {
+        var preview = value.slice(0, 2).join(', ');
+        if (value.length > 2) preview += ', \u2026';
+        label += ' (' + _esc(preview) + ')';
+      }
+      return label;
+    }
+    if (typeof value === 'object') return Object.keys(value).length + ' entries';
+    return _esc(String(value));
+  }
+
   // ── Internal state ──
   var _options = null;
   var _checkedItems = {};      // { 'added-0': true, 'modified-2': false, ... }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772830744';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772830884';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772831308';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772831424';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772764737';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772830744';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.56-b1772832643';
+const CACHE_NAME = 'staktrakr-v3.33.56-b1772838426';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772830884';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772830986';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772830986';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772831103';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772831103';
+const CACHE_NAME = 'staktrakr-v3.33.55-b1772831308';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.55-b1772831424';
+const CACHE_NAME = 'staktrakr-v3.33.56-b1772832643';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.55",
+  "version": "3.33.56",
   "releaseDate": "2026-03-06",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -2,7 +2,7 @@
 title: Data Model
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
+lastUpdated: v3.33.56
 date: 2026-03-06
 sourceFiles:
   - js/constants.js

--- a/wiki/dom-patterns.md
+++ b/wiki/dom-patterns.md
@@ -2,7 +2,7 @@
 title: DOM Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
+lastUpdated: v3.33.56
 date: 2026-03-06
 sourceFiles:
   - js/utils.js

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -2,7 +2,7 @@
 title: Frontend Overview
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
+lastUpdated: v3.33.56
 date: 2026-03-06
 sourceFiles:
   - index.html
@@ -17,7 +17,7 @@ relatedPages:
 ---
 # Frontend Overview
 
-> **Last updated:** v3.33.52 — 2026-03-05
+> **Last updated:** v3.33.56 — 2026-03-06
 > **Source files:** `index.html`, `js/constants.js`, `sw.js`, `js/file-protocol-fix.js`
 
 ## Overview
@@ -71,12 +71,12 @@ index.html  (single-page app — all UI panels, modals, and sections)
 `APP_VERSION` in `js/constants.js` follows the `BRANCH.RELEASE.PATCH` format:
 
 ```text
-3   .   33   .   44
+3   .   33   .   56
 ^       ^        ^
 Branch  Release  Patch
 ```
 
-Current version: **3.33.52**
+Current version: **3.33.56**
 
 Optional state suffixes: `a` = alpha, `b` = beta, `rc` = release candidate.
 
@@ -139,6 +139,24 @@ Full order is canonical in `sw.js` `CORE_ASSETS` and reflected in `index.html`.
 - This ensures inventory reads and writes work even in environments where `file://` origins block `localStorage`.
 
 On `http://` or `https://` origins the wrapping is still installed but never triggered — native `localStorage` calls succeed normally.
+
+### Diff review modal (`#diffReviewModal`)
+
+The diff review modal is a reusable change-review UI used by cloud sync and import flows (STAK-184, STAK-451). It is defined in `index.html` with a scoped `<style>` block immediately before its markup.
+
+**Layout:** `max-width: 860px`. At or below the `768px` breakpoint the modal expands to full-screen (`width: 100vw; height: 100dvh; max-width: none; border-radius: 0`).
+
+**Section containers** inside `#diffReviewModal .modal-body`:
+
+| Element ID | Purpose |
+|---|---|
+| `diffSummaryDashboard` | High-level counts dashboard shown at the top of the review |
+| `diffProgressTracker` | Progress indicator while diff is being computed |
+| `diffSectionConflicts` | Renders conflicting items that require user resolution |
+| `diffSectionOrphans` | Renders orphaned items (present in remote but not local, or vice versa) |
+| `diffSectionModified` | Scrollable list of modified items (max-height 320px, bordered) |
+
+Supporting elements: `diffReviewTitle`, `diffReviewSource`, `diffReviewCountRow`, `diffReviewCountWarning`, `diffReviewSummary`, `diffReviewSettings`. Action buttons: `diffReviewSelectAll`, `diffReviewDismissX`.
 
 ### Vendor libraries
 

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -151,12 +151,12 @@ The diff review modal is a reusable change-review UI used by cloud sync and impo
 | Element ID | Purpose |
 |---|---|
 | `diffSummaryDashboard` | High-level counts dashboard shown at the top of the review |
-| `diffProgressTracker` | Progress indicator while diff is being computed |
+| `diffProgressTracker` | Conflict-resolution progress bar (visible only for cloud sync sources) |
 | `diffSectionConflicts` | Renders conflicting items that require user resolution |
-| `diffSectionOrphans` | Renders orphaned items (present in remote but not local, or vice versa) |
+| `diffSectionOrphans` | Reserved placeholder for future orphan item rendering (currently unused) |
 | `diffSectionModified` | Scrollable list of modified items (max-height 320px, bordered) |
 
-Supporting elements: `diffReviewTitle`, `diffReviewSource`, `diffReviewCountRow`, `diffReviewCountWarning`, `diffReviewSummary`, `diffReviewSettings`. Action buttons: `diffReviewSelectAll`, `diffReviewDismissX`.
+Supporting elements: `diffReviewTitle`, `diffReviewSource`, `diffReviewCountRow`, `diffReviewCountWarning`, `diffReviewSettings`. Action buttons: `diffReviewSelectAll`, `diffReviewDismissX`.
 
 ### Vendor libraries
 

--- a/wiki/release-workflow.md
+++ b/wiki/release-workflow.md
@@ -2,7 +2,7 @@
 title: Release Workflow
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
+lastUpdated: v3.33.56
 date: 2026-03-06
 sourceFiles:
   - .claude/skills/release/SKILL.md

--- a/wiki/service-worker.md
+++ b/wiki/service-worker.md
@@ -2,7 +2,7 @@
 title: Service Worker
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
+lastUpdated: v3.33.56
 date: 2026-03-06
 sourceFiles:
   - sw.js

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -2,7 +2,7 @@
 title: Storage Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
+lastUpdated: v3.33.56
 date: 2026-03-06
 sourceFiles:
   - js/utils.js


### PR DESCRIPTION
## Summary

- **STAK-451**: Complete DiffModal UX overhaul — replaces flat radio-button conflict list with grouped card-based UI
- Adds settings categories/labels data maps, summary dashboard with progress tracker, per-item conflict cards with click-to-pick, and settings category cards with human-readable labels
- Restructures `#diffReviewModal` HTML (860px width, responsive CSS, new section containers)
- Refactors `_render()` orchestrator, `show()` per-field conflict init, and `_buildSelectedChanges()` per-setting resolution

## Files Changed

- `js/diff-modal.js` — 6 new render helpers, 2 data maps, refactored integration
- `index.html` — restructured modal HTML, responsive CSS
- `js/constants.js`, `sw.js`, `version.json`, `js/about.js`, `CHANGELOG.md`, `docs/announcements.md` — version bump
- `wiki/*.md` (6 pages) — frontmatter + content updates

## Test Plan

- [ ] Smoke test via `/bb-test sections=03,04` against Cloudflare preview URL
- [ ] Manual cloud sync conflict test at beta.staktrakr.com (OAuth constraint prevents Browserbase testing)
- [ ] Verify modal renders correctly at various viewport widths
- [ ] Verify click-to-pick conflict resolution works for both inventory items and settings

## Linear Issue

[STAK-451](https://linear.app/staktrakr/issue/STAK-451)

🤖 Generated with [Claude Code](https://claude.com/claude-code)