### PR TITLE
Update nightwatch log with retail-modal.md finding

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 6,
+  "nextIndex": 7,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -35,6 +35,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "Claims 'TTL is 30 minutes per claim' but devops/version-lock-protocol.md defines three tiers: Hotfix = 30min, Spec implementation = 4h, Pre-assigned queued slot = 4h.",
+      "verified": []
+    },
+    {
+      "date": "2026-03-06",
+      "page": "retail-modal.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "INACCURACY FOUND:\nPage: retail-modal.md\nSection: Current Prices (Vendor Legend)\nWiki claims: \"- OOS with last-known price: ~~\\$XX.XX~~ OOS (strikethrough + badge) / - OOS with no known price: — OOS\"\nCode shows: \"_buildVendorLegend explicitly skips rendering vendors if price == null and never applies strikethrough or an OOS badge.\"\nFile: js/retail-view-modal.js",
       "verified": []
     }
   ]


### PR DESCRIPTION
This PR updates `wiki/.nightwatch-log.json` to record a specific inaccuracy found in the `retail-modal.md` wiki page based on the rotation state. It correctly increments `nextIndex` and appends a properly formatted `INACCURACY FOUND` entry to the `history` array.

---
*PR created automatically by Jules for task [11082502469262461563](https://jules.google.com/task/11082502469262461563) started by @lbruton*