### PR TITLE
chore: document retail-modal.md inaccuracy in nightwatch log

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 6,
+  "nextIndex": 7,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -35,6 +35,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "Claims 'TTL is 30 minutes per claim' but devops/version-lock-protocol.md defines three tiers: Hotfix = 30min, Spec implementation = 4h, Pre-assigned queued slot = 4h.",
+      "verified": []
+    },
+    {
+      "date": "2026-03-07",
+      "page": "retail-modal.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "Wiki claims _buildVendorLegend renders OOS vendors at opacity: 0.5 with strikethrough price and 'OOS' badge, but js/retail-view-modal.js simply skips them with `if (price == null) return;` inside the loop.",
       "verified": []
     }
   ]


### PR DESCRIPTION
This PR adds a new entry to the `wiki/.nightwatch-log.json` to log an inaccuracy found in the `retail-modal.md` wiki page. The wiki incorrectly claimed that out-of-stock (OOS) vendors are rendered at 50% opacity with a strikethrough price and an 'OOS' badge in `_buildVendorLegend()`. The actual code in `js/retail-view-modal.js` completely skips OOS vendors due to an `if (price == null) return;` statement inside the loop. The `nextIndex` was correctly incremented to 7.

---
*PR created automatically by Jules for task [10978149950063003104](https://jules.google.com/task/10978149950063003104) started by @lbruton*