### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat instances in js/utils.js

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -551,6 +551,19 @@ const formatDisplayDate = (dateStr) => {
 };
 
 /**
+ * Global cache for Intl.NumberFormat instances to prevent repetitive
+ * instantiation overhead during loop-based rendering (e.g., inventory list).
+ * Keys are currency codes (e.g., 'USD').
+ */
+const _currencyFormatters = new Map();
+
+/**
+ * Global cache for 'en' locale Intl.NumberFormat instances used specifically
+ * for extracting base currency symbols (STACK-50). Keys are currency codes.
+ */
+const _currencySymbolFormatters = new Map();
+
+/**
  * Formats a number as a currency string using the default currency
  *
  * @param {number|string} value - Number to format
@@ -564,10 +577,12 @@ const formatCurrency = (value, currency = (typeof displayCurrency !== 'undefined
   const rate = (typeof getExchangeRate === 'function') ? getExchangeRate(currency) : 1;
   const converted = num * rate;
   try {
-    return new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency,
-    }).format(converted);
+    let formatter = _currencyFormatters.get(currency);
+    if (!formatter) {
+      formatter = new Intl.NumberFormat(undefined, { style: "currency", currency });
+      _currencyFormatters.set(currency, formatter);
+    }
+    return formatter.format(converted);
   } catch (e) {
     // Fallback for environments without Intl support
     return `${currency} ${converted.toFixed(2)}`;
@@ -604,7 +619,12 @@ const saveDisplayCurrency = (code) => {
 const getCurrencySymbol = (currency) => {
   const code = currency || (typeof displayCurrency !== 'undefined' ? displayCurrency : 'USD');
   try {
-    const parts = new Intl.NumberFormat('en', { style: 'currency', currency: code }).formatToParts(0);
+    let formatter = _currencySymbolFormatters.get(code);
+    if (!formatter) {
+      formatter = new Intl.NumberFormat('en', { style: 'currency', currency: code });
+      _currencySymbolFormatters.set(code, formatter);
+    }
+    const parts = formatter.formatToParts(0);
     const sym = parts.find(p => p.type === 'currency');
     return sym ? sym.value : code;
   } catch (e) { return code; }


### PR DESCRIPTION
💡 **What**: Added global `Map` caches (`_currencyFormatters` and `_currencySymbolFormatters`) to `js/utils.js` to store and reuse `Intl.NumberFormat` instances by currency code.

🎯 **Why**: Instantiating `Intl.NumberFormat` is computationally expensive. In loops (like rendering hundreds of inventory items where each requires `formatCurrency`), repeatedly instantiating these objects introduces significant, unnecessary overhead and blocks the main thread.

📊 **Impact**: Expected to drastically reduce execution time of formatting functions (often by 10x to 100x per call after the initial instantiation), accelerating UI rendering for large datasets.

🔬 **Measurement**: Measure the time spent in `formatCurrency` during a full inventory re-render (e.g., `renderCardView` or `renderTableView`) before and after the change using the Chrome DevTools Performance Profiler.

---
*PR created automatically by Jules for task [8415842598627350399](https://jules.google.com/task/8415842598627350399) started by @lbruton*