### PR TITLE
v3.33.58 — STAK-454: DiffModal item cards with per-field merge selection

### DIFF
--- a/.spec-workflow/templates/design-template.md
+++ b/.spec-workflow/templates/design-template.md
@@ -76,6 +76,35 @@ graph TD
 - [Additional properties as needed]
 ```
 
+## UI Impact Assessment
+
+### Has UI Changes: [Yes / No]
+
+_If **No**, skip this section entirely. If **Yes**, complete all fields below — this gates Phase 4._
+
+### Visual Scope
+- **Impact Level:** [New screen / New modal or panel / Redesign existing component / Minor element additions]
+- **Components Affected:** [List every UI component this spec creates or modifies]
+- **Prototype Required:** [Yes — if 3+ data elements, new layout, or uncertain visual hierarchy / No — single-element additions with clear analogues]
+
+### Prototype Artifacts
+- **Stitch Screen IDs:** [To be filled during prototype phase — leave blank in design doc]
+- **Playground File:** [To be filled during prototype phase — leave blank in design doc]
+- **Reference HTML/Mockup:** [Path to any existing prototype, mockup, or reference HTML provided with the spec]
+
+### Design Constraints
+- **Theme Compatibility:** [Must work in: light / dark / sepia / all]
+- **Existing Patterns to Match:** [Name specific existing components whose visual style this should follow]
+- **Responsive Behavior:** [How this renders on mobile / tablet / desktop]
+
+### Visual Approval Gate
+> **BLOCKING:** If `Prototype Required` is **Yes**, no UI implementation task may begin until:
+> 1. A Stitch mockup or equivalent visual is created and reviewed
+> 2. A Playground prototype (or reference HTML) is interactively approved by the user
+> 3. Both artifact paths are filled in above
+>
+> This gate is enforced in Phase 4 — the orchestrator MUST check this section before dispatching any task tagged with `ui:true`.
+
 ## Error Handling
 
 ### Error Scenarios
@@ -89,14 +118,11 @@ graph TD
 
 ## Testing Strategy
 
-### Unit Testing
-- [Unit testing approach]
-- [Key components to test]
+### Runbook E2E Tests (Primary)
+- Identify affected `tests/runbook/` section(s): [01-page-load, 02-crud, 03-backup-restore, 04-import-export, 05-market, 06-ui-ux, 07-activity-log, 08-spot-prices]
+- New test blocks to write (TDD — before implementation): [describe tests]
+- Run via `/bb-test sections=NN` against PR preview URL
 
-### Integration Testing
-- [Integration testing approach]
-- [Key flows to test]
-
-### End-to-End Testing
-- [E2E testing approach]
-- [User scenarios to test]
+### Manual Verification
+- [Any flows that require manual testing, e.g., OAuth/Dropbox cloud sync at beta.staktrakr.com]
+- [Flows requiring API keys from Infisical]

--- a/.spec-workflow/templates/implementer-prompt-template.md
+++ b/.spec-workflow/templates/implementer-prompt-template.md
@@ -89,3 +89,34 @@ When done, report:
 - Self-review findings (if any)
 - Any issues or concerns
 ```
+
+---
+
+## Quick Fix / Bug Fix Variant
+
+Use this variant when dispatching for a Linear issue fix WITHOUT a full spec. Replace the "Before You Begin" section above with this adversarial pre-implementation challenge.
+
+```
+You are fixing {LINEAR_ISSUE_ID}: {ISSUE_TITLE}
+
+## Bug Description
+
+{Description from Linear issue}
+
+## Adversarial Pre-Check (answer BEFORE writing any code)
+
+Stop and think critically:
+
+1. **What could go wrong?** What side effects might this fix introduce? What other code paths touch the same data/DOM/state?
+2. **What assumptions are you making?** Are you assuming the bug is where it appears to be? Could the root cause be upstream?
+3. **Is this really as simple as you think?** Quick fixes that seem obvious are often masking deeper issues. Have you verified the root cause, or are you patching a symptom?
+4. **What's the blast radius?** List every file and function this change could affect. Are there callers you haven't checked?
+5. **How will you verify it's fixed?** What specific test or manual check will confirm the fix works AND hasn't broken anything else?
+6. **Should this use Ralph Loop?** If the root cause is uncertain AND your answer to Q5 is a runnable test (e.g., `/bb-test sections=NN`, a unit test command, a grep assertion), consider `/ralph-loop` with `--completion-promise` set to the expected pass output. Skip Ralph if the fix is straightforward or there's no testable oracle.
+
+Write your answers to these 6 questions, then proceed with implementation. If any answer reveals uncertainty, investigate before coding. If Q6 says yes, start a Ralph Loop instead of coding directly.
+
+## Your Job
+
+{Same implementation steps as the spec variant above}
+```

--- a/.spec-workflow/templates/tasks-template.md
+++ b/.spec-workflow/templates/tasks-template.md
@@ -6,6 +6,37 @@
 - **GitHub PR:** [#NNN](https://github.com/owner/repo/pull/NNN)
 - **Spec Path:** `.spec-workflow/specs/{spec-name}/`
 
+## UI Prototype Gate (conditional — include ONLY if design.md declares `Has UI Changes: Yes` AND `Prototype Required: Yes`)
+
+> **BLOCKING:** Tasks 0.1–0.3 MUST be completed and approved before ANY task tagged `ui:true` begins.
+> If the spec has no UI changes, delete this entire section.
+
+- [ ] 0.1 Create visual mockup (Stitch or equivalent)
+  - Invoke the `ui-mockup` skill (Step 1–4) OR the `frontend-design` skill
+  - If design.md references a prototype HTML file, use it as the starting point
+  - Generate mockups for all states: populated, loading, empty, error
+  - Include light and dark theme variants
+  - Purpose: Establish visual direction before writing any UI code
+  - _Requirements: All UI-related requirements_
+  - _Prompt: Role: UI/UX Designer | Task: Create visual mockups using the ui-mockup skill (Stitch) or frontend-design skill for all new/modified UI components described in design.md. Cover all visual states (populated, loading, empty, error) and theme variants (light, dark). If a reference HTML prototype exists at the path noted in design.md, use it as the baseline. | Restrictions: Do NOT write any production code. Output is mockup artifacts only. | Success: Stitch screen IDs or equivalent visual artifacts are generated and presented to the user for review._
+
+- [ ] 0.2 Build interactive prototype (Playground)
+  - Invoke the `playground` skill using the approved mockup as spec
+  - Must use the project's actual tech stack (Bootstrap 5, CSS variables, data-theme attribute)
+  - Include realistic sample data, interactive controls, and all data states
+  - Purpose: Validate UX feel and interactions before production code
+  - _Requirements: All UI-related requirements_
+  - _Prompt: Role: Frontend Prototyper | Task: Build an interactive single-file HTML playground using the playground skill. Source visual design from the approved Stitch mockup (Task 0.1). Use the project's actual CSS framework and theme system. Include realistic data, clickable controls, hover states, and all data states (populated, loading, empty, error). | Restrictions: This is a throwaway prototype — do NOT integrate into the codebase. Must match the project's tech stack. | Success: User can interact with the prototype in a browser, validate layout/UX, and give explicit approval before implementation begins._
+
+- [ ] 0.3 Visual approval checkpoint
+  - Present prototype to user for explicit approval
+  - Update design.md `Prototype Artifacts` section with Stitch IDs and playground file path
+  - Purpose: Hard gate — no UI implementation proceeds without visual sign-off
+  - _Requirements: All UI-related requirements_
+  - _Prompt: Role: Project Coordinator | Task: Present the interactive prototype (Task 0.2) to the user. Ask explicitly - does this look and feel right? Collect approval or revision feedback. If approved, update the UI Impact Assessment section in design.md with the Stitch screen IDs and playground file path. | Restrictions: Do NOT proceed to any ui:true implementation task until the user explicitly approves the prototype. Verbal approval IS accepted for this visual checkpoint (unlike spec phase approvals). | Success: User has approved the visual design. design.md Prototype Artifacts section is populated. Implementation tasks may now begin._
+
+---
+
 - [ ] 1. Create core interfaces in src/types/feature.ts
   - File: src/types/feature.ts
   - Define TypeScript interfaces for feature data structures
@@ -123,19 +154,26 @@
   - _Prompt: Role: React Developer with expertise in state management and API integration | Task: Implement feature-specific components following requirements 5.2 and 5.3, using API hooks from src/hooks/useApi.ts and extending BaseComponent patterns | Restrictions: Must use existing state management patterns, handle loading and error states properly, maintain component performance | Success: Components are fully functional with proper state management, API integration works smoothly, user experience is responsive and intuitive_
 
 - [ ] 6. Integration and testing
-  - Plan integration approach
-  - _Leverage: src/utils/integrationUtils.ts, tests/helpers/testUtils.ts_
+  - Plan integration approach and identify affected runbook sections for TDD test authoring
+  - _Leverage: tests/runbook/*.md, /browserbase-test-maintenance skill_
   - _Requirements: 6.0_
-  - _Prompt: Role: Integration Engineer with expertise in system integration and testing strategies | Task: Plan comprehensive integration approach following requirement 6.0, leveraging integration utilities from src/utils/integrationUtils.ts and test helpers | Restrictions: Must consider all system components, ensure proper test coverage, maintain integration test reliability | Success: Integration plan is comprehensive and feasible, all system components work together correctly, integration points are well-tested_
+  - _Prompt: Role: Integration Engineer with expertise in system integration and testing strategies | Task: Plan comprehensive integration approach following requirement 6.0. Identify which tests/runbook/ section files are affected by this spec and write new runbook test blocks BEFORE implementation tasks begin (TDD). Use the /browserbase-test-maintenance skill for format guidance and section mapping. | Restrictions: Must consider all system components, ensure proper test coverage, write tests in the standard 7-field runbook format | Success: Integration plan is comprehensive, runbook test blocks are written for all new user-facing behavior, tests are appended to the correct section files_
 
-- [ ] 6.1 Write end-to-end tests
-  - Write user journey tests using Browserbase/Stagehand natural-language automation
-  - Test against the PR preview URL (get from Cloudflare Pages check on the draft PR)
-  - _Leverage: /bb-test skill, mcp__browserbase__* tools, PR preview URL from gh pr checks_
+- [ ] 6.1 Write end-to-end runbook tests (TDD — write BEFORE implementation)
+  - Write runbook test blocks in tests/runbook/*.md for new user-facing behavior
+  - Use the /browserbase-test-maintenance skill for the standard 7-field format
+  - Map implementation changes to the correct runbook section file
+  - _Leverage: /browserbase-test-maintenance skill, tests/runbook/*.md section files_
   - _Requirements: All_
-  - _Prompt: Role: QA Automation Engineer with expertise in Browserbase/Stagehand natural-language browser automation | Task: Implement end-to-end tests for all critical user journeys using Browserbase Stagehand tools (browserbase_session_create, stagehand_navigate, stagehand_act, stagehand_extract, browserbase_screenshot). Test against the PR preview URL — get it with: gh pr checks <PR_NUMBER> --json name,state,targetUrl | python3 -c "import sys,json; checks=json.load(sys.stdin); [print(c['targetUrl']) for c in checks if 'pages.dev' in c.get('targetUrl','')]". Do NOT use Playwright or browserless — they are unavailable. Each test step has a 10-minute timeout: if a step stalls, skip it and log a warning. | Restrictions: Use stagehand_act for all interactions, stagehand_extract for all assertions, no javascript_tool. Test real user workflows end-to-end. | Success: All critical user journeys tested against PR preview URL, session recording available in Browserbase dashboard, results logged via log-implementation_
+  - _Prompt: Role: QA Automation Engineer with expertise in Browserbase/Stagehand natural-language browser automation | Task: Write runbook test blocks in tests/runbook/*.md for all new user-facing behavior using the /browserbase-test-maintenance skill. Each test block must use the 7-field format (Test name, Added, Preconditions, Steps, Pass criteria, Tags, Section). Map changes to the correct section file. After implementation, verify by running /bb-test sections=NN against the PR preview URL. | Restrictions: Use the standard runbook format, append to section files (never modify existing tests), act steps must be atomic. No Playwright, no browserless. | Success: All new user-facing behavior has corresponding runbook test blocks, tests pass when run via /bb-test against the PR preview URL_
 
-- [ ] 6.2 Final integration and cleanup
+- [ ] 6.2 Verify tests against PR preview
+  - Run /bb-test sections=NN against PR preview URL to verify all new tests pass
+  - _Leverage: /bb-test skill, PR preview URL from gh pr checks_
+  - _Requirements: All_
+  - _Prompt: Role: QA Automation Engineer | Task: Run /bb-test sections=NN against the PR preview URL to verify all new runbook tests pass. Get the preview URL with: gh pr checks <PR_NUMBER> --json name,state,targetUrl. For 1-3 tests, consider manual verification via Chrome DevTools instead of a full Browserbase session. | Restrictions: Do NOT use Playwright or browserless. | Success: All new tests pass against the PR preview URL_
+
+- [ ] 6.3 Final integration and cleanup
   - Integrate all components
   - Fix any integration issues
   - Clean up code and documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.58] - 2026-03-07
+
+### Added — STAK-454: DiffModal Item Cards
+
+- **Added**: Item cards with bordered card layout, metal-colored image placeholders, and async image loading replace flat checkbox rows in DiffModal (STAK-454)
+- **Added**: Per-field checkboxes on modified items enabling granular merge field selection with master checkbox indeterminate state (STAK-454)
+- **Added**: "N fields changed" pill badge on modified item cards with expand/collapse toggle (STAK-454)
+- **Changed**: Apply button count now reflects individual field selections, not just item-level selections (STAK-454)
+
+---
+
 ## [3.33.57] - 2026-03-06
 
 ### Fixed — STAK-452: Australian Coin Slug Names in Market View

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added — STAK-454: DiffModal Item Cards
 
 - **Added**: Item cards with bordered card layout, metal-colored image placeholders, and async image loading replace flat checkbox rows in DiffModal (STAK-454)
-- **Added**: Per-field checkboxes on modified items enabling granular merge field selection with master checkbox indeterminate state (STAK-454)
+- **Added**: Click-to-pick field selection on modified items enabling granular merge control with visual local/remote highlighting (STAK-454)
 - **Added**: "N fields changed" pill badge on modified item cards with expand/collapse toggle (STAK-454)
 - **Changed**: Apply button count now reflects individual field selections, not just item-level selections (STAK-454)
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **DiffModal Item Cards (v3.33.58)**: Item cards with bordered layout, metal-colored image placeholders, async image loading, and per-field checkboxes for granular merge selection on modified items (STAK-454).
 - **Australian Coin Names Fix (v3.33.57)**: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452).
-- **DiffModal UX Overhaul (v3.33.56)**: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts. Modal widened to 860px desktop, full-screen mobile (STAK-451).
-- **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449).
+- **DiffModal UX Overhaul (v3.33.56)**: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts (STAK-451).
+- **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication (STAK-449).
 - **Dateless Items Sort as Oldest (v3.33.54)**: Items with no purchase date now sort as "infinitely old" — top when oldest-first, bottom when newest-first (STAK-448).
-- **Numista N# Search Image URL + Metal Auto-Population (v3.33.53)**: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431).
-- **Market Controls Mobile Fix + Metal Filter Buttons (v3.33.52)**: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434).
 
 ## Development Roadmap
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **DiffModal Item Cards (v3.33.58)**: Item cards with bordered layout, metal-colored image placeholders, async image loading, and per-field checkboxes for granular merge selection on modified items (STAK-454).
+- **DiffModal Item Cards (v3.33.58)**: Item cards with bordered layout, metal-colored image placeholders, async image loading, and click-to-pick field selection for granular merge control on modified items (STAK-454).
 - **Australian Coin Names Fix (v3.33.57)**: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452).
 - **DiffModal UX Overhaul (v3.33.56)**: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts (STAK-451).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication (STAK-449).

--- a/index.html
+++ b/index.html
@@ -4544,7 +4544,7 @@
         padding: 0.35rem 0.6rem; border-radius: 8px; min-height: 1.8rem;
         font-size: 0.82rem; cursor: pointer; transition: all 0.15s;
         border: 2px solid transparent; text-align: center;
-        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+        word-break: break-word;
       }
       #diffReviewModal .dm-field-value.local { background: rgba(99,102,241,0.15); }
       #diffReviewModal .dm-field-value.remote { background: rgba(59,130,246,0.12); }

--- a/index.html
+++ b/index.html
@@ -4505,7 +4505,7 @@
           <div id="diffProgressTracker" style="margin:0.5rem 0"></div>
           <div id="diffSectionConflicts" style="margin-bottom:1rem"></div>
           <div id="diffSectionOrphans" style="margin-bottom:1rem"></div>
-          <div id="diffSectionModified" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
+          <div id="diffSectionModified" style="max-height:500px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
           <div id="diffReviewSettings" style="margin-bottom:1rem"></div>
           <div class="encryption-actions" style="gap:0.5rem;flex-wrap:wrap">
             <button class="btn btn-sm" id="diffReviewSelectAll">Select All</button>

--- a/index.html
+++ b/index.html
@@ -4505,7 +4505,7 @@
           <div id="diffProgressTracker" style="margin:0.5rem 0"></div>
           <div id="diffSectionConflicts" style="margin-bottom:1rem"></div>
           <div id="diffSectionOrphans" style="margin-bottom:1rem"></div>
-          <div id="diffSectionModified" style="max-height:500px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
+          <div id="diffSectionModified" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
           <div id="diffReviewSettings" style="margin-bottom:1rem"></div>
           <div class="encryption-actions" style="gap:0.5rem;flex-wrap:wrap">
             <button class="btn btn-sm" id="diffReviewSelectAll">Select All</button>

--- a/index.html
+++ b/index.html
@@ -4617,6 +4617,13 @@
       }
       #diffReviewModal .dm-btn-secondary:hover { background: #22253a; color: var(--text-primary,#f0f0f5); }
       #diffReviewModal .dm-btn-loss { background: var(--loss,#ef4444); color: #fff; }
+      #diffReviewModal .dm-btn-gain { background: var(--gain,#22c55e); color: #fff; }
+      #diffReviewModal .dm-btn-gain:hover { background: #16a34a; box-shadow: 0 2px 12px rgba(34,197,94,0.4); }
+      #diffReviewModal .dm-btn-muted {
+        background: var(--bg-tertiary,#262a3a); color: var(--text-muted,#64748b);
+        border: 1px solid var(--border-color,rgba(255,255,255,0.08)); opacity: 0.7;
+      }
+      #diffReviewModal .dm-btn-muted:hover { opacity: 1; }
       #diffReviewModal .dm-card.resolved { opacity: 0.5; transform: scale(0.98); transition: all 0.3s; }
       #diffReviewModal .fade-in { animation: dmFadeIn 0.3s ease; }
       @keyframes dmFadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }

--- a/index.html
+++ b/index.html
@@ -3292,7 +3292,7 @@
                 </div>
               </div>
 
-              <!-- ── Import + Third-Party ── -->
+              <!-- ── Import + Export ── -->
               <div class="settings-card-grid" style="margin-bottom:1rem">
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
@@ -3306,9 +3306,7 @@
                     <div class="import-block">
                       <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:0.4rem">
                         <button class="btn warning" id="importCsvOverride" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import CSV</button>
-                        <button class="btn success" id="importCsvMerge" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Merge CSV</button>
                         <button class="btn warning" id="importJsonOverride" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import JSON</button>
-                        <button class="btn success" id="importJsonMerge" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Merge JSON</button>
                       </div>
                       <input accept=".csv" hidden id="importCsvFile" type="file" />
                       <input accept=".json" hidden id="importJsonFile" type="file" />
@@ -3317,29 +3315,6 @@
                     </div>
                   </div>
                 </div>
-                <div class="cloud-provider-card">
-                  <div class="cloud-provider-card-header">
-                    <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-                      Third-Party
-                    </span>
-                  </div>
-                  <p class="settings-subtext">Import data from external services like Numista.</p>
-                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
-                    <div class="third-party-block">
-                      <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:0.4rem">
-                        <button class="btn warning" id="importNumistaBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import Numista</button>
-                        <button class="btn success" id="mergeNumistaBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Merge Numista</button>
-                      </div>
-                      <input type="file" id="numistaImportFile" accept=".csv" hidden />
-                      <div class="beta-warning" style="margin-top:0.4rem">Numista import is a beta feature</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- ── Export + Encrypted Backup ── -->
-              <div class="settings-card-grid" style="margin-bottom:1rem">
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
@@ -3362,6 +3337,28 @@
                         <button class="btn warning" id="importZipBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;grid-column:span 2">Restore ZIP Backup</button>
                         <input accept=".zip" hidden id="importZipFile" type="file" />
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- ── Third-Party + Encrypted Backup ── -->
+              <div class="settings-card-grid" style="margin-bottom:1rem">
+                <div class="cloud-provider-card">
+                  <div class="cloud-provider-card-header">
+                    <span class="cloud-provider-card-title">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                      Third-Party
+                    </span>
+                  </div>
+                  <p class="settings-subtext">Import data from external services like Numista.</p>
+                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
+                    <div class="third-party-block">
+                      <div style="display:grid;grid-template-columns:1fr;gap:0.4rem">
+                        <button class="btn warning" id="importNumistaBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import Numista</button>
+                      </div>
+                      <input type="file" id="numistaImportFile" accept=".csv" hidden />
+                      <div class="beta-warning" style="margin-top:0.4rem">Numista import is a beta feature</div>
                     </div>
                   </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -4541,7 +4541,7 @@
         letter-spacing: 0.06em; font-weight: 500;
       }
       #diffReviewModal .dm-field-value {
-        padding: 0.35rem 0.6rem; border-radius: 8px;
+        padding: 0.35rem 0.6rem; border-radius: 8px; min-height: 1.8rem;
         font-size: 0.82rem; cursor: pointer; transition: all 0.15s;
         border: 2px solid transparent; text-align: center;
         white-space: nowrap; overflow: hidden; text-overflow: ellipsis;

--- a/index.html
+++ b/index.html
@@ -4475,7 +4475,7 @@
       </div>
     </div>
 
-    <!-- Diff Review Modal — reusable change-review UI (STAK-184, STAK-451) -->
+    <!-- Diff Review Modal — reusable change-review UI (STAK-184, STAK-451, STAK-454) -->
     <style>
       #diffReviewModal .modal-content {
         max-height: 90vh;
@@ -4489,6 +4489,142 @@
           max-height: none;
           border-radius: 0;
         }
+      }
+      /* STAK-454: Card-based item rendering (from playground/diffmodal-item-cards.html) */
+      #diffReviewModal .dm-card {
+        background: var(--bg-card,#1a1d27); border: 1px solid var(--border-color,rgba(255,255,255,0.08));
+        border-radius: 12px; padding: 1rem;
+        transition: border-color 0.2s, box-shadow 0.2s;
+      }
+      #diffReviewModal .dm-card:hover { border-color: rgba(99,102,241,0.4); box-shadow: 0 4px 24px rgba(0,0,0,0.3); }
+      #diffReviewModal .dm-orphan-card {
+        display: flex; align-items: center; gap: 0.75rem;
+        margin-bottom: 0.5rem; padding: 0.75rem 1rem; cursor: pointer;
+      }
+      #diffReviewModal .dm-orphan-card.skipped { opacity: 0.4; transition: opacity 0.3s; }
+      #diffReviewModal .dm-orphan-actions { display: flex; gap: 0.4rem; flex-shrink: 0; }
+      #diffReviewModal .dm-conflict-card { margin-bottom: 0.75rem; }
+      #diffReviewModal .dm-conflict-card-header {
+        display: flex; align-items: center; gap: 0.75rem;
+        padding-bottom: 0.75rem; margin-bottom: 0.75rem;
+        border-bottom: 1px solid var(--border-color,rgba(255,255,255,0.08));
+      }
+      #diffReviewModal .dm-item-thumb {
+        width: 44px; height: 44px; border-radius: 8px;
+        background: var(--bg-tertiary,#262a3a); display: flex; align-items: center;
+        justify-content: center; font-size: 1.2rem; flex-shrink: 0;
+        border: 1px solid var(--border-color,rgba(255,255,255,0.08));
+      }
+      #diffReviewModal .dm-item-thumb-pair { display: flex; gap: 4px; flex-shrink: 0; }
+      #diffReviewModal .dm-item-thumb-pair .dm-item-thumb {
+        width: 40px; height: 40px; font-size: 0.6rem;
+        color: var(--text-muted,#6b7094); text-align: center;
+        line-height: 1.2; padding: 2px;
+      }
+      #diffReviewModal .dm-item-identity { flex: 1; min-width: 0; }
+      #diffReviewModal .dm-item-name {
+        font-weight: 600; font-size: 0.9rem; white-space: nowrap;
+        overflow: hidden; text-overflow: ellipsis;
+      }
+      #diffReviewModal .dm-item-meta {
+        font-size: 0.72rem; color: var(--text-muted,#6b7094);
+        display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.15rem;
+      }
+      #diffReviewModal .dm-field-diff {
+        display: grid; grid-template-columns: 120px 1fr auto 1fr; gap: 0.5rem;
+        align-items: center; padding: 0.5rem 0;
+        border-bottom: 1px solid rgba(255,255,255,0.03);
+      }
+      #diffReviewModal .dm-field-diff:last-child { border-bottom: none; }
+      #diffReviewModal .dm-field-label {
+        font-size: 0.72rem; color: var(--text-muted,#6b7094); text-transform: uppercase;
+        letter-spacing: 0.06em; font-weight: 500;
+      }
+      #diffReviewModal .dm-field-value {
+        padding: 0.35rem 0.6rem; border-radius: 8px;
+        font-size: 0.82rem; cursor: pointer; transition: all 0.15s;
+        border: 2px solid transparent; text-align: center;
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      }
+      #diffReviewModal .dm-field-value.local { background: rgba(99,102,241,0.15); }
+      #diffReviewModal .dm-field-value.remote { background: rgba(59,130,246,0.12); }
+      #diffReviewModal .dm-field-value.selected {
+        border-color: var(--gain,#22c55e); box-shadow: 0 0 0 1px var(--gain,#22c55e);
+        background: rgba(34,197,94,0.12); color: var(--gain,#22c55e); font-weight: 600;
+      }
+      #diffReviewModal .dm-field-value:hover:not(.selected) { border-color: var(--text-muted,#6b7094); }
+      #diffReviewModal .dm-field-arrow { color: var(--text-muted,#6b7094); font-size: 0.8rem; text-align: center; }
+      #diffReviewModal .dm-card-actions {
+        display: flex; gap: 0.5rem; margin-top: 0.75rem; padding-top: 0.75rem;
+        border-top: 1px solid var(--border-color,rgba(255,255,255,0.08)); justify-content: flex-end;
+      }
+      #diffReviewModal .dm-section-header {
+        display: flex; align-items: center; justify-content: space-between;
+        margin-bottom: 0.75rem; padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border-color,rgba(255,255,255,0.08));
+      }
+      #diffReviewModal .dm-section-title {
+        font-size: 0.9rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem;
+      }
+      #diffReviewModal .dm-section-actions { display: flex; gap: 0.5rem; }
+      #diffReviewModal .dm-collapse-toggle {
+        cursor: pointer; font-size: 0.7rem; color: var(--text-muted,#6b7094);
+        transition: transform 0.2s; user-select: none;
+      }
+      #diffReviewModal .dm-collapse-toggle.collapsed { transform: rotate(-90deg); }
+      #diffReviewModal .dm-section-body.collapsed { display: none; }
+      #diffReviewModal .dm-conflict-details { transition: all 0.3s ease; }
+      #diffReviewModal .dm-conflict-details.collapsed {
+        max-height: 0; overflow: hidden; margin: 0; padding: 0; opacity: 0;
+      }
+      #diffReviewModal .dm-chip {
+        display: inline-flex; align-items: center; gap: 0.25rem;
+        padding: 0.2rem 0.5rem; border-radius: 999px;
+        font-size: 0.7rem; background: var(--bg-tertiary,#262a3a); color: var(--text-secondary,#b0b3c6);
+      }
+      #diffReviewModal .dm-pill {
+        display: inline-flex; align-items: center; gap: 0.3rem;
+        padding: 0.25rem 0.65rem; border-radius: 999px;
+        font-size: 0.75rem; font-weight: 600;
+      }
+      #diffReviewModal .dm-pill-warning { background: rgba(217,119,6,0.12); color: var(--warning,#d97706); }
+      #diffReviewModal .dm-pill-gain { background: rgba(34,197,94,0.12); color: var(--gain,#22c55e); }
+      #diffReviewModal .dm-resolve-status {
+        display: flex; align-items: center; gap: 0.75rem;
+        padding: 0.6rem 1rem; background: var(--bg-tertiary,#262a3a);
+        border-radius: 999px; margin-bottom: 1rem; font-size: 0.8rem;
+      }
+      #diffReviewModal .dm-status-text { flex: 1; color: var(--text-secondary,#b0b3c6); }
+      #diffReviewModal .dm-progress-bar {
+        height: 4px; background: var(--bg-tertiary,#262a3a); border-radius: 2px;
+        overflow: hidden; margin-bottom: 1rem;
+      }
+      #diffReviewModal .dm-progress-fill {
+        height: 100%; border-radius: 2px; transition: width 0.4s ease;
+        background: linear-gradient(90deg, #6366f1, #22c55e);
+      }
+      #diffReviewModal .dm-btn {
+        padding: 0.5rem 1.1rem; border: none; border-radius: 999px;
+        font-size: 0.82rem; font-weight: 600; cursor: pointer; transition: all 0.2s;
+        display: inline-flex; align-items: center; gap: 0.4rem;
+      }
+      #diffReviewModal .dm-btn-sm { padding: 0.3rem 0.7rem; font-size: 0.75rem; }
+      #diffReviewModal .dm-btn-primary { background: var(--primary,#6366f1); color: #fff; }
+      #diffReviewModal .dm-btn-primary:hover { background: #818cf8; box-shadow: 0 2px 12px rgba(99,102,241,0.4); }
+      #diffReviewModal .dm-btn-secondary {
+        background: var(--bg-tertiary,#262a3a); color: var(--text-secondary,#b0b3c6);
+        border: 1px solid var(--border-color,rgba(255,255,255,0.08));
+      }
+      #diffReviewModal .dm-btn-secondary:hover { background: #22253a; color: var(--text-primary,#f0f0f5); }
+      #diffReviewModal .dm-btn-loss { background: var(--loss,#ef4444); color: #fff; }
+      #diffReviewModal .dm-card.resolved { opacity: 0.5; transform: scale(0.98); transition: all 0.3s; }
+      #diffReviewModal .fade-in { animation: dmFadeIn 0.3s ease; }
+      @keyframes dmFadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+      @media (max-width: 700px) {
+        #diffReviewModal .dm-field-diff { grid-template-columns: 80px 1fr auto 1fr; }
+      }
+      @media (max-width: 480px) {
+        #diffReviewModal .dm-field-diff { grid-template-columns: 1fr; gap: 0.25rem; }
       }
     </style>
     <div class="modal" id="diffReviewModal" style="display: none">
@@ -4505,7 +4641,7 @@
           <div id="diffProgressTracker" style="margin:0.5rem 0"></div>
           <div id="diffSectionConflicts" style="margin-bottom:1rem"></div>
           <div id="diffSectionOrphans" style="margin-bottom:1rem"></div>
-          <div id="diffSectionModified" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
+          <div id="diffSectionModified" style="max-height:500px;overflow-y:auto;border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
           <div id="diffReviewSettings" style="margin-bottom:1rem"></div>
           <div class="encryption-actions" style="gap:0.5rem;flex-wrap:wrap">
             <button class="btn btn-sm" id="diffReviewSelectAll">Select All</button>

--- a/js/about.js
+++ b/js/about.js
@@ -283,7 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.33.58 &ndash; DiffModal Item Cards</strong>: Item cards with bordered layout, metal-colored image placeholders, async image loading, and per-field checkboxes for granular merge selection on modified items (STAK-454)</li>
+    <li><strong>v3.33.58 &ndash; DiffModal Item Cards</strong>: Item cards with bordered layout, metal-colored image placeholders, async image loading, and click-to-pick field selection for granular merge control on modified items (STAK-454)</li>
     <li><strong>v3.33.57 &ndash; Australian Coin Names Fix</strong>: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452)</li>
     <li><strong>v3.33.56 &ndash; DiffModal UX Overhaul</strong>: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts (STAK-451)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication (STAK-449)</li>

--- a/js/about.js
+++ b/js/about.js
@@ -283,12 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.58 &ndash; DiffModal Item Cards</strong>: Item cards with bordered layout, metal-colored image placeholders, async image loading, and per-field checkboxes for granular merge selection on modified items (STAK-454)</li>
     <li><strong>v3.33.57 &ndash; Australian Coin Names Fix</strong>: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452)</li>
-    <li><strong>v3.33.56 &ndash; DiffModal UX Overhaul</strong>: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts. Modal widened to 860px desktop, full-screen mobile (STAK-451)</li>
-    <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication. Sign out of Dropbox helper link for clearing browser sessions (STAK-449)</li>
+    <li><strong>v3.33.56 &ndash; DiffModal UX Overhaul</strong>: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts (STAK-451)</li>
+    <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication (STAK-449)</li>
     <li><strong>v3.33.54 &ndash; Dateless Items Sort as Oldest</strong>: Items with no purchase date now sort as &ldquo;infinitely old&rdquo; &mdash; top when oldest-first, bottom when newest-first (STAK-448)</li>
-    <li><strong>v3.33.53 &ndash; Numista N# Search Image URL + Metal Auto-Population</strong>: Numista N# search now auto-populates obverse/reverse image URLs and metal type into inventory items. Field picker shows new checkboxes for images and metal with opt-out control (STAK-431)</li>
-    <li><strong>v3.33.52 &ndash; Market Controls Mobile Fix + Metal Filter Buttons</strong>: Fixed mobile search bar crushed to 2 chars and controls overflow. Fixed Expand/Collapse text flip on search. Added metal filter pill buttons (All/Silver/Gold/Goldback/Platinum/Palladium) with color-coded active states (STAK-433, STAK-434)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.57";
+const APP_VERSION = "3.33.58";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -296,13 +296,16 @@
   function _renderSummaryDashboard(container, diff, conflicts) {
     if (!container) return;
     var matched = (diff.unchanged || []).length;
-    var conflictCount = (conflicts && conflicts.conflicts || []).length;
+    var syncConflicts = (conflicts && conflicts.conflicts || []).length;
+    var modifiedCount = (diff.modified || []).length;
+    // Show whichever is relevant: true sync conflicts, or modified items for imports
+    var conflictCount = syncConflicts > 0 ? syncConflicts : modifiedCount;
     var remoteOnly = (diff.added || []).length;
     var localOnly = (diff.deleted || []).length;
 
     var cards = [
       { count: matched, label: 'Matched', target: 'diffSectionModified', color: '', style: 'opacity:0.5' },
-      { count: conflictCount, label: 'Conflicts', target: 'diffSectionConflicts', color: conflictCount > 0 ? 'color:#d97706' : '', style: '' },
+      { count: conflictCount, label: 'Conflicts', target: syncConflicts > 0 ? 'diffSectionConflicts' : 'diffSectionModified', color: conflictCount > 0 ? 'color:#d97706' : '', style: '' },
       { count: remoteOnly, label: 'Remote Only', target: 'diffSectionModified', color: '', style: '' },
       { count: localOnly, label: 'Local Only', target: 'diffSectionModified', color: '', style: '' }
     ];

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -133,13 +133,11 @@
   // ── Internal state ──
   var _options = null;
   var _checkedItems = {};      // { 'added-0': true, 'modified-2': false, ... }
-  var _checkedFields = {};      // { 'modified-0-purchasePrice': true, ... }
   var _conflictResolutions = {}; // { 'c0': 'local'|'remote', ... }
   var _collapsedCategories = {}; // { added: true, ... }
   var _expandedModified = {};    // { 0: true, 1: false, ... }
   var _expandedSettingsCategories = {}; // { 'Display & Appearance': true, ... }
   var _selectAllState = 0;  // 0=none, 1=added+modified, 2=all
-  var _showAllItems = {};    // { added: true, deleted: true, modified: true }
 
   // ── Helpers ──
 
@@ -172,24 +170,8 @@
   /** Count currently checked items */
   function _checkedCount() {
     var count = 0;
-    var diff = _options ? _options.diff || {} : {};
     for (var k in _checkedItems) {
-      if (!_checkedItems.hasOwnProperty(k) || !_checkedItems[k]) continue;
-      // For modified items, count individual fields instead of the whole item
-      if (k.indexOf('modified-') === 0) {
-        var mIdx = parseInt(k.split('-')[1], 10);
-        var modItem = (diff.modified || [])[mIdx];
-        if (modItem) {
-          var changes = modItem.changes || [];
-          for (var c = 0; c < changes.length; c++) {
-            if (_checkedFields['modified-' + mIdx + '-' + changes[c].field] !== false) {
-              count++;
-            }
-          }
-        }
-      } else {
-        count++;
-      }
+      if (_checkedItems.hasOwnProperty(k) && _checkedItems[k]) count++;
     }
     return count;
   }
@@ -651,51 +633,25 @@
     // Conflict cards (replaces old inline conflict rendering)
     _renderConflictCards(safeGetElement('diffSectionConflicts'), conflicts);
 
-    // Item cards — Added and Deleted render to #diffSectionOrphans
-    var orphanEl = safeGetElement('diffSectionOrphans');
-    if (orphanEl) {
-      var orphanHtml = '';
-      orphanHtml += _renderItemCards(orphanEl, added, 'added', 'Added');
-      orphanHtml += _renderItemCards(orphanEl, deleted, 'deleted', 'Deleted');
-      if (orphanHtml) {
-        orphanEl.style.display = '';
-        orphanEl.innerHTML = orphanHtml;
+    // Change list — retarget to diffSectionModified container
+    var listEl = safeGetElement('diffSectionModified');
+    if (listEl) {
+      var totalChanges = added.length + modified.length + deleted.length;
+      var lHtml = '';
+
+      if (totalChanges === 0) {
+        lHtml = '<div style="padding:2rem;text-align:center;opacity:0.45;font-size:0.85rem">No item changes detected</div>';
       } else {
-        orphanEl.style.display = 'none';
-        orphanEl.innerHTML = '';
+        // Added
+        if (added.length > 0) lHtml += _renderCategory('added', 'Added', '+', added);
+        // Modified
+        if (modified.length > 0) lHtml += _renderCategory('modified', 'Modified', '&#9998;', modified);
+        // Deleted
+        if (deleted.length > 0) lHtml += _renderCategory('deleted', 'Deleted', '&minus;', deleted);
       }
-    }
 
-    // Item cards — Modified renders to #diffSectionModified
-    var modEl = safeGetElement('diffSectionModified');
-    if (modEl) {
-      var modHtml = _renderModifiedCards(modEl, modified);
-      if (modHtml) {
-        modEl.style.display = '';
-        modEl.innerHTML = modHtml;
-      } else {
-        modEl.style.display = 'none';
-        modEl.innerHTML = '';
-      }
+      listEl.innerHTML = lHtml;
     }
-
-    // No changes message
-    if (added.length + modified.length + deleted.length === 0) {
-      var noChangesHtml = '<div style="padding:2rem;text-align:center;opacity:0.45;font-size:0.85rem">No item changes detected</div>';
-      if (modEl) { modEl.style.display = ''; modEl.innerHTML = noChangesHtml; }
-    }
-
-    // Set indeterminate state on master checkboxes (must happen after innerHTML)
-    var modal = safeGetElement('diffReviewModal');
-    if (modal) {
-      var indets = modal.querySelectorAll('[data-indeterminate="true"]');
-      for (var ii = 0; ii < indets.length; ii++) {
-        indets[ii].indeterminate = true;
-      }
-    }
-
-    // Async image loading
-    _loadItemImages();
 
     // Settings cards (replaces old settings <details>)
     _renderSettingsCards(safeGetElement('diffReviewSettings'), _options.settingsDiff);
@@ -719,233 +675,70 @@
     deleted: { bg: 'rgba(220,38,38,0.12)',  color: 'var(--danger,#dc2626)' }
   };
 
-
-  /** Metal emoji for item card image placeholders */
-  function _metalEmoji() {
-    return '\uD83E\uDE99';
-  }
-
-  /** Background color per metal for card image area */
-  function _metalBgColor(metal) {
-    var m = (metal || '').toLowerCase();
-    if (m === 'gold') return 'rgba(255,215,0,0.12)';
-    if (m === 'silver') return 'rgba(192,192,192,0.12)';
-    if (m === 'platinum') return 'rgba(229,228,226,0.12)';
-    if (m === 'palladium') return 'rgba(206,208,206,0.12)';
-    return 'rgba(255,255,255,0.06)';
-  }
-
-  /** Text color per metal for card image area */
-  function _metalTextColor(metal) {
-    var m = (metal || '').toLowerCase();
-    if (m === 'gold') return 'var(--gold,#FFD700)';
-    if (m === 'silver') return 'var(--silver,#C0C0C0)';
-    if (m === 'platinum') return 'var(--platinum,#E5E4E2)';
-    if (m === 'palladium') return 'var(--palladium,#CED0CE)';
-    return 'var(--text-secondary)';
-  }
-
-  /** Render Added or Deleted items as bordered cards */
-  function _renderItemCards(container, items, type, label) {
-    if (!container || !items || items.length === 0) {
-      if (container) {
-        container.style.display = 'none';
-        container.innerHTML = '';
-      }
-      return '';
-    }
-
-    var cc = _catColors[type];
+  /** Render a category group (added/modified/deleted) */
+  function _renderCategory(type, label, icon, items) {
     var collapsed = _collapsedCategories[type];
-    var icon = (type === 'deleted') ? '&minus;' : '+';
-    var html = '';
+    var cc = _catColors[type];
+    var html = '<div data-cat="' + type + '" style="' + (collapsed ? '' : '') + '">';
 
-    // Section header
-    html += '<div data-cat-toggle="' + type + '" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none">';
+    // Header
+    html += '<div class="diff-cat-header" data-cat-toggle="' + type + '" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none;font-size:0.8rem;font-weight:600">';
     html += '<span style="font-size:0.6rem;opacity:0.4;transition:transform 0.2s;' + (collapsed ? 'transform:rotate(-90deg)' : '') + '">&#9660;</span>';
     html += '<span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:4px;font-size:0.7rem;font-weight:700;background:' + cc.bg + ';color:' + cc.color + '">' + icon + '</span>';
-    html += '<span style="font-weight:600;font-size:0.8rem">' + _esc(label) + '</span>';
+    html += '<span>' + label + '</span>';
     html += '<span style="font-weight:400;opacity:0.5;font-size:0.73rem">(' + items.length + ')</span>';
     html += '</div>';
 
-    // Card container
-    html += '<div style="padding:0 0.65rem;' + (collapsed ? 'display:none' : '') + '">';
-
-    var limit = (_showAllItems[type] || items.length <= 20) ? items.length : 20;
-    for (var i = 0; i < limit; i++) {
-      var item = items[i];
+    // Items
+    html += '<div class="diff-cat-items" style="' + (collapsed ? 'display:none' : '') + '">';
+    for (var i = 0; i < items.length; i++) {
       var key = type + '-' + i;
-      var checked = _checkedItems[key] !== false;
+      var checked = _checkedItems[key] !== false; // default true
+      var item = type === 'modified' ? items[i].item : items[i];
       var name = _esc(item.name || 'Unnamed item');
-      var metalBg = _metalBgColor(item.metal);
-      var metalCol = _metalTextColor(item.metal);
 
-      // Card wrapper
-      html += '<div style="border-radius:8px;border:1px solid var(--border-color,rgba(255,255,255,0.08));padding:0.65rem;margin-bottom:0.5rem;background:var(--bg-card,#1a1d27)">';
-      html += '<div style="display:flex;gap:0.5rem;align-items:center">';
+      html += '<div style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.45rem 0.65rem;font-size:0.85rem">';
+      html += '<input type="checkbox" data-check="' + key + '" ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);margin-top:2px;flex-shrink:0;cursor:pointer">';
+      html += '<div style="flex-shrink:0;width:20px;height:20px;border-radius:5px;display:flex;align-items:center;justify-content:center;font-size:0.75rem;font-weight:700;margin-top:1px;background:' + cc.bg + ';color:' + cc.color + '">' + icon + '</div>';
 
-      // Checkbox
-      html += '<input type="checkbox" data-check="' + key + '" ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);flex-shrink:0;cursor:pointer">';
-
-      // Image area
-      html += '<div' + (item.uuid ? ' data-uuid="' + _esc(item.uuid) + '"' : '') + ' style="width:40px;height:40px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;background:' + metalBg + ';color:' + metalCol + '">';
-      html += _metalEmoji(item.metal);
-      html += '</div>';
-
-      // Content area
       html += '<div style="flex:1;min-width:0">';
-      html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + '</div>';
 
-      // Metadata
-      var detail = [];
-      if (item.metal) detail.push(_esc(item.metal));
-      if (item.weight != null) detail.push(_esc(item.weight) + _esc(item.weightUnit || 'oz'));
-      if (item.qty != null) detail.push('\u00d7 ' + _esc(item.qty));
-      if (detail.length > 0) {
-        html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';
-      }
-
-      html += '</div>'; // content area
-      html += '</div>'; // flex row
-      html += '</div>'; // card
-    }
-
-    // "Show N more" button
-    if (items.length > 20) {
-      var remaining = items.length - 20;
-      html += '<div data-show-more="' + type + '" style="font-size:0.78rem;text-align:center;cursor:pointer;padding:0.5rem;opacity:0.6">Show ' + remaining + ' more</div>';
-    }
-
-    html += '</div>'; // card container
-
-    return html;
-  }
-
-  /** Render Modified items as expandable cards with per-field checkboxes */
-  function _renderModifiedCards(container, modifiedItems) {
-    if (!container || !modifiedItems || modifiedItems.length === 0) {
-      if (container) {
-        container.style.display = 'none';
-        container.innerHTML = '';
-      }
-      return '';
-    }
-
-    var cc = _catColors.modified;
-    var collapsed = _collapsedCategories.modified;
-    var html = '';
-
-    // Section header
-    html += '<div data-cat-toggle="modified" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none">';
-    html += '<span style="font-size:0.6rem;opacity:0.4;transition:transform 0.2s;' + (collapsed ? 'transform:rotate(-90deg)' : '') + '">&#9660;</span>';
-    html += '<span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:4px;font-size:0.7rem;font-weight:700;background:' + cc.bg + ';color:' + cc.color + '">&#9998;</span>';
-    html += '<span style="font-weight:600;font-size:0.8rem">' + _esc('Modified') + '</span>';
-    html += '<span style="font-weight:400;opacity:0.5;font-size:0.73rem">(' + modifiedItems.length + ')</span>';
-    html += '</div>';
-
-    // Card container
-    html += '<div style="padding:0 0.65rem;' + (collapsed ? 'display:none' : '') + '">';
-
-    var limit = (_showAllItems.modified || modifiedItems.length <= 20) ? modifiedItems.length : 20;
-    for (var i = 0; i < limit; i++) {
-      var mod = modifiedItems[i];
-      var item = mod.item;
-      var changes = mod.changes || [];
-      var key = 'modified-' + i;
-      var checked = _checkedItems[key] !== false;
-      var name = _esc(item.name || 'Unnamed item');
-      var metalBg = _metalBgColor(item.metal);
-      var metalCol = _metalTextColor(item.metal);
-      var expanded = _expandedModified[i];
-
-      // Count checked fields for indeterminate hint
-      var checkedFieldCount = 0;
-      for (var fc = 0; fc < changes.length; fc++) {
-        if (_checkedFields[key + '-' + changes[fc].field] !== false) {
-          checkedFieldCount++;
-        }
-      }
-      var allFieldsChecked = checkedFieldCount === changes.length;
-      var someFieldsChecked = checkedFieldCount > 0 && !allFieldsChecked;
-
-      // Card wrapper
-      html += '<div style="border-radius:8px;border:1px solid var(--border-color,rgba(255,255,255,0.08));padding:0.65rem;margin-bottom:0.5rem;background:var(--bg-card,#1a1d27)">';
-      html += '<div style="display:flex;gap:0.5rem;align-items:center">';
-
-      // Master checkbox
-      html += '<input type="checkbox" data-check="' + key + '"' + (someFieldsChecked ? ' data-indeterminate="true"' : '') + ' ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);flex-shrink:0;cursor:pointer">';
-
-      // Image area
-      html += '<div' + (item.uuid ? ' data-uuid="' + _esc(item.uuid) + '"' : '') + ' style="width:40px;height:40px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;background:' + metalBg + ';color:' + metalCol + '">';
-      html += _metalEmoji(item.metal);
-      html += '</div>';
-
-      // Item identity
-      html += '<div style="flex:1;min-width:0">';
-      html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name;
-      html += '<span style="display:inline-block;background:rgba(217,119,6,0.1);color:#d97706;border-radius:12px;padding:0.1rem 0.5rem;font-size:0.7rem;margin-left:0.4rem">' + changes.length + ' field' + (changes.length !== 1 ? 's' : '') + ' changed</span>';
-      html += '</div>';
-      html += '</div>';
-
-      // Expand toggle
-      html += '<div class="diff-mod-toggle" data-mod-idx="' + i + '" style="cursor:pointer;padding:0.25rem 0.4rem;user-select:none">';
-      html += '<span style="font-size:0.65rem;opacity:0.35;transition:transform 0.2s;display:inline-block;' + (expanded ? '' : 'transform:rotate(-90deg)') + '">&#9660;</span>';
-      html += '</div>';
-
-      html += '</div>'; // flex row
-
-      // Expanded field rows
-      if (expanded) {
-        for (var fi = 0; fi < changes.length; fi++) {
-          var ch = changes[fi];
-          var fieldKey = key + '-' + ch.field;
-          var fieldChecked = _checkedFields[fieldKey] !== false;
-          var localDisplay = ch.localVal == null ? '\u2014' : _esc(String(ch.localVal));
-          var remoteDisplay = ch.remoteVal == null ? '\u2014' : _esc(String(ch.remoteVal));
-
-          html += '<div style="display:flex;align-items:center;gap:0.5rem;padding:0.2rem 0 0.2rem 3rem">';
-          html += '<input type="checkbox" data-field-check="' + fieldKey + '" ' + (fieldChecked ? 'checked' : '') + ' style="width:14px;height:14px;min-width:14px;padding:0;border:none;accent-color:var(--primary,#3b82f6);flex-shrink:0;cursor:pointer">';
-          html += '<span style="min-width:100px;font-size:0.78rem;opacity:0.5">' + _esc(ch.field) + '</span>';
-          html += '<span style="text-decoration:line-through;opacity:0.45;font-size:0.78rem">' + localDisplay + '</span>';
-          html += '<span style="opacity:0.35;font-size:0.7rem">&rarr;</span>';
-          html += '<span style="font-weight:500;color:var(--warning,#d97706);font-size:0.78rem">' + remoteDisplay + '</span>';
+      if (type === 'modified') {
+        var mod = items[i];
+        var expanded = _expandedModified[i];
+        html += '<div class="diff-mod-toggle" data-mod-idx="' + i + '" style="cursor:pointer">';
+        html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + ' <span style="font-size:0.65rem;opacity:0.35">' + (expanded ? '&#9650;' : '&#9660;') + '</span></div>';
+        html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + mod.changes.length + ' field' + (mod.changes.length > 1 ? 's' : '') + ' changed</div>';
+        if (expanded) {
+          html += '<div style="margin-top:0.35rem;padding-left:0.25rem;font-size:0.78rem">';
+          for (var c = 0; c < mod.changes.length; c++) {
+            var ch = mod.changes[c];
+            html += '<div style="padding:0.15rem 0;display:flex;gap:0.3rem;align-items:baseline">';
+            html += '<span style="opacity:0.5;min-width:80px">' + _esc(ch.field) + '</span>';
+            html += '<span style="text-decoration:line-through;opacity:0.45">' + _esc(String(ch.localVal != null ? ch.localVal : '\u2014')) + '</span>';
+            html += '<span style="opacity:0.35;font-size:0.7rem">&rarr;</span>';
+            html += '<span style="font-weight:500;color:var(--warning,#d97706)">' + _esc(String(ch.remoteVal != null ? ch.remoteVal : '\u2014')) + '</span>';
+            html += '</div>';
+          }
           html += '</div>';
         }
+        html += '</div>';
+      } else {
+        html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + '</div>';
+        // Detail line
+        var detail = [];
+        if (item.metal) detail.push(_esc(item.metal));
+        if (item.weight != null) detail.push(item.weight + _esc(item.weightUnit || 'oz'));
+        if (item.qty != null) detail.push('\u00d7 ' + item.qty);
+        if (detail.length > 0) {
+          html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';
+        }
       }
 
-      html += '</div>'; // card
+      html += '</div></div>';
     }
-
-    // "Show N more" button
-    if (modifiedItems.length > 20) {
-      var remaining = modifiedItems.length - 20;
-      html += '<div data-show-more="modified" style="font-size:0.78rem;text-align:center;cursor:pointer;padding:0.5rem;opacity:0.6">Show ' + remaining + ' more</div>';
-    }
-
-    html += '</div>'; // card container
-
+    html += '</div></div>';
     return html;
-  }
-
-  /** Load item images asynchronously for cards with data-uuid */
-  function _loadItemImages() {
-    try {
-      if (typeof imageCache === 'undefined' || !imageCache || !imageCache.getUserImageUrl) return;
-      var modal = safeGetElement('diffReviewModal');
-      if (!modal) return;
-      var els = modal.querySelectorAll('[data-uuid]');
-      for (var i = 0; i < els.length; i++) {
-        (function (el) {
-          imageCache.getUserImageUrl(el.dataset.uuid, 'obverse').then(function (url) {
-            if (url) {
-              el.innerHTML = '<img src="' + url + '" style="width:40px;height:40px;object-fit:cover;border-radius:6px" alt="">';
-            }
-          }).catch(function () { /* silent fallback — keep emoji */ });
-        })(els[i]);
-      }
-    } catch (ex) {
-      // imageCache not available — silently keep emoji placeholders
-    }
   }
 
   // ── Event delegation ──
@@ -953,68 +746,9 @@
   function _onListClick(e) {
     var target = e.target;
 
-    // Per-field checkbox toggle
-    if (target.type === 'checkbox' && target.dataset.fieldCheck) {
-      var fKey = target.dataset.fieldCheck;
-      _checkedFields[fKey] = target.checked;
-      // Sync master checkbox — parse item index from key like 'modified-0-fieldName'
-      var parts = fKey.split('-');
-      var itemIdx = parseInt(parts[1], 10);
-      var masterKey = 'modified-' + itemIdx;
-      var diff = _options.diff || {};
-      var modItem = (diff.modified || [])[itemIdx];
-      if (modItem) {
-        var changes = modItem.changes || [];
-        var allChecked = true;
-        var noneChecked = true;
-        for (var fc = 0; fc < changes.length; fc++) {
-          var cfk = 'modified-' + itemIdx + '-' + changes[fc].field;
-          if (_checkedFields[cfk] !== false) {
-            noneChecked = false;
-          } else {
-            allChecked = false;
-          }
-        }
-        // Update master checkbox state
-        _checkedItems[masterKey] = !noneChecked;
-        var masterCb = safeGetElement('diffSectionModified');
-        if (masterCb) {
-          var mc = masterCb.querySelector('[data-check="' + masterKey + '"]');
-          if (mc) {
-            mc.checked = !noneChecked;
-            mc.indeterminate = !allChecked && !noneChecked;
-          }
-        }
-      }
-      _updateApplyCount();
-      return;
-    }
-
     // Checkbox toggle
     if (target.type === 'checkbox' && target.dataset.check) {
-      var chkKey = target.dataset.check;
-      _checkedItems[chkKey] = target.checked;
-      // If this is a modified master checkbox, toggle all field checkboxes too
-      if (chkKey.indexOf('modified-') === 0) {
-        var mIdx = parseInt(chkKey.split('-')[1], 10);
-        var diff2 = _options.diff || {};
-        var modItem2 = (diff2.modified || [])[mIdx];
-        if (modItem2) {
-          var changes2 = modItem2.changes || [];
-          for (var fc2 = 0; fc2 < changes2.length; fc2++) {
-            _checkedFields['modified-' + mIdx + '-' + changes2[fc2].field] = target.checked;
-          }
-          // Update field checkbox DOM elements without full re-render
-          var container2 = target.closest('[style*="border-radius:8px"]');
-          if (container2) {
-            var fieldCbs = container2.querySelectorAll('[data-field-check]');
-            for (var fi2 = 0; fi2 < fieldCbs.length; fi2++) {
-              fieldCbs[fi2].checked = target.checked;
-            }
-          }
-        }
-        target.indeterminate = false;
-      }
+      _checkedItems[target.dataset.check] = target.checked;
       _updateApplyCount();
       return;
     }
@@ -1033,14 +767,6 @@
     if (modToggle) {
       var idx = parseInt(modToggle.dataset.modIdx, 10);
       _expandedModified[idx] = !_expandedModified[idx];
-      _render();
-      return;
-    }
-
-    // "Show more" button
-    var showMoreBtn = target.closest('[data-show-more]');
-    if (showMoreBtn) {
-      _showAllItems[showMoreBtn.dataset.showMore] = true;
       _render();
       return;
     }
@@ -1129,22 +855,19 @@
       }
     }
 
-    // Modified items — one entry per checked field
+    // Modified items — one entry per changed field
     for (var m = 0; m < modified.length; m++) {
       if (_checkedItems['modified-' + m] !== false) {
         var mod = modified[m];
         var key = _itemKey(mod.item);
         for (var c = 0; c < mod.changes.length; c++) {
           var ch = mod.changes[c];
-          // Only emit fields that are individually checked (backward compat: if key missing, treat as true)
-          if (_checkedFields['modified-' + m + '-' + ch.field] !== false) {
-            result.push({
-              type: 'modify',
-              itemKey: key,
-              field: ch.field,
-              value: ch.remoteVal
-            });
-          }
+          result.push({
+            type: 'modify',
+            itemKey: key,
+            field: ch.field,
+            value: ch.remoteVal
+          });
         }
       }
     }
@@ -1229,13 +952,6 @@
       listEl.addEventListener('click', _onListClick);
     }
 
-    // Event delegation on orphan items (added/deleted cards)
-    var orphanListEl = safeGetElement('diffSectionOrphans');
-    if (orphanListEl) {
-      orphanListEl.removeEventListener('click', _onListClick);
-      orphanListEl.addEventListener('click', _onListClick);
-    }
-
     // Pill buttons
     var btnStyle = 'display:inline-flex;align-items:center;gap:0.3rem;border-radius:999px;font-size:0.73rem;font-weight:500;cursor:pointer;transition:all 0.15s;';
 
@@ -1306,27 +1022,17 @@
 
       // Reset internal state
       _checkedItems = {};
-      _checkedFields = {};
       _conflictResolutions = {};
       _collapsedCategories = {};
       _expandedModified = {};
       _expandedSettingsCategories = {};
       _selectAllState = 0;
-      _showAllItems = {};
 
       // Default all items to checked
       var diff = _options.diff || {};
       for (var a = 0; a < (diff.added || []).length; a++) _checkedItems['added-' + a] = true;
       for (var m = 0; m < (diff.modified || []).length; m++) _checkedItems['modified-' + m] = true;
       for (var d = 0; d < (diff.deleted || []).length; d++) _checkedItems['deleted-' + d] = true;
-
-      // Default all modified item fields to checked (accept remote)
-      for (var mf = 0; mf < (diff.modified || []).length; mf++) {
-        var modChanges = diff.modified[mf].changes || [];
-        for (var c = 0; c < modChanges.length; c++) {
-          _checkedFields['modified-' + mf + '-' + modChanges[c].field] = true;
-        }
-      }
 
       // Default conflict resolutions to 'remote' (per-field keys)
       if (_options.conflicts && _options.conflicts.conflicts) {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -165,6 +165,7 @@
   var _orphanActions = {};       // { 'added-0': 'import'|'skip', 'deleted-1': 'keep'|'remove' }
   var _fieldSelections = {};     // { 'conflict-0-purchasePrice': 'local'|'remote' }
   var _resolvedConflicts = {};   // { 0: true, 1: true }
+  var _blobUrls = [];            // Tracked blob URLs for revocation on re-render/close
 
   // ── Helpers ──
 
@@ -306,8 +307,8 @@
     var cards = [
       { count: matched, label: 'Matched', target: 'diffSectionModified', color: '', style: 'opacity:0.5' },
       { count: conflictCount, label: 'Conflicts', target: syncConflicts > 0 ? 'diffSectionConflicts' : 'diffSectionModified', color: conflictCount > 0 ? 'color:#d97706' : '', style: '' },
-      { count: remoteOnly, label: 'Remote Only', target: 'diffSectionModified', color: '', style: '' },
-      { count: localOnly, label: 'Local Only', target: 'diffSectionModified', color: '', style: '' }
+      { count: remoteOnly, label: 'Remote Only', target: 'diffSectionOrphans', color: '', style: '' },
+      { count: localOnly, label: 'Local Only', target: 'diffSectionOrphans', color: '', style: '' }
     ];
 
     var cardStyle = 'flex:1;min-width:120px;border-radius:8px;padding:0.6rem;border:1px solid var(--border-color,#ddd);cursor:pointer;text-align:center';
@@ -604,6 +605,19 @@
 
   // ── Card-based renderers (STAK-454 — matches playground/diffmodal-item-cards.html) ──
 
+  /** Shared card header: dual OBV/REV thumbnails + item identity. Used by orphan and conflict cards. */
+  function _renderCardHeader(item, uuid) {
+    var grad = _metalBgGradient(item.metal);
+    var mColor = _metalColor(item.metal);
+    var html = '';
+    // Dual OBV/REV thumbnails
+    html += '<div class="dm-item-thumb-pair">';
+    html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="obverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">OBV</span></div>';
+    html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="reverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">REV</span></div>';
+    html += '</div>';
+    return html;
+  }
+
   /** Render Added or Deleted items as orphan cards. Returns HTML string. */
   function _renderOrphanCards(type, items) {
     if (!items || items.length === 0) return '';
@@ -635,29 +649,25 @@
 
     // Section body
     html += '<div class="dm-section-body' + (collapsed ? ' collapsed' : '') + '">';
-    var limit = items.length > 30 ? 30 : items.length;
+    var showAll = _collapsedCategories['_showAll_' + type];
+    var limit = (!showAll && items.length > 30) ? 30 : items.length;
     for (var i = 0; i < limit; i++) {
       var item = items[i];
       var key = type + '-' + i;
       var action = _orphanActions[key] || (isAdded ? 'import' : 'keep');
       var isSkipped = (isAdded && action === 'skip') || (!isAdded && action === 'remove');
-      var grad = _metalBgGradient(item.metal);
       var mColor = _metalColor(item.metal);
       var uuid = item.uuid || '';
 
       html += '<div class="dm-card dm-orphan-card' + (isSkipped ? ' skipped' : '') + '" data-action="' + action + '" data-idx="' + i + '" data-type="' + type + '">';
-      // Dual OBV/REV thumbnails
-      html += '<div class="dm-item-thumb-pair">';
-      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="obverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">OBV</span></div>';
-      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="reverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">REV</span></div>';
-      html += '</div>';
+      html += _renderCardHeader(item, uuid);
       // Item identity
       html += '<div class="dm-item-identity">';
       html += '<div class="dm-item-name" style="color:' + mColor + '">' + _esc(item.name || 'Unnamed item') + '</div>';
       html += '<div class="dm-item-meta">';
       html += '<span style="color:' + mColor + '">' + _esc(item.metal || '') + '</span>';
-      if (item.weight != null) html += '<span>&#8226;</span><span>' + item.weight + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
-      if (item.qty != null) html += '<span>&#8226;</span><span>Qty: ' + item.qty + '</span>';
+      if (item.weight != null) html += '<span>&#8226;</span><span>' + _esc(String(item.weight)) + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
+      if (item.qty != null) html += '<span>&#8226;</span><span>Qty: ' + _esc(String(item.qty)) + '</span>';
       html += '</div></div>';
       // Action buttons — active action gets prominent color, inactive gets muted
       html += '<div class="dm-orphan-actions">';
@@ -673,7 +683,7 @@
       html += '</div>';
       html += '</div>';
     }
-    if (items.length > 30) {
+    if (!showAll && items.length > 30) {
       html += '<div class="dm-show-more" data-show-more="' + type + '" style="text-align:center;padding:0.5rem;font-size:0.78rem;cursor:pointer;color:var(--primary,#6366f1)">Show ' + (items.length - 30) + ' more...</div>';
     }
     html += '</div></div>';
@@ -725,7 +735,6 @@
       var mod = modifiedItems[i];
       var item = mod.item;
       var changes = mod.changes || [];
-      var grad = _metalBgGradient(item.metal);
       var mColor = _metalColor(item.metal);
       var uuid = item.uuid || '';
       var isResolved = _resolvedConflicts[i];
@@ -735,17 +744,13 @@
 
       // Card header
       html += '<div class="dm-conflict-card-header" data-toggle-conflict="' + i + '" style="cursor:pointer">';
-      // Thumbnails
-      html += '<div class="dm-item-thumb-pair">';
-      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="obverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">OBV</span></div>';
-      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="reverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">REV</span></div>';
-      html += '</div>';
+      html += _renderCardHeader(item, uuid);
       // Identity
       html += '<div class="dm-item-identity">';
       html += '<div class="dm-item-name">' + _esc(item.name || 'Unnamed item') + '</div>';
       html += '<div class="dm-item-meta">';
       html += '<span style="color:' + mColor + '">' + _esc(item.metal || '') + '</span>';
-      if (item.weight != null) html += '<span>&#8226;</span><span>' + item.weight + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
+      if (item.weight != null) html += '<span>&#8226;</span><span>' + _esc(String(item.weight)) + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
       html += '<span>&#8226;</span><span class="dm-chip" style="font-size:0.65rem">ID: ' + _esc(itemKey).substring(0, 16) + '</span>';
       html += '</div></div>';
       // Field count pill
@@ -793,6 +798,12 @@
   /** Load images asynchronously using resolveImageUrlForItem (same as main app) */
   function _loadItemImages() {
     try {
+      // Revoke previous blob URLs to prevent memory leaks
+      for (var bi = 0; bi < _blobUrls.length; bi++) {
+        try { URL.revokeObjectURL(_blobUrls[bi]); } catch(e) { /* ignore */ }
+      }
+      _blobUrls = [];
+
       var modal = safeGetElement(MODAL_ID);
       if (!modal || typeof imageCache === 'undefined' || !imageCache.resolveImageUrlForItem) return;
 
@@ -819,15 +830,23 @@
           if (!item) return;
           try {
             imageCache.resolveImageUrlForItem(item, side).then(function(url) {
-              if (url) {
-                el.innerHTML = '<img src="' + url + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
-                return;
+              var imgUrl = url;
+              if (!imgUrl) {
+                // Fallback: CDN URL from item properties (same as main app tier 2)
+                var urlKey = side === 'reverse' ? 'reverseImageUrl' : 'obverseImageUrl';
+                var cdnUrl = item[urlKey];
+                if (cdnUrl && /^https?:\/\/[^\s"'<>]+$/i.test(cdnUrl)) {
+                  imgUrl = cdnUrl;
+                }
               }
-              // Fallback: CDN URL from item properties (same as main app tier 2)
-              var urlKey = side === 'reverse' ? 'reverseImageUrl' : 'obverseImageUrl';
-              var cdnUrl = item[urlKey];
-              if (cdnUrl && /^https?:\/\/.+\..+/i.test(cdnUrl)) {
-                el.innerHTML = '<img src="' + cdnUrl + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
+              if (imgUrl) {
+                if (imgUrl.indexOf('blob:') === 0) _blobUrls.push(imgUrl);
+                var img = document.createElement('img');
+                img.src = imgUrl;
+                img.alt = side;
+                img.style.cssText = 'width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)';
+                el.textContent = '';
+                el.appendChild(img);
               }
             }).catch(function() { /* silent fallback to OBV/REV text */ });
           } catch(e) { /* imageCache not available */ }
@@ -1277,6 +1296,15 @@
     for (var d = 0; d < (diff.deleted || []).length; d++) {
       _orphanActions['deleted-' + d] = 'keep';
     }
+    // Reset modified field selections to local (deselect = keep local values)
+    for (var m = 0; m < (diff.modified || []).length; m++) {
+      var mod = (diff.modified || [])[m];
+      if (mod && mod.changes) {
+        for (var c = 0; c < mod.changes.length; c++) {
+          _fieldSelections['conflict-' + m + '-' + mod.changes[c].field] = 'local';
+        }
+      }
+    }
     _render();
   }
 
@@ -1292,7 +1320,15 @@
         _orphanActions['added-' + i] = 'import';
         _checkedItems['added-' + i] = true;
       }
-      for (var j = 0; j < (diff.modified || []).length; j++) _checkedItems['modified-' + j] = true;
+      for (var j = 0; j < (diff.modified || []).length; j++) {
+        _checkedItems['modified-' + j] = true;
+        var mod1 = (diff.modified || [])[j];
+        if (mod1 && mod1.changes) {
+          for (var c1 = 0; c1 < mod1.changes.length; c1++) {
+            _fieldSelections['conflict-' + j + '-' + mod1.changes[c1].field] = 'remote';
+          }
+        }
+      }
       for (var k = 0; k < (diff.deleted || []).length; k++) {
         _orphanActions['deleted-' + k] = 'keep';
         _checkedItems['deleted-' + k] = false;
@@ -1314,6 +1350,15 @@
       }
       for (var d = 0; d < (diff.deleted || []).length; d++) {
         _orphanActions['deleted-' + d] = 'keep';
+      }
+      // Reset field selections to local
+      for (var m3 = 0; m3 < (diff.modified || []).length; m3++) {
+        var mod3 = (diff.modified || [])[m3];
+        if (mod3 && mod3.changes) {
+          for (var c3 = 0; c3 < mod3.changes.length; c3++) {
+            _fieldSelections['conflict-' + m3 + '-' + mod3.changes[c3].field] = 'local';
+          }
+        }
       }
     }
     var toggleBtn = safeGetElement('diffReviewSelectAllToggle');
@@ -1598,6 +1643,11 @@
      * Close the modal programmatically.
      */
     close: function () {
+      // Revoke tracked blob URLs to prevent memory leaks
+      for (var bi = 0; bi < _blobUrls.length; bi++) {
+        try { URL.revokeObjectURL(_blobUrls[bi]); } catch(e) { /* ignore */ }
+      }
+      _blobUrls = [];
       if (typeof closeModalById === 'function') {
         closeModalById(MODAL_ID);
       } else {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -765,9 +765,11 @@
 
         html += '<div class="dm-field-diff">';
         html += '<div class="dm-field-label">' + _esc(ch.field) + '</div>';
-        html += '<div class="dm-field-value local' + localSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(String(ch.localVal != null ? ch.localVal : '\u2014')) + '</div>';
+        var localDisplay = (ch.localVal != null && ch.localVal !== '') ? String(ch.localVal) : '\u2014';
+        var remoteDisplay = (ch.remoteVal != null && ch.remoteVal !== '') ? String(ch.remoteVal) : '\u2014';
+        html += '<div class="dm-field-value local' + localSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(localDisplay) + '</div>';
         html += '<div class="dm-field-arrow">&#10231;</div>';
-        html += '<div class="dm-field-value remote' + remoteSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(String(ch.remoteVal != null ? ch.remoteVal : '\u2014')) + '</div>';
+        html += '<div class="dm-field-value remote' + remoteSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(remoteDisplay) + '</div>';
         html += '</div>';
       }
       // Card actions

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -622,10 +622,10 @@
     html += '<div class="dm-section-actions">';
     if (isAdded) {
       html += '<button class="dm-btn dm-btn-sm dm-btn-primary" data-bulk-action="import" data-bulk-section="added">Import All</button>';
-      html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-bulk-action="skip" data-bulk-section="added">Skip All</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-muted" data-bulk-action="skip" data-bulk-section="added">Skip All</button>';
     } else {
-      html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-bulk-action="keep" data-bulk-section="deleted">Keep All</button>';
-      html += '<button class="dm-btn dm-btn-sm dm-btn-loss" data-bulk-action="remove" data-bulk-section="deleted">Remove All</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-gain" data-bulk-action="keep" data-bulk-section="deleted">Keep All</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-muted" data-bulk-action="remove" data-bulk-section="deleted">Remove All</button>';
     }
     html += '</div>';
     html += '</div>';
@@ -656,14 +656,16 @@
       if (item.weight != null) html += '<span>&#8226;</span><span>' + item.weight + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
       if (item.qty != null) html += '<span>&#8226;</span><span>Qty: ' + item.qty + '</span>';
       html += '</div></div>';
-      // Action buttons
+      // Action buttons — active action gets prominent color, inactive gets muted
       html += '<div class="dm-orphan-actions">';
       if (isAdded) {
-        html += '<button class="dm-btn dm-btn-sm dm-btn-primary dm-action-btn" data-set-action="import" data-idx="' + i + '" data-type="' + type + '">&#8595; Import</button>';
-        html += '<button class="dm-btn dm-btn-sm dm-btn-secondary dm-skip-btn" data-set-action="skip" data-idx="' + i + '" data-type="' + type + '">Skip</button>';
+        var importActive = (action === 'import');
+        html += '<button class="dm-btn dm-btn-sm ' + (importActive ? 'dm-btn-primary' : 'dm-btn-muted') + ' dm-action-btn" data-set-action="import" data-idx="' + i + '" data-type="' + type + '">&#8595; Import</button>';
+        html += '<button class="dm-btn dm-btn-sm ' + (!importActive ? 'dm-btn-loss' : 'dm-btn-muted') + ' dm-skip-btn" data-set-action="skip" data-idx="' + i + '" data-type="' + type + '">Skip</button>';
       } else {
-        html += '<button class="dm-btn dm-btn-sm dm-btn-secondary dm-keep-btn" data-set-action="keep" data-idx="' + i + '" data-type="' + type + '">Keep</button>';
-        html += '<button class="dm-btn dm-btn-sm dm-btn-loss dm-remove-btn" data-set-action="remove" data-idx="' + i + '" data-type="' + type + '">Remove</button>';
+        var keepActive = (action === 'keep');
+        html += '<button class="dm-btn dm-btn-sm ' + (keepActive ? 'dm-btn-gain' : 'dm-btn-muted') + ' dm-keep-btn" data-set-action="keep" data-idx="' + i + '" data-type="' + type + '">Keep</button>';
+        html += '<button class="dm-btn dm-btn-sm ' + (!keepActive ? 'dm-btn-loss' : 'dm-btn-muted') + ' dm-remove-btn" data-set-action="remove" data-idx="' + i + '" data-type="' + type + '">Remove</button>';
       }
       html += '</div>';
       html += '</div>';
@@ -928,6 +930,28 @@
 
   // ── Event delegation (STAK-454 — card-based interactions) ──
 
+  /** Swap a button's style class based on active state and section type */
+  function _swapBtnClass(btn, sectionType, actionName, isActive) {
+    btn.classList.remove('dm-btn-primary', 'dm-btn-gain', 'dm-btn-loss', 'dm-btn-muted', 'dm-btn-secondary');
+    if (!isActive) {
+      btn.classList.add('dm-btn-muted');
+      return;
+    }
+    // Active: positive actions get their accent color, negative actions get loss
+    if (actionName === 'import') btn.classList.add('dm-btn-primary');
+    else if (actionName === 'keep') btn.classList.add('dm-btn-gain');
+    else btn.classList.add('dm-btn-loss'); // skip, remove
+  }
+
+  /** Update both action buttons on an orphan card to reflect the current action */
+  function _updateOrphanBtnStyles(card, type, action) {
+    var btns = card.querySelectorAll('[data-set-action]');
+    for (var bi = 0; bi < btns.length; bi++) {
+      var btnAction = btns[bi].dataset.setAction;
+      _swapBtnClass(btns[bi], type, btnAction, btnAction === action);
+    }
+  }
+
   /** Handle clicks on orphan cards (Added/Deleted) */
   function _onOrphanClick(e) {
     var target = e.target;
@@ -944,12 +968,13 @@
       // Also sync _checkedItems for backward compat
       if (type === 'added') _checkedItems[key] = (action !== 'skip');
       if (type === 'deleted') _checkedItems[key] = (action === 'remove');
-      // Toggle visual state
+      // Toggle visual state on card and buttons
       var card = actionBtn.closest('.dm-orphan-card');
       if (card) {
         var isSkipped = (action === 'skip' || action === 'remove');
         card.classList.toggle('skipped', isSkipped);
         card.dataset.action = action;
+        _updateOrphanBtnStyles(card, type, action);
       }
       _updateApplyCount();
       return;
@@ -971,6 +996,17 @@
         var bSkipped = (bulkAction === 'skip' || bulkAction === 'remove');
         bCard.classList.toggle('skipped', bSkipped);
         bCard.dataset.action = bulkAction;
+        _updateOrphanBtnStyles(bCard, bulkSection, bulkAction);
+      }
+      // Update bulk button styles in section header
+      var sectionWrapper = bulkBtn.closest('.dm-section-wrapper');
+      if (sectionWrapper) {
+        var bulkBtns = sectionWrapper.querySelectorAll('[data-bulk-action]');
+        for (var bbi = 0; bbi < bulkBtns.length; bbi++) {
+          var bb = bulkBtns[bbi];
+          var isActive = (bb.dataset.bulkAction === bulkAction);
+          _swapBtnClass(bb, bulkSection, bb.dataset.bulkAction, isActive);
+        }
       }
       _updateApplyCount();
       return;
@@ -1510,7 +1546,7 @@
         }
       }
       for (var d = 0; d < (diff.deleted || []).length; d++) {
-        _checkedItems['deleted-' + d] = true;
+        _checkedItems['deleted-' + d] = false;
         _orphanActions['deleted-' + d] = 'keep';
       }
 

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -721,12 +721,7 @@
 
 
   /** Metal emoji for item card image placeholders */
-  function _metalEmoji(metal) {
-    var m = (metal || '').toLowerCase();
-    if (m === 'gold') return '\uD83E\uDE99';
-    if (m === 'silver') return '\uD83E\uDE99';
-    if (m === 'platinum') return '\uD83E\uDE99';
-    if (m === 'palladium') return '\uD83E\uDE99';
+  function _metalEmoji() {
     return '\uD83E\uDE99';
   }
 
@@ -804,8 +799,8 @@
       // Metadata
       var detail = [];
       if (item.metal) detail.push(_esc(item.metal));
-      if (item.weight != null) detail.push(item.weight + _esc(item.weightUnit || 'oz'));
-      if (item.qty != null) detail.push('\u00d7 ' + item.qty);
+      if (item.weight != null) detail.push(_esc(item.weight) + _esc(item.weightUnit || 'oz'));
+      if (item.qty != null) detail.push('\u00d7 ' + _esc(item.qty));
       if (detail.length > 0) {
         html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';
       }
@@ -982,7 +977,7 @@
         }
         // Update master checkbox state
         _checkedItems[masterKey] = !noneChecked;
-        var masterCb = target.closest('[data-cat="modified"]') || safeGetElement('diffSectionModified');
+        var masterCb = safeGetElement('diffSectionModified');
         if (masterCb) {
           var mc = masterCb.querySelector('[data-check="' + masterKey + '"]');
           if (mc) {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -770,9 +770,9 @@
         html += '<div class="dm-field-label">' + _esc(ch.field) + '</div>';
         var localDisplay = (ch.localVal != null && ch.localVal !== '') ? String(ch.localVal) : '\u2014';
         var remoteDisplay = (ch.remoteVal != null && ch.remoteVal !== '') ? String(ch.remoteVal) : '\u2014';
-        html += '<div class="dm-field-value local' + localSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(localDisplay) + '</div>';
+        html += '<div class="dm-field-value local' + localSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '" title="' + _esc(localDisplay) + '">' + _esc(localDisplay) + '</div>';
         html += '<div class="dm-field-arrow">&#10231;</div>';
-        html += '<div class="dm-field-value remote' + remoteSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(remoteDisplay) + '</div>';
+        html += '<div class="dm-field-value remote' + remoteSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '" title="' + _esc(remoteDisplay) + '">' + _esc(remoteDisplay) + '</div>';
         html += '</div>';
       }
       // Card actions

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -816,7 +816,16 @@
           if (!item) return;
           try {
             imageCache.resolveImageUrlForItem(item, side).then(function(url) {
-              if (url) el.innerHTML = '<img src="' + url + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
+              if (url) {
+                el.innerHTML = '<img src="' + url + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
+                return;
+              }
+              // Fallback: CDN URL from item properties (same as main app tier 2)
+              var urlKey = side === 'reverse' ? 'reverseImageUrl' : 'obverseImageUrl';
+              var cdnUrl = item[urlKey];
+              if (cdnUrl && /^https?:\/\/.+\..+/i.test(cdnUrl)) {
+                el.innerHTML = '<img src="' + cdnUrl + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
+              }
             }).catch(function() { /* silent fallback to OBV/REV text */ });
           } catch(e) { /* imageCache not available */ }
         })(thumbs[t]);

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -133,11 +133,13 @@
   // ── Internal state ──
   var _options = null;
   var _checkedItems = {};      // { 'added-0': true, 'modified-2': false, ... }
+  var _checkedFields = {};      // { 'modified-0-purchasePrice': true, ... }
   var _conflictResolutions = {}; // { 'c0': 'local'|'remote', ... }
   var _collapsedCategories = {}; // { added: true, ... }
   var _expandedModified = {};    // { 0: true, 1: false, ... }
   var _expandedSettingsCategories = {}; // { 'Display & Appearance': true, ... }
   var _selectAllState = 0;  // 0=none, 1=added+modified, 2=all
+  var _showAllItems = {};    // { added: true, deleted: true, modified: true }
 
   // ── Helpers ──
 
@@ -170,8 +172,24 @@
   /** Count currently checked items */
   function _checkedCount() {
     var count = 0;
+    var diff = _options ? _options.diff || {} : {};
     for (var k in _checkedItems) {
-      if (_checkedItems.hasOwnProperty(k) && _checkedItems[k]) count++;
+      if (!_checkedItems.hasOwnProperty(k) || !_checkedItems[k]) continue;
+      // For modified items, count individual fields instead of the whole item
+      if (k.indexOf('modified-') === 0) {
+        var mIdx = parseInt(k.split('-')[1], 10);
+        var modItem = (diff.modified || [])[mIdx];
+        if (modItem) {
+          var changes = modItem.changes || [];
+          for (var c = 0; c < changes.length; c++) {
+            if (_checkedFields['modified-' + mIdx + '-' + changes[c].field] !== false) {
+              count++;
+            }
+          }
+        }
+      } else {
+        count++;
+      }
     }
     return count;
   }
@@ -633,25 +651,51 @@
     // Conflict cards (replaces old inline conflict rendering)
     _renderConflictCards(safeGetElement('diffSectionConflicts'), conflicts);
 
-    // Change list — retarget to diffSectionModified container
-    var listEl = safeGetElement('diffSectionModified');
-    if (listEl) {
-      var totalChanges = added.length + modified.length + deleted.length;
-      var lHtml = '';
-
-      if (totalChanges === 0) {
-        lHtml = '<div style="padding:2rem;text-align:center;opacity:0.45;font-size:0.85rem">No item changes detected</div>';
+    // Item cards — Added and Deleted render to #diffSectionOrphans
+    var orphanEl = safeGetElement('diffSectionOrphans');
+    if (orphanEl) {
+      var orphanHtml = '';
+      orphanHtml += _renderItemCards(orphanEl, added, 'added', 'Added');
+      orphanHtml += _renderItemCards(orphanEl, deleted, 'deleted', 'Deleted');
+      if (orphanHtml) {
+        orphanEl.style.display = '';
+        orphanEl.innerHTML = orphanHtml;
       } else {
-        // Added
-        if (added.length > 0) lHtml += _renderCategory('added', 'Added', '+', added);
-        // Modified
-        if (modified.length > 0) lHtml += _renderCategory('modified', 'Modified', '&#9998;', modified);
-        // Deleted
-        if (deleted.length > 0) lHtml += _renderCategory('deleted', 'Deleted', '&minus;', deleted);
+        orphanEl.style.display = 'none';
+        orphanEl.innerHTML = '';
       }
-
-      listEl.innerHTML = lHtml;
     }
+
+    // Item cards — Modified renders to #diffSectionModified
+    var modEl = safeGetElement('diffSectionModified');
+    if (modEl) {
+      var modHtml = _renderModifiedCards(modEl, modified);
+      if (modHtml) {
+        modEl.style.display = '';
+        modEl.innerHTML = modHtml;
+      } else {
+        modEl.style.display = 'none';
+        modEl.innerHTML = '';
+      }
+    }
+
+    // No changes message
+    if (added.length + modified.length + deleted.length === 0) {
+      var noChangesHtml = '<div style="padding:2rem;text-align:center;opacity:0.45;font-size:0.85rem">No item changes detected</div>';
+      if (modEl) { modEl.style.display = ''; modEl.innerHTML = noChangesHtml; }
+    }
+
+    // Set indeterminate state on master checkboxes (must happen after innerHTML)
+    var modal = safeGetElement('diffReviewModal');
+    if (modal) {
+      var indets = modal.querySelectorAll('[data-indeterminate="true"]');
+      for (var ii = 0; ii < indets.length; ii++) {
+        indets[ii].indeterminate = true;
+      }
+    }
+
+    // Async image loading
+    _loadItemImages();
 
     // Settings cards (replaces old settings <details>)
     _renderSettingsCards(safeGetElement('diffReviewSettings'), _options.settingsDiff);
@@ -675,70 +719,238 @@
     deleted: { bg: 'rgba(220,38,38,0.12)',  color: 'var(--danger,#dc2626)' }
   };
 
-  /** Render a category group (added/modified/deleted) */
-  function _renderCategory(type, label, icon, items) {
-    var collapsed = _collapsedCategories[type];
-    var cc = _catColors[type];
-    var html = '<div data-cat="' + type + '" style="' + (collapsed ? '' : '') + '">';
 
-    // Header
-    html += '<div class="diff-cat-header" data-cat-toggle="' + type + '" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none;font-size:0.8rem;font-weight:600">';
+  /** Metal emoji for item card image placeholders */
+  function _metalEmoji(metal) {
+    var m = (metal || '').toLowerCase();
+    if (m === 'gold') return '\uD83E\uDE99';
+    if (m === 'silver') return '\uD83E\uDE99';
+    if (m === 'platinum') return '\uD83E\uDE99';
+    if (m === 'palladium') return '\uD83E\uDE99';
+    return '\uD83E\uDE99';
+  }
+
+  /** Background color per metal for card image area */
+  function _metalBgColor(metal) {
+    var m = (metal || '').toLowerCase();
+    if (m === 'gold') return 'rgba(255,215,0,0.12)';
+    if (m === 'silver') return 'rgba(192,192,192,0.12)';
+    if (m === 'platinum') return 'rgba(229,228,226,0.12)';
+    if (m === 'palladium') return 'rgba(206,208,206,0.12)';
+    return 'rgba(255,255,255,0.06)';
+  }
+
+  /** Text color per metal for card image area */
+  function _metalTextColor(metal) {
+    var m = (metal || '').toLowerCase();
+    if (m === 'gold') return 'var(--gold,#FFD700)';
+    if (m === 'silver') return 'var(--silver,#C0C0C0)';
+    if (m === 'platinum') return 'var(--platinum,#E5E4E2)';
+    if (m === 'palladium') return 'var(--palladium,#CED0CE)';
+    return 'var(--text-secondary)';
+  }
+
+  /** Render Added or Deleted items as bordered cards */
+  function _renderItemCards(container, items, type, label) {
+    if (!container || !items || items.length === 0) {
+      if (container) {
+        container.style.display = 'none';
+        container.innerHTML = '';
+      }
+      return '';
+    }
+
+    var cc = _catColors[type];
+    var collapsed = _collapsedCategories[type];
+    var icon = (type === 'deleted') ? '&minus;' : '+';
+    var html = '';
+
+    // Section header
+    html += '<div data-cat-toggle="' + type + '" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none">';
     html += '<span style="font-size:0.6rem;opacity:0.4;transition:transform 0.2s;' + (collapsed ? 'transform:rotate(-90deg)' : '') + '">&#9660;</span>';
     html += '<span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:4px;font-size:0.7rem;font-weight:700;background:' + cc.bg + ';color:' + cc.color + '">' + icon + '</span>';
-    html += '<span>' + label + '</span>';
+    html += '<span style="font-weight:600;font-size:0.8rem">' + _esc(label) + '</span>';
     html += '<span style="font-weight:400;opacity:0.5;font-size:0.73rem">(' + items.length + ')</span>';
     html += '</div>';
 
-    // Items
-    html += '<div class="diff-cat-items" style="' + (collapsed ? 'display:none' : '') + '">';
-    for (var i = 0; i < items.length; i++) {
+    // Card container
+    html += '<div style="padding:0 0.65rem;' + (collapsed ? 'display:none' : '') + '">';
+
+    var limit = (_showAllItems[type] || items.length <= 20) ? items.length : 20;
+    for (var i = 0; i < limit; i++) {
+      var item = items[i];
       var key = type + '-' + i;
-      var checked = _checkedItems[key] !== false; // default true
-      var item = type === 'modified' ? items[i].item : items[i];
+      var checked = _checkedItems[key] !== false;
       var name = _esc(item.name || 'Unnamed item');
+      var metalBg = _metalBgColor(item.metal);
+      var metalCol = _metalTextColor(item.metal);
 
-      html += '<div style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.45rem 0.65rem;font-size:0.85rem">';
-      html += '<input type="checkbox" data-check="' + key + '" ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);margin-top:2px;flex-shrink:0;cursor:pointer">';
-      html += '<div style="flex-shrink:0;width:20px;height:20px;border-radius:5px;display:flex;align-items:center;justify-content:center;font-size:0.75rem;font-weight:700;margin-top:1px;background:' + cc.bg + ';color:' + cc.color + '">' + icon + '</div>';
+      // Card wrapper
+      html += '<div style="border-radius:8px;border:1px solid var(--border-color,rgba(255,255,255,0.08));padding:0.65rem;margin-bottom:0.5rem;background:var(--bg-card,#1a1d27)">';
+      html += '<div style="display:flex;gap:0.5rem;align-items:center">';
 
+      // Checkbox
+      html += '<input type="checkbox" data-check="' + key + '" ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);flex-shrink:0;cursor:pointer">';
+
+      // Image area
+      html += '<div' + (item.uuid ? ' data-uuid="' + _esc(item.uuid) + '"' : '') + ' style="width:40px;height:40px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;background:' + metalBg + ';color:' + metalCol + '">';
+      html += _metalEmoji(item.metal);
+      html += '</div>';
+
+      // Content area
       html += '<div style="flex:1;min-width:0">';
+      html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + '</div>';
 
-      if (type === 'modified') {
-        var mod = items[i];
-        var expanded = _expandedModified[i];
-        html += '<div class="diff-mod-toggle" data-mod-idx="' + i + '" style="cursor:pointer">';
-        html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + ' <span style="font-size:0.65rem;opacity:0.35">' + (expanded ? '&#9650;' : '&#9660;') + '</span></div>';
-        html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + mod.changes.length + ' field' + (mod.changes.length > 1 ? 's' : '') + ' changed</div>';
-        if (expanded) {
-          html += '<div style="margin-top:0.35rem;padding-left:0.25rem;font-size:0.78rem">';
-          for (var c = 0; c < mod.changes.length; c++) {
-            var ch = mod.changes[c];
-            html += '<div style="padding:0.15rem 0;display:flex;gap:0.3rem;align-items:baseline">';
-            html += '<span style="opacity:0.5;min-width:80px">' + _esc(ch.field) + '</span>';
-            html += '<span style="text-decoration:line-through;opacity:0.45">' + _esc(String(ch.localVal != null ? ch.localVal : '\u2014')) + '</span>';
-            html += '<span style="opacity:0.35;font-size:0.7rem">&rarr;</span>';
-            html += '<span style="font-weight:500;color:var(--warning,#d97706)">' + _esc(String(ch.remoteVal != null ? ch.remoteVal : '\u2014')) + '</span>';
-            html += '</div>';
-          }
-          html += '</div>';
+      // Metadata
+      var detail = [];
+      if (item.metal) detail.push(_esc(item.metal));
+      if (item.weight != null) detail.push(item.weight + _esc(item.weightUnit || 'oz'));
+      if (item.qty != null) detail.push('\u00d7 ' + item.qty);
+      if (detail.length > 0) {
+        html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';
+      }
+
+      html += '</div>'; // content area
+      html += '</div>'; // flex row
+      html += '</div>'; // card
+    }
+
+    // "Show N more" button
+    if (items.length > 20) {
+      var remaining = items.length - 20;
+      html += '<div data-show-more="' + type + '" style="font-size:0.78rem;text-align:center;cursor:pointer;padding:0.5rem;opacity:0.6">Show ' + remaining + ' more</div>';
+    }
+
+    html += '</div>'; // card container
+
+    return html;
+  }
+
+  /** Render Modified items as expandable cards with per-field checkboxes */
+  function _renderModifiedCards(container, modifiedItems) {
+    if (!container || !modifiedItems || modifiedItems.length === 0) {
+      if (container) {
+        container.style.display = 'none';
+        container.innerHTML = '';
+      }
+      return '';
+    }
+
+    var cc = _catColors.modified;
+    var collapsed = _collapsedCategories.modified;
+    var html = '';
+
+    // Section header
+    html += '<div data-cat-toggle="modified" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none">';
+    html += '<span style="font-size:0.6rem;opacity:0.4;transition:transform 0.2s;' + (collapsed ? 'transform:rotate(-90deg)' : '') + '">&#9660;</span>';
+    html += '<span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:4px;font-size:0.7rem;font-weight:700;background:' + cc.bg + ';color:' + cc.color + '">&#9998;</span>';
+    html += '<span style="font-weight:600;font-size:0.8rem">' + _esc('Modified') + '</span>';
+    html += '<span style="font-weight:400;opacity:0.5;font-size:0.73rem">(' + modifiedItems.length + ')</span>';
+    html += '</div>';
+
+    // Card container
+    html += '<div style="padding:0 0.65rem;' + (collapsed ? 'display:none' : '') + '">';
+
+    var limit = (_showAllItems.modified || modifiedItems.length <= 20) ? modifiedItems.length : 20;
+    for (var i = 0; i < limit; i++) {
+      var mod = modifiedItems[i];
+      var item = mod.item;
+      var changes = mod.changes || [];
+      var key = 'modified-' + i;
+      var checked = _checkedItems[key] !== false;
+      var name = _esc(item.name || 'Unnamed item');
+      var metalBg = _metalBgColor(item.metal);
+      var metalCol = _metalTextColor(item.metal);
+      var expanded = _expandedModified[i];
+
+      // Count checked fields for indeterminate hint
+      var checkedFieldCount = 0;
+      for (var fc = 0; fc < changes.length; fc++) {
+        if (_checkedFields[key + '-' + changes[fc].field] !== false) {
+          checkedFieldCount++;
         }
-        html += '</div>';
-      } else {
-        html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + '</div>';
-        // Detail line
-        var detail = [];
-        if (item.metal) detail.push(_esc(item.metal));
-        if (item.weight != null) detail.push(item.weight + _esc(item.weightUnit || 'oz'));
-        if (item.qty != null) detail.push('\u00d7 ' + item.qty);
-        if (detail.length > 0) {
-          html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';
+      }
+      var allFieldsChecked = checkedFieldCount === changes.length;
+      var someFieldsChecked = checkedFieldCount > 0 && !allFieldsChecked;
+
+      // Card wrapper
+      html += '<div style="border-radius:8px;border:1px solid var(--border-color,rgba(255,255,255,0.08));padding:0.65rem;margin-bottom:0.5rem;background:var(--bg-card,#1a1d27)">';
+      html += '<div style="display:flex;gap:0.5rem;align-items:center">';
+
+      // Master checkbox
+      html += '<input type="checkbox" data-check="' + key + '"' + (someFieldsChecked ? ' data-indeterminate="true"' : '') + ' ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);flex-shrink:0;cursor:pointer">';
+
+      // Image area
+      html += '<div' + (item.uuid ? ' data-uuid="' + _esc(item.uuid) + '"' : '') + ' style="width:40px;height:40px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;background:' + metalBg + ';color:' + metalCol + '">';
+      html += _metalEmoji(item.metal);
+      html += '</div>';
+
+      // Item identity
+      html += '<div style="flex:1;min-width:0">';
+      html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name;
+      html += '<span style="display:inline-block;background:rgba(217,119,6,0.1);color:#d97706;border-radius:12px;padding:0.1rem 0.5rem;font-size:0.7rem;margin-left:0.4rem">' + changes.length + ' field' + (changes.length !== 1 ? 's' : '') + ' changed</span>';
+      html += '</div>';
+      html += '</div>';
+
+      // Expand toggle
+      html += '<div class="diff-mod-toggle" data-mod-idx="' + i + '" style="cursor:pointer;padding:0.25rem 0.4rem;user-select:none">';
+      html += '<span style="font-size:0.65rem;opacity:0.35;transition:transform 0.2s;display:inline-block;' + (expanded ? '' : 'transform:rotate(-90deg)') + '">&#9660;</span>';
+      html += '</div>';
+
+      html += '</div>'; // flex row
+
+      // Expanded field rows
+      if (expanded) {
+        for (var fi = 0; fi < changes.length; fi++) {
+          var ch = changes[fi];
+          var fieldKey = key + '-' + ch.field;
+          var fieldChecked = _checkedFields[fieldKey] !== false;
+          var localDisplay = ch.localVal == null ? '\u2014' : _esc(String(ch.localVal));
+          var remoteDisplay = ch.remoteVal == null ? '\u2014' : _esc(String(ch.remoteVal));
+
+          html += '<div style="display:flex;align-items:center;gap:0.5rem;padding:0.2rem 0 0.2rem 3rem">';
+          html += '<input type="checkbox" data-field-check="' + fieldKey + '" ' + (fieldChecked ? 'checked' : '') + ' style="width:14px;height:14px;min-width:14px;padding:0;border:none;accent-color:var(--primary,#3b82f6);flex-shrink:0;cursor:pointer">';
+          html += '<span style="min-width:100px;font-size:0.78rem;opacity:0.5">' + _esc(ch.field) + '</span>';
+          html += '<span style="text-decoration:line-through;opacity:0.45;font-size:0.78rem">' + localDisplay + '</span>';
+          html += '<span style="opacity:0.35;font-size:0.7rem">&rarr;</span>';
+          html += '<span style="font-weight:500;color:var(--warning,#d97706);font-size:0.78rem">' + remoteDisplay + '</span>';
+          html += '</div>';
         }
       }
 
-      html += '</div></div>';
+      html += '</div>'; // card
     }
-    html += '</div></div>';
+
+    // "Show N more" button
+    if (modifiedItems.length > 20) {
+      var remaining = modifiedItems.length - 20;
+      html += '<div data-show-more="modified" style="font-size:0.78rem;text-align:center;cursor:pointer;padding:0.5rem;opacity:0.6">Show ' + remaining + ' more</div>';
+    }
+
+    html += '</div>'; // card container
+
     return html;
+  }
+
+  /** Load item images asynchronously for cards with data-uuid */
+  function _loadItemImages() {
+    try {
+      if (typeof imageCache === 'undefined' || !imageCache || !imageCache.getUserImageUrl) return;
+      var modal = safeGetElement('diffReviewModal');
+      if (!modal) return;
+      var els = modal.querySelectorAll('[data-uuid]');
+      for (var i = 0; i < els.length; i++) {
+        (function (el) {
+          imageCache.getUserImageUrl(el.dataset.uuid, 'obverse').then(function (url) {
+            if (url) {
+              el.innerHTML = '<img src="' + url + '" style="width:40px;height:40px;object-fit:cover;border-radius:6px" alt="">';
+            }
+          }).catch(function () { /* silent fallback — keep emoji */ });
+        })(els[i]);
+      }
+    } catch (ex) {
+      // imageCache not available — silently keep emoji placeholders
+    }
   }
 
   // ── Event delegation ──
@@ -746,9 +958,68 @@
   function _onListClick(e) {
     var target = e.target;
 
+    // Per-field checkbox toggle
+    if (target.type === 'checkbox' && target.dataset.fieldCheck) {
+      var fKey = target.dataset.fieldCheck;
+      _checkedFields[fKey] = target.checked;
+      // Sync master checkbox — parse item index from key like 'modified-0-fieldName'
+      var parts = fKey.split('-');
+      var itemIdx = parseInt(parts[1], 10);
+      var masterKey = 'modified-' + itemIdx;
+      var diff = _options.diff || {};
+      var modItem = (diff.modified || [])[itemIdx];
+      if (modItem) {
+        var changes = modItem.changes || [];
+        var allChecked = true;
+        var noneChecked = true;
+        for (var fc = 0; fc < changes.length; fc++) {
+          var cfk = 'modified-' + itemIdx + '-' + changes[fc].field;
+          if (_checkedFields[cfk] !== false) {
+            noneChecked = false;
+          } else {
+            allChecked = false;
+          }
+        }
+        // Update master checkbox state
+        _checkedItems[masterKey] = !noneChecked;
+        var masterCb = target.closest('[data-cat="modified"]') || safeGetElement('diffSectionModified');
+        if (masterCb) {
+          var mc = masterCb.querySelector('[data-check="' + masterKey + '"]');
+          if (mc) {
+            mc.checked = !noneChecked;
+            mc.indeterminate = !allChecked && !noneChecked;
+          }
+        }
+      }
+      _updateApplyCount();
+      return;
+    }
+
     // Checkbox toggle
     if (target.type === 'checkbox' && target.dataset.check) {
-      _checkedItems[target.dataset.check] = target.checked;
+      var chkKey = target.dataset.check;
+      _checkedItems[chkKey] = target.checked;
+      // If this is a modified master checkbox, toggle all field checkboxes too
+      if (chkKey.indexOf('modified-') === 0) {
+        var mIdx = parseInt(chkKey.split('-')[1], 10);
+        var diff2 = _options.diff || {};
+        var modItem2 = (diff2.modified || [])[mIdx];
+        if (modItem2) {
+          var changes2 = modItem2.changes || [];
+          for (var fc2 = 0; fc2 < changes2.length; fc2++) {
+            _checkedFields['modified-' + mIdx + '-' + changes2[fc2].field] = target.checked;
+          }
+          // Update field checkbox DOM elements without full re-render
+          var container2 = target.closest('[style*="border-radius:8px"]');
+          if (container2) {
+            var fieldCbs = container2.querySelectorAll('[data-field-check]');
+            for (var fi2 = 0; fi2 < fieldCbs.length; fi2++) {
+              fieldCbs[fi2].checked = target.checked;
+            }
+          }
+        }
+        target.indeterminate = false;
+      }
       _updateApplyCount();
       return;
     }
@@ -767,6 +1038,14 @@
     if (modToggle) {
       var idx = parseInt(modToggle.dataset.modIdx, 10);
       _expandedModified[idx] = !_expandedModified[idx];
+      _render();
+      return;
+    }
+
+    // "Show more" button
+    var showMoreBtn = target.closest('[data-show-more]');
+    if (showMoreBtn) {
+      _showAllItems[showMoreBtn.dataset.showMore] = true;
       _render();
       return;
     }
@@ -855,19 +1134,22 @@
       }
     }
 
-    // Modified items — one entry per changed field
+    // Modified items — one entry per checked field
     for (var m = 0; m < modified.length; m++) {
       if (_checkedItems['modified-' + m] !== false) {
         var mod = modified[m];
         var key = _itemKey(mod.item);
         for (var c = 0; c < mod.changes.length; c++) {
           var ch = mod.changes[c];
-          result.push({
-            type: 'modify',
-            itemKey: key,
-            field: ch.field,
-            value: ch.remoteVal
-          });
+          // Only emit fields that are individually checked (backward compat: if key missing, treat as true)
+          if (_checkedFields['modified-' + m + '-' + ch.field] !== false) {
+            result.push({
+              type: 'modify',
+              itemKey: key,
+              field: ch.field,
+              value: ch.remoteVal
+            });
+          }
         }
       }
     }
@@ -952,6 +1234,13 @@
       listEl.addEventListener('click', _onListClick);
     }
 
+    // Event delegation on orphan items (added/deleted cards)
+    var orphanListEl = safeGetElement('diffSectionOrphans');
+    if (orphanListEl) {
+      orphanListEl.removeEventListener('click', _onListClick);
+      orphanListEl.addEventListener('click', _onListClick);
+    }
+
     // Pill buttons
     var btnStyle = 'display:inline-flex;align-items:center;gap:0.3rem;border-radius:999px;font-size:0.73rem;font-weight:500;cursor:pointer;transition:all 0.15s;';
 
@@ -1022,17 +1311,27 @@
 
       // Reset internal state
       _checkedItems = {};
+      _checkedFields = {};
       _conflictResolutions = {};
       _collapsedCategories = {};
       _expandedModified = {};
       _expandedSettingsCategories = {};
       _selectAllState = 0;
+      _showAllItems = {};
 
       // Default all items to checked
       var diff = _options.diff || {};
       for (var a = 0; a < (diff.added || []).length; a++) _checkedItems['added-' + a] = true;
       for (var m = 0; m < (diff.modified || []).length; m++) _checkedItems['modified-' + m] = true;
       for (var d = 0; d < (diff.deleted || []).length; d++) _checkedItems['deleted-' + d] = true;
+
+      // Default all modified item fields to checked (accept remote)
+      for (var mf = 0; mf < (diff.modified || []).length; mf++) {
+        var modChanges = diff.modified[mf].changes || [];
+        for (var c = 0; c < modChanges.length; c++) {
+          _checkedFields['modified-' + mf + '-' + modChanges[c].field] = true;
+        }
+      }
 
       // Default conflict resolutions to 'remote' (per-field keys)
       if (_options.conflicts && _options.conflicts.conflicts) {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -130,6 +130,28 @@
     return _esc(String(value));
   }
 
+  // ── Metal helpers ──
+
+  var _metalRgb = {
+    gold: '255,215,0', silver: '192,192,192',
+    platinum: '229,228,226', palladium: '206,208,206'
+  };
+  var _metalCssVar = {
+    gold: 'var(--gold)', silver: 'var(--silver)',
+    platinum: 'var(--platinum)', palladium: 'var(--palladium)'
+  };
+
+  function _metalColor(metal) {
+    var key = (metal || '').toLowerCase();
+    return _metalCssVar[key] || 'var(--text-muted,#6b7094)';
+  }
+
+  function _metalBgGradient(metal) {
+    var key = (metal || '').toLowerCase();
+    var rgb = _metalRgb[key] || '128,128,128';
+    return 'linear-gradient(135deg, rgba(' + rgb + ',0.15), rgba(' + rgb + ',0.05))';
+  }
+
   // ── Internal state ──
   var _options = null;
   var _checkedItems = {};      // { 'added-0': true, 'modified-2': false, ... }
@@ -138,6 +160,11 @@
   var _expandedModified = {};    // { 0: true, 1: false, ... }
   var _expandedSettingsCategories = {}; // { 'Display & Appearance': true, ... }
   var _selectAllState = 0;  // 0=none, 1=added+modified, 2=all
+
+  // Card-based state (STAK-454)
+  var _orphanActions = {};       // { 'added-0': 'import'|'skip', 'deleted-1': 'keep'|'remove' }
+  var _fieldSelections = {};     // { 'conflict-0-purchasePrice': 'local'|'remote' }
+  var _resolvedConflicts = {};   // { 0: true, 1: true }
 
   // ── Helpers ──
 
@@ -572,6 +599,211 @@
     };
   }
 
+  // ── Card-based renderers (STAK-454 — matches playground/diffmodal-item-cards.html) ──
+
+  /** Render Added or Deleted items as orphan cards. Returns HTML string. */
+  function _renderOrphanCards(type, items) {
+    if (!items || items.length === 0) return '';
+    var collapsed = _collapsedCategories[type];
+    var isAdded = (type === 'added');
+    var sectionColor = isAdded ? 'var(--info,#3b82f6)' : 'var(--loss,#ef4444)';
+    var sectionIcon = isAdded ? '&#8595;' : '&#8593;';
+    var sectionLabel = isAdded ? 'Added / Remote Only' : 'Deleted / Local Only';
+
+    var html = '<div class="dm-section-wrapper" data-section="' + type + '" style="margin-top:1rem">';
+
+    // Section header
+    html += '<div class="dm-section-header">';
+    html += '<div class="dm-section-title">';
+    html += '<span class="dm-collapse-toggle' + (collapsed ? ' collapsed' : '') + '" data-cat-toggle="' + type + '">' + (collapsed ? '&#9654;' : '&#9660;') + '</span>';
+    html += '<span style="color:' + sectionColor + '">' + sectionIcon + '</span> ' + sectionLabel;
+    html += '<span class="dm-chip">' + items.length + ' item' + (items.length !== 1 ? 's' : '') + '</span>';
+    html += '</div>';
+    html += '<div class="dm-section-actions">';
+    if (isAdded) {
+      html += '<button class="dm-btn dm-btn-sm dm-btn-primary" data-bulk-action="import" data-bulk-section="added">Import All</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-bulk-action="skip" data-bulk-section="added">Skip All</button>';
+    } else {
+      html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-bulk-action="keep" data-bulk-section="deleted">Keep All</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-loss" data-bulk-action="remove" data-bulk-section="deleted">Remove All</button>';
+    }
+    html += '</div>';
+    html += '</div>';
+
+    // Section body
+    html += '<div class="dm-section-body' + (collapsed ? ' collapsed' : '') + '">';
+    var limit = items.length > 30 ? 30 : items.length;
+    for (var i = 0; i < limit; i++) {
+      var item = items[i];
+      var key = type + '-' + i;
+      var action = _orphanActions[key] || (isAdded ? 'import' : 'keep');
+      var isSkipped = (isAdded && action === 'skip') || (!isAdded && action === 'remove');
+      var grad = _metalBgGradient(item.metal);
+      var mColor = _metalColor(item.metal);
+      var uuid = item.uuid || '';
+
+      html += '<div class="dm-card dm-orphan-card' + (isSkipped ? ' skipped' : '') + '" data-action="' + action + '" data-idx="' + i + '" data-type="' + type + '">';
+      // Dual OBV/REV thumbnails
+      html += '<div class="dm-item-thumb-pair">';
+      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="obverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">OBV</span></div>';
+      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="reverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">REV</span></div>';
+      html += '</div>';
+      // Item identity
+      html += '<div class="dm-item-identity">';
+      html += '<div class="dm-item-name" style="color:' + mColor + '">' + _esc(item.name || 'Unnamed item') + '</div>';
+      html += '<div class="dm-item-meta">';
+      html += '<span style="color:' + mColor + '">' + _esc(item.metal || '') + '</span>';
+      if (item.weight != null) html += '<span>&#8226;</span><span>' + item.weight + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
+      if (item.qty != null) html += '<span>&#8226;</span><span>Qty: ' + item.qty + '</span>';
+      html += '</div></div>';
+      // Action buttons
+      html += '<div class="dm-orphan-actions">';
+      if (isAdded) {
+        html += '<button class="dm-btn dm-btn-sm dm-btn-primary dm-action-btn" data-set-action="import" data-idx="' + i + '" data-type="' + type + '">&#8595; Import</button>';
+        html += '<button class="dm-btn dm-btn-sm dm-btn-secondary dm-skip-btn" data-set-action="skip" data-idx="' + i + '" data-type="' + type + '">Skip</button>';
+      } else {
+        html += '<button class="dm-btn dm-btn-sm dm-btn-secondary dm-keep-btn" data-set-action="keep" data-idx="' + i + '" data-type="' + type + '">Keep</button>';
+        html += '<button class="dm-btn dm-btn-sm dm-btn-loss dm-remove-btn" data-set-action="remove" data-idx="' + i + '" data-type="' + type + '">Remove</button>';
+      }
+      html += '</div>';
+      html += '</div>';
+    }
+    if (items.length > 30) {
+      html += '<div class="dm-show-more" data-show-more="' + type + '" style="text-align:center;padding:0.5rem;font-size:0.78rem;cursor:pointer;color:var(--primary,#6366f1)">Show ' + (items.length - 30) + ' more...</div>';
+    }
+    html += '</div></div>';
+    return html;
+  }
+
+  /** Render Modified items as conflict cards with click-to-pick field values. Returns HTML string. */
+  function _renderModifiedSection(modifiedItems) {
+    if (!modifiedItems || modifiedItems.length === 0) return '';
+
+    var collapsed = _collapsedCategories.modified;
+    var html = '<div class="dm-section-wrapper" data-section="modified" style="margin-top:1rem">';
+
+    // Section header
+    html += '<div class="dm-section-header">';
+    html += '<div class="dm-section-title">';
+    html += '<span class="dm-collapse-toggle' + (collapsed ? ' collapsed' : '') + '" data-cat-toggle="modified">' + (collapsed ? '&#9654;' : '&#9660;') + '</span>';
+    html += '<span style="color:var(--warning,#d97706)">&#9888;</span> Modified / Conflicts';
+    html += '<span class="dm-chip">' + modifiedItems.length + ' item' + (modifiedItems.length !== 1 ? 's' : '') + '</span>';
+    html += '</div>';
+    html += '<div class="dm-section-actions">';
+    html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-global-action="keep-all-local">Keep All Local</button>';
+    html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-global-action="keep-all-remote">Keep All Remote</button>';
+    html += '</div>';
+    html += '</div>';
+
+    // Resolve progress
+    var resolvedCount = 0;
+    for (var rc = 0; rc < modifiedItems.length; rc++) {
+      if (_resolvedConflicts[rc]) resolvedCount++;
+    }
+    var remaining = modifiedItems.length - resolvedCount;
+    var pct = modifiedItems.length > 0 ? Math.round((resolvedCount / modifiedItems.length) * 100) : 0;
+
+    html += '<div class="dm-resolve-status">';
+    html += '<span class="dm-status-text">Resolved <strong>' + resolvedCount + '</strong> of <strong>' + modifiedItems.length + '</strong> conflicts</span>';
+    if (remaining === 0 && modifiedItems.length > 0) {
+      html += '<span class="dm-pill dm-pill-gain">All resolved &#10003;</span>';
+    } else {
+      html += '<span class="dm-pill dm-pill-warning">' + remaining + ' remaining</span>';
+    }
+    html += '</div>';
+    html += '<div class="dm-progress-bar"><div class="dm-progress-fill" style="width:' + pct + '%"></div></div>';
+
+    // Section body
+    html += '<div class="dm-section-body' + (collapsed ? ' collapsed' : '') + '">';
+
+    for (var i = 0; i < modifiedItems.length; i++) {
+      var mod = modifiedItems[i];
+      var item = mod.item;
+      var changes = mod.changes || [];
+      var grad = _metalBgGradient(item.metal);
+      var mColor = _metalColor(item.metal);
+      var uuid = item.uuid || '';
+      var isResolved = _resolvedConflicts[i];
+      var itemKey = _itemKey(item);
+
+      html += '<div class="dm-card dm-conflict-card' + (isResolved ? ' resolved' : '') + '" id="dm-conflict-' + i + '">';
+
+      // Card header
+      html += '<div class="dm-conflict-card-header" data-toggle-conflict="' + i + '" style="cursor:pointer">';
+      // Thumbnails
+      html += '<div class="dm-item-thumb-pair">';
+      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="obverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">OBV</span></div>';
+      html += '<div class="dm-item-thumb" style="background:' + grad + '"' + (uuid ? ' data-uuid="' + _esc(uuid) + '" data-side="reverse"' : '') + '><span style="color:' + mColor + ';font-size:0.55rem">REV</span></div>';
+      html += '</div>';
+      // Identity
+      html += '<div class="dm-item-identity">';
+      html += '<div class="dm-item-name">' + _esc(item.name || 'Unnamed item') + '</div>';
+      html += '<div class="dm-item-meta">';
+      html += '<span style="color:' + mColor + '">' + _esc(item.metal || '') + '</span>';
+      if (item.weight != null) html += '<span>&#8226;</span><span>' + item.weight + ' ' + _esc(item.weightUnit || 'oz') + '</span>';
+      html += '<span>&#8226;</span><span class="dm-chip" style="font-size:0.65rem">ID: ' + _esc(itemKey).substring(0, 16) + '</span>';
+      html += '</div></div>';
+      // Field count pill
+      if (isResolved) {
+        html += '<span class="dm-pill dm-pill-gain">&#10003; Resolved</span>';
+      } else {
+        html += '<span class="dm-pill dm-pill-warning">' + changes.length + ' field' + (changes.length !== 1 ? 's' : '') + ' changed</span>';
+      }
+      html += '</div>';
+
+      // Conflict details (field rows)
+      var detailsCollapsed = isResolved;
+      html += '<div class="dm-conflict-details' + (detailsCollapsed ? ' collapsed' : '') + '" id="dm-conflict-details-' + i + '">';
+      for (var c = 0; c < changes.length; c++) {
+        var ch = changes[c];
+        var fKey = 'conflict-' + i + '-' + ch.field;
+        var sel = _fieldSelections[fKey] || 'remote';
+        var localSelected = sel === 'local' ? ' selected' : '';
+        var remoteSelected = sel === 'remote' ? ' selected' : '';
+
+        html += '<div class="dm-field-diff">';
+        html += '<div class="dm-field-label">' + _esc(ch.field) + '</div>';
+        html += '<div class="dm-field-value local' + localSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(String(ch.localVal != null ? ch.localVal : '\u2014')) + '</div>';
+        html += '<div class="dm-field-arrow">&#10231;</div>';
+        html += '<div class="dm-field-value remote' + remoteSelected + '" data-field="' + _esc(ch.field) + '" data-card="' + i + '">' + _esc(String(ch.remoteVal != null ? ch.remoteVal : '\u2014')) + '</div>';
+        html += '</div>';
+      }
+      // Card actions
+      html += '<div class="dm-card-actions">';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-card-action="keep-local" data-card="' + i + '">Keep All Local</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-secondary" data-card-action="keep-remote" data-card="' + i + '">Keep All Remote</button>';
+      html += '<button class="dm-btn dm-btn-sm dm-btn-primary" data-card-action="resolve" data-card="' + i + '">&#10003; Confirm</button>';
+      html += '</div>';
+      html += '</div>'; // .dm-conflict-details
+
+      html += '</div>'; // .dm-conflict-card
+    }
+
+    html += '</div></div>';
+    return html;
+  }
+
+  /** Load images asynchronously for items with data-uuid attributes */
+  function _loadItemImages() {
+    try {
+      var modal = safeGetElement(MODAL_ID);
+      if (!modal || typeof imageCache === 'undefined') return;
+      var thumbs = modal.querySelectorAll('[data-uuid]');
+      for (var t = 0; t < thumbs.length; t++) {
+        (function(el) {
+          var uuid = el.dataset.uuid;
+          var side = el.dataset.side || 'obverse';
+          if (!uuid) return;
+          try {
+            imageCache.getUserImageUrl(uuid, side).then(function(url) {
+              if (url) el.innerHTML = '<img src="' + url + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
+            }).catch(function() { /* silent fallback to OBV/REV text */ });
+          } catch(e) { /* imageCache not available */ }
+        })(thumbs[t]);
+      }
+    } catch(e) { /* silent */ }
+  }
+
   function _updateApplyButton() {
     var applyBtn = safeGetElement('diffReviewApplyBtn');
     if (!applyBtn) return;
@@ -633,25 +865,33 @@
     // Conflict cards (replaces old inline conflict rendering)
     _renderConflictCards(safeGetElement('diffSectionConflicts'), conflicts);
 
-    // Change list — retarget to diffSectionModified container
-    var listEl = safeGetElement('diffSectionModified');
-    if (listEl) {
-      var totalChanges = added.length + modified.length + deleted.length;
-      var lHtml = '';
-
-      if (totalChanges === 0) {
-        lHtml = '<div style="padding:2rem;text-align:center;opacity:0.45;font-size:0.85rem">No item changes detected</div>';
-      } else {
-        // Added
-        if (added.length > 0) lHtml += _renderCategory('added', 'Added', '+', added);
-        // Modified
-        if (modified.length > 0) lHtml += _renderCategory('modified', 'Modified', '&#9998;', modified);
-        // Deleted
-        if (deleted.length > 0) lHtml += _renderCategory('deleted', 'Deleted', '&minus;', deleted);
-      }
-
-      listEl.innerHTML = lHtml;
+    // Orphan cards (Added + Deleted) — render into #diffSectionOrphans
+    var orphanEl = safeGetElement('diffSectionOrphans');
+    if (orphanEl) {
+      var orphanHtml = '';
+      if (added.length > 0) orphanHtml += _renderOrphanCards('added', added);
+      if (deleted.length > 0) orphanHtml += _renderOrphanCards('deleted', deleted);
+      orphanEl.innerHTML = orphanHtml;
+      orphanEl.style.display = orphanHtml ? '' : 'none';
     }
+
+    // Modified conflict cards — render into #diffSectionModified
+    var modifiedEl = safeGetElement('diffSectionModified');
+    if (modifiedEl) {
+      var modHtml = '';
+      if (modified.length > 0) {
+        modHtml = _renderModifiedSection(modified);
+      } else {
+        var totalChanges = added.length + deleted.length;
+        if (totalChanges === 0) {
+          modHtml = '<div style="padding:2rem;text-align:center;opacity:0.45;font-size:0.85rem">No item changes detected</div>';
+        }
+      }
+      modifiedEl.innerHTML = modHtml;
+    }
+
+    // Async image loading
+    _loadItemImages();
 
     // Settings cards (replaces old settings <details>)
     _renderSettingsCards(safeGetElement('diffReviewSettings'), _options.settingsDiff);
@@ -668,92 +908,59 @@
       + '</div>';
   }
 
-  /** Color configs per category */
-  var _catColors = {
-    added:   { bg: 'rgba(5,150,105,0.12)', color: 'var(--success,#059669)' },
-    modified:{ bg: 'rgba(217,119,6,0.12)',  color: 'var(--warning,#d97706)' },
-    deleted: { bg: 'rgba(220,38,38,0.12)',  color: 'var(--danger,#dc2626)' }
-  };
+  // _renderCategory() has been replaced by _renderOrphanCards() and _renderModifiedSection() (STAK-454)
 
-  /** Render a category group (added/modified/deleted) */
-  function _renderCategory(type, label, icon, items) {
-    var collapsed = _collapsedCategories[type];
-    var cc = _catColors[type];
-    var html = '<div data-cat="' + type + '" style="' + (collapsed ? '' : '') + '">';
+  // ── Event delegation (STAK-454 — card-based interactions) ──
 
-    // Header
-    html += '<div class="diff-cat-header" data-cat-toggle="' + type + '" style="display:flex;align-items:center;gap:0.4rem;padding:0.5rem 0.65rem;cursor:pointer;user-select:none;font-size:0.8rem;font-weight:600">';
-    html += '<span style="font-size:0.6rem;opacity:0.4;transition:transform 0.2s;' + (collapsed ? 'transform:rotate(-90deg)' : '') + '">&#9660;</span>';
-    html += '<span style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:4px;font-size:0.7rem;font-weight:700;background:' + cc.bg + ';color:' + cc.color + '">' + icon + '</span>';
-    html += '<span>' + label + '</span>';
-    html += '<span style="font-weight:400;opacity:0.5;font-size:0.73rem">(' + items.length + ')</span>';
-    html += '</div>';
-
-    // Items
-    html += '<div class="diff-cat-items" style="' + (collapsed ? 'display:none' : '') + '">';
-    for (var i = 0; i < items.length; i++) {
-      var key = type + '-' + i;
-      var checked = _checkedItems[key] !== false; // default true
-      var item = type === 'modified' ? items[i].item : items[i];
-      var name = _esc(item.name || 'Unnamed item');
-
-      html += '<div style="display:flex;align-items:flex-start;gap:0.5rem;padding:0.45rem 0.65rem;font-size:0.85rem">';
-      html += '<input type="checkbox" data-check="' + key + '" ' + (checked ? 'checked' : '') + ' style="width:16px;height:16px;min-width:16px;padding:0;border:none;accent-color:var(--primary,#3b82f6);margin-top:2px;flex-shrink:0;cursor:pointer">';
-      html += '<div style="flex-shrink:0;width:20px;height:20px;border-radius:5px;display:flex;align-items:center;justify-content:center;font-size:0.75rem;font-weight:700;margin-top:1px;background:' + cc.bg + ';color:' + cc.color + '">' + icon + '</div>';
-
-      html += '<div style="flex:1;min-width:0">';
-
-      if (type === 'modified') {
-        var mod = items[i];
-        var expanded = _expandedModified[i];
-        html += '<div class="diff-mod-toggle" data-mod-idx="' + i + '" style="cursor:pointer">';
-        html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + ' <span style="font-size:0.65rem;opacity:0.35">' + (expanded ? '&#9650;' : '&#9660;') + '</span></div>';
-        html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + mod.changes.length + ' field' + (mod.changes.length > 1 ? 's' : '') + ' changed</div>';
-        if (expanded) {
-          html += '<div style="margin-top:0.35rem;padding-left:0.25rem;font-size:0.78rem">';
-          for (var c = 0; c < mod.changes.length; c++) {
-            var ch = mod.changes[c];
-            html += '<div style="padding:0.15rem 0;display:flex;gap:0.3rem;align-items:baseline">';
-            html += '<span style="opacity:0.5;min-width:80px">' + _esc(ch.field) + '</span>';
-            html += '<span style="text-decoration:line-through;opacity:0.45">' + _esc(String(ch.localVal != null ? ch.localVal : '\u2014')) + '</span>';
-            html += '<span style="opacity:0.35;font-size:0.7rem">&rarr;</span>';
-            html += '<span style="font-weight:500;color:var(--warning,#d97706)">' + _esc(String(ch.remoteVal != null ? ch.remoteVal : '\u2014')) + '</span>';
-            html += '</div>';
-          }
-          html += '</div>';
-        }
-        html += '</div>';
-      } else {
-        html += '<div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + name + '</div>';
-        // Detail line
-        var detail = [];
-        if (item.metal) detail.push(_esc(item.metal));
-        if (item.weight != null) detail.push(item.weight + _esc(item.weightUnit || 'oz'));
-        if (item.qty != null) detail.push('\u00d7 ' + item.qty);
-        if (detail.length > 0) {
-          html += '<div style="font-size:0.73rem;opacity:0.5;margin-top:0.1rem">' + detail.join(' \u00b7 ') + '</div>';
-        }
-      }
-
-      html += '</div></div>';
-    }
-    html += '</div></div>';
-    return html;
-  }
-
-  // ── Event delegation ──
-
-  function _onListClick(e) {
+  /** Handle clicks on orphan cards (Added/Deleted) */
+  function _onOrphanClick(e) {
     var target = e.target;
 
-    // Checkbox toggle
-    if (target.type === 'checkbox' && target.dataset.check) {
-      _checkedItems[target.dataset.check] = target.checked;
+    // Orphan card action button (Import/Skip/Keep/Remove)
+    var actionBtn = target.closest('[data-set-action]');
+    if (actionBtn) {
+      e.stopPropagation();
+      var action = actionBtn.dataset.setAction;
+      var idx = parseInt(actionBtn.dataset.idx, 10);
+      var type = actionBtn.dataset.type;
+      var key = type + '-' + idx;
+      _orphanActions[key] = action;
+      // Also sync _checkedItems for backward compat
+      if (type === 'added') _checkedItems[key] = (action !== 'skip');
+      if (type === 'deleted') _checkedItems[key] = (action === 'remove');
+      // Toggle visual state
+      var card = actionBtn.closest('.dm-orphan-card');
+      if (card) {
+        var isSkipped = (action === 'skip' || action === 'remove');
+        card.classList.toggle('skipped', isSkipped);
+        card.dataset.action = action;
+      }
       _updateApplyCount();
       return;
     }
 
-    // Category collapse toggle
+    // Bulk action buttons (Import All, Skip All, Keep All, Remove All)
+    var bulkBtn = target.closest('[data-bulk-action]');
+    if (bulkBtn) {
+      var bulkAction = bulkBtn.dataset.bulkAction;
+      var bulkSection = bulkBtn.dataset.bulkSection;
+      var cards = e.currentTarget.querySelectorAll('.dm-orphan-card[data-type="' + bulkSection + '"]');
+      for (var bi = 0; bi < cards.length; bi++) {
+        var bCard = cards[bi];
+        var bIdx = parseInt(bCard.dataset.idx, 10);
+        var bKey = bulkSection + '-' + bIdx;
+        _orphanActions[bKey] = bulkAction;
+        if (bulkSection === 'added') _checkedItems[bKey] = (bulkAction !== 'skip');
+        if (bulkSection === 'deleted') _checkedItems[bKey] = (bulkAction === 'remove');
+        var bSkipped = (bulkAction === 'skip' || bulkAction === 'remove');
+        bCard.classList.toggle('skipped', bSkipped);
+        bCard.dataset.action = bulkAction;
+      }
+      _updateApplyCount();
+      return;
+    }
+
+    // Section collapse toggle
     var catToggle = target.closest('[data-cat-toggle]');
     if (catToggle) {
       var cat = catToggle.dataset.catToggle;
@@ -762,32 +969,206 @@
       return;
     }
 
-    // Modified row expand toggle
-    var modToggle = target.closest('.diff-mod-toggle');
-    if (modToggle) {
-      var idx = parseInt(modToggle.dataset.modIdx, 10);
-      _expandedModified[idx] = !_expandedModified[idx];
+    // Show more button
+    var showMore = target.closest('[data-show-more]');
+    if (showMore) {
+      var smType = showMore.dataset.showMore;
+      // Remove the limit and re-render (set a flag to show all)
+      _collapsedCategories['_showAll_' + smType] = true;
       _render();
       return;
     }
   }
 
-  function _onConflictsChange(e) {
-    if (e.target.type === 'radio' && e.target.dataset.conflict != null) {
-      _conflictResolutions['c' + e.target.dataset.conflict] = e.target.value;
+  /** Handle clicks on modified/conflict cards */
+  function _onModifiedClick(e) {
+    var target = e.target;
+
+    // Field value click (click to pick local or remote)
+    var fieldVal = target.closest('.dm-field-value');
+    if (fieldVal && fieldVal.dataset.field && fieldVal.dataset.card != null) {
+      var field = fieldVal.dataset.field;
+      var cardIdx = parseInt(fieldVal.dataset.card, 10);
+      var fKey = 'conflict-' + cardIdx + '-' + field;
+      var side = fieldVal.classList.contains('local') ? 'local' : 'remote';
+      _fieldSelections[fKey] = side;
+      // Update visual: remove selected from sibling, add to clicked
+      var row = fieldVal.closest('.dm-field-diff');
+      if (row) {
+        var siblings = row.querySelectorAll('.dm-field-value');
+        for (var si = 0; si < siblings.length; si++) siblings[si].classList.remove('selected');
+      }
+      fieldVal.classList.add('selected');
+      _updateApplyCount();
+      return;
     }
+
+    // Per-card action buttons (Keep All Local, Keep All Remote, Confirm)
+    var cardAction = target.closest('[data-card-action]');
+    if (cardAction) {
+      var action = cardAction.dataset.cardAction;
+      var ci = parseInt(cardAction.dataset.card, 10);
+      var card = e.currentTarget.querySelector('#dm-conflict-' + ci);
+      if (!card) return;
+
+      if (action === 'keep-local' || action === 'keep-remote') {
+        var pickSide = action === 'keep-local' ? 'local' : 'remote';
+        var fieldVals = card.querySelectorAll('.dm-field-value.' + pickSide);
+        for (var fvi = 0; fvi < fieldVals.length; fvi++) {
+          var fv = fieldVals[fvi];
+          var fRow = fv.closest('.dm-field-diff');
+          if (fRow) {
+            var fSiblings = fRow.querySelectorAll('.dm-field-value');
+            for (var fsi = 0; fsi < fSiblings.length; fsi++) fSiblings[fsi].classList.remove('selected');
+          }
+          fv.classList.add('selected');
+          if (fv.dataset.field) {
+            _fieldSelections['conflict-' + ci + '-' + fv.dataset.field] = pickSide;
+          }
+        }
+        _updateApplyCount();
+        return;
+      }
+
+      if (action === 'resolve') {
+        // Validate all fields have a selection
+        var fieldDiffs = card.querySelectorAll('.dm-field-diff');
+        var allResolved = true;
+        for (var fd = 0; fd < fieldDiffs.length; fd++) {
+          if (!fieldDiffs[fd].querySelector('.dm-field-value.selected')) {
+            allResolved = false;
+            // Flash unresolved field
+            fieldDiffs[fd].style.background = 'rgba(239,68,68,0.1)';
+            (function(el) {
+              setTimeout(function() { el.style.background = ''; }, 600);
+            })(fieldDiffs[fd]);
+          }
+        }
+        if (!allResolved) return;
+
+        // Mark resolved
+        _resolvedConflicts[ci] = true;
+        card.classList.add('resolved');
+        var pill = card.querySelector('.dm-conflict-card-header .dm-pill');
+        if (pill) {
+          pill.className = 'dm-pill dm-pill-gain';
+          pill.innerHTML = '&#10003; Resolved';
+        }
+        // Collapse the details
+        var details = card.querySelector('.dm-conflict-details');
+        if (details) details.classList.add('collapsed');
+
+        // Update progress
+        _updateModifiedProgress();
+        _updateApplyCount();
+        return;
+      }
+      return;
+    }
+
+    // Global Keep All Local / Keep All Remote
+    var globalAction = target.closest('[data-global-action]');
+    if (globalAction) {
+      var gAction = globalAction.dataset.globalAction;
+      var gSide = gAction === 'keep-all-local' ? 'local' : 'remote';
+      var allFieldVals = e.currentTarget.querySelectorAll('.dm-field-value.' + gSide);
+      for (var gfi = 0; gfi < allFieldVals.length; gfi++) {
+        var gfv = allFieldVals[gfi];
+        var gRow = gfv.closest('.dm-field-diff');
+        if (gRow) {
+          var gSiblings = gRow.querySelectorAll('.dm-field-value');
+          for (var gsi = 0; gsi < gSiblings.length; gsi++) gSiblings[gsi].classList.remove('selected');
+        }
+        gfv.classList.add('selected');
+        if (gfv.dataset.field && gfv.dataset.card != null) {
+          _fieldSelections['conflict-' + gfv.dataset.card + '-' + gfv.dataset.field] = gSide;
+        }
+      }
+      _updateApplyCount();
+      return;
+    }
+
+    // Conflict card header click — toggle expand/collapse
+    var conflictToggle = target.closest('[data-toggle-conflict]');
+    if (conflictToggle) {
+      var tIdx = parseInt(conflictToggle.dataset.toggleConflict, 10);
+      var tDetails = e.currentTarget.querySelector('#dm-conflict-details-' + tIdx);
+      if (tDetails) tDetails.classList.toggle('collapsed');
+      return;
+    }
+
+    // Section collapse toggle
+    var catToggle = target.closest('[data-cat-toggle]');
+    if (catToggle) {
+      var cat = catToggle.dataset.catToggle;
+      _collapsedCategories[cat] = !_collapsedCategories[cat];
+      _render();
+      return;
+    }
+  }
+
+  /** Update the modified section's progress bar and status text */
+  function _updateModifiedProgress() {
+    var diff = _options ? _options.diff || {} : {};
+    var modified = diff.modified || [];
+    if (modified.length === 0) return;
+    var resolved = 0;
+    for (var i = 0; i < modified.length; i++) {
+      if (_resolvedConflicts[i]) resolved++;
+    }
+    var remaining = modified.length - resolved;
+    var pct = Math.round((resolved / modified.length) * 100);
+
+    // Update progress bar
+    var bar = safeGetElement('diffSectionModified');
+    if (bar) {
+      var fill = bar.querySelector('.dm-progress-fill');
+      if (fill) fill.style.width = pct + '%';
+      var statusText = bar.querySelector('.dm-status-text');
+      if (statusText) statusText.innerHTML = 'Resolved <strong>' + resolved + '</strong> of <strong>' + modified.length + '</strong> conflicts';
+      var pillEl = bar.querySelector('.dm-resolve-status .dm-pill');
+      if (pillEl) {
+        if (remaining === 0) {
+          pillEl.className = 'dm-pill dm-pill-gain';
+          pillEl.innerHTML = 'All resolved &#10003;';
+        } else {
+          pillEl.className = 'dm-pill dm-pill-warning';
+          pillEl.textContent = remaining + ' remaining';
+        }
+      }
+    }
+  }
+
+  /** Count selected items for the Apply button (card-based state) */
+  function _cardBasedCount() {
+    var count = 0;
+    var diff = _options ? _options.diff || {} : {};
+    var added = diff.added || [];
+    var modified = diff.modified || [];
+    var deleted = diff.deleted || [];
+
+    for (var a = 0; a < added.length; a++) {
+      if (_orphanActions['added-' + a] !== 'skip') count++;
+    }
+    for (var m = 0; m < modified.length; m++) {
+      count++; // modified items always included (user picks field winners)
+    }
+    for (var d = 0; d < deleted.length; d++) {
+      if (_orphanActions['deleted-' + d] === 'remove') count++;
+    }
+    return count;
   }
 
   /** Update just the Apply button count without full re-render */
   function _updateApplyCount() {
     var applyBtn = safeGetElement('diffReviewApplyBtn');
     if (applyBtn) {
-      var count = _checkedCount();
-      var hasSelectableItems = Object.keys(_checkedItems).length > 0;
+      var hasCardState = Object.keys(_orphanActions).length > 0 || Object.keys(_fieldSelections).length > 0;
+      var count = hasCardState ? _cardBasedCount() : _checkedCount();
       var hasSettings = _options && _options.settingsDiff && _options.settingsDiff.changed && _options.settingsDiff.changed.length > 0;
       applyBtn.textContent = count > 0 ? 'Apply (' + count + ')' : 'Apply';
-      applyBtn.disabled = hasSelectableItems && count === 0 && !hasSettings;
-      applyBtn.style.opacity = (hasSelectableItems && count === 0 && !hasSettings) ? '0.4' : '';
+      applyBtn.disabled = count === 0 && !hasSettings;
+      applyBtn.style.opacity = (count === 0 && !hasSettings) ? '0.4' : '';
     }
     _updateCountRow();
   }
@@ -796,47 +1177,85 @@
 
   function _selectAll() {
     var diff = _options.diff || {};
-    for (var i = 0; i < (diff.added || []).length; i++) _checkedItems['added-' + i] = true;
-    for (var j = 0; j < (diff.modified || []).length; j++) _checkedItems['modified-' + j] = true;
-    for (var k = 0; k < (diff.deleted || []).length; k++) _checkedItems['deleted-' + k] = true;
-    _render(); // _render calls _updateCountRow internally
+    // Card-based: set all orphan actions to include
+    for (var i = 0; i < (diff.added || []).length; i++) {
+      _orphanActions['added-' + i] = 'import';
+      _checkedItems['added-' + i] = true;
+    }
+    for (var j = 0; j < (diff.modified || []).length; j++) {
+      _checkedItems['modified-' + j] = true;
+      // Select all remote for each modified field
+      var mod = (diff.modified || [])[j];
+      if (mod && mod.changes) {
+        for (var c = 0; c < mod.changes.length; c++) {
+          _fieldSelections['conflict-' + j + '-' + mod.changes[c].field] = 'remote';
+        }
+      }
+    }
+    for (var k = 0; k < (diff.deleted || []).length; k++) {
+      _orphanActions['deleted-' + k] = 'remove';
+      _checkedItems['deleted-' + k] = true;
+    }
+    _render();
   }
 
   function _deselectAll() {
-    for (var key in _checkedItems) {
-      if (_checkedItems.hasOwnProperty(key)) _checkedItems[key] = false;
+    var diff = _options.diff || {};
+    for (var i = 0; i < (diff.added || []).length; i++) {
+      _orphanActions['added-' + i] = 'skip';
+      _checkedItems['added-' + i] = false;
     }
-    _render(); // _render calls _updateCountRow internally
+    for (var k in _checkedItems) {
+      if (_checkedItems.hasOwnProperty(k)) _checkedItems[k] = false;
+    }
+    for (var d = 0; d < (diff.deleted || []).length; d++) {
+      _orphanActions['deleted-' + d] = 'keep';
+    }
+    _render();
   }
 
   /**
    * Toggle "Select All / Deselect All" for the backup import flow.
-   * First call selects all added + modified; label changes to "Deselect All".
-   * Second call deselects all; label goes back to "Select All".
    */
   function _toggleSelectAll() {
-    const diff = _options ? _options.diff || {} : {};
+    var diff = _options ? _options.diff || {} : {};
     _selectAllState = (_selectAllState + 1) % 3;
     if (_selectAllState === 1) {
-      // First press: select added + modified, keep deleted unchecked
-      for (let i = 0; i < (diff.added || []).length; i++) _checkedItems['added-' + i] = true;
-      for (let j = 0; j < (diff.modified || []).length; j++) _checkedItems['modified-' + j] = true;
-      for (let k = 0; k < (diff.deleted || []).length; k++) _checkedItems['deleted-' + k] = false;
+      // First press: import all added, keep deleted untouched
+      for (var i = 0; i < (diff.added || []).length; i++) {
+        _orphanActions['added-' + i] = 'import';
+        _checkedItems['added-' + i] = true;
+      }
+      for (var j = 0; j < (diff.modified || []).length; j++) _checkedItems['modified-' + j] = true;
+      for (var k = 0; k < (diff.deleted || []).length; k++) {
+        _orphanActions['deleted-' + k] = 'keep';
+        _checkedItems['deleted-' + k] = false;
+      }
     } else if (_selectAllState === 2) {
-      // Second press: also select deleted rows
-      for (let k = 0; k < (diff.deleted || []).length; k++) _checkedItems['deleted-' + k] = true;
+      // Second press: also mark deleted for removal
+      for (var k2 = 0; k2 < (diff.deleted || []).length; k2++) {
+        _orphanActions['deleted-' + k2] = 'remove';
+        _checkedItems['deleted-' + k2] = true;
+      }
     } else {
       // Third press: deselect all
-      for (const key in _checkedItems) {
+      for (var a = 0; a < (diff.added || []).length; a++) {
+        _orphanActions['added-' + a] = 'skip';
+        _checkedItems['added-' + a] = false;
+      }
+      for (var key in _checkedItems) {
         if (_checkedItems.hasOwnProperty(key)) _checkedItems[key] = false;
       }
+      for (var d = 0; d < (diff.deleted || []).length; d++) {
+        _orphanActions['deleted-' + d] = 'keep';
+      }
     }
-    const toggleBtn = safeGetElement('diffReviewSelectAllToggle');
+    var toggleBtn = safeGetElement('diffReviewSelectAllToggle');
     if (toggleBtn) {
-      const labels = ['Select All', 'Add Deleted', 'Deselect All'];
+      var labels = ['Select All', 'Add Deleted', 'Deselect All'];
       toggleBtn.textContent = labels[_selectAllState];
     }
-    _render(); // _render calls _updateCountRow internally
+    _render();
   }
 
   // ── Apply / Cancel ──
@@ -847,39 +1266,61 @@
     var added = diff.added || [];
     var modified = diff.modified || [];
     var deleted = diff.deleted || [];
+    var hasCardState = Object.keys(_orphanActions).length > 0 || Object.keys(_fieldSelections).length > 0;
 
-    // Added items
+    // Added items — card state or legacy fallback
     for (var a = 0; a < added.length; a++) {
-      if (_checkedItems['added-' + a] !== false) {
+      var includeAdded = hasCardState
+        ? (_orphanActions['added-' + a] !== 'skip')
+        : (_checkedItems['added-' + a] !== false);
+      if (includeAdded) {
         result.push({ type: 'add', item: added[a] });
       }
     }
 
-    // Modified items — one entry per changed field
+    // Modified items — per-field selection via _fieldSelections
     for (var m = 0; m < modified.length; m++) {
-      if (_checkedItems['modified-' + m] !== false) {
-        var mod = modified[m];
-        var key = _itemKey(mod.item);
+      var mod = modified[m];
+      var mKey = _itemKey(mod.item);
+      if (hasCardState) {
+        // Card-based: always emit all fields, user picks local vs remote per field
         for (var c = 0; c < mod.changes.length; c++) {
           var ch = mod.changes[c];
+          var fSel = _fieldSelections['conflict-' + m + '-' + ch.field] || 'remote';
           result.push({
             type: 'modify',
-            itemKey: key,
+            itemKey: mKey,
             field: ch.field,
-            value: ch.remoteVal
+            value: fSel === 'local' ? ch.localVal : ch.remoteVal
           });
+        }
+      } else {
+        // Legacy fallback: emit all fields if item is checked
+        if (_checkedItems['modified-' + m] !== false) {
+          for (var c2 = 0; c2 < mod.changes.length; c2++) {
+            var ch2 = mod.changes[c2];
+            result.push({
+              type: 'modify',
+              itemKey: mKey,
+              field: ch2.field,
+              value: ch2.remoteVal
+            });
+          }
         }
       }
     }
 
-    // Deleted items
+    // Deleted items — card state or legacy fallback
     for (var d = 0; d < deleted.length; d++) {
-      if (_checkedItems['deleted-' + d] !== false) {
+      var includeDeleted = hasCardState
+        ? (_orphanActions['deleted-' + d] === 'remove')
+        : (_checkedItems['deleted-' + d] !== false);
+      if (includeDeleted) {
         result.push({ type: 'delete', itemKey: _itemKey(deleted[d]) });
       }
     }
 
-    // Item conflict resolutions — per-field local/remote picks
+    // Item conflict resolutions (sync-specific conflicts section — separate from modified cards)
     var conflictsArr = (_options.conflicts && _options.conflicts.conflicts) || [];
     for (var ci = 0; ci < conflictsArr.length; ci++) {
       var conf = conflictsArr[ci];
@@ -894,7 +1335,7 @@
       });
     }
 
-    // Settings changes — resolution-aware (local/remote toggle per setting)
+    // Settings changes
     var settingsDiff = _options.settingsDiff || {};
     var changedSettings = settingsDiff.changed || [];
     for (var s = 0; s < changedSettings.length; s++) {
@@ -946,10 +1387,15 @@
     // Determine whether we're in backup-count mode
     var hasBackupCount = _options && _options.backupCount != null;
 
-    // Event delegation on item list
+    // Event delegation on card containers
+    var orphanEl = safeGetElement('diffSectionOrphans');
+    if (orphanEl) {
+      orphanEl.removeEventListener('click', _onOrphanClick);
+      orphanEl.addEventListener('click', _onOrphanClick);
+    }
     if (listEl) {
-      listEl.removeEventListener('click', _onListClick);
-      listEl.addEventListener('click', _onListClick);
+      listEl.removeEventListener('click', _onModifiedClick);
+      listEl.addEventListener('click', _onModifiedClick);
     }
 
     // Pill buttons
@@ -1027,12 +1473,30 @@
       _expandedModified = {};
       _expandedSettingsCategories = {};
       _selectAllState = 0;
+      _orphanActions = {};
+      _fieldSelections = {};
+      _resolvedConflicts = {};
 
-      // Default all items to checked
+      // Default all items to checked (legacy compat) + initialize card-based state
       var diff = _options.diff || {};
-      for (var a = 0; a < (diff.added || []).length; a++) _checkedItems['added-' + a] = true;
-      for (var m = 0; m < (diff.modified || []).length; m++) _checkedItems['modified-' + m] = true;
-      for (var d = 0; d < (diff.deleted || []).length; d++) _checkedItems['deleted-' + d] = true;
+      for (var a = 0; a < (diff.added || []).length; a++) {
+        _checkedItems['added-' + a] = true;
+        _orphanActions['added-' + a] = 'import';
+      }
+      for (var m = 0; m < (diff.modified || []).length; m++) {
+        _checkedItems['modified-' + m] = true;
+        // Initialize per-field selections to 'remote' (default: accept incoming)
+        var mod = (diff.modified || [])[m];
+        if (mod && mod.changes) {
+          for (var fc = 0; fc < mod.changes.length; fc++) {
+            _fieldSelections['conflict-' + m + '-' + mod.changes[fc].field] = 'remote';
+          }
+        }
+      }
+      for (var d = 0; d < (diff.deleted || []).length; d++) {
+        _checkedItems['deleted-' + d] = true;
+        _orphanActions['deleted-' + d] = 'keep';
+      }
 
       // Default conflict resolutions to 'remote' (per-field keys)
       if (_options.conflicts && _options.conflicts.conflicts) {

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -783,19 +783,35 @@
     return html;
   }
 
-  /** Load images asynchronously for items with data-uuid attributes */
+  /** Load images asynchronously using resolveImageUrlForItem (same as main app) */
   function _loadItemImages() {
     try {
       var modal = safeGetElement(MODAL_ID);
-      if (!modal || typeof imageCache === 'undefined') return;
+      if (!modal || typeof imageCache === 'undefined' || !imageCache.resolveImageUrlForItem) return;
+
+      // Build UUID → item lookup from current diff data
+      var itemByUuid = {};
+      var diff = _options ? _options.diff || {} : {};
+      var allItems = (diff.added || []).concat(diff.deleted || []);
+      for (var mi = 0; mi < (diff.modified || []).length; mi++) {
+        allItems.push((diff.modified || [])[mi].item);
+      }
+      for (var ai = 0; ai < allItems.length; ai++) {
+        if (allItems[ai] && allItems[ai].uuid) {
+          itemByUuid[allItems[ai].uuid] = allItems[ai];
+        }
+      }
+
       var thumbs = modal.querySelectorAll('[data-uuid]');
       for (var t = 0; t < thumbs.length; t++) {
         (function(el) {
           var uuid = el.dataset.uuid;
           var side = el.dataset.side || 'obverse';
           if (!uuid) return;
+          var item = itemByUuid[uuid];
+          if (!item) return;
           try {
-            imageCache.getUserImageUrl(uuid, side).then(function(url) {
+            imageCache.resolveImageUrlForItem(item, side).then(function(url) {
               if (url) el.innerHTML = '<img src="' + url + '" style="width:100%;height:100%;object-fit:cover;border-radius:var(--radius,8px)" alt="' + side + '">';
             }).catch(function() { /* silent fallback to OBV/REV text */ });
           } catch(e) { /* imageCache not available */ }

--- a/js/events.js
+++ b/js/events.js
@@ -347,32 +347,23 @@ const handleImageDeletion = async (uuid) => {
 };
 
 /**
- * Sets up the override/merge/file-input triad for a single import format.
- * @param {HTMLElement|null} overrideBtn - "Override" button element
- * @param {HTMLElement|null} mergeBtn - "Merge" button element
+ * Sets up import button(s) and file-input for a single import format.
+ * All imports route through the DiffModal for review — no silent override.
+ * @param {HTMLElement|null} overrideBtn - Primary "Import" button element
+ * @param {HTMLElement|null} mergeBtn - Legacy "Merge" button element (pending removal)
  * @param {HTMLElement|null} fileInput - Hidden file input element
- * @param {Function} importFn - Import function (file, isOverride) => void
+ * @param {Function} importFn - Import function (file, override) => void
  * @param {string} formatName - Human label (e.g. "CSV", "JSON", "Numista CSV")
  */
 const setupFormatImport = (overrideBtn, mergeBtn, fileInput, importFn, formatName) => {
-  let isOverride = false;
-
   if (overrideBtn && fileInput) {
-    safeAttachListener(overrideBtn, "click", async () => {
-      const confirmed = await appConfirm(
-        `Importing ${formatName} will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.`,
-        `${formatName} Import`,
-      );
-      if (confirmed) {
-        isOverride = true;
-        fileInput.click();
-      }
-    }, `${formatName} override button`);
+    safeAttachListener(overrideBtn, "click", () => {
+      fileInput.click();
+    }, `${formatName} import button`);
   }
 
   if (mergeBtn && fileInput) {
     safeAttachListener(mergeBtn, "click", () => {
-      isOverride = false;
       fileInput.click();
     }, `${formatName} merge button`);
   }
@@ -380,7 +371,7 @@ const setupFormatImport = (overrideBtn, mergeBtn, fileInput, importFn, formatNam
   optionalListener(fileInput, "change", function (e) {
     if (e.target.files.length > 0) {
       const file = e.target.files[0];
-      importFn(file, isOverride);
+      importFn(file, false);
     }
     this.value = "";
   }, `${formatName} import`);

--- a/js/events.js
+++ b/js/events.js
@@ -2438,12 +2438,12 @@ const setupDataManagementListeners = () => {
 const setupImportExportListeners = () => {
   debugLog("Setting up import/export listeners...");
 
-  // Import triads: Override / Merge / File-input for each format
-  setupFormatImport(elements.importCsvOverride, elements.importCsvMerge, elements.importCsvFile, importCsv, "CSV");
-  setupFormatImport(elements.importJsonOverride, elements.importJsonMerge, elements.importJsonFile, importJson, "JSON");
+  // Import pairs: Import button / File-input for each format (Merge buttons removed — all imports route through DiffModal)
+  setupFormatImport(elements.importCsvOverride, null, elements.importCsvFile, importCsv, "CSV");
+  setupFormatImport(elements.importJsonOverride, null, elements.importJsonFile, importJson, "JSON");
   setupFormatImport(
     document.getElementById("importNumistaBtn"),
-    document.getElementById("mergeNumistaBtn"),
+    null,
     elements.numistaImportFile, importNumistaCsv, "Numista CSV"
   );
 

--- a/js/init.js
+++ b/js/init.js
@@ -173,15 +173,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     debugLog("Phase 3: Initializing import/export elements...");
     elements.importCsvFile = safeGetElement("importCsvFile");
     elements.importCsvOverride = safeGetElement("importCsvOverride");
-    elements.importCsvMerge = safeGetElement("importCsvMerge");
     elements.importJsonFile = safeGetElement("importJsonFile");
     elements.importJsonOverride = safeGetElement("importJsonOverride");
-    elements.importJsonMerge = safeGetElement("importJsonMerge");
     elements.importProgress = safeGetElement("importProgress");
     elements.importProgressText = safeGetElement("importProgressText");
     elements.numistaImportBtn = safeGetElement("numistaImportBtn");
     elements.numistaImportFile = safeGetElement("numistaImportFile");
-    elements.numistaMerge = safeGetElement("numistaMerge");
       elements.numistaImportOptions = safeGetElement("numistaImportOptions");
       elements.exportCsvBtn = safeGetElement("exportCsvBtn");
     elements.exportJsonBtn = safeGetElement("exportJsonBtn");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -184,11 +184,13 @@ const createBackupZip = async () => {
       zip.file('item_tags.json', JSON.stringify(itemTagsData, null, 2));
     }
 
-    // 4. Generate and add CSV export (portfolio format)
+    // 4. Generate and add CSV export (portfolio format — synced with exportCsv())
     const csvHeaders = [
-      "Date", "Metal", "Type", "Name", "Qty", "Weight(oz)", "Weight Unit", "Purity",
-      "Purchase Price", "Melt Value", "Retail Price", "Gain/Loss",
-      "Purchase Location", "N#", "PCGS #", "Serial Number", "Tags", "Notes"
+      "Date","Metal","Type","Name","Year","Qty","Weight(oz)","Weight Unit","Purity",
+      "Purchase Price","Melt Value","Retail Price","Gain/Loss",
+      "Purchase Location","Storage Location","N#","PCGS #","Grade","Grading Authority","Cert #","Serial Number","Notes","Tags","UUID",
+      "Obverse Image URL","Reverse Image URL",
+      "Disposition Type","Disposition Date","Disposition Amount","Realized Gain/Loss"
     ];
     const sortedInventory = sortInventoryByDateNewestFirst();
     const csvRows = [];
@@ -206,6 +208,7 @@ const createBackupZip = async () => {
         item.metal || 'Silver',
         item.type,
         item.name,
+        item.year || '',
         item.qty,
         parseFloat(item.weight).toFixed(4),
         item.weightUnit || 'oz',
@@ -215,11 +218,22 @@ const createBackupZip = async () => {
         formatCurrency(item.marketValue || 0),
         gainLoss !== null ? formatCurrency(gainLoss) : '—',
         item.purchaseLocation,
+        item.storageLocation || '',
         item.numistaId || '',
         item.pcgsNumber || '',
+        item.grade || '',
+        item.gradingAuthority || '',
+        item.certNumber || '',
         item.serialNumber || '',
+        item.notes || '',
         typeof getItemTags === 'function' ? getItemTags(item.uuid).join('; ') : '',
-        item.notes || ''
+        item.uuid || '',
+        item.obverseImageUrl || '',
+        item.reverseImageUrl || '',
+        item.disposition ? (typeof DISPOSITION_TYPES !== 'undefined' && DISPOSITION_TYPES[item.disposition.type] ? DISPOSITION_TYPES[item.disposition.type].label : item.disposition.type) : '',
+        item.disposition ? (item.disposition.date || '') : '',
+        item.disposition ? (item.disposition.amount || 0) : '',
+        item.disposition ? (item.disposition.realizedGainLoss || 0) : ''
       ]);
     }
     const csvContent = Papa.unparse([csvHeaders, ...csvRows]);

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -2801,13 +2801,23 @@ const showImportDiffReview = (parsedItems, sourceInfo, options, onComplete) => {
   // Enrich imported items: copy local UUID when serials match, so DiffEngine
   // can match them by the same key tier.
   const localUuidBySerial = new Map();
+  const localUuidByNumista = new Map();
   for (const item of inventory) {
     if (item.serial && item.uuid) localUuidBySerial.set(String(item.serial), item.uuid);
+    // STAK-454: Also index by numistaId+date for CSV imports (which lack serial)
+    if (item.numistaId && item.uuid) {
+      localUuidByNumista.set(item.numistaId + '|' + (item.date || ''), item.uuid);
+    }
   }
   for (const item of parsedItems) {
     if (!item.uuid && item.serial) {
       const localUuid = localUuidBySerial.get(String(item.serial));
       if (localUuid) item.uuid = localUuid;
+    }
+    // STAK-454: Fallback — match by numistaId+date when serial enrichment missed
+    if (!item.uuid && item.numistaId) {
+      const numistaUuid = localUuidByNumista.get(item.numistaId + '|' + (item.date || ''));
+      if (numistaUuid) item.uuid = numistaUuid;
     }
   }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -2803,9 +2803,7 @@ const showImportDiffReview = (parsedItems, sourceInfo, options, onComplete) => {
     debugLog('showImportDiffReview fallback', 'DiffEngine/DiffModal unavailable');
     inventory = inventory.concat(parsedItems);
     _postImportCleanup(parsedItems, options.pendingTagsByUuid);
-    if (typeof showImportSummaryBanner === 'function') {
-      showImportSummaryBanner({ added: parsedItems.length, modified: 0, deleted: 0, skipped: 0, skippedReasons: [] });
-    }
+    if (typeof showToast === 'function') showToast('Import complete: ' + parsedItems.length + ' added');
     if (onComplete) onComplete({ added: parsedItems.length, modified: 0, deleted: 0 });
     return;
   }
@@ -2910,20 +2908,6 @@ const showImportDiffReview = (parsedItems, sourceInfo, options, onComplete) => {
         showToast('Import complete: ' + (parts.length > 0 ? parts.join(', ') : 'no changes applied'));
       }
 
-      // Post-import summary banner (STAK-374)
-      if (typeof showImportSummaryBanner === 'function') {
-        var _skippedReasons = [];
-        if (options.validationResult && options.validationResult.invalid) {
-          _skippedReasons = options.validationResult.invalid.slice(0, 5).map(function(i) { return i.reasons[0]; });
-        }
-        showImportSummaryBanner({
-          added: selectedChanges.filter(function(c) { return c.type === 'add'; }).length,
-          modified: selectedChanges.filter(function(c) { return c.type === 'modify'; }).length,
-          deleted: selectedChanges.filter(function(c) { return c.type === 'delete'; }).length,
-          skipped: options.validationResult ? (options.validationResult.skippedCount || 0) : 0,
-          skippedReasons: _skippedReasons
-        });
-      }
 
       if (onComplete) onComplete({ added: addCount, modified: modCount, deleted: delCount });
 

--- a/js/state.js
+++ b/js/state.js
@@ -91,14 +91,11 @@ const elements = {
   // Import elements
   importCsvFile: null,
   importCsvOverride: null,
-  importCsvMerge: null,
   importJsonFile: null,
   importJsonOverride: null,
-  importJsonMerge: null,
   importProgress: null,
   importProgressText: null,
   numistaImportFile: null,
-  numistaMerge: null,
 
   // Export elements
   exportCsvBtn: null,

--- a/js/utils.js
+++ b/js/utils.js
@@ -1171,60 +1171,6 @@ const buildImportValidationResult = (items, skippedNonPM) => {
 };
 
 /**
- * Renders a persistent, dismissible import summary banner above the inventory table.
- * Falls back to showToast() if the DOM target is not found.
- * @param {{ added: number, modified: number, deleted: number, skipped: number, skippedReasons: string[] }} result
- */
-const showImportSummaryBanner = (result) => {
-  const added = result.added || 0;
-  const modified = result.modified || 0;
-  const deleted = result.deleted || 0;
-  const skipped = result.skipped || 0;
-  const skippedReasons = result.skippedReasons || [];
-
-  // Remove any existing banner
-  const existing = document.getElementById('import-summary-banner');
-  if (existing) { existing.parentNode.removeChild(existing); }
-
-  const hasSkipped = skipped > 0;
-  const iconClass = hasSkipped ? 'banner-warn' : 'banner-success';
-  const iconChar = hasSkipped ? '\u26A0' : '\u2713';
-
-  let reasonsHtml = '';
-  if (hasSkipped && skippedReasons.length > 0) {
-    const items = skippedReasons.slice(0, 5).map((r) => {
-      return '<li>' + sanitizeHtml(String(r)) + '</li>';
-    }).join('');
-    reasonsHtml = '<details class="banner-details"><summary>Why were items skipped?</summary><ul>' + items + '</ul></details>';
-  }
-
-  const skippedText = hasSkipped ? ('  \u2717 ' + skipped + ' skipped') : '';
-  const bannerHtml = '<div id="import-summary-banner" class="import-summary-banner">' +
-    '<span class="' + iconClass + '">' + iconChar + '</span> ' +
-    '+ ' + added + ' added&nbsp;&nbsp;~' + modified + ' updated&nbsp;&nbsp;&minus;' + deleted + ' removed' +
-    skippedText +
-    reasonsHtml +
-    '<button class="banner-dismiss" aria-label="Dismiss" onclick="(function(el){el.parentNode.removeChild(el);})(this.parentNode)">\u00D7</button>' +
-    '</div>';
-
-  // Try to insert before the inventory table container
-  const target = document.getElementById('inventory-container') ||
-                 document.getElementById('inventoryTable') ||
-                 document.getElementById('tableContainer');
-  if (target) {
-    const div = document.createElement('div');
-    div.innerHTML = bannerHtml;
-    target.parentNode.insertBefore(div.firstChild, target);
-    return;
-  }
-
-  // Fallback to toast
-  let summary = '+' + added + ' added, ~' + modified + ' updated, -' + deleted + ' removed';
-  if (hasSkipped) { summary += ', ' + skipped + ' skipped'; }
-  if (typeof showToast === 'function') { showToast('Import complete: ' + summary); }
-};
-
-/**
  * Sanitizes imported inventory data, coercing invalid fields to safe defaults.
  *
  * String fields default to an empty string and numeric fields become null when

--- a/js/vault.js
+++ b/js/vault.js
@@ -692,16 +692,6 @@ async function vaultRestoreWithPreview(fileBytes, password) {
           showToast('Backup restored: ' + (parts.length > 0 ? parts.join(', ') : 'no changes applied'));
         }
 
-        // Post-import summary banner (STAK-374)
-        if (typeof showImportSummaryBanner === 'function') {
-          showImportSummaryBanner({
-            added: addCount,
-            modified: modCount,
-            deleted: delCount,
-            skipped: 0,
-            skippedReasons: []
-          });
-        }
 
         // Restore companion photo vault if present
         if (capturedImageFile && typeof vaultDecryptAndRestoreImages === 'function') {

--- a/playground/diffmodal-item-cards.html
+++ b/playground/diffmodal-item-cards.html
@@ -3,11 +3,12 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>StakTrakr — DiffModal Item Cards Playground</title>
+<title>StakTrakr Playground — DiffModal Item Cards</title>
 <style>
-/* ═══════════════════════════════════════════
-   STAKTRAKR DESIGN TOKENS (production)
-   ═══════════════════════════════════════════ */
+/* ===================================================================
+   CSS EXTRACTED FROM staktrakr-merge-ui-prototype.html
+   All design tokens, card classes, pills, chips, animations
+   =================================================================== */
 :root {
   --primary: #6366f1;
   --primary-hover: #818cf8;
@@ -47,18 +48,19 @@
 
 /* Light theme override */
 [data-theme="light"] {
-  --bg-body: #f5f5f8;
+  --bg-body: #f4f5f7;
   --bg-card: #ffffff;
-  --bg-card-hover: #f0f0f5;
-  --bg-tertiary: #e8e9f0;
-  --bg-input: #f0f0f5;
-  --text-primary: #1a1a2e;
-  --text-secondary: #4a4b6a;
-  --text-muted: #8b8da8;
+  --bg-card-hover: #f0f1f5;
+  --bg-tertiary: #e8eaef;
+  --bg-input: #f0f1f5;
+  --text-primary: #1a1d27;
+  --text-secondary: #555a70;
+  --text-muted: #8890a8;
   --border-color: rgba(0,0,0,0.1);
   --border-active: rgba(99,102,241,0.4);
-  --glass: rgba(0,0,0,0.03);
   --shadow: 0 4px 24px rgba(0,0,0,0.08);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.12);
+  --glass: rgba(0,0,0,0.02);
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -70,10 +72,8 @@ body {
   min-height: 100vh;
 }
 
-/* ═══════════════════════════════════════════
-   LAYOUT
-   ═══════════════════════════════════════════ */
-.app-container { max-width: 640px; margin: 0 auto; padding: 1rem; }
+/* Layout */
+.app-container { max-width: 960px; margin: 0 auto; padding: 1rem; }
 
 .app-header {
   display: flex; align-items: center; justify-content: space-between;
@@ -84,375 +84,445 @@ body {
 .app-header h1 { font-size: 1.1rem; font-weight: 600; }
 .app-header h1 span { color: var(--primary); }
 
-/* ═══════════════════════════════════════════
-   CONTROLS PANEL
-   ═══════════════════════════════════════════ */
-.controls-panel {
-  display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
-  padding: 0.6rem 1rem; margin-bottom: 1rem;
-  background: var(--bg-card); border-radius: var(--radius);
-  border: 1px solid var(--border-color); font-size: 0.8rem;
+/* Shared: Cards, Pills, Chips, Buttons */
+.card {
+  background: var(--bg-card); border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg); padding: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
 }
-.controls-panel label {
-  display: flex; align-items: center; gap: 0.4rem;
-  cursor: pointer; color: var(--text-secondary);
-}
-.controls-panel input[type="checkbox"] {
-  width: 14px; height: 14px; accent-color: var(--primary);
-}
+.card:hover { border-color: var(--border-active); box-shadow: var(--shadow); }
 
-/* ═══════════════════════════════════════════
-   SHARED: PILLS, BADGES
-   ═══════════════════════════════════════════ */
 .pill {
   display: inline-flex; align-items: center; gap: 0.3rem;
-  padding: 0.15rem 0.5rem; border-radius: var(--radius-pill);
-  font-size: 0.7rem; font-weight: 600; border: none;
-  white-space: nowrap;
+  padding: 0.25rem 0.65rem; border-radius: var(--radius-pill);
+  font-size: 0.75rem; font-weight: 600; border: none; cursor: pointer;
+  transition: all 0.2s;
 }
+.pill-primary { background: var(--primary-dim); color: var(--primary); }
+.pill-primary:hover, .pill-primary.active { background: var(--primary); color: #fff; }
 .pill-gain { background: var(--gain-dim); color: var(--gain); }
 .pill-loss { background: var(--loss-dim); color: var(--loss); }
 .pill-warning { background: var(--warning-dim); color: var(--warning); }
+.pill-info { background: var(--info-dim); color: var(--info); }
 .pill-muted { background: var(--bg-tertiary); color: var(--text-muted); }
 
-/* ═══════════════════════════════════════════
-   SECTION HEADERS
-   ═══════════════════════════════════════════ */
-.diff-section { margin-bottom: 1rem; }
-
-.section-header {
-  display: flex; align-items: center; gap: 0.5rem;
-  padding: 0.5rem 0.65rem;
-  background: var(--bg-card); border: 1px solid var(--border-color);
-  border-radius: var(--radius); cursor: pointer;
-  user-select: none; transition: background 0.15s;
-  margin-bottom: 0.5rem;
+.chip {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  padding: 0.2rem 0.5rem; border-radius: var(--radius-pill);
+  font-size: 0.7rem; background: var(--bg-tertiary); color: var(--text-secondary);
 }
-.section-header:hover { background: var(--bg-card-hover); }
-.section-icon { font-size: 0.85rem; flex-shrink: 0; }
-.section-label { font-size: 0.82rem; font-weight: 600; flex: 1; }
-.section-count {
+
+.btn {
+  padding: 0.5rem 1.1rem; border: none; border-radius: var(--radius-pill);
+  font-size: 0.82rem; font-weight: 600; cursor: pointer; transition: all 0.2s;
+  display: inline-flex; align-items: center; gap: 0.4rem;
+}
+.btn-primary { background: var(--primary); color: #fff; }
+.btn-primary:hover { background: var(--primary-hover); box-shadow: 0 2px 12px rgba(99,102,241,0.4); }
+.btn-secondary { background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-color); }
+.btn-secondary:hover { background: var(--bg-card-hover); color: var(--text-primary); }
+.btn-gain { background: var(--gain); color: #fff; }
+.btn-loss { background: var(--loss); color: #fff; }
+.btn-sm { padding: 0.3rem 0.7rem; font-size: 0.75rem; }
+
+.badge {
   display: inline-flex; align-items: center; justify-content: center;
-  min-width: 1.3rem; height: 1.3rem; border-radius: var(--radius-pill);
-  font-size: 0.65rem; font-weight: 700;
-}
-.section-count.gain { background: var(--gain-dim); color: var(--gain); }
-.section-count.loss { background: var(--loss-dim); color: var(--loss); }
-.section-count.warning { background: var(--warning-dim); color: var(--warning); }
-.section-toggle {
-  font-size: 0.65rem; color: var(--text-muted);
-  transition: transform 0.2s; flex-shrink: 0;
-}
-.section-header.collapsed .section-toggle { transform: rotate(-90deg); }
-.section-body { transition: all 0.2s; }
-.section-body.hidden { display: none; }
-
-/* ═══════════════════════════════════════════
-   ITEM CARDS — Added / Deleted (simple)
-   ═══════════════════════════════════════════ */
-.item-card {
-  display: flex; align-items: center; gap: 0.6rem;
-  border: 1px solid var(--border-color); border-radius: var(--radius);
-  padding: 0.65rem; margin-bottom: 0.5rem;
-  background: var(--bg-card); transition: border-color 0.15s;
-}
-.item-card:hover { border-color: var(--border-active); }
-.item-card:last-child { margin-bottom: 0; }
-
-.item-card .card-checkbox {
-  width: 16px; height: 16px; accent-color: var(--primary);
-  flex-shrink: 0; cursor: pointer;
+  min-width: 1.5rem; height: 1.5rem; border-radius: var(--radius-pill);
+  font-size: 0.7rem; font-weight: 700;
 }
 
-/* Image / metal emoji placeholder */
+/* Section headers */
+.section-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 0.75rem; padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+.section-title { font-size: 0.9rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; }
+.section-actions { display: flex; gap: 0.5rem; }
+
+/* Conflict cards */
+.conflict-card { margin-bottom: 0.75rem; }
+.conflict-card-header {
+  display: flex; align-items: center; gap: 0.75rem;
+  padding-bottom: 0.75rem; margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* Item thumb — dual image layout */
 .item-thumb {
-  width: 40px; height: 40px; border-radius: 6px;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 1.1rem; flex-shrink: 0;
+  width: 44px; height: 44px; border-radius: var(--radius);
+  background: var(--bg-tertiary); display: flex; align-items: center;
+  justify-content: center; font-size: 1.2rem; flex-shrink: 0;
   border: 1px solid var(--border-color);
 }
-.item-thumb.gold { background: rgba(255,215,0,0.12); }
-.item-thumb.silver { background: rgba(192,192,192,0.12); }
-.item-thumb.platinum { background: rgba(229,228,226,0.12); }
-.item-thumb.palladium { background: rgba(206,208,206,0.12); }
-
-.item-thumb img {
-  width: 100%; height: 100%; object-fit: cover;
-  border-radius: 5px; display: none;
+.item-thumb-pair {
+  display: flex; gap: 4px; flex-shrink: 0;
 }
-.show-images .item-thumb img { display: block; }
-.show-images .item-thumb .thumb-emoji { display: none; }
+.item-thumb-pair .item-thumb {
+  width: 40px; height: 40px; font-size: 0.6rem;
+  color: var(--text-muted); text-align: center;
+  line-height: 1.2; padding: 2px;
+}
 
 .item-identity { flex: 1; min-width: 0; }
-.item-name {
-  font-weight: 600; font-size: 0.85rem;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.item-meta {
-  display: flex; gap: 0.35rem; align-items: center;
-  font-size: 0.73rem; color: var(--text-muted); opacity: 0.5;
-  margin-top: 0.1rem;
-}
-.item-meta .dot { font-size: 0.5rem; }
-
-/* Deleted/local-only accent */
-.item-card.deleted-card {
-  border-left: 3px solid var(--loss);
-}
-
-/* ═══════════════════════════════════════════
-   MODIFIED ITEM CARDS (expandable)
-   ═══════════════════════════════════════════ */
-.modified-card {
-  border: 1px solid var(--border-color); border-radius: var(--radius);
-  padding: 0.65rem; margin-bottom: 0.5rem;
-  background: var(--bg-card); transition: border-color 0.15s;
-}
-.modified-card:hover { border-color: var(--border-active); }
-.modified-card:last-child { margin-bottom: 0; }
-
-.modified-card-header {
-  display: flex; align-items: center; gap: 0.6rem;
-  cursor: pointer; user-select: none;
-}
-
-.modified-card .master-checkbox {
-  width: 16px; height: 16px; accent-color: var(--primary);
-  flex-shrink: 0; cursor: pointer;
-}
-
-.modified-card .changes-pill {
-  font-size: 0.68rem; flex-shrink: 0;
-}
-
-.modified-card .expand-toggle {
-  font-size: 0.6rem; color: var(--text-muted);
-  transition: transform 0.2s; flex-shrink: 0; margin-left: auto;
-}
-.modified-card.collapsed .expand-toggle { transform: rotate(-90deg); }
+.item-name { font-weight: 600; font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.item-meta { font-size: 0.72rem; color: var(--text-muted); display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.15rem; }
 
 /* Field diff rows */
-.field-diffs { padding-top: 0.5rem; margin-top: 0.5rem; border-top: 1px solid var(--border-color); }
-.field-diffs.hidden { display: none; }
-
-.field-row {
-  display: flex; align-items: center; gap: 0.5rem;
-  padding: 0.35rem 0; font-size: 0.8rem;
-  border-bottom: 1px solid rgba(255,255,255,0.025);
+.field-diff {
+  display: grid; grid-template-columns: 120px 1fr auto 1fr; gap: 0.5rem;
+  align-items: center; padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
 }
-.field-row:last-child { border-bottom: none; }
-
-.field-row .field-checkbox {
-  width: 14px; height: 14px; accent-color: var(--primary);
-  flex-shrink: 0; cursor: pointer;
-}
+.field-diff:last-child { border-bottom: none; }
 .field-label {
-  min-width: 100px; font-size: 0.72rem; color: var(--text-muted);
-  text-transform: capitalize; font-weight: 500; flex-shrink: 0;
+  font-size: 0.72rem; color: var(--text-muted); text-transform: uppercase;
+  letter-spacing: 0.06em; font-weight: 500;
 }
-.field-local {
-  text-decoration: line-through; opacity: 0.45;
+.field-value {
+  padding: 0.35rem 0.6rem; border-radius: var(--radius);
+  font-size: 0.82rem; cursor: pointer; transition: all 0.15s;
+  border: 2px solid transparent; text-align: center;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.field-value.local { background: var(--primary-dim); }
+.field-value.remote { background: var(--info-dim); }
+.field-value.selected {
+  border-color: var(--gain); box-shadow: 0 0 0 1px var(--gain);
+  background: var(--gain-dim); color: var(--gain); font-weight: 600;
+}
+.field-value:hover:not(.selected) { border-color: var(--text-muted); }
+.field-arrow { color: var(--text-muted); font-size: 0.8rem; text-align: center; }
+
+/* Card-level quick actions */
+.card-actions {
+  display: flex; gap: 0.5rem; margin-top: 0.75rem; padding-top: 0.75rem;
+  border-top: 1px solid var(--border-color); justify-content: flex-end;
+}
+
+/* Orphan items */
+.orphan-card {
+  display: flex; align-items: center; gap: 0.75rem;
+  margin-bottom: 0.5rem; padding: 0.75rem 1rem;
+  cursor: pointer;
+}
+.orphan-card .item-identity { flex: 1; }
+.orphan-actions { display: flex; gap: 0.4rem; flex-shrink: 0; }
+
+/* Card toggle states */
+.orphan-card.skipped {
+  opacity: 0.4; transition: opacity 0.3s;
+}
+
+/* Collapsible sections */
+.section-header .collapse-toggle {
+  cursor: pointer; font-size: 0.7rem; color: var(--text-muted);
+  transition: transform 0.2s; margin-left: 0.25rem;
+  user-select: none;
+}
+.section-header .collapse-toggle.collapsed { transform: rotate(-90deg); }
+.section-body.collapsed { display: none; }
+
+/* Expand/collapse for conflict card details */
+.conflict-details { transition: all 0.3s ease; }
+.conflict-details.collapsed {
+  max-height: 0; overflow: hidden; margin: 0; padding: 0;
+  opacity: 0;
+}
+
+/* Progress & resolve tracker */
+.progress-bar {
+  height: 4px; background: var(--bg-tertiary); border-radius: 2px;
+  overflow: hidden; margin-bottom: 1rem;
+}
+.progress-fill {
+  height: 100%; border-radius: 2px; transition: width 0.4s ease;
+  background: linear-gradient(90deg, var(--primary), var(--gain));
+}
+.resolve-status {
+  display: flex; align-items: center; gap: 0.75rem;
+  padding: 0.6rem 1rem; background: var(--bg-tertiary);
+  border-radius: var(--radius-pill); margin-bottom: 1rem;
   font-size: 0.8rem;
 }
-.field-arrow { color: var(--text-muted); font-size: 0.75rem; margin: 0 0.15rem; flex-shrink: 0; }
-.field-remote { font-weight: 500; color: var(--warning); font-size: 0.8rem; }
+.resolve-status .status-text { flex: 1; color: var(--text-secondary); }
 
-/* ═══════════════════════════════════════════
-   SCROLLBAR
-   ═══════════════════════════════════════════ */
+/* Controls panel */
+.controls-panel {
+  display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap;
+  padding: 0.6rem 1rem; margin-bottom: 1rem;
+  background: var(--bg-card); border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color); font-size: 0.8rem;
+}
+.controls-panel label {
+  display: flex; align-items: center; gap: 0.4rem; cursor: pointer;
+  color: var(--text-secondary); font-size: 0.78rem;
+}
+.controls-panel input[type="checkbox"] { accent-color: var(--primary); }
+
+/* Scrollbar */
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--bg-tertiary); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
-/* ═══════════════════════════════════════════
-   RESPONSIVE
-   ═══════════════════════════════════════════ */
-@media (max-width: 480px) {
-  .app-container { padding: 0.5rem; }
-  .field-label { min-width: 80px; }
-  .item-name { font-size: 0.8rem; }
-}
-
-/* ═══════════════════════════════════════════
-   ANIMATION
-   ═══════════════════════════════════════════ */
+/* Animation */
 .fade-in { animation: fadeIn 0.3s ease; }
-@keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+.card.resolved { opacity: 0.5; transform: scale(0.98); transition: all 0.3s; }
+
+/* Responsive */
+@media (max-width: 700px) {
+  .field-diff { grid-template-columns: 80px 1fr auto 1fr; }
+}
+@media (max-width: 480px) {
+  .field-diff { grid-template-columns: 1fr; gap: 0.25rem; }
+  .field-label { margin-bottom: 0.15rem; }
+}
 </style>
 </head>
 <body>
 <div class="app-container">
 
-  <!-- HEADER -->
+  <!-- Header -->
   <header class="app-header">
-    <h1>DiffModal Item Cards <span>Playground</span></h1>
-    <span style="font-size:0.7rem;color:var(--text-muted);">STAK-454</span>
+    <h1>DiffModal <span>Item Cards</span> Playground</h1>
+    <div style="display:flex;gap:0.4rem;">
+      <span class="chip">Prototype CSS</span>
+      <span class="chip">Interactive</span>
+    </div>
   </header>
 
-  <!-- CONTROLS PANEL -->
+  <!-- Controls Panel -->
   <div class="controls-panel">
+    <span style="font-weight:600; color:var(--text-primary);">Controls</span>
     <label>
-      <input type="checkbox" id="ctrl-dark" checked>
-      Dark Theme
+      <input type="checkbox" id="toggleTheme" onchange="toggleTheme()">
+      Light theme
     </label>
     <label>
-      <input type="checkbox" id="ctrl-images">
-      Show Image Placeholders
+      <input type="checkbox" id="toggleImages" checked onchange="toggleImages()">
+      Show image placeholders
     </label>
   </div>
 
-  <!-- ═══════════════════════════════════════
-       (a) ADDED ITEMS SECTION
-       ═══════════════════════════════════════ -->
-  <div class="diff-section fade-in" id="section-added">
-    <div class="section-header" data-section="added">
-      <span class="section-icon">+</span>
-      <span class="section-label">Added</span>
-      <span class="section-count gain">3</span>
-      <span class="section-toggle">&#9660;</span>
+  <!-- ===============================================
+       SECTION: ADDED / REMOTE ONLY (3 items)
+       =============================================== -->
+  <div class="section-wrapper" data-section="added">
+    <div class="section-header">
+      <div class="section-title">
+        <span class="collapse-toggle" onclick="toggleSection('added')">&#9660;</span>
+        <span style="color:var(--info)">&#8595;</span> Added / Remote Only
+        <span class="chip">3 items</span>
+      </div>
+      <div class="section-actions">
+        <button class="btn btn-sm btn-primary" onclick="bulkAction('added','import')">Import All</button>
+        <button class="btn btn-sm btn-secondary" onclick="bulkAction('added','skip')">Skip All</button>
+      </div>
     </div>
-    <div class="section-body" id="body-added">
+    <div class="section-body" id="section-body-added">
 
-      <div class="item-card">
-        <input type="checkbox" class="card-checkbox" checked>
-        <div class="item-thumb gold" data-uuid="aaa-001">
-          <!-- Async image loads here via imageCache.getImage(uuid) -->
-          <img src="" alt="">
-          <span class="thumb-emoji">&#129689;</span>
+      <!-- Added Item 1: Gold Eagle -->
+      <div class="card orphan-card fade-in" data-action="import" onclick="toggleOrphanAction(this)">
+        <div class="item-thumb-pair images-visible">
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(255,215,0,0.15), rgba(255,215,0,0.05));">
+            <span style="color:var(--gold); font-size:0.55rem;">OBV</span>
+          </div>
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(255,215,0,0.15), rgba(255,215,0,0.05));">
+            <span style="color:var(--gold); font-size:0.55rem;">REV</span>
+          </div>
         </div>
         <div class="item-identity">
           <div class="item-name">2024 American Gold Eagle 1oz</div>
           <div class="item-meta">
-            <span>Gold</span><span class="dot">&#8226;</span>
-            <span>1oz</span><span class="dot">&#8226;</span>
-            <span>Qty 2</span>
+            <span style="color:var(--gold);">Gold</span>
+            <span>&#8226;</span>
+            <span>1 oz</span>
+            <span>&#8226;</span>
+            <span>Qty: 2</span>
           </div>
+        </div>
+        <div class="orphan-actions">
+          <button class="btn btn-sm btn-primary action-btn" onclick="event.stopPropagation(); setOrphanAction(this.closest('.orphan-card'), 'import')">&#8595; Import</button>
+          <button class="btn btn-sm btn-secondary skip-btn" onclick="event.stopPropagation(); setOrphanAction(this.closest('.orphan-card'), 'skip')">Skip</button>
         </div>
       </div>
 
-      <div class="item-card">
-        <input type="checkbox" class="card-checkbox" checked>
-        <div class="item-thumb silver" data-uuid="aaa-002">
-          <img src="" alt="">
-          <span class="thumb-emoji">&#129689;</span>
+      <!-- Added Item 2: Silver Maple -->
+      <div class="card orphan-card fade-in" data-action="import" onclick="toggleOrphanAction(this)">
+        <div class="item-thumb-pair images-visible">
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(192,192,192,0.15), rgba(192,192,192,0.05));">
+            <span style="color:var(--silver); font-size:0.55rem;">OBV</span>
+          </div>
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(192,192,192,0.15), rgba(192,192,192,0.05));">
+            <span style="color:var(--silver); font-size:0.55rem;">REV</span>
+          </div>
         </div>
         <div class="item-identity">
           <div class="item-name">2024 Canadian Silver Maple 1oz</div>
           <div class="item-meta">
-            <span>Silver</span><span class="dot">&#8226;</span>
-            <span>1oz</span><span class="dot">&#8226;</span>
-            <span>Qty 10</span>
+            <span style="color:var(--silver);">Silver</span>
+            <span>&#8226;</span>
+            <span>1 oz</span>
+            <span>&#8226;</span>
+            <span>Qty: 10</span>
           </div>
+        </div>
+        <div class="orphan-actions">
+          <button class="btn btn-sm btn-primary action-btn" onclick="event.stopPropagation(); setOrphanAction(this.closest('.orphan-card'), 'import')">&#8595; Import</button>
+          <button class="btn btn-sm btn-secondary skip-btn" onclick="event.stopPropagation(); setOrphanAction(this.closest('.orphan-card'), 'skip')">Skip</button>
         </div>
       </div>
 
-      <div class="item-card">
-        <input type="checkbox" class="card-checkbox" checked>
-        <div class="item-thumb platinum" data-uuid="aaa-003">
-          <img src="" alt="">
-          <span class="thumb-emoji">&#129689;</span>
+      <!-- Added Item 3: Platinum Britannia -->
+      <div class="card orphan-card fade-in" data-action="import" onclick="toggleOrphanAction(this)">
+        <div class="item-thumb-pair images-visible">
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(229,228,226,0.15), rgba(229,228,226,0.05));">
+            <span style="color:var(--platinum); font-size:0.55rem;">OBV</span>
+          </div>
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(229,228,226,0.15), rgba(229,228,226,0.05));">
+            <span style="color:var(--platinum); font-size:0.55rem;">REV</span>
+          </div>
         </div>
         <div class="item-identity">
           <div class="item-name">2024 Platinum Britannia 1oz</div>
           <div class="item-meta">
-            <span>Platinum</span><span class="dot">&#8226;</span>
-            <span>1oz</span><span class="dot">&#8226;</span>
-            <span>Qty 1</span>
+            <span style="color:var(--platinum);">Platinum</span>
+            <span>&#8226;</span>
+            <span>1 oz</span>
+            <span>&#8226;</span>
+            <span>Qty: 1</span>
           </div>
         </div>
+        <div class="orphan-actions">
+          <button class="btn btn-sm btn-primary action-btn" onclick="event.stopPropagation(); setOrphanAction(this.closest('.orphan-card'), 'import')">&#8595; Import</button>
+          <button class="btn btn-sm btn-secondary skip-btn" onclick="event.stopPropagation(); setOrphanAction(this.closest('.orphan-card'), 'skip')">Skip</button>
+        </div>
       </div>
-
     </div>
   </div>
 
-  <!-- ═══════════════════════════════════════
-       (b) MODIFIED ITEMS SECTION
-       ═══════════════════════════════════════ -->
-  <div class="diff-section fade-in" id="section-modified">
-    <div class="section-header" data-section="modified">
-      <span class="section-icon">&#9998;</span>
-      <span class="section-label">Modified</span>
-      <span class="section-count warning">2</span>
-      <span class="section-toggle">&#9660;</span>
+  <!-- ===============================================
+       SECTION: MODIFIED / CONFLICTS (2 items)
+       =============================================== -->
+  <div class="section-wrapper" data-section="modified" style="margin-top:1.5rem;">
+    <div class="section-header">
+      <div class="section-title">
+        <span class="collapse-toggle" onclick="toggleSection('modified')">&#9660;</span>
+        <span style="color:var(--warning)">&#9888;</span> Modified / Conflicts
+        <span class="chip">2 items</span>
+      </div>
+      <div class="section-actions">
+        <button class="btn btn-sm btn-secondary" onclick="keepAllLocalGlobal()">Keep All Local</button>
+        <button class="btn btn-sm btn-secondary" onclick="keepAllRemoteGlobal()">Keep All Remote</button>
+      </div>
     </div>
-    <div class="section-body" id="body-modified">
 
-      <!-- Modified card 1: Silver Eagle -->
-      <div class="modified-card" id="mod-1">
-        <div class="modified-card-header" data-card="mod-1">
-          <input type="checkbox" class="master-checkbox" checked>
-          <div class="item-thumb silver" data-uuid="mod-001">
-            <img src="" alt="">
-            <span class="thumb-emoji">&#129689;</span>
+    <!-- Resolve progress -->
+    <div class="resolve-status">
+      <span class="status-text">Resolved <strong id="resolvedCount">0</strong> of <strong>2</strong> conflicts</span>
+      <span class="pill pill-warning" id="unresolvedPill">2 remaining</span>
+    </div>
+    <div class="progress-bar"><div class="progress-fill" id="progressFill" style="width:0%"></div></div>
+
+    <div class="section-body" id="section-body-modified">
+
+      <!-- Conflict Card 1: ASE 2025 -->
+      <div class="card conflict-card fade-in" id="conflict-0">
+        <div class="conflict-card-header" style="cursor:pointer;" onclick="toggleConflictDetails(0)">
+          <div class="item-thumb-pair images-visible">
+            <div class="item-thumb" style="background: linear-gradient(135deg, rgba(192,192,192,0.15), rgba(192,192,192,0.05));">
+              <span style="color:var(--silver); font-size:0.55rem;">OBV</span>
+            </div>
+            <div class="item-thumb" style="background: linear-gradient(135deg, rgba(192,192,192,0.15), rgba(192,192,192,0.05));">
+              <span style="color:var(--silver); font-size:0.55rem;">REV</span>
+            </div>
           </div>
           <div class="item-identity">
             <div class="item-name">SAMPLE - American Silver Eagle 2025</div>
             <div class="item-meta">
-              <span>Silver</span><span class="dot">&#8226;</span>
-              <span>1oz</span>
+              <span style="color:var(--silver);">Silver</span>
+              <span>&#8226;</span>
+              <span>1 oz</span>
+              <span>&#8226;</span>
+              <span class="chip" style="font-size:0.65rem">ID: ase-2025-001</span>
             </div>
           </div>
-          <span class="pill pill-warning changes-pill">3 fields changed</span>
-          <span class="expand-toggle">&#9660;</span>
+          <span class="pill pill-warning">3 fields changed</span>
         </div>
-        <div class="field-diffs" data-fields-for="mod-1">
-          <div class="field-row">
-            <input type="checkbox" class="field-checkbox" checked>
-            <span class="field-label">Purchase Price</span>
-            <span class="field-local">$28.50</span>
-            <span class="field-arrow">&#8594;</span>
-            <span class="field-remote">$31.00</span>
+        <div class="conflict-details" id="conflict-details-0">
+          <!-- Field: purchasePrice -->
+          <div class="field-diff">
+            <div class="field-label">Purchase Price</div>
+            <div class="field-value local" onclick="selectField(this)">$28.50</div>
+            <div class="field-arrow">&#10231;</div>
+            <div class="field-value remote" onclick="selectField(this)">$31.00</div>
           </div>
-          <div class="field-row">
-            <input type="checkbox" class="field-checkbox" checked>
-            <span class="field-label">Quantity</span>
-            <span class="field-local">5</span>
-            <span class="field-arrow">&#8594;</span>
-            <span class="field-remote">3</span>
+          <!-- Field: quantity -->
+          <div class="field-diff">
+            <div class="field-label">Quantity</div>
+            <div class="field-value local" onclick="selectField(this)">5</div>
+            <div class="field-arrow">&#10231;</div>
+            <div class="field-value remote" onclick="selectField(this)">3</div>
           </div>
-          <div class="field-row">
-            <input type="checkbox" class="field-checkbox" checked>
-            <span class="field-label">Notes</span>
-            <span class="field-local">BU</span>
-            <span class="field-arrow">&#8594;</span>
-            <span class="field-remote">Proof</span>
+          <!-- Field: notes -->
+          <div class="field-diff">
+            <div class="field-label">Notes</div>
+            <div class="field-value local" onclick="selectField(this)" title="BU">BU</div>
+            <div class="field-arrow">&#10231;</div>
+            <div class="field-value remote" onclick="selectField(this)" title="Proof">Proof</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-sm btn-secondary" onclick="keepCardLocal(0)">Keep All Local</button>
+            <button class="btn btn-sm btn-secondary" onclick="keepCardRemote(0)">Keep All Remote</button>
+            <button class="btn btn-sm btn-primary" onclick="resolveCard(0)">&#10003; Confirm</button>
           </div>
         </div>
       </div>
 
-      <!-- Modified card 2: Gold Maple -->
-      <div class="modified-card" id="mod-2">
-        <div class="modified-card-header" data-card="mod-2">
-          <input type="checkbox" class="master-checkbox" checked>
-          <div class="item-thumb gold" data-uuid="mod-002">
-            <img src="" alt="">
-            <span class="thumb-emoji">&#129689;</span>
+      <!-- Conflict Card 2: Gold Maple 2025 -->
+      <div class="card conflict-card fade-in" id="conflict-1">
+        <div class="conflict-card-header" style="cursor:pointer;" onclick="toggleConflictDetails(1)">
+          <div class="item-thumb-pair images-visible">
+            <div class="item-thumb" style="background: linear-gradient(135deg, rgba(255,215,0,0.15), rgba(255,215,0,0.05));">
+              <span style="color:var(--gold); font-size:0.55rem;">OBV</span>
+            </div>
+            <div class="item-thumb" style="background: linear-gradient(135deg, rgba(255,215,0,0.15), rgba(255,215,0,0.05));">
+              <span style="color:var(--gold); font-size:0.55rem;">REV</span>
+            </div>
           </div>
           <div class="item-identity">
             <div class="item-name">SAMPLE - Canadian Gold Maple 2025</div>
             <div class="item-meta">
-              <span>Gold</span><span class="dot">&#8226;</span>
-              <span>1oz</span>
+              <span style="color:var(--gold);">Gold</span>
+              <span>&#8226;</span>
+              <span>1 oz</span>
+              <span>&#8226;</span>
+              <span class="chip" style="font-size:0.65rem">ID: cgm-2025-001</span>
             </div>
           </div>
-          <span class="pill pill-warning changes-pill">2 fields changed</span>
-          <span class="expand-toggle">&#9660;</span>
+          <span class="pill pill-warning">2 fields changed</span>
         </div>
-        <div class="field-diffs" data-fields-for="mod-2">
-          <div class="field-row">
-            <input type="checkbox" class="field-checkbox" checked>
-            <span class="field-label">Purchase Price</span>
-            <span class="field-local">$1,850.00</span>
-            <span class="field-arrow">&#8594;</span>
-            <span class="field-remote">$1,920.00</span>
+        <div class="conflict-details" id="conflict-details-1">
+          <!-- Field: purchasePrice -->
+          <div class="field-diff">
+            <div class="field-label">Purchase Price</div>
+            <div class="field-value local" onclick="selectField(this)">$1,850.00</div>
+            <div class="field-arrow">&#10231;</div>
+            <div class="field-value remote" onclick="selectField(this)">$1,920.00</div>
           </div>
-          <div class="field-row">
-            <input type="checkbox" class="field-checkbox" checked>
-            <span class="field-label">Grade</span>
-            <span class="field-local">MS69</span>
-            <span class="field-arrow">&#8594;</span>
-            <span class="field-remote">MS70</span>
+          <!-- Field: grade -->
+          <div class="field-diff">
+            <div class="field-label">Grade</div>
+            <div class="field-value local" onclick="selectField(this)">MS69</div>
+            <div class="field-arrow">&#10231;</div>
+            <div class="field-value remote" onclick="selectField(this)">MS70</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-sm btn-secondary" onclick="keepCardLocal(1)">Keep All Local</button>
+            <button class="btn btn-sm btn-secondary" onclick="keepCardRemote(1)">Keep All Remote</button>
+            <button class="btn btn-sm btn-primary" onclick="resolveCard(1)">&#10003; Confirm</button>
           </div>
         </div>
       </div>
@@ -460,47 +530,72 @@ body {
     </div>
   </div>
 
-  <!-- ═══════════════════════════════════════
-       (c) DELETED / LOCAL ONLY SECTION
-       ═══════════════════════════════════════ -->
-  <div class="diff-section fade-in" id="section-deleted">
-    <div class="section-header" data-section="deleted">
-      <span class="section-icon">&#8722;</span>
-      <span class="section-label">Deleted</span>
-      <span class="section-count loss">2</span>
-      <span class="section-toggle">&#9660;</span>
+  <!-- ===============================================
+       SECTION: DELETED / LOCAL ONLY (2 items)
+       =============================================== -->
+  <div class="section-wrapper" data-section="deleted" style="margin-top:1.5rem;">
+    <div class="section-header">
+      <div class="section-title">
+        <span class="collapse-toggle" onclick="toggleSection('deleted')">&#9660;</span>
+        <span style="color:var(--loss)">&#8593;</span> Deleted / Local Only
+        <span class="chip">2 items</span>
+      </div>
+      <div class="section-actions">
+        <button class="btn btn-sm btn-secondary" onclick="bulkAction('deleted','keep')">Keep All</button>
+        <button class="btn btn-sm btn-loss" onclick="bulkAction('deleted','remove')">Remove All</button>
+      </div>
     </div>
-    <div class="section-body" id="body-deleted">
+    <div class="section-body" id="section-body-deleted">
 
-      <div class="item-card deleted-card">
-        <input type="checkbox" class="card-checkbox" checked>
-        <div class="item-thumb silver" data-uuid="del-001">
-          <img src="" alt="">
-          <span class="thumb-emoji">&#129689;</span>
+      <!-- Deleted Item 1: ASE 2023 -->
+      <div class="card orphan-card fade-in" data-action="keep" onclick="toggleDeletedAction(this)">
+        <div class="item-thumb-pair images-visible">
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(192,192,192,0.15), rgba(192,192,192,0.05));">
+            <span style="color:var(--silver); font-size:0.55rem;">OBV</span>
+          </div>
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(192,192,192,0.15), rgba(192,192,192,0.05));">
+            <span style="color:var(--silver); font-size:0.55rem;">REV</span>
+          </div>
         </div>
         <div class="item-identity">
           <div class="item-name">2023 American Silver Eagle</div>
           <div class="item-meta">
-            <span>Silver</span><span class="dot">&#8226;</span>
-            <span>1oz</span><span class="dot">&#8226;</span>
-            <span>Qty 5</span>
+            <span style="color:var(--silver);">Silver</span>
+            <span>&#8226;</span>
+            <span>1 oz</span>
+            <span>&#8226;</span>
+            <span>Qty: 5</span>
           </div>
+        </div>
+        <div class="orphan-actions">
+          <button class="btn btn-sm btn-secondary keep-btn" onclick="event.stopPropagation(); setDeletedAction(this.closest('.orphan-card'), 'keep')">Keep</button>
+          <button class="btn btn-sm btn-loss remove-btn" onclick="event.stopPropagation(); setDeletedAction(this.closest('.orphan-card'), 'remove')">Remove</button>
         </div>
       </div>
 
-      <div class="item-card deleted-card">
-        <input type="checkbox" class="card-checkbox" checked>
-        <div class="item-thumb gold" data-uuid="del-002">
-          <img src="" alt="">
-          <span class="thumb-emoji">&#129689;</span>
+      <!-- Deleted Item 2: Krugerrand 2022 -->
+      <div class="card orphan-card fade-in" data-action="keep" onclick="toggleDeletedAction(this)">
+        <div class="item-thumb-pair images-visible">
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(255,215,0,0.15), rgba(255,215,0,0.05));">
+            <span style="color:var(--gold); font-size:0.55rem;">OBV</span>
+          </div>
+          <div class="item-thumb" style="background: linear-gradient(135deg, rgba(255,215,0,0.15), rgba(255,215,0,0.05));">
+            <span style="color:var(--gold); font-size:0.55rem;">REV</span>
+          </div>
         </div>
         <div class="item-identity">
           <div class="item-name">2022 Gold Krugerrand 1oz</div>
           <div class="item-meta">
-            <span>Gold</span><span class="dot">&#8226;</span>
-            <span>1oz</span><span class="dot">&#8226;</span>
-            <span>Qty 1</span>
+            <span style="color:var(--gold);">Gold</span>
+            <span>&#8226;</span>
+            <span>1 oz</span>
+            <span>&#8226;</span>
+            <span>Qty: 1</span>
           </div>
+        </div>
+        <div class="orphan-actions">
+          <button class="btn btn-sm btn-secondary keep-btn" onclick="event.stopPropagation(); setDeletedAction(this.closest('.orphan-card'), 'keep')">Keep</button>
+          <button class="btn btn-sm btn-loss remove-btn" onclick="event.stopPropagation(); setDeletedAction(this.closest('.orphan-card'), 'remove')">Remove</button>
         </div>
       </div>
 
@@ -509,107 +604,180 @@ body {
 
 </div>
 
+<!-- ===================================================================
+     JAVASCRIPT - Interactive Behavior (based on prototype patterns)
+     =================================================================== -->
 <script>
-/* ═══════════════════════════════════════════
-   CONTROLS PANEL
-   ═══════════════════════════════════════════ */
-(function() {
-  var ctrlDark = document.getElementById('ctrl-dark');
-  var ctrlImages = document.getElementById('ctrl-images');
+// Theme toggle
+function toggleTheme() {
+  var html = document.documentElement;
+  var isDark = html.getAttribute('data-theme') === 'dark';
+  html.setAttribute('data-theme', isDark ? 'light' : 'dark');
+}
 
-  ctrlDark.addEventListener('change', function() {
-    document.documentElement.setAttribute('data-theme', this.checked ? 'dark' : 'light');
+// Image placeholder toggle
+function toggleImages() {
+  var pairs = document.querySelectorAll('.item-thumb-pair');
+  var show = document.getElementById('toggleImages').checked;
+  pairs.forEach(function(pair) {
+    pair.style.display = show ? 'flex' : 'none';
   });
+}
 
-  ctrlImages.addEventListener('change', function() {
-    document.body.classList.toggle('show-images', this.checked);
-  });
-})();
-
-/* ═══════════════════════════════════════════
-   SECTION COLLAPSE / EXPAND
-   ═══════════════════════════════════════════ */
-(function() {
-  var headers = document.querySelectorAll('.section-header');
-  headers.forEach(function(header) {
-    header.addEventListener('click', function(e) {
-      if (e.target.tagName === 'INPUT') return;
-      var sectionName = this.getAttribute('data-section');
-      var body = document.getElementById('body-' + sectionName);
-      if (!body) return;
-      var isCollapsed = this.classList.toggle('collapsed');
-      body.classList.toggle('hidden', isCollapsed);
-    });
-  });
-})();
-
-/* ═══════════════════════════════════════════
-   MODIFIED CARD EXPAND / COLLAPSE
-   ═══════════════════════════════════════════ */
-(function() {
-  var modHeaders = document.querySelectorAll('.modified-card-header');
-  modHeaders.forEach(function(header) {
-    header.addEventListener('click', function(e) {
-      if (e.target.tagName === 'INPUT') return;
-      var cardId = this.getAttribute('data-card');
-      var card = document.getElementById(cardId);
-      var diffs = document.querySelector('[data-fields-for="' + cardId + '"]');
-      if (!card || !diffs) return;
-      var isCollapsed = card.classList.toggle('collapsed');
-      diffs.classList.toggle('hidden', isCollapsed);
-    });
-  });
-})();
-
-/* ═══════════════════════════════════════════
-   MASTER CHECKBOX + FIELD CHECKBOX SYNC
-   ═══════════════════════════════════════════ */
-(function() {
-  var modCards = document.querySelectorAll('.modified-card');
-
-  modCards.forEach(function(card) {
-    var master = card.querySelector('.master-checkbox');
-    var fieldBoxes = card.querySelectorAll('.field-checkbox');
-
-    if (!master || fieldBoxes.length === 0) return;
-
-    master.addEventListener('change', function() {
-      var checked = this.checked;
-      fieldBoxes.forEach(function(fb) { fb.checked = checked; });
-      this.indeterminate = false;
-    });
-
-    fieldBoxes.forEach(function(fb) {
-      fb.addEventListener('change', function() {
-        syncMaster(master, fieldBoxes);
-      });
-    });
-  });
-
-  function syncMaster(master, fieldBoxes) {
-    var total = fieldBoxes.length;
-    var checkedCount = 0;
-    fieldBoxes.forEach(function(fb) { if (fb.checked) checkedCount++; });
-
-    if (checkedCount === 0) {
-      master.checked = false;
-      master.indeterminate = false;
-    } else if (checkedCount === total) {
-      master.checked = true;
-      master.indeterminate = false;
-    } else {
-      master.checked = false;
-      master.indeterminate = true;
-    }
+// Section collapse/expand
+function toggleSection(sectionName) {
+  var body = document.getElementById('section-body-' + sectionName);
+  var toggle = document.querySelector('[data-section="' + sectionName + '"] .collapse-toggle');
+  if (!body || !toggle) return;
+  var isCollapsed = body.classList.contains('collapsed');
+  if (isCollapsed) {
+    body.classList.remove('collapsed');
+    toggle.classList.remove('collapsed');
+    toggle.innerHTML = '&#9660;';
+  } else {
+    body.classList.add('collapsed');
+    toggle.classList.add('collapsed');
+    toggle.innerHTML = '&#9654;';
   }
-})();
+}
 
-/* ═══════════════════════════════════════════
-   SIMPLE CARD CHECKBOX (Added / Deleted)
-   Checkboxes are native — no extra JS needed
-   for basic toggle. This block is reserved for
-   future select-all logic.
-   ═══════════════════════════════════════════ */
+// Conflict card expand/collapse
+function toggleConflictDetails(idx) {
+  var details = document.getElementById('conflict-details-' + idx);
+  if (!details) return;
+  details.classList.toggle('collapsed');
+}
+
+// Field selection (click to pick winner) -- from prototype
+function selectField(el) {
+  var row = el.closest('.field-diff');
+  row.querySelectorAll('.field-value').forEach(function(v) { v.classList.remove('selected'); });
+  el.classList.add('selected');
+}
+
+// Keep all local/remote for a single card -- from prototype
+function keepCardLocal(idx) {
+  var card = document.getElementById('conflict-' + idx);
+  card.querySelectorAll('.field-value.local').forEach(function(v) {
+    v.closest('.field-diff').querySelectorAll('.field-value').forEach(function(fv) { fv.classList.remove('selected'); });
+    v.classList.add('selected');
+  });
+}
+function keepCardRemote(idx) {
+  var card = document.getElementById('conflict-' + idx);
+  card.querySelectorAll('.field-value.remote').forEach(function(v) {
+    v.closest('.field-diff').querySelectorAll('.field-value').forEach(function(fv) { fv.classList.remove('selected'); });
+    v.classList.add('selected');
+  });
+}
+
+// Global keep all local/remote across all conflict cards
+function keepAllLocalGlobal() {
+  document.querySelectorAll('.conflict-card .field-value.local').forEach(function(v) {
+    v.closest('.field-diff').querySelectorAll('.field-value').forEach(function(fv) { fv.classList.remove('selected'); });
+    v.classList.add('selected');
+  });
+}
+function keepAllRemoteGlobal() {
+  document.querySelectorAll('.conflict-card .field-value.remote').forEach(function(v) {
+    v.closest('.field-diff').querySelectorAll('.field-value').forEach(function(fv) { fv.classList.remove('selected'); });
+    v.classList.add('selected');
+  });
+}
+
+// Resolve a conflict card -- from prototype
+var resolvedCards = new Set();
+function resolveCard(idx) {
+  var card = document.getElementById('conflict-' + idx);
+  var fields = card.querySelectorAll('.field-diff');
+  var allResolved = true;
+  fields.forEach(function(f) {
+    if (!f.querySelector('.field-value.selected')) allResolved = false;
+  });
+  if (!allResolved) {
+    // Flash unresolved fields
+    fields.forEach(function(f) {
+      if (!f.querySelector('.field-value.selected')) {
+        f.style.background = 'rgba(239,68,68,0.1)';
+        setTimeout(function() { f.style.background = ''; }, 600);
+      }
+    });
+    return;
+  }
+  card.classList.add('resolved');
+  var pill = card.querySelector('.conflict-card-header .pill');
+  pill.className = 'pill pill-gain';
+  pill.textContent = '\u2713 Resolved';
+  // Hide field diffs and actions
+  card.querySelectorAll('.field-diff, .card-actions').forEach(function(el) { el.style.display = 'none'; });
+  resolvedCards.add(idx);
+  updateProgress();
+}
+
+// Progress tracking
+var totalConflicts = 2;
+function updateProgress() {
+  var resolved = resolvedCards.size;
+  var pct = Math.round((resolved / totalConflicts) * 100);
+  document.getElementById('progressFill').style.width = pct + '%';
+  document.getElementById('resolvedCount').textContent = resolved;
+  var remaining = totalConflicts - resolved;
+  var pill = document.getElementById('unresolvedPill');
+  if (remaining === 0) {
+    pill.className = 'pill pill-gain';
+    pill.textContent = 'All resolved \u2713';
+  } else {
+    pill.className = 'pill pill-warning';
+    pill.textContent = remaining + ' remaining';
+  }
+}
+
+// Orphan card click-to-toggle (Added/Remote Only section)
+function toggleOrphanAction(card) {
+  var current = card.getAttribute('data-action');
+  setOrphanAction(card, current === 'import' ? 'skip' : 'import');
+}
+
+function setOrphanAction(card, action) {
+  card.setAttribute('data-action', action);
+  if (action === 'skip') {
+    card.classList.add('skipped');
+  } else {
+    card.classList.remove('skipped');
+  }
+}
+
+// Deleted card click-to-toggle
+function toggleDeletedAction(card) {
+  var current = card.getAttribute('data-action');
+  setDeletedAction(card, current === 'keep' ? 'remove' : 'keep');
+}
+
+function setDeletedAction(card, action) {
+  card.setAttribute('data-action', action);
+  if (action === 'remove') {
+    card.classList.add('skipped');
+  } else {
+    card.classList.remove('skipped');
+  }
+}
+
+// Bulk actions for sections
+function bulkAction(section, action) {
+  var body = document.getElementById('section-body-' + section);
+  if (!body) return;
+  var cards = body.querySelectorAll('.orphan-card');
+  cards.forEach(function(card) {
+    if (section === 'added') {
+      setOrphanAction(card, action);
+    } else if (section === 'deleted') {
+      setDeletedAction(card, action);
+    }
+  });
+}
+
+// Init
+updateProgress();
 </script>
 </body>
 </html>

--- a/playground/diffmodal-item-cards.html
+++ b/playground/diffmodal-item-cards.html
@@ -1,0 +1,615 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>StakTrakr — DiffModal Item Cards Playground</title>
+<style>
+/* ═══════════════════════════════════════════
+   STAKTRAKR DESIGN TOKENS (production)
+   ═══════════════════════════════════════════ */
+:root {
+  --primary: #6366f1;
+  --primary-hover: #818cf8;
+  --primary-dim: rgba(99,102,241,0.15);
+  --gain: #22c55e;
+  --gain-dim: rgba(34,197,94,0.12);
+  --loss: #ef4444;
+  --loss-dim: rgba(239,68,68,0.12);
+  --warning: #d97706;
+  --warning-dim: rgba(217,119,6,0.12);
+  --info: #3b82f6;
+  --info-dim: rgba(59,130,246,0.12);
+
+  --bg-body: #0f1117;
+  --bg-card: #1a1d27;
+  --bg-card-hover: #22253a;
+  --bg-tertiary: #262a3a;
+  --bg-input: #1e2130;
+  --text-primary: #f0f0f5;
+  --text-secondary: #b0b3c6;
+  --text-muted: #6b7094;
+  --border-color: rgba(255,255,255,0.08);
+  --border-active: rgba(99,102,241,0.4);
+
+  --radius: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 999px;
+  --shadow: 0 4px 24px rgba(0,0,0,0.3);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
+  --glass: rgba(255,255,255,0.03);
+
+  --gold: #FFD700;
+  --silver: #C0C0C0;
+  --platinum: #E5E4E2;
+  --palladium: #CED0CE;
+}
+
+/* Light theme override */
+[data-theme="light"] {
+  --bg-body: #f5f5f8;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f0f0f5;
+  --bg-tertiary: #e8e9f0;
+  --bg-input: #f0f0f5;
+  --text-primary: #1a1a2e;
+  --text-secondary: #4a4b6a;
+  --text-muted: #8b8da8;
+  --border-color: rgba(0,0,0,0.1);
+  --border-active: rgba(99,102,241,0.4);
+  --glass: rgba(0,0,0,0.03);
+  --shadow: 0 4px 24px rgba(0,0,0,0.08);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg-body);
+  color: var(--text-primary);
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+/* ═══════════════════════════════════════════
+   LAYOUT
+   ═══════════════════════════════════════════ */
+.app-container { max-width: 640px; margin: 0 auto; padding: 1rem; }
+
+.app-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0.75rem 1rem; margin-bottom: 1rem;
+  background: var(--bg-card); border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+}
+.app-header h1 { font-size: 1.1rem; font-weight: 600; }
+.app-header h1 span { color: var(--primary); }
+
+/* ═══════════════════════════════════════════
+   CONTROLS PANEL
+   ═══════════════════════════════════════════ */
+.controls-panel {
+  display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+  padding: 0.6rem 1rem; margin-bottom: 1rem;
+  background: var(--bg-card); border-radius: var(--radius);
+  border: 1px solid var(--border-color); font-size: 0.8rem;
+}
+.controls-panel label {
+  display: flex; align-items: center; gap: 0.4rem;
+  cursor: pointer; color: var(--text-secondary);
+}
+.controls-panel input[type="checkbox"] {
+  width: 14px; height: 14px; accent-color: var(--primary);
+}
+
+/* ═══════════════════════════════════════════
+   SHARED: PILLS, BADGES
+   ═══════════════════════════════════════════ */
+.pill {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  padding: 0.15rem 0.5rem; border-radius: var(--radius-pill);
+  font-size: 0.7rem; font-weight: 600; border: none;
+  white-space: nowrap;
+}
+.pill-gain { background: var(--gain-dim); color: var(--gain); }
+.pill-loss { background: var(--loss-dim); color: var(--loss); }
+.pill-warning { background: var(--warning-dim); color: var(--warning); }
+.pill-muted { background: var(--bg-tertiary); color: var(--text-muted); }
+
+/* ═══════════════════════════════════════════
+   SECTION HEADERS
+   ═══════════════════════════════════════════ */
+.diff-section { margin-bottom: 1rem; }
+
+.section-header {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  background: var(--bg-card); border: 1px solid var(--border-color);
+  border-radius: var(--radius); cursor: pointer;
+  user-select: none; transition: background 0.15s;
+  margin-bottom: 0.5rem;
+}
+.section-header:hover { background: var(--bg-card-hover); }
+.section-icon { font-size: 0.85rem; flex-shrink: 0; }
+.section-label { font-size: 0.82rem; font-weight: 600; flex: 1; }
+.section-count {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 1.3rem; height: 1.3rem; border-radius: var(--radius-pill);
+  font-size: 0.65rem; font-weight: 700;
+}
+.section-count.gain { background: var(--gain-dim); color: var(--gain); }
+.section-count.loss { background: var(--loss-dim); color: var(--loss); }
+.section-count.warning { background: var(--warning-dim); color: var(--warning); }
+.section-toggle {
+  font-size: 0.65rem; color: var(--text-muted);
+  transition: transform 0.2s; flex-shrink: 0;
+}
+.section-header.collapsed .section-toggle { transform: rotate(-90deg); }
+.section-body { transition: all 0.2s; }
+.section-body.hidden { display: none; }
+
+/* ═══════════════════════════════════════════
+   ITEM CARDS — Added / Deleted (simple)
+   ═══════════════════════════════════════════ */
+.item-card {
+  display: flex; align-items: center; gap: 0.6rem;
+  border: 1px solid var(--border-color); border-radius: var(--radius);
+  padding: 0.65rem; margin-bottom: 0.5rem;
+  background: var(--bg-card); transition: border-color 0.15s;
+}
+.item-card:hover { border-color: var(--border-active); }
+.item-card:last-child { margin-bottom: 0; }
+
+.item-card .card-checkbox {
+  width: 16px; height: 16px; accent-color: var(--primary);
+  flex-shrink: 0; cursor: pointer;
+}
+
+/* Image / metal emoji placeholder */
+.item-thumb {
+  width: 40px; height: 40px; border-radius: 6px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.1rem; flex-shrink: 0;
+  border: 1px solid var(--border-color);
+}
+.item-thumb.gold { background: rgba(255,215,0,0.12); }
+.item-thumb.silver { background: rgba(192,192,192,0.12); }
+.item-thumb.platinum { background: rgba(229,228,226,0.12); }
+.item-thumb.palladium { background: rgba(206,208,206,0.12); }
+
+.item-thumb img {
+  width: 100%; height: 100%; object-fit: cover;
+  border-radius: 5px; display: none;
+}
+.show-images .item-thumb img { display: block; }
+.show-images .item-thumb .thumb-emoji { display: none; }
+
+.item-identity { flex: 1; min-width: 0; }
+.item-name {
+  font-weight: 600; font-size: 0.85rem;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.item-meta {
+  display: flex; gap: 0.35rem; align-items: center;
+  font-size: 0.73rem; color: var(--text-muted); opacity: 0.5;
+  margin-top: 0.1rem;
+}
+.item-meta .dot { font-size: 0.5rem; }
+
+/* Deleted/local-only accent */
+.item-card.deleted-card {
+  border-left: 3px solid var(--loss);
+}
+
+/* ═══════════════════════════════════════════
+   MODIFIED ITEM CARDS (expandable)
+   ═══════════════════════════════════════════ */
+.modified-card {
+  border: 1px solid var(--border-color); border-radius: var(--radius);
+  padding: 0.65rem; margin-bottom: 0.5rem;
+  background: var(--bg-card); transition: border-color 0.15s;
+}
+.modified-card:hover { border-color: var(--border-active); }
+.modified-card:last-child { margin-bottom: 0; }
+
+.modified-card-header {
+  display: flex; align-items: center; gap: 0.6rem;
+  cursor: pointer; user-select: none;
+}
+
+.modified-card .master-checkbox {
+  width: 16px; height: 16px; accent-color: var(--primary);
+  flex-shrink: 0; cursor: pointer;
+}
+
+.modified-card .changes-pill {
+  font-size: 0.68rem; flex-shrink: 0;
+}
+
+.modified-card .expand-toggle {
+  font-size: 0.6rem; color: var(--text-muted);
+  transition: transform 0.2s; flex-shrink: 0; margin-left: auto;
+}
+.modified-card.collapsed .expand-toggle { transform: rotate(-90deg); }
+
+/* Field diff rows */
+.field-diffs { padding-top: 0.5rem; margin-top: 0.5rem; border-top: 1px solid var(--border-color); }
+.field-diffs.hidden { display: none; }
+
+.field-row {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.35rem 0; font-size: 0.8rem;
+  border-bottom: 1px solid rgba(255,255,255,0.025);
+}
+.field-row:last-child { border-bottom: none; }
+
+.field-row .field-checkbox {
+  width: 14px; height: 14px; accent-color: var(--primary);
+  flex-shrink: 0; cursor: pointer;
+}
+.field-label {
+  min-width: 100px; font-size: 0.72rem; color: var(--text-muted);
+  text-transform: capitalize; font-weight: 500; flex-shrink: 0;
+}
+.field-local {
+  text-decoration: line-through; opacity: 0.45;
+  font-size: 0.8rem;
+}
+.field-arrow { color: var(--text-muted); font-size: 0.75rem; margin: 0 0.15rem; flex-shrink: 0; }
+.field-remote { font-weight: 500; color: var(--warning); font-size: 0.8rem; }
+
+/* ═══════════════════════════════════════════
+   SCROLLBAR
+   ═══════════════════════════════════════════ */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--bg-tertiary); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
+/* ═══════════════════════════════════════════
+   RESPONSIVE
+   ═══════════════════════════════════════════ */
+@media (max-width: 480px) {
+  .app-container { padding: 0.5rem; }
+  .field-label { min-width: 80px; }
+  .item-name { font-size: 0.8rem; }
+}
+
+/* ═══════════════════════════════════════════
+   ANIMATION
+   ═══════════════════════════════════════════ */
+.fade-in { animation: fadeIn 0.3s ease; }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+</style>
+</head>
+<body>
+<div class="app-container">
+
+  <!-- HEADER -->
+  <header class="app-header">
+    <h1>DiffModal Item Cards <span>Playground</span></h1>
+    <span style="font-size:0.7rem;color:var(--text-muted);">STAK-454</span>
+  </header>
+
+  <!-- CONTROLS PANEL -->
+  <div class="controls-panel">
+    <label>
+      <input type="checkbox" id="ctrl-dark" checked>
+      Dark Theme
+    </label>
+    <label>
+      <input type="checkbox" id="ctrl-images">
+      Show Image Placeholders
+    </label>
+  </div>
+
+  <!-- ═══════════════════════════════════════
+       (a) ADDED ITEMS SECTION
+       ═══════════════════════════════════════ -->
+  <div class="diff-section fade-in" id="section-added">
+    <div class="section-header" data-section="added">
+      <span class="section-icon">+</span>
+      <span class="section-label">Added</span>
+      <span class="section-count gain">3</span>
+      <span class="section-toggle">&#9660;</span>
+    </div>
+    <div class="section-body" id="body-added">
+
+      <div class="item-card">
+        <input type="checkbox" class="card-checkbox" checked>
+        <div class="item-thumb gold" data-uuid="aaa-001">
+          <!-- Async image loads here via imageCache.getImage(uuid) -->
+          <img src="" alt="">
+          <span class="thumb-emoji">&#129689;</span>
+        </div>
+        <div class="item-identity">
+          <div class="item-name">2024 American Gold Eagle 1oz</div>
+          <div class="item-meta">
+            <span>Gold</span><span class="dot">&#8226;</span>
+            <span>1oz</span><span class="dot">&#8226;</span>
+            <span>Qty 2</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="item-card">
+        <input type="checkbox" class="card-checkbox" checked>
+        <div class="item-thumb silver" data-uuid="aaa-002">
+          <img src="" alt="">
+          <span class="thumb-emoji">&#129689;</span>
+        </div>
+        <div class="item-identity">
+          <div class="item-name">2024 Canadian Silver Maple 1oz</div>
+          <div class="item-meta">
+            <span>Silver</span><span class="dot">&#8226;</span>
+            <span>1oz</span><span class="dot">&#8226;</span>
+            <span>Qty 10</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="item-card">
+        <input type="checkbox" class="card-checkbox" checked>
+        <div class="item-thumb platinum" data-uuid="aaa-003">
+          <img src="" alt="">
+          <span class="thumb-emoji">&#129689;</span>
+        </div>
+        <div class="item-identity">
+          <div class="item-name">2024 Platinum Britannia 1oz</div>
+          <div class="item-meta">
+            <span>Platinum</span><span class="dot">&#8226;</span>
+            <span>1oz</span><span class="dot">&#8226;</span>
+            <span>Qty 1</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════
+       (b) MODIFIED ITEMS SECTION
+       ═══════════════════════════════════════ -->
+  <div class="diff-section fade-in" id="section-modified">
+    <div class="section-header" data-section="modified">
+      <span class="section-icon">&#9998;</span>
+      <span class="section-label">Modified</span>
+      <span class="section-count warning">2</span>
+      <span class="section-toggle">&#9660;</span>
+    </div>
+    <div class="section-body" id="body-modified">
+
+      <!-- Modified card 1: Silver Eagle -->
+      <div class="modified-card" id="mod-1">
+        <div class="modified-card-header" data-card="mod-1">
+          <input type="checkbox" class="master-checkbox" checked>
+          <div class="item-thumb silver" data-uuid="mod-001">
+            <img src="" alt="">
+            <span class="thumb-emoji">&#129689;</span>
+          </div>
+          <div class="item-identity">
+            <div class="item-name">SAMPLE - American Silver Eagle 2025</div>
+            <div class="item-meta">
+              <span>Silver</span><span class="dot">&#8226;</span>
+              <span>1oz</span>
+            </div>
+          </div>
+          <span class="pill pill-warning changes-pill">3 fields changed</span>
+          <span class="expand-toggle">&#9660;</span>
+        </div>
+        <div class="field-diffs" data-fields-for="mod-1">
+          <div class="field-row">
+            <input type="checkbox" class="field-checkbox" checked>
+            <span class="field-label">Purchase Price</span>
+            <span class="field-local">$28.50</span>
+            <span class="field-arrow">&#8594;</span>
+            <span class="field-remote">$31.00</span>
+          </div>
+          <div class="field-row">
+            <input type="checkbox" class="field-checkbox" checked>
+            <span class="field-label">Quantity</span>
+            <span class="field-local">5</span>
+            <span class="field-arrow">&#8594;</span>
+            <span class="field-remote">3</span>
+          </div>
+          <div class="field-row">
+            <input type="checkbox" class="field-checkbox" checked>
+            <span class="field-label">Notes</span>
+            <span class="field-local">BU</span>
+            <span class="field-arrow">&#8594;</span>
+            <span class="field-remote">Proof</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Modified card 2: Gold Maple -->
+      <div class="modified-card" id="mod-2">
+        <div class="modified-card-header" data-card="mod-2">
+          <input type="checkbox" class="master-checkbox" checked>
+          <div class="item-thumb gold" data-uuid="mod-002">
+            <img src="" alt="">
+            <span class="thumb-emoji">&#129689;</span>
+          </div>
+          <div class="item-identity">
+            <div class="item-name">SAMPLE - Canadian Gold Maple 2025</div>
+            <div class="item-meta">
+              <span>Gold</span><span class="dot">&#8226;</span>
+              <span>1oz</span>
+            </div>
+          </div>
+          <span class="pill pill-warning changes-pill">2 fields changed</span>
+          <span class="expand-toggle">&#9660;</span>
+        </div>
+        <div class="field-diffs" data-fields-for="mod-2">
+          <div class="field-row">
+            <input type="checkbox" class="field-checkbox" checked>
+            <span class="field-label">Purchase Price</span>
+            <span class="field-local">$1,850.00</span>
+            <span class="field-arrow">&#8594;</span>
+            <span class="field-remote">$1,920.00</span>
+          </div>
+          <div class="field-row">
+            <input type="checkbox" class="field-checkbox" checked>
+            <span class="field-label">Grade</span>
+            <span class="field-local">MS69</span>
+            <span class="field-arrow">&#8594;</span>
+            <span class="field-remote">MS70</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ═══════════════════════════════════════
+       (c) DELETED / LOCAL ONLY SECTION
+       ═══════════════════════════════════════ -->
+  <div class="diff-section fade-in" id="section-deleted">
+    <div class="section-header" data-section="deleted">
+      <span class="section-icon">&#8722;</span>
+      <span class="section-label">Deleted</span>
+      <span class="section-count loss">2</span>
+      <span class="section-toggle">&#9660;</span>
+    </div>
+    <div class="section-body" id="body-deleted">
+
+      <div class="item-card deleted-card">
+        <input type="checkbox" class="card-checkbox" checked>
+        <div class="item-thumb silver" data-uuid="del-001">
+          <img src="" alt="">
+          <span class="thumb-emoji">&#129689;</span>
+        </div>
+        <div class="item-identity">
+          <div class="item-name">2023 American Silver Eagle</div>
+          <div class="item-meta">
+            <span>Silver</span><span class="dot">&#8226;</span>
+            <span>1oz</span><span class="dot">&#8226;</span>
+            <span>Qty 5</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="item-card deleted-card">
+        <input type="checkbox" class="card-checkbox" checked>
+        <div class="item-thumb gold" data-uuid="del-002">
+          <img src="" alt="">
+          <span class="thumb-emoji">&#129689;</span>
+        </div>
+        <div class="item-identity">
+          <div class="item-name">2022 Gold Krugerrand 1oz</div>
+          <div class="item-meta">
+            <span>Gold</span><span class="dot">&#8226;</span>
+            <span>1oz</span><span class="dot">&#8226;</span>
+            <span>Qty 1</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div>
+
+<script>
+/* ═══════════════════════════════════════════
+   CONTROLS PANEL
+   ═══════════════════════════════════════════ */
+(function() {
+  var ctrlDark = document.getElementById('ctrl-dark');
+  var ctrlImages = document.getElementById('ctrl-images');
+
+  ctrlDark.addEventListener('change', function() {
+    document.documentElement.setAttribute('data-theme', this.checked ? 'dark' : 'light');
+  });
+
+  ctrlImages.addEventListener('change', function() {
+    document.body.classList.toggle('show-images', this.checked);
+  });
+})();
+
+/* ═══════════════════════════════════════════
+   SECTION COLLAPSE / EXPAND
+   ═══════════════════════════════════════════ */
+(function() {
+  var headers = document.querySelectorAll('.section-header');
+  headers.forEach(function(header) {
+    header.addEventListener('click', function(e) {
+      if (e.target.tagName === 'INPUT') return;
+      var sectionName = this.getAttribute('data-section');
+      var body = document.getElementById('body-' + sectionName);
+      if (!body) return;
+      var isCollapsed = this.classList.toggle('collapsed');
+      body.classList.toggle('hidden', isCollapsed);
+    });
+  });
+})();
+
+/* ═══════════════════════════════════════════
+   MODIFIED CARD EXPAND / COLLAPSE
+   ═══════════════════════════════════════════ */
+(function() {
+  var modHeaders = document.querySelectorAll('.modified-card-header');
+  modHeaders.forEach(function(header) {
+    header.addEventListener('click', function(e) {
+      if (e.target.tagName === 'INPUT') return;
+      var cardId = this.getAttribute('data-card');
+      var card = document.getElementById(cardId);
+      var diffs = document.querySelector('[data-fields-for="' + cardId + '"]');
+      if (!card || !diffs) return;
+      var isCollapsed = card.classList.toggle('collapsed');
+      diffs.classList.toggle('hidden', isCollapsed);
+    });
+  });
+})();
+
+/* ═══════════════════════════════════════════
+   MASTER CHECKBOX + FIELD CHECKBOX SYNC
+   ═══════════════════════════════════════════ */
+(function() {
+  var modCards = document.querySelectorAll('.modified-card');
+
+  modCards.forEach(function(card) {
+    var master = card.querySelector('.master-checkbox');
+    var fieldBoxes = card.querySelectorAll('.field-checkbox');
+
+    if (!master || fieldBoxes.length === 0) return;
+
+    master.addEventListener('change', function() {
+      var checked = this.checked;
+      fieldBoxes.forEach(function(fb) { fb.checked = checked; });
+      this.indeterminate = false;
+    });
+
+    fieldBoxes.forEach(function(fb) {
+      fb.addEventListener('change', function() {
+        syncMaster(master, fieldBoxes);
+      });
+    });
+  });
+
+  function syncMaster(master, fieldBoxes) {
+    var total = fieldBoxes.length;
+    var checkedCount = 0;
+    fieldBoxes.forEach(function(fb) { if (fb.checked) checkedCount++; });
+
+    if (checkedCount === 0) {
+      master.checked = false;
+      master.indeterminate = false;
+    } else if (checkedCount === total) {
+      master.checked = true;
+      master.indeterminate = false;
+    } else {
+      master.checked = false;
+      master.indeterminate = true;
+    }
+  }
+})();
+
+/* ═══════════════════════════════════════════
+   SIMPLE CARD CHECKBOX (Added / Deleted)
+   Checkboxes are native — no extra JS needed
+   for basic toggle. This block is reserved for
+   future select-all logic.
+   ═══════════════════════════════════════════ */
+</script>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772902018';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772902503';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772901747';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772902018';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772899411';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772900022';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.57-b1772896958';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772897034';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772902503';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772902547';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772900681';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772901107';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772900022';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772900681';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772901509';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772901747';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772901107';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772901509';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772898255';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772899411';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772903077';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772904883';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772902547';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772903077';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.57-b1772847828';
+const CACHE_NAME = 'staktrakr-v3.33.57-b1772896958';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772897034';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772897639';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.58-b1772897639';
+const CACHE_NAME = 'staktrakr-v3.33.58-b1772898255';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.57",
-  "releaseDate": "2026-03-06",
+  "version": "3.33.58",
+  "releaseDate": "2026-03-07",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,8 +2,8 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.55
-date: 2026-03-06
+lastUpdated: v3.33.58
+date: 2026-03-07
 sourceFiles:
   - js/cloud-storage.js
   - js/cloud-sync.js
@@ -15,7 +15,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.51 — 2026-03-05
+> **Last updated:** v3.33.58 — 2026-03-07
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`, `js/vault.js`
 
 ## Overview
@@ -59,7 +59,7 @@ There is no dedicated `backup.js` or `restore.js`. All backup and restore logic 
 - **All imports go through `buildImportValidationResult()` before DiffModal opens.** Items that fail validation are surfaced as a pre-validation warning toast and excluded from the DiffModal. If all items are invalid, the import is aborted with an error toast.
 - **All exports embed `exportOrigin` (`window.location.origin`).** On import, if the file's `exportOrigin` differs from the current domain, a cross-domain warning toast is shown before the DiffModal opens. This is informational only and never blocks the import.
 - **DiffModal shows a live count header** (Backup / Current / After import) and a warning when the projected count is less than the backup count.
-- **A summary banner appears after every import** (`showImportSummaryBanner()`) showing added / updated / removed / skipped counts, with collapsible skip reasons when items were rejected.
+- **A toast notification appears after every import** showing added / updated / removed / skipped counts. The former persistent `showImportSummaryBanner()` was removed in v3.33.58 — all post-import feedback now uses the standard toast system.
 
 ---
 
@@ -129,7 +129,7 @@ All remote changes (both sync updates and conflicts) flow directly into `handleR
 `js/utils.js` provides the import validation pipeline shared across all import paths:
 
 - `buildImportValidationResult(items, skippedNonPM)` — batch validation before DiffModal
-- `showImportSummaryBanner(result)` — persistent dismissible banner after import completes
+
 - `saveData(key, value)` / `loadData(key)` — all localStorage reads/writes go through these (never direct `localStorage.setItem`)
 - `sanitizeImportedItem(item)` — sanitizes raw imported item before validation
 
@@ -263,7 +263,7 @@ The backup/export panel shows a `<small class="format-desc">` beneath each optio
 5. If all invalid: abort with error toast
 6. If some invalid: show warning toast, proceed with valid items only
 7. Open `DiffModal` with `backupCount` and `localCount` for live count header
-8. On apply: merge items, call post-restore sequence, show `showImportSummaryBanner(result)`
+8. On apply: merge items, call post-restore sequence, show import summary toast
 
 ### ZIP Restore (`restoreBackupZip`)
 
@@ -369,7 +369,6 @@ Image blobs are NOT restored via vault — requires a separate ZIP or image vaul
 | Function | Signature | Purpose |
 |----------|-----------|---------|
 | `buildImportValidationResult` | `(items, skippedNonPM)` → `object` | Batch-validate sanitized items; returns `{ valid, invalid, skippedNonPM, skippedCount }` |
-| `showImportSummaryBanner` | `(result)` | Render dismissible summary banner above inventory table after import |
 | `saveData` | `(key, value)` | Write to localStorage via allowed-key guard |
 | `loadData` | `(key, defaultValue)` | Read from localStorage with JSON parse |
 
@@ -486,10 +485,10 @@ All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
 | "Numista images came back immediately after vault restore" | Expected behavior. Numista CDN URLs (`obverseImageUrl`, `reverseImageUrl`) are stored on the inventory items in localStorage, so they survive any vault restore without touching IDB. | No action needed — this is correct. |
 | "Image vault upload failed during cloud push" | Image vault upload is non-fatal — the inventory vault still succeeds. | Check Dropbox token validity. The next successful push will retry the image vault if the hash changed. |
 | "Conflict prompt appeared after cloud pull" | Both local and remote have diverged — last push is more recent than last pull, meaning both sides have independent changes. | Review the DiffModal and choose which version to keep. |
-| "DiffModal shows fewer items than I expected" | Pre-validation in `buildImportValidationResult()` filters out invalid items before DiffModal opens. The count header shows backup count (including skipped) vs. projected count. | Check the pre-validation warning toast for the number of skipped items and their reasons. The post-import summary banner also lists skip reasons. |
+| "DiffModal shows fewer items than I expected" | Pre-validation in `buildImportValidationResult()` filters out invalid items before DiffModal opens. The count header shows backup count (including skipped) vs. projected count. | Check the pre-validation warning toast for the number of skipped items and their reasons. |
 | "I see a yellow cross-domain warning on import" | The file's `exportOrigin` (e.g., `https://beta.staktrakr.com`) differs from the current domain. | The warning is informational only. Proceed if you intentionally want to merge across environments. |
 | "The JSON file I exported doesn't look like a plain array anymore" | `exportJson()` now wraps items in an object with `items` and `exportMeta` fields. | Both the wrapped format and the legacy plain-array format are supported on import. Old files still import correctly. |
-| "Import shows a banner but also a toast" | If `safeGetElement()` cannot find the inventory table container, `showImportSummaryBanner()` falls back to `showToast()`. | Verify the inventory container element id is present in the DOM at import time. |
+| "Import only shows a toast, not the old banner" | The persistent `showImportSummaryBanner()` was removed in v3.33.58. All post-import feedback now uses standard toast notifications. | This is expected behavior. The toast shows added/updated/removed counts. |
 | "Push was blocked with 'Empty vault — pull first'" | Empty-vault guard in `pushSyncVault()` detected remote has items but local is empty. | Pull from cloud first to restore local inventory, then push will proceed normally. |
 | "OAuth relay rejected with 'state mismatch'" | `cloudCheckOAuthRelay` validates the `state` parameter from the localStorage relay against `cloud_oauth_state` in `sessionStorage`. A mismatch means the relay entry is stale or from a different OAuth session. | Re-initiate the OAuth flow from Settings → Cloud → Connect. |
 

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -2,8 +2,8 @@
 title: Frontend Overview
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.56
-date: 2026-03-06
+lastUpdated: v3.33.58
+date: 2026-03-07
 sourceFiles:
   - index.html
   - js/constants.js
@@ -17,7 +17,7 @@ relatedPages:
 ---
 # Frontend Overview
 
-> **Last updated:** v3.33.56 — 2026-03-06
+> **Last updated:** v3.33.58 — 2026-03-07
 > **Source files:** `index.html`, `js/constants.js`, `sw.js`, `js/file-protocol-fix.js`
 
 ## Overview
@@ -142,7 +142,7 @@ On `http://` or `https://` origins the wrapping is still installed but never tri
 
 ### Diff review modal (`#diffReviewModal`)
 
-The diff review modal is a reusable change-review UI used by cloud sync and import flows (STAK-184, STAK-451). It is defined in `index.html` with a scoped `<style>` block immediately before its markup.
+The diff review modal is a reusable change-review UI used by cloud sync and import flows (STAK-184, STAK-451, STAK-454). It is defined in `index.html` with a scoped `<style>` block immediately before its markup. All CSS classes are prefixed with `dm-` and scoped under `#diffReviewModal` to avoid conflicts with existing app styles.
 
 **Layout:** `max-width: 860px`. At or below the `768px` breakpoint the modal expands to full-screen (`width: 100vw; height: 100dvh; max-width: none; border-radius: 0`).
 
@@ -153,8 +153,10 @@ The diff review modal is a reusable change-review UI used by cloud sync and impo
 | `diffSummaryDashboard` | High-level counts dashboard shown at the top of the review |
 | `diffProgressTracker` | Conflict-resolution progress bar (visible only for cloud sync sources) |
 | `diffSectionConflicts` | Renders conflicting items that require user resolution |
-| `diffSectionOrphans` | Renders Added and Deleted item cards with metal-colored image placeholders and async image loading |
-| `diffSectionModified` | Renders Modified item cards with expandable per-field checkboxes for granular merge selection (max-height 500px, bordered) |
+| `diffSectionOrphans` | Card-based rendering of Added and Deleted items. Each card shows dual OBV/REV image thumbnails (3-tier: IndexedDB blob → CDN URL → metal gradient placeholder), metal-colored name, weight/qty metadata, and Import/Skip or Keep/Remove action buttons |
+| `diffSectionModified` | Card-based rendering of Modified items with expandable per-field click-to-pick values (local vs remote), resolve progress bar, and per-card/section-level bulk actions (max-height 500px, bordered) |
+
+**State model (STAK-454):** The card-based UI uses three state objects: `_orphanActions` (per-item import/skip/keep/remove), `_fieldSelections` (per-field local/remote winner), and `_resolvedConflicts` (confirmed conflict cards). Legacy `_checkedItems` is maintained for backward compatibility with older callers.
 
 Supporting elements: `diffReviewTitle`, `diffReviewSource`, `diffReviewCountRow`, `diffReviewCountWarning`, `diffReviewSettings`. Action buttons: `diffReviewSelectAll`, `diffReviewDismissX`.
 

--- a/wiki/frontend-overview.md
+++ b/wiki/frontend-overview.md
@@ -153,8 +153,8 @@ The diff review modal is a reusable change-review UI used by cloud sync and impo
 | `diffSummaryDashboard` | High-level counts dashboard shown at the top of the review |
 | `diffProgressTracker` | Conflict-resolution progress bar (visible only for cloud sync sources) |
 | `diffSectionConflicts` | Renders conflicting items that require user resolution |
-| `diffSectionOrphans` | Reserved placeholder for future orphan item rendering (currently unused) |
-| `diffSectionModified` | Scrollable list of modified items (max-height 320px, bordered) |
+| `diffSectionOrphans` | Renders Added and Deleted item cards with metal-colored image placeholders and async image loading |
+| `diffSectionModified` | Renders Modified item cards with expandable per-field checkboxes for granular merge selection (max-height 500px, bordered) |
 
 Supporting elements: `diffReviewTitle`, `diffReviewSource`, `diffReviewCountRow`, `diffReviewCountWarning`, `diffReviewSettings`. Action buttons: `diffReviewSelectAll`, `diffReviewDismissX`.
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Item cards**: Added/Deleted items now render as bordered cards with metal-colored image placeholders (40x40 with coin emoji, async image loading via imageCache) instead of flat checkbox rows
- **Modified item cards**: Expandable cards with "N fields changed" pill badge and per-field checkboxes enabling granular merge field selection
- **Master checkbox indeterminate**: When some fields are unchecked on a modified item, the master checkbox shows indeterminate state
- **Apply count**: Now reflects individual field selections, not just item-level counts
- **Container updates**: `#diffSectionOrphans` now holds Added/Deleted cards, `#diffSectionModified` max-height increased to 500px

## Linear Issues

- [STAK-454: DiffModal Phase 2 — Item Cards](https://linear.app/lbruton/issue/STAK-454)

## Files Changed

- `js/diff-modal.js` — New renderers (`_renderItemCards`, `_renderModifiedCards`), metal helpers, `_checkedFields` state, updated event delegation, deleted `_renderCategory()`
- `index.html` — `#diffSectionModified` max-height 320px → 500px
- `wiki/frontend-overview.md` — Updated container descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)