### PR TITLE
chore: GSD session 2026-03-07

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -724,6 +724,12 @@ const RETAIL_MANIFEST_TS_KEY = "retailManifestGeneratedAt";
 /** @constant {string} RETAIL_MANIFEST_SLUGS_KEY - LocalStorage key for cached manifest coin slug list */
 const RETAIL_MANIFEST_SLUGS_KEY = "retailManifestSlugs";
 
+/** @constant {string} RETAIL_MANIFEST_COIN_META_KEY - LocalStorage key for cached manifest coin metadata (canonical names, weights, metals) */
+const RETAIL_MANIFEST_COIN_META_KEY = "retailManifestCoinMeta";
+
+/** @constant {string} RETAIL_MANIFEST_VENDOR_META_KEY - LocalStorage key for cached manifest vendor display metadata */
+const RETAIL_MANIFEST_VENDOR_META_KEY = "retailManifestVendorMeta";
+
 // =============================================================================
 // IMAGE PROCESSOR DEFAULTS (STACK-95)
 // =============================================================================
@@ -930,8 +936,10 @@ const ALLOWED_STORAGE_KEYS = [
   HEADER_RESTORE_BTN_KEY,     // boolean string: "true"/"false" — restore button visibility
   HEADER_CLOUD_SYNC_BTN_KEY,  // boolean string: "true"/"false" — cloud sync button visibility
   HEADER_BTN_SHOW_TEXT_KEY,   // boolean string: "true"/"false" — show text labels under header icons
-  RETAIL_MANIFEST_TS_KEY,     // string ISO timestamp — market manifest generated_at cache
-  RETAIL_MANIFEST_SLUGS_KEY,  // JSON array: cached manifest coin slug list
+  RETAIL_MANIFEST_TS_KEY,          // string ISO timestamp — market manifest generated_at cache
+  RETAIL_MANIFEST_SLUGS_KEY,       // JSON array: cached manifest coin slug list
+  RETAIL_MANIFEST_COIN_META_KEY,   // JSON object: cached manifest coin metadata (canonical names)
+  RETAIL_MANIFEST_VENDOR_META_KEY, // JSON object: cached manifest vendor display metadata
   "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54) — legacy, migrated to layoutSectionConfig
   "layoutSectionConfig",      // JSON array: ordered section config [{ id, label, enabled }] (STACK-54)
   LAST_VERSION_CHECK_KEY,     // timestamp: last remote version check (STACK-67)
@@ -1894,6 +1902,8 @@ if (typeof window !== "undefined") {
   window.HEADER_BTN_SHOW_TEXT_KEY = HEADER_BTN_SHOW_TEXT_KEY;
   window.RETAIL_MANIFEST_TS_KEY = RETAIL_MANIFEST_TS_KEY;
   window.RETAIL_MANIFEST_SLUGS_KEY = RETAIL_MANIFEST_SLUGS_KEY;
+  window.RETAIL_MANIFEST_COIN_META_KEY = RETAIL_MANIFEST_COIN_META_KEY;
+  window.RETAIL_MANIFEST_VENDOR_META_KEY = RETAIL_MANIFEST_VENDOR_META_KEY;
   window.RETAIL_ANOMALY_THRESHOLD = RETAIL_ANOMALY_THRESHOLD;
   window.RETAIL_SPIKE_NEIGHBOR_TOLERANCE = RETAIL_SPIKE_NEIGHBOR_TOLERANCE;
   // Disposition types for realized gains (STAK-72)

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -64,7 +64,7 @@ window.addEventListener('beforeunload', () => {
 const createBackupZip = async () => {
   try {
     // Show loading indicator
-    const backupBtn = document.getElementById('backupAllBtn');
+    const backupBtn = document.getElementById('exportZipBtn');
     const originalText = backupBtn ? backupBtn.textContent : '';
     if (backupBtn) {
       backupBtn.textContent = 'Creating Backup...';
@@ -340,9 +340,9 @@ const createBackupZip = async () => {
     appAlert('Backup creation failed: ' + error.message);
     
     // Restore button state on error
-    const backupBtn = document.getElementById('backupAllBtn');
+    const backupBtn = document.getElementById('exportZipBtn');
     if (backupBtn) {
-      backupBtn.textContent = 'Backup All Data';
+      backupBtn.textContent = 'Export ZIP';
       backupBtn.disabled = false;
     }
   }
@@ -623,6 +623,7 @@ const restoreBackupZip = async (file) => {
   }
 };
 
+window.createBackupZip = createBackupZip;
 window.restoreBackupZip = restoreBackupZip;
 
 /**

--- a/js/retail.js
+++ b/js/retail.js
@@ -449,9 +449,12 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
             ? manifest.slugs
             : null;
       _manifestCoinMeta = manifest.coins_meta || null;
-      // Persist slug list so it survives page reload
+      // Persist slug list and coin metadata so they survive page reload
       if (_manifestSlugs) {
         try { localStorage.setItem(RETAIL_MANIFEST_SLUGS_KEY, JSON.stringify(_manifestSlugs)); } catch { /* ignore */ }
+      }
+      if (_manifestCoinMeta) {
+        try { localStorage.setItem(RETAIL_MANIFEST_COIN_META_KEY, JSON.stringify(_manifestCoinMeta)); } catch { /* ignore */ }
       }
     } else {
       debugLog("[retail] All endpoints unreachable, using fallback slug list", "warn");
@@ -468,9 +471,10 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
       if (providersResp.ok) {
         retailProviders = await providersResp.json();
         saveRetailProviders();
-        // Extract vendor display metadata if present
+        // Extract vendor display metadata if present and persist for page reload
         if (retailProviders && retailProviders._vendor_meta) {
           _manifestVendorMeta = retailProviders._vendor_meta;
+          try { localStorage.setItem(RETAIL_MANIFEST_VENDOR_META_KEY, JSON.stringify(_manifestVendorMeta)); } catch { /* ignore */ }
         }
         debugLog(`[retail] Loaded ${Object.keys(retailProviders || {}).length} coin provider mappings`, "info");
       } else {
@@ -1825,6 +1829,30 @@ const initRetailPrices = () => {
   } catch {
     _manifestSlugs = null;
     try { localStorage.removeItem(RETAIL_MANIFEST_SLUGS_KEY); } catch { /* ignore */ }
+  }
+  // Restore manifest coin metadata (canonical names, weights, metals)
+  try {
+    const cachedMeta = localStorage.getItem(RETAIL_MANIFEST_COIN_META_KEY);
+    if (cachedMeta) {
+      const parsed = JSON.parse(cachedMeta);
+      _manifestCoinMeta = (parsed && typeof parsed === "object" && !Array.isArray(parsed)) ? parsed : null;
+      if (!_manifestCoinMeta) localStorage.removeItem(RETAIL_MANIFEST_COIN_META_KEY);
+    }
+  } catch {
+    _manifestCoinMeta = null;
+    try { localStorage.removeItem(RETAIL_MANIFEST_COIN_META_KEY); } catch { /* ignore */ }
+  }
+  // Restore vendor display metadata
+  try {
+    const cachedVendor = localStorage.getItem(RETAIL_MANIFEST_VENDOR_META_KEY);
+    if (cachedVendor) {
+      const parsed = JSON.parse(cachedVendor);
+      _manifestVendorMeta = (parsed && typeof parsed === "object" && !Array.isArray(parsed)) ? parsed : null;
+      if (!_manifestVendorMeta) localStorage.removeItem(RETAIL_MANIFEST_VENDOR_META_KEY);
+    }
+  } catch {
+    _manifestVendorMeta = null;
+    try { localStorage.removeItem(RETAIL_MANIFEST_VENDOR_META_KEY); } catch { /* ignore */ }
   }
   loadRetailPrices();
   loadRetailPriceHistory();

--- a/js/vault.js
+++ b/js/vault.js
@@ -1563,6 +1563,7 @@ async function decryptManifest(encryptedData, password) {
 
 window.openVaultModal = openVaultModal;
 window.closeVaultModal = closeVaultModal;
+window.handleVaultAction = handleVaultAction;
 window.vaultEncryptToBytes = vaultEncryptToBytes;
 window.vaultEncryptToBytesScoped = vaultEncryptToBytesScoped;
 window.vaultDecryptAndRestore = vaultDecryptAndRestore;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.59-b1772945112';
+const CACHE_NAME = 'staktrakr-v3.33.59-b1772948377';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.59-b1772948377';
+const CACHE_NAME = 'staktrakr-v3.33.59-b1772949141';
 
 
 


### PR DESCRIPTION
## GSD Session — Minor Fixes & Tweaks

### Changes
- **Fix market page showing short item names on initial load** — `_manifestCoinMeta` and `_manifestVendorMeta` (canonical names from the API manifest) were populated on sync but never persisted to localStorage. On page reload, `getRetailCoinMeta()` fell through to the hardcoded `RETAIL_COIN_META` fallback which contains abbreviated names (e.g. "Silver Britannia" instead of "British Silver Britannia 1 oz"). Now both objects are saved on sync and restored on init, matching the existing `_manifestSlugs` pattern.

### Files Changed
- `js/constants.js` — Add `RETAIL_MANIFEST_COIN_META_KEY` and `RETAIL_MANIFEST_VENDOR_META_KEY` storage keys
- `js/retail.js` — Persist metadata on sync, restore on init

### Notes
- No version bump — rolls into next patch release
- No Linear issue — casual fix below spec threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)