### PR TITLE
v3.33.60 — STAK-457: ZIP backup restore routes through DiffModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.60] - 2026-03-08
+
+### Fixed — STAK-457: ZIP Backup Restore Routes Through DiffModal
+
+- **Fixed**: ZIP backup restore now routes through DiffModal for item and settings review instead of directly overwriting localStorage (STAK-457)
+
+---
+
 ## [3.33.59] - 2026-03-07
 
 ### Added — STAK-455: DiffModal Settings Cards Rich Renderers

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,8 +1,8 @@
 ## What's New
 
+- **ZIP Restore DiffModal (v3.33.60)**: ZIP backup restore now routes through DiffModal for item and settings review instead of directly overwriting localStorage (STAK-457).
 - **DiffModal Settings Renderers (v3.33.59)**: Five rich chip-strip renderers replace opaque "N items" text for complex settings. Per-element click-to-pick merge for chip configs, seed rules, and provider priorities. itemTags leak fixed (STAK-455).
 - **DiffModal Item Cards (v3.33.58)**: Item cards with bordered layout, metal-colored image placeholders, async image loading, and click-to-pick field selection for granular merge control on modified items (STAK-454).
-- **Australian Coin Names Fix (v3.33.57)**: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452).
 - **DiffModal UX Overhaul (v3.33.56)**: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts (STAK-451).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication (STAK-449).
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,9 +283,9 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.60 &ndash; ZIP Restore DiffModal</strong>: ZIP backup restore now routes through DiffModal for item and settings review instead of directly overwriting localStorage (STAK-457)</li>
     <li><strong>v3.33.59 &ndash; DiffModal Settings Renderers</strong>: Five rich chip-strip renderers replace opaque &ldquo;N items&rdquo; text for complex settings. Per-element click-to-pick merge for chip configs, seed rules, and provider priorities. itemTags leak fixed (STAK-455)</li>
     <li><strong>v3.33.58 &ndash; DiffModal Item Cards</strong>: Item cards with bordered layout, metal-colored image placeholders, async image loading, and click-to-pick field selection for granular merge control on modified items (STAK-454)</li>
-    <li><strong>v3.33.57 &ndash; Australian Coin Names Fix</strong>: Kangaroo, Koala, and Kookaburra silver coins now display proper names instead of raw slugs in Market view (STAK-452)</li>
     <li><strong>v3.33.56 &ndash; DiffModal UX Overhaul</strong>: Card-based diff review with summary dashboard, per-item conflict cards with click-to-pick resolution, 7 settings category groups with human-readable labels, progress tracker for sync conflicts (STAK-451)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name now shown in Cloud settings. Switch Account button forces re-authentication (STAK-449)</li>
   `;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.59";
+const APP_VERSION = "3.33.60";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -470,7 +470,7 @@ const restoreBackupZip = async (file) => {
       }
 
       // Catalog mappings
-      if (settingsObj && settingsObj.catalogMappings) {
+      if (settingsObj && settingsObj.catalogMappings && typeof catalogManager !== 'undefined') {
         catalogManager.importMappings(settingsObj.catalogMappings, false);
       }
 
@@ -485,13 +485,6 @@ const restoreBackupZip = async (file) => {
         mergeItemPriceHistory(ancillary.itemPriceHistory);
       } else if (typeof loadItemPriceHistory === 'function') {
         loadItemPriceHistory();
-      }
-
-      // Item tags not handled by pendingTagsByUuid (items that weren't in the diff)
-      if (Object.keys(pendingTagsByUuid).length > 0 && typeof addItemTag === 'function') {
-        for (const [uuid, tags] of Object.entries(pendingTagsByUuid)) {
-          for (const tag of tags) addItemTag(uuid, tag);
-        }
       }
 
       // Retail prices
@@ -606,7 +599,13 @@ const restoreBackupZip = async (file) => {
       } : null,
     }, async function(summary) {
       debugLog('restoreBackupZip DiffModal complete', summary.added, 'added', summary.modified, 'modified', summary.deleted, 'deleted');
-      await applyAncillaryData();
+      try {
+        await applyAncillaryData();
+      } catch (ancillaryErr) {
+        debugWarn('restoreBackupZip: ancillary data restore partial failure', ancillaryErr);
+        showToast('ZIP restored with warnings — some ancillary data may not have been applied', 'warning');
+        return;
+      }
       showToast('ZIP backup restored successfully');
     });
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -403,15 +403,15 @@ const restoreBackupZip = async (file) => {
       if (settingsObj.goldbackPriceHistory != null) remoteSettings[GOLDBACK_PRICE_HISTORY_KEY] = settingsObj.goldbackPriceHistory;
     }
 
-    // 1c. Parse item tags for pendingTagsByUuid
-    const pendingTagsByUuid = {};
+    // 1c. Parse item tags for pendingTagsByUuid (must be a Map — showImportDiffReview uses .get())
+    const pendingTagsByUuid = new Map();
     const itemTagsStr = await zip.file("item_tags.json")?.async("string");
     if (itemTagsStr) {
       try {
         const itemTagsObj = JSON.parse(itemTagsStr);
         if (itemTagsObj.tags && typeof itemTagsObj.tags === 'object' && !Array.isArray(itemTagsObj.tags)) {
           for (const [uuid, tags] of Object.entries(itemTagsObj.tags)) {
-            if (Array.isArray(tags) && tags.length > 0) pendingTagsByUuid[uuid] = tags;
+            if (Array.isArray(tags) && tags.length > 0) pendingTagsByUuid.set(uuid, tags);
           }
         }
       } catch (e) {
@@ -597,16 +597,14 @@ const restoreBackupZip = async (file) => {
         appVersion: settingsObj.version || null,
         exportTimestamp: settingsObj.exportDate || null
       } : null,
-    }, async function(summary) {
+    }, function(summary) {
       debugLog('restoreBackupZip DiffModal complete', summary.added, 'added', summary.modified, 'modified', summary.deleted, 'deleted');
-      try {
-        await applyAncillaryData();
-      } catch (ancillaryErr) {
+      applyAncillaryData().then(function() {
+        showToast('ZIP backup restored successfully');
+      }).catch(function(ancillaryErr) {
         debugWarn('restoreBackupZip: ancillary data restore partial failure', ancillaryErr);
         showToast('ZIP restored with warnings — some ancillary data may not have been applied', 'warning');
-        return;
-      }
-      showToast('ZIP backup restored successfully');
+      });
     });
 
   } catch (err) {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -362,225 +362,226 @@ const restoreBackupZip = async (file) => {
   try {
     const zip = await JSZip.loadAsync(file);
 
+    // ── Phase 1: Parse all ZIP contents without writing to storage (STAK-457) ──
+
+    // 1a. Parse inventory items
+    let parsedItems = [];
     const inventoryStr = await zip.file("inventory_data.json")?.async("string");
     if (inventoryStr) {
       const invObj = JSON.parse(inventoryStr);
-      localStorage.setItem(LS_KEY, JSON.stringify(invObj.inventory || []));
+      parsedItems = invObj.inventory || [];
     }
 
+    // 1b. Parse settings and build a flat key→value map for DiffEngine
+    let settingsObj = null;
+    const remoteSettings = {};
     const settingsStr = await zip.file("settings.json")?.async("string");
     if (settingsStr) {
-      const settingsObj = JSON.parse(settingsStr);
-      if (settingsObj.spotPrices) {
-        Object.entries(settingsObj.spotPrices).forEach(([metal, price]) => {
-          const metalConfig = METALS[metal.toUpperCase()];
-          if (metalConfig) {
-            localStorage.setItem(
-              metalConfig.localStorageKey,
-              JSON.stringify(price),
-            );
-          }
-        });
-      }
-      if (settingsObj.theme) {
-        localStorage.setItem(THEME_KEY, settingsObj.theme);
-      }
-      
-      // Handle catalog mappings if present in backup
-      if (settingsObj.catalogMappings) {
-        // Use catalog manager to import mappings
-        catalogManager.importMappings(settingsObj.catalogMappings, false);
-      }
+      settingsObj = JSON.parse(settingsStr);
 
-      // Restore chip grouping settings (v3.16.00+)
-      if (Array.isArray(settingsObj.chipCustomGroups)) {
-        saveDataSync('chipCustomGroups', settingsObj.chipCustomGroups);
-      }
-      if (Array.isArray(settingsObj.chipBlacklist)) {
-        saveDataSync('chipBlacklist', settingsObj.chipBlacklist);
-      }
-      if (settingsObj.chipMinCount != null) {
-        localStorage.setItem('chipMinCount', settingsObj.chipMinCount);
-      }
-      if (settingsObj.chipMaxCount != null) {
-        localStorage.setItem('chipMaxCount', settingsObj.chipMaxCount);
-      }
-      if (settingsObj.featureFlags != null) {
-        localStorage.setItem(FEATURE_FLAGS_KEY, settingsObj.featureFlags);
-      }
-      // Restore inline chip config (v3.17.00+)
-      if (settingsObj.inlineChipConfig != null) {
-        localStorage.setItem('inlineChipConfig', settingsObj.inlineChipConfig);
-      }
-      // Restore Goldback denomination pricing (STACK-45)
-      if (settingsObj.goldbackPrices != null) {
-        saveDataSync(GOLDBACK_PRICES_KEY, settingsObj.goldbackPrices);
-        goldbackPrices = settingsObj.goldbackPrices;
-      }
-      if (settingsObj.goldbackPriceHistory != null) {
-        saveDataSync(GOLDBACK_PRICE_HISTORY_KEY, settingsObj.goldbackPriceHistory);
-        goldbackPriceHistory = settingsObj.goldbackPriceHistory;
-      }
-      if (settingsObj.goldbackEnabled != null) {
-        saveDataSync(GOLDBACK_ENABLED_KEY, settingsObj.goldbackEnabled === true);
-        goldbackEnabled = settingsObj.goldbackEnabled === true;
-      }
-      if (settingsObj.goldbackEstimateEnabled != null) {
-        saveDataSync(GOLDBACK_ESTIMATE_ENABLED_KEY, settingsObj.goldbackEstimateEnabled === true);
-        goldbackEstimateEnabled = settingsObj.goldbackEstimateEnabled === true;
-      }
+      // Map ZIP field names → localStorage keys used by SYNC_SCOPE_KEYS
+      if (settingsObj.theme) remoteSettings['appTheme'] = settingsObj.theme;
+      if (settingsObj.itemsPerPage != null) remoteSettings['settingsItemsPerPage'] = settingsObj.itemsPerPage;
+      if (settingsObj.sortColumn != null) remoteSettings['defaultSortColumn'] = settingsObj.sortColumn;
+      if (settingsObj.sortDirection != null) remoteSettings['defaultSortDir'] = settingsObj.sortDirection;
+      if (settingsObj.tableImageSides != null) remoteSettings['tableImageSides'] = settingsObj.tableImageSides;
+      if (settingsObj.tableImagesEnabled != null) remoteSettings['tableImagesEnabled'] = settingsObj.tableImagesEnabled;
+      if (Array.isArray(settingsObj.chipCustomGroups)) remoteSettings['chipCustomGroups'] = settingsObj.chipCustomGroups;
+      if (Array.isArray(settingsObj.chipBlacklist)) remoteSettings['chipBlacklist'] = settingsObj.chipBlacklist;
+      if (settingsObj.chipMinCount != null) remoteSettings['chipMinCount'] = settingsObj.chipMinCount;
+      if (settingsObj.chipMaxCount != null) remoteSettings['chipMaxCount'] = settingsObj.chipMaxCount;
+      if (settingsObj.featureFlags != null) remoteSettings[FEATURE_FLAGS_KEY] = settingsObj.featureFlags;
+      if (settingsObj.inlineChipConfig != null) remoteSettings['inlineChipConfig'] = settingsObj.inlineChipConfig;
+      // Goldback keys use localStorage key names directly
+      if (settingsObj.goldbackEnabled != null) remoteSettings[GOLDBACK_ENABLED_KEY] = settingsObj.goldbackEnabled === true;
+      if (settingsObj.goldbackEstimateEnabled != null) remoteSettings[GOLDBACK_ESTIMATE_ENABLED_KEY] = settingsObj.goldbackEstimateEnabled === true;
       if (settingsObj.goldbackEstimateModifier != null) {
         const mod = parseFloat(settingsObj.goldbackEstimateModifier);
-        if (!isNaN(mod) && mod > 0) {
-          saveDataSync(GB_ESTIMATE_MODIFIER_KEY, mod);
-          goldbackEstimateModifier = mod;
-        }
+        if (!isNaN(mod) && mod > 0) remoteSettings[GB_ESTIMATE_MODIFIER_KEY] = mod;
       }
-      // Restore display settings (backed up but previously not restored)
-      if (settingsObj.itemsPerPage != null) {
-        const ippRestore = settingsObj.itemsPerPage;
-        localStorage.setItem(ITEMS_PER_PAGE_KEY, String(ippRestore));
-        itemsPerPage = ippRestore === 'all' || ippRestore === Infinity ? Infinity : Number(ippRestore);
-      }
-      if (settingsObj.sortColumn != null) {
-        sortColumn = settingsObj.sortColumn;
-      }
-      if (settingsObj.sortDirection != null) {
-        sortDirection = settingsObj.sortDirection;
-      }
-      if (settingsObj.tableImageSides != null) {
-        localStorage.setItem('tableImageSides', settingsObj.tableImageSides);
-      }
-      if (settingsObj.tableImagesEnabled != null) {
-        localStorage.setItem('tableImagesEnabled', String(settingsObj.tableImagesEnabled));
-      }
+      if (settingsObj.goldbackPrices != null) remoteSettings[GOLDBACK_PRICES_KEY] = settingsObj.goldbackPrices;
+      if (settingsObj.goldbackPriceHistory != null) remoteSettings[GOLDBACK_PRICE_HISTORY_KEY] = settingsObj.goldbackPriceHistory;
     }
 
-    const historyStr = await zip
-      .file("spot_price_history.json")
-      ?.async("string");
-    if (historyStr) {
-      const histObj = JSON.parse(historyStr);
-      localStorage.setItem(
-        SPOT_HISTORY_KEY,
-        JSON.stringify(histObj.history || []),
-      );
-    }
-
-    await loadInventory();
-    renderTable();
-    renderActiveFilters();
-    loadSpotHistory();
-
-    // Restore per-item price history with merge (STACK-43)
-    const itemHistoryStr = await zip.file("item_price_history.json")?.async("string");
-    if (itemHistoryStr) {
-      const itemHistObj = JSON.parse(itemHistoryStr);
-      if (typeof mergeItemPriceHistory === 'function') {
-        mergeItemPriceHistory(itemHistObj.history || {});
-      }
-    } else if (typeof loadItemPriceHistory === 'function') {
-      loadItemPriceHistory();
-    }
-
-    // Restore item tags (STAK-126)
+    // 1c. Parse item tags for pendingTagsByUuid
+    const pendingTagsByUuid = {};
     const itemTagsStr = await zip.file("item_tags.json")?.async("string");
-    let restoredTags = null;
     if (itemTagsStr) {
       try {
         const itemTagsObj = JSON.parse(itemTagsStr);
         if (itemTagsObj.tags && typeof itemTagsObj.tags === 'object' && !Array.isArray(itemTagsObj.tags)) {
-          restoredTags = itemTagsObj.tags;
+          for (const [uuid, tags] of Object.entries(itemTagsObj.tags)) {
+            if (Array.isArray(tags) && tags.length > 0) pendingTagsByUuid[uuid] = tags;
+          }
         }
       } catch (e) {
         debugWarn('restoreBackupZip: item_tags.json parse error', e);
       }
     }
-    itemTags = restoredTags || {};
-    if (typeof saveItemTags === 'function') saveItemTags();
 
-    // Restore retail market prices
+    // 1d. Pre-parse ancillary data (applied after user accepts DiffModal)
+    const ancillary = {};
+    const historyStr = await zip.file("spot_price_history.json")?.async("string");
+    if (historyStr) ancillary.spotHistory = JSON.parse(historyStr).history || [];
+
+    const itemHistoryStr = await zip.file("item_price_history.json")?.async("string");
+    if (itemHistoryStr) ancillary.itemPriceHistory = JSON.parse(itemHistoryStr).history || {};
+
     const retailPricesStr = await zip.file("retail_prices.json")?.async("string");
     if (retailPricesStr) {
-      try {
-        const retailPricesRestored = JSON.parse(retailPricesStr);
-        saveDataSync(RETAIL_PRICES_KEY, retailPricesRestored);
-        if (typeof loadRetailPrices === 'function') loadRetailPrices();
-      } catch (e) {
+      try { ancillary.retailPrices = JSON.parse(retailPricesStr); } catch (e) {
         debugWarn('restoreBackupZip: retail_prices.json parse error', e);
       }
     }
     const retailHistoryStr = await zip.file("retail_price_history.json")?.async("string");
     if (retailHistoryStr) {
       try {
-        const retailHistoryRestored = JSON.parse(retailHistoryStr);
-        if (!Array.isArray(retailHistoryRestored) && typeof retailHistoryRestored === 'object') {
-          saveDataSync(RETAIL_PRICE_HISTORY_KEY, retailHistoryRestored);
-          if (typeof loadRetailPriceHistory === 'function') loadRetailPriceHistory();
-        }
+        const rh = JSON.parse(retailHistoryStr);
+        if (!Array.isArray(rh) && typeof rh === 'object') ancillary.retailHistory = rh;
       } catch (e) {
         debugWarn('restoreBackupZip: retail_price_history.json parse error', e);
       }
     }
 
-    // Restore cached coin images (STACK-88)
-    if (window.imageCache?.isAvailable()) {
-      const imgFolder = zip.folder('images');
-      const imgEntries = [];
-      if (imgFolder) {
-        imgFolder.forEach((path, file) => { imgEntries.push({ path, file }); });
+    // ── Phase 2: Build settings diff via DiffEngine (STAK-457) ──
+
+    let settingsDiff = null;
+    if (Object.keys(remoteSettings).length > 0 &&
+        typeof DiffEngine !== 'undefined' && typeof DiffEngine.compareSettings === 'function') {
+      const settingsKeys = Object.keys(remoteSettings);
+      const localSettings = {};
+      for (const key of settingsKeys) {
+        const val = loadDataSync(key, null);
+        if (val !== null) localSettings[key] = val;
+      }
+      settingsDiff = DiffEngine.compareSettings(localSettings, remoteSettings);
+      if (settingsDiff.changed.length === 0) settingsDiff = null;
+    }
+
+    // ── Phase 3: Ancillary data applicator (runs after user accepts DiffModal) ──
+
+    const applyAncillaryData = async () => {
+      // Spot prices from ZIP settings (not in SYNC_SCOPE_KEYS, applied directly)
+      if (settingsObj && settingsObj.spotPrices) {
+        Object.entries(settingsObj.spotPrices).forEach(([metal, price]) => {
+          const metalConfig = METALS[metal.toUpperCase()];
+          if (metalConfig) saveDataSync(metalConfig.localStorageKey, price);
+        });
       }
 
-      if (imgEntries.length > 0) {
-        // Legacy coinImages from old backups are skipped — no longer importing to dead store
-        debugLog('ZIP restore: skipping legacy coinImages folder (store deprecated)');
+      // Catalog mappings
+      if (settingsObj && settingsObj.catalogMappings) {
+        catalogManager.importMappings(settingsObj.catalogMappings, false);
       }
 
-      // Restore metadata
-      const metaStr = await zip.file('image_metadata.json')?.async('string');
-      if (metaStr) {
-        const metaObj = JSON.parse(metaStr);
-        if (Array.isArray(metaObj.metadata)) {
-          for (const rec of metaObj.metadata) {
-            await imageCache.importMetadataRecord(rec);
-          }
+      // Spot price history
+      if (ancillary.spotHistory) {
+        saveDataSync(SPOT_HISTORY_KEY, ancillary.spotHistory);
+        loadSpotHistory();
+      }
+
+      // Per-item price history (merge, not overwrite)
+      if (ancillary.itemPriceHistory && typeof mergeItemPriceHistory === 'function') {
+        mergeItemPriceHistory(ancillary.itemPriceHistory);
+      } else if (typeof loadItemPriceHistory === 'function') {
+        loadItemPriceHistory();
+      }
+
+      // Item tags not handled by pendingTagsByUuid (items that weren't in the diff)
+      if (Object.keys(pendingTagsByUuid).length > 0 && typeof addItemTag === 'function') {
+        for (const [uuid, tags] of Object.entries(pendingTagsByUuid)) {
+          for (const tag of tags) addItemTag(uuid, tag);
         }
       }
 
-      // Restore user-uploaded photos (STAK-225 / STAK-226)
-      const userImgFolder = zip.folder('user_images');
-      if (userImgFolder) {
-        // STAK-226: use manifest when present for reliable UUID→file mapping
-        const manifestFile = zip.file('user_image_manifest.json');
-        if (manifestFile) {
-          const manifestData = JSON.parse(await manifestFile.async('string'));
-          for (const entry of (manifestData.entries || [])) {
-            const obverseFile = entry.obverseFile ? zip.file(entry.obverseFile) : null;
-            const reverseFile = entry.reverseFile ? zip.file(entry.reverseFile) : null;
-            const obverse = obverseFile ? await obverseFile.async('blob') : null;
-            const reverse = reverseFile ? await reverseFile.async('blob') : null;
-            await imageCache.importUserImageRecord({
-              uuid: entry.uuid,
-              obverse,
-              reverse,
-              cachedAt: entry.cachedAt || Date.now(),
-              size: entry.size || (obverse?.size || 0) + (reverse?.size || 0),
-            });
+      // Retail prices
+      if (ancillary.retailPrices) {
+        saveDataSync(RETAIL_PRICES_KEY, ancillary.retailPrices);
+        if (typeof loadRetailPrices === 'function') loadRetailPrices();
+      }
+      if (ancillary.retailHistory) {
+        saveDataSync(RETAIL_PRICE_HISTORY_KEY, ancillary.retailHistory);
+        if (typeof loadRetailPriceHistory === 'function') loadRetailPriceHistory();
+      }
+
+      // Restore cached coin images (STACK-88)
+      if (window.imageCache?.isAvailable()) {
+        const imgFolder = zip.folder('images');
+        const imgEntries = [];
+        if (imgFolder) {
+          imgFolder.forEach((path, zipFile) => { imgEntries.push({ path, file: zipFile }); });
+        }
+        if (imgEntries.length > 0) {
+          debugLog('ZIP restore: skipping legacy coinImages folder (store deprecated)');
+        }
+
+        // Restore metadata
+        const metaStr = await zip.file('image_metadata.json')?.async('string');
+        if (metaStr) {
+          const metaObj = JSON.parse(metaStr);
+          if (Array.isArray(metaObj.metadata)) {
+            for (const rec of metaObj.metadata) {
+              await imageCache.importMetadataRecord(rec);
+            }
           }
-        } else {
-          // Fallback: filename parsing for ZIPs created before STAK-226
-          const userEntries = [];
-          userImgFolder.forEach((path, file) => userEntries.push({ path, file }));
-          const userImageMap = new Map();
-          for (const { path, file } of userEntries) {
+        }
+
+        // Restore user-uploaded photos (STAK-225 / STAK-226)
+        const userImgFolder = zip.folder('user_images');
+        if (userImgFolder) {
+          const manifestFile = zip.file('user_image_manifest.json');
+          if (manifestFile) {
+            const manifestData = JSON.parse(await manifestFile.async('string'));
+            for (const entry of (manifestData.entries || [])) {
+              const obverseFile = entry.obverseFile ? zip.file(entry.obverseFile) : null;
+              const reverseFile = entry.reverseFile ? zip.file(entry.reverseFile) : null;
+              const obverse = obverseFile ? await obverseFile.async('blob') : null;
+              const reverse = reverseFile ? await reverseFile.async('blob') : null;
+              await imageCache.importUserImageRecord({
+                uuid: entry.uuid,
+                obverse,
+                reverse,
+                cachedAt: entry.cachedAt || Date.now(),
+                size: entry.size || (obverse?.size || 0) + (reverse?.size || 0),
+              });
+            }
+          } else {
+            const userEntries = [];
+            userImgFolder.forEach((path, zipFile) => userEntries.push({ path, file: zipFile }));
+            const userImageMap = new Map();
+            for (const { path, file: zipFile } of userEntries) {
+              const m = path.match(/^(.+)_(obverse|reverse)\.jpg$/);
+              if (!m) continue;
+              if (!userImageMap.has(m[1])) userImageMap.set(m[1], {});
+              userImageMap.get(m[1])[m[2]] = await zipFile.async('blob');
+            }
+            for (const [uuid, sides] of userImageMap) {
+              await imageCache.importUserImageRecord({
+                uuid,
+                obverse: sides.obverse || null,
+                reverse: sides.reverse || null,
+                cachedAt: Date.now(),
+                size: (sides.obverse?.size || 0) + (sides.reverse?.size || 0),
+              });
+            }
+          }
+        }
+
+        // Restore custom pattern rule images (STAK-225)
+        const patternImgFolder = zip.folder('pattern_images');
+        if (patternImgFolder) {
+          const patternEntries = [];
+          patternImgFolder.forEach((path, zipFile) => patternEntries.push({ path, file: zipFile }));
+          const patternImageMap = new Map();
+          for (const { path, file: zipFile } of patternEntries) {
             const m = path.match(/^(.+)_(obverse|reverse)\.jpg$/);
             if (!m) continue;
-            if (!userImageMap.has(m[1])) userImageMap.set(m[1], {});
-            userImageMap.get(m[1])[m[2]] = await file.async('blob');
+            if (!patternImageMap.has(m[1])) patternImageMap.set(m[1], {});
+            patternImageMap.get(m[1])[m[2]] = await zipFile.async('blob');
           }
-          for (const [uuid, sides] of userImageMap) {
-            await imageCache.importUserImageRecord({
-              uuid,
+          for (const [ruleId, sides] of patternImageMap) {
+            await imageCache.importPatternImageRecord({
+              ruleId,
               obverse: sides.obverse || null,
               reverse: sides.reverse || null,
               cachedAt: Date.now(),
@@ -590,33 +591,25 @@ const restoreBackupZip = async (file) => {
         }
       }
 
-      // Restore custom pattern rule images (STAK-225)
-      const patternImgFolder = zip.folder('pattern_images');
-      if (patternImgFolder) {
-        const patternEntries = [];
-        patternImgFolder.forEach((path, file) => patternEntries.push({ path, file }));
-        const patternImageMap = new Map();
-        for (const { path, file } of patternEntries) {
-          const m = path.match(/^(.+)_(obverse|reverse)\.jpg$/);
-          if (!m) continue;
-          if (!patternImageMap.has(m[1])) patternImageMap.set(m[1], {});
-          patternImageMap.get(m[1])[m[2]] = await file.async('blob');
-        }
-        for (const [ruleId, sides] of patternImageMap) {
-          await imageCache.importPatternImageRecord({
-            ruleId,
-            obverse: sides.obverse || null,
-            reverse: sides.reverse || null,
-            cachedAt: Date.now(),
-            size: (sides.obverse?.size || 0) + (sides.reverse?.size || 0),
-          });
-        }
-      }
-    }
+      fetchSpotPrice();
+    };
 
-    fetchSpotPrice();
-    await appAlert("Data imported successfully. The page will now reload.");
-    location.reload();
+    // ── Phase 4: Route through DiffModal (STAK-457) ──
+
+    showImportDiffReview(parsedItems, { type: 'zip', label: file.name }, {
+      settingsDiff: settingsDiff,
+      pendingTagsByUuid: pendingTagsByUuid,
+      exportMeta: settingsObj ? {
+        exportOrigin: settingsObj.exportOrigin || null,
+        appVersion: settingsObj.version || null,
+        exportTimestamp: settingsObj.exportDate || null
+      } : null,
+    }, async function(summary) {
+      debugLog('restoreBackupZip DiffModal complete', summary.added, 'added', summary.modified, 'modified', summary.deleted, 'deleted');
+      await applyAncillaryData();
+      showToast('ZIP backup restored successfully');
+    });
+
   } catch (err) {
     console.error("Restore failed", err);
     appAlert("Restore failed: " + err.message);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.60-b1772961886';
+const CACHE_NAME = 'staktrakr-v3.33.60-b1772961966';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.59-b1772949141';
+const CACHE_NAME = 'staktrakr-v3.33.60-b1772959654';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.60-b1772959654';
+const CACHE_NAME = 'staktrakr-v3.33.60-b1772961886';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.59",
-  "releaseDate": "2026-03-07",
+  "version": "3.33.60",
+  "releaseDate": "2026-03-08",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -17,7 +17,7 @@ relatedPages:
 # Backup & Restore
 
 > **Last updated:** v3.33.60 — 2026-03-08
-> **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`, `js/vault.js`
+> **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/inventory.js`, `js/utils.js`, `js/vault.js`
 
 ## Overview
 

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -280,22 +280,22 @@ The backup/export panel shows a `<small class="format-desc">` beneath each optio
 
 **Phase 2 — Build settings diff:**
 
-6. Build `remoteSettings` flat map from ZIP settings using `SYNC_SCOPE_KEYS`-compatible keys
-7. Compare against current localStorage values via `DiffEngine.compareSettings()`
-8. Spot prices (per-metal keys not in `SYNC_SCOPE_KEYS`) are applied directly in the ancillary step
+1. Build `remoteSettings` flat map from ZIP settings using `SYNC_SCOPE_KEYS`-compatible keys
+2. Compare against current localStorage values via `DiffEngine.compareSettings()`
+3. Spot prices (per-metal keys not in `SYNC_SCOPE_KEYS`) are applied directly in the ancillary step
 
 **Phase 3 — DiffModal review:**
 
-9. Call `showImportDiffReview()` with parsed items, settings diff, and pending tags
-10. DiffModal shows item-level and settings-level diffs for user review
-11. User selects which changes to apply via the standard DiffModal UI
+1. Call `showImportDiffReview()` with parsed items, settings diff, and pending tags
+2. DiffModal shows item-level and settings-level diffs for user review
+3. User selects which changes to apply via the standard DiffModal UI
 
 **Phase 4 — Apply (on user accept):**
 
-12. `showImportDiffReview` applies selected item and settings changes
-13. `onComplete` callback applies ancillary data: spot prices, catalog mappings, spot history, item price history (merged via `mergeItemPriceHistory`), item tags, retail prices/history
-14. Restore IDB stores: `userImages` from `user_images/` using `user_image_manifest.json` (falls back to filename parsing for old ZIPs pre-STAK-226), `patternImages` from `pattern_images/`, `coinMetadata` from `image_metadata.json`
-15. Explicitly skip `coinImages/` folder (logs: `"skipping legacy coinImages folder (store deprecated)"`)
+1. `showImportDiffReview` applies selected item and settings changes
+2. `onComplete` callback applies ancillary data: spot prices, catalog mappings, spot history, item price history (merged via `mergeItemPriceHistory`), retail prices/history
+3. Restore IDB stores: `userImages` from `user_images/` using `user_image_manifest.json` (falls back to filename parsing for old ZIPs pre-STAK-226), `patternImages` from `pattern_images/`, `coinMetadata` from `image_metadata.json`
+4. Explicitly skip `coinImages/` folder (logs: `"skipping legacy coinImages folder (store deprecated)"`)
 
 **Fallback:** If `DiffEngine` or `DiffModal` are unavailable, `showImportDiffReview` falls back to a concat-all merge (same fallback path as JSON/CSV imports).
 

--- a/wiki/backup-restore.md
+++ b/wiki/backup-restore.md
@@ -2,11 +2,12 @@
 title: Backup & Restore
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.59
-date: 2026-03-07
+lastUpdated: v3.33.60
+date: 2026-03-08
 sourceFiles:
   - js/cloud-storage.js
   - js/cloud-sync.js
+  - js/inventory.js
   - js/utils.js
   - js/vault.js
 relatedPages:
@@ -15,7 +16,7 @@ relatedPages:
 ---
 # Backup & Restore
 
-> **Last updated:** v3.33.58 — 2026-03-07
+> **Last updated:** v3.33.60 — 2026-03-08
 > **Source files:** `js/cloud-storage.js`, `js/cloud-sync.js`, `js/utils.js`, `js/vault.js`
 
 ## Overview
@@ -267,15 +268,36 @@ The backup/export panel shows a `<small class="format-desc">` beneath each optio
 
 ### ZIP Restore (`restoreBackupZip`)
 
-> **Destructive restore:** ZIP restore replaces all data — all localStorage keys are overwritten with backup values, and all IDB image stores (`userImages`, `patternImages`, `coinMetadata`) are replaced. There is no merge option. If cloud sync is active when you initiate a ZIP restore, the restore will be blocked until sync completes (STAK-427).
+> **DiffModal-routed restore (STAK-457, v3.33.60):** ZIP restore now routes through DiffModal for item and settings review, matching the behavior of JSON import, CSV import, and vault restore. If cloud sync is active when you initiate a ZIP restore, the restore will be blocked until sync completes (STAK-427).
 
-1. Unzip all files
-2. Restore localStorage keys from `inventory_data.json`, `settings.json`, `spot_price_history.json`, etc.
-3. Restore `userImages` IDB from `user_images/` using `user_image_manifest.json`; falls back to filename parsing for old ZIPs pre-STAK-226
-4. Restore `patternImages` IDB from `pattern_images/`
-5. Restore `coinMetadata` IDB from `image_metadata.json`
-6. Explicitly skip `coinImages/` folder (logs: `"skipping legacy coinImages folder (store deprecated)"`)
-7. Post-restore sequence: `loadInventory()` → `renderTable()` → `renderActiveFilters()` → `loadSpotHistory()`
+**Phase 1 — Parse (no writes):**
+
+1. Unzip all files and parse contents into memory without writing to localStorage or IDB
+2. Parse inventory items from `inventory_data.json`
+3. Parse settings from `settings.json` and map ZIP field names to localStorage keys (e.g., `theme` → `appTheme`, `itemsPerPage` → `settingsItemsPerPage`)
+4. Parse item tags from `item_tags.json` into `pendingTagsByUuid` map
+5. Pre-parse ancillary data: spot history, item price history, retail prices, retail history
+
+**Phase 2 — Build settings diff:**
+
+6. Build `remoteSettings` flat map from ZIP settings using `SYNC_SCOPE_KEYS`-compatible keys
+7. Compare against current localStorage values via `DiffEngine.compareSettings()`
+8. Spot prices (per-metal keys not in `SYNC_SCOPE_KEYS`) are applied directly in the ancillary step
+
+**Phase 3 — DiffModal review:**
+
+9. Call `showImportDiffReview()` with parsed items, settings diff, and pending tags
+10. DiffModal shows item-level and settings-level diffs for user review
+11. User selects which changes to apply via the standard DiffModal UI
+
+**Phase 4 — Apply (on user accept):**
+
+12. `showImportDiffReview` applies selected item and settings changes
+13. `onComplete` callback applies ancillary data: spot prices, catalog mappings, spot history, item price history (merged via `mergeItemPriceHistory`), item tags, retail prices/history
+14. Restore IDB stores: `userImages` from `user_images/` using `user_image_manifest.json` (falls back to filename parsing for old ZIPs pre-STAK-226), `patternImages` from `pattern_images/`, `coinMetadata` from `image_metadata.json`
+15. Explicitly skip `coinImages/` folder (logs: `"skipping legacy coinImages folder (store deprecated)"`)
+
+**Fallback:** If `DiffEngine` or `DiffModal` are unavailable, `showImportDiffReview` falls back to a concat-all merge (same fallback path as JSON/CSV imports).
 
 ### Vault Restore (`vaultDecryptAndRestore`)
 
@@ -401,12 +423,12 @@ The backup count badge on the restore button shows the count of **manual backups
 
 ### Merge strategy during import
 
-All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
+All JSON/CSV/vault/ZIP imports use a **merge strategy** (not replace-all):
 
 - Items in the import are merged into the existing inventory using `DiffEngine`
 - DiffModal shows added / modified / removed diffs; user selects which to apply
 - The apply callback calls `saveData` with the merged result
-- Post-apply summary banner shows final counts
+- Post-apply toast shows final counts
 
 ---
 
@@ -455,8 +477,10 @@ All JSON/CSV/vault imports use a **merge strategy** (not replace-all):
 
 1. Settings → "Backup All Data" produces the ZIP
 2. Settings → Restore → select the `.zip` file → `restoreBackupZip(file)`
-3. Restores: localStorage keys + `userImages` + `patternImages` + `coinMetadata`
-4. Verify inventory loads and photos appear
+3. DiffModal opens showing item and settings diffs for review (STAK-457, v3.33.60)
+4. User selects which changes to apply; ancillary data (spot history, images, retail) applied automatically on accept
+5. Restores: selected inventory items + settings via DiffModal, plus `userImages` + `patternImages` + `coinMetadata` IDB stores
+6. Verify inventory loads and photos appear
 
 ### Scenario B: Full restore from vault + image vault
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: ZIP backup restore (`restoreBackupZip`) now parses all data without writing to localStorage, builds a settings diff via `DiffEngine.compareSettings`, and routes through `showImportDiffReview` for user review before applying changes (STAK-457)
- Ancillary data (spot history, images, retail prices, tags, catalog mappings) applied in `onComplete` callback after user accepts
- ZIP settings mapped to SYNC_SCOPE_KEYS-compatible localStorage keys for proper DiffEngine comparison
- Wiki `backup-restore.md` updated to reflect new DiffModal-routed flow; added `js/inventory.js` to sourceFiles

## Linear Issues

- [STAK-457: ZIP backup restore bypasses DiffModal — direct overwrite](https://linear.app/lbruton/issue/STAK-457)

🤖 Generated with [Claude Code](https://claude.com/claude-code)