### PR TITLE
v3.33.57 — STAK-452: Australian coin slug names in Market view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.57] - 2026-03-06
+
+### Fixed — STAK-452: Australian Coin Slug Names in Market View
+
+- **Fixed**: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slug strings in Market view (STAK-452)
+
+---
+
 ## [3.33.56] - 2026-03-06
 
 ### Added — STAK-451: DiffModal UX Overhaul

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Australian Coin Names Fix (v3.33.57)**: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452).
 - **DiffModal UX Overhaul (v3.33.56)**: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts. Modal widened to 860px desktop, full-screen mobile (STAK-451).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449).
 - **Dateless Items Sort as Oldest (v3.33.54)**: Items with no purchase date now sort as "infinitely old" — top when oldest-first, bottom when newest-first (STAK-448).

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.57 &ndash; Australian Coin Names Fix</strong>: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452)</li>
     <li><strong>v3.33.56 &ndash; DiffModal UX Overhaul</strong>: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts. Modal widened to 860px desktop, full-screen mobile (STAK-451)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449)</li>
     <li><strong>v3.33.54 &ndash; Dateless Items Sort as Oldest</strong>: Items with no purchase date now sort as &ldquo;infinitely old&rdquo; &mdash; top when oldest-first, bottom when newest-first (STAK-448)</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.56";
+const APP_VERSION = "3.33.57";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -4,6 +4,7 @@
 /** All tracked coin slugs, display order */
 const RETAIL_SLUGS = [
   "ase", "maple-silver", "britannia-silver", "krugerrand-silver",
+  "kangaroo-silver", "koala-silver", "kookaburra-silver",
   "generic-silver-round", "generic-silver-bar-10oz",
   "age", "buffalo", "maple-gold", "krugerrand-gold", "ape",
   "goldback-oklahoma-g1",
@@ -22,6 +23,9 @@ const RETAIL_COIN_META = {
   "maple-gold":              { name: "Gold Maple Leaf",          weight: 1.0,  metal: "gold"     },
   "krugerrand-gold":         { name: "Gold Krugerrand",          weight: 1.0,  metal: "gold"     },
   "ape":                     { name: "American Platinum Eagle",   weight: 1.0, metal: "platinum" },
+  "kangaroo-silver":         { name: "Silver Kangaroo",           weight: 1.0,  metal: "silver"   },
+  "koala-silver":            { name: "Silver Koala",              weight: 1.0,  metal: "silver"   },
+  "kookaburra-silver":       { name: "Silver Kookaburra",         weight: 1.0,  metal: "silver"   },
   "goldback-oklahoma-g1":    { name: "G1 Oklahoma Goldback",     weight: 0.001, metal: "goldback" },
 };
 

--- a/js/retail.js
+++ b/js/retail.js
@@ -16,6 +16,9 @@ const RETAIL_COIN_META = {
   "maple-silver":            { name: "Silver Maple Leaf",        weight: 1.0,  metal: "silver"   },
   "britannia-silver":        { name: "Silver Britannia",         weight: 1.0,  metal: "silver"   },
   "krugerrand-silver":       { name: "Silver Krugerrand",        weight: 1.0,  metal: "silver"   },
+  "kangaroo-silver":         { name: "Silver Kangaroo",          weight: 1.0,  metal: "silver"   },
+  "koala-silver":            { name: "Silver Koala",             weight: 1.0,  metal: "silver"   },
+  "kookaburra-silver":       { name: "Silver Kookaburra",        weight: 1.0,  metal: "silver"   },
   "generic-silver-round":    { name: "Generic Silver Round",     weight: 1.0,  metal: "silver"   },
   "generic-silver-bar-10oz": { name: "Generic 10oz Silver Bar",  weight: 10.0, metal: "silver"   },
   "age":                     { name: "American Gold Eagle",      weight: 1.0,  metal: "gold"     },
@@ -23,9 +26,6 @@ const RETAIL_COIN_META = {
   "maple-gold":              { name: "Gold Maple Leaf",          weight: 1.0,  metal: "gold"     },
   "krugerrand-gold":         { name: "Gold Krugerrand",          weight: 1.0,  metal: "gold"     },
   "ape":                     { name: "American Platinum Eagle",   weight: 1.0, metal: "platinum" },
-  "kangaroo-silver":         { name: "Silver Kangaroo",           weight: 1.0,  metal: "silver"   },
-  "koala-silver":            { name: "Silver Koala",              weight: 1.0,  metal: "silver"   },
-  "kookaburra-silver":       { name: "Silver Kookaburra",         weight: 1.0,  metal: "silver"   },
   "goldback-oklahoma-g1":    { name: "G1 Oklahoma Goldback",     weight: 0.001, metal: "goldback" },
 };
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.56-b1772838426';
+const CACHE_NAME = 'staktrakr-v3.33.57-b1772838589';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.57-b1772838589';
+const CACHE_NAME = 'staktrakr-v3.33.57-b1772847828';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.56",
+  "version": "3.33.57",
   "releaseDate": "2026-03-06",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/retail-modal.md
+++ b/wiki/retail-modal.md
@@ -2,8 +2,8 @@
 title: Retail Modal
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.52
-date: 2026-03-05
+lastUpdated: v3.33.57
+date: 2026-03-06
 sourceFiles:
   - js/retail-view-modal.js
   - js/retail.js
@@ -424,6 +424,8 @@ Both `_retailViewModalChart` and `_retailViewIntradayChart` must be explicitly d
 ### Opening the modal for a slug not in `RETAIL_COIN_META`
 
 `openRetailViewModal` reads `RETAIL_COIN_META[slug]` and returns early if not found. Dynamic slugs (Goldbacks, manifest-added coins) are resolved via `getRetailCoinMeta(slug)` in `retail.js`, but the modal uses the raw `RETAIL_COIN_META` constant directly. If a new slug from the manifest is not in that constant and has no Goldback pattern match, the modal will silently refuse to open.
+
+As of v3.33.57, `RETAIL_COIN_META` includes 15 hardcoded entries covering all standard coins plus the three Australian silver coins (Kangaroo, Koala, Kookaburra). The manifest's `coins_meta` field provides runtime metadata but is not persisted to localStorage — on page reload before the manifest re-fetches, only the hardcoded entries are available.
 
 ---
 

--- a/wiki/vendor-quirks.md
+++ b/wiki/vendor-quirks.md
@@ -2,8 +2,8 @@
 title: Vendor Quirks
 category: infrastructure
 owner: staktrakr
-lastUpdated: v3.33.52
-date: 2026-03-05
+lastUpdated: v3.33.57
+date: 2026-03-06
 sourceFiles:
   - js/retail.js
   - js/api.js


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Added kangaroo-silver, koala-silver, and kookaburra-silver to `RETAIL_COIN_META` and `RETAIL_SLUGS` so Market view displays proper names instead of raw slug strings (STAK-452)
- Root cause: manifest `coins_meta` is not persisted to localStorage, so on page reload before manifest re-fetch, these three Australian coins fell through to the default `{ name: slug }` handler

## Linear Issues

- STAK-452: Market view showing slug names for kangaroo/koala/kookaburra coins

🤖 Generated with [Claude Code](https://claude.com/claude-code)