### PR TITLE
chore: worktree lock protocol + gitignore simplification

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -105,21 +105,37 @@ Use the `version` from your claim as the target for all subsequent steps — do 
 **4. Create the worktree + branch immediately:**
 
 ```bash
-git worktree add .claude/worktrees/patch-VERSION -b patch/VERSION
+git worktree add .worktrees/patch-VERSION -b patch/VERSION
 ```
 
-Example: `git worktree add .claude/worktrees/patch-3.32.29 -b patch/3.32.29`
+Example: `git worktree add .worktrees/patch-3.32.29 -b patch/3.32.29`
+
+**5. Write a session lock file** to prevent other sessions from using this worktree concurrently:
+
+```bash
+cat > .worktrees/patch-VERSION/.worktree.lock <<LOCK
+{
+  "session_id": "$(date +%s)-$$",
+  "claimed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "branch": "patch/VERSION",
+  "task": "STAK-XXX brief description"
+}
+LOCK
+```
+
+Before entering any existing worktree, check for a lock file. If `.worktree.lock` exists and `claimed_at` is less than 2 hours old, **STOP** — another session may be active. Ask the user before proceeding.
 
 **All subsequent work (file edits, version bumps, commits) happens inside the worktree directory.**
 If you are running as an interactive Claude Code session, inform the user:
 
 ```
-Worktree created at: .claude/worktrees/patch-VERSION/
+Worktree created at: .worktrees/patch-VERSION/
 Branch: patch/VERSION
 
 All work for this release will happen in that worktree.
 After merging to dev, run cleanup:
-  git worktree remove .claude/worktrees/patch-VERSION --force
+  rm -f .worktrees/patch-VERSION/.worktree.lock
+  git worktree remove .worktrees/patch-VERSION --force
   git branch -d patch/VERSION
   Remove your claim entry from devops/version.lock (leave other active claims intact)
 ```
@@ -337,7 +353,8 @@ git tag vNEW_VERSION origin/dev
 git push origin vNEW_VERSION
 
 # Remove the worktree
-git worktree remove .claude/worktrees/patch-VERSION --force
+rm -f .worktrees/patch-VERSION/.worktree.lock
+git worktree remove .worktrees/patch-VERSION --force
 
 # Delete the local branch
 git branch -d patch/VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -3,36 +3,12 @@
 .AppleDouble
 .LSOverride
 
-# Claude Code — all project skills tracked in git to prevent loss;
-# user-level skills live in ~/.claude/skills/ (outside repo)
+# Claude Code — skills and commands tracked, everything else ignored
 .claude/*
 !.claude/skills/
-.claude/skills/*
-!.claude/skills/api-infrastructure/
-!.claude/skills/bb-test/
-!.claude/skills/brainstorming/
-!.claude/skills/browserbase-test-maintenance/
-!.claude/skills/bug-report/
-!.claude/skills/coding-standards/
-!.claude/skills/devops-dashboard/
-!.claude/skills/finishing-a-development-branch/
-!.claude/skills/homepoller-ssh/
-!.claude/skills/markdown-standards/
-!.claude/skills/prime/
-!.claude/skills/release/
-!.claude/skills/repo-boundaries/
-!.claude/skills/retail-poller/
-!.claude/skills/retail-provider-fix/
-!.claude/skills/scan-mentions/
-!.claude/skills/seed-sync/
-!.claude/skills/ship/
-!.claude/skills/sync-poller/
-!.claude/skills/ui-mockup/
-!.claude/skills/wiki-audit/
-!.claude/skills/wiki-search/
-!.claude/skills/wiki-sweep/
-!.claude/skills/wiki-update/
-.claude/commands/
+!.claude/skills/**
+!.claude/commands/
+!.claude/commands/**
 .mcp.json
 SPRINT.md
 


### PR DESCRIPTION
## Summary

Follow-up to #798 (merged). Standardizes worktree workflow and simplifies skill tracking.

- **Worktree path**: `.claude/worktrees/` → `.worktrees/` in release skill (prevents cross-session blindness)
- **Session lock protocol**: `.worktree.lock` file prevents concurrent session conflicts
- **`.gitignore` simplified**: 25-line skills allowlist replaced with `!.claude/skills/**` wildcard — new skills auto-tracked
- **Commands tracked**: `.claude/commands/` now committed alongside skills

## Context

Discovered orphaned `patch/3.33.59` worktree in `.claude/worktrees/` — a different session's work was invisible because the path differed from `.worktrees/`. Lock protocol and single canonical path prevent this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)