### PR TITLE
Update nightwatch log with retail-modal.md inaccuracy

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 6,
+  "nextIndex": 7,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -35,6 +35,14 @@
       "track": "frontend",
       "status": "inaccuracy_found",
       "finding": "Claims 'TTL is 30 minutes per claim' but devops/version-lock-protocol.md defines three tiers: Hotfix = 30min, Spec implementation = 4h, Pre-assigned queued slot = 4h.",
+      "verified": []
+    },
+    {
+      "date": "2026-03-08",
+      "page": "retail-modal.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "Wiki claims OOS vendors render with opacity, <del>, and tooltips, but _buildVendorLegend in js/retail-view-modal.js explicitly skips vendors if price is null and lacks any OOS UI rendering code.",
       "verified": []
     }
   ]


### PR DESCRIPTION
Updated wiki/.nightwatch-log.json with the inaccurary found on retail-modal.md and incremented nextIndex.

---
*PR created automatically by Jules for task [2574257687701172611](https://jules.google.com/task/2574257687701172611) started by @lbruton*