### PR TITLE
chore: GSD session 2026-03-09

### DIFF
--- a/.claude/skills/sync-poller/SKILL.md
+++ b/.claude/skills/sync-poller/SKILL.md
@@ -1,25 +1,40 @@
 ---
 name: sync-poller
 description: >
-  Deploy poller code changes to the home VM via Portainer API. Use when you've committed changes
-  to devops/pollers/ (shared/, home-poller/, or compose files) and need to redeploy the running
-  container. Also use when the user says "sync poller", "deploy poller", "redeploy home poller",
-  "push poller changes", or after any session that modified files in devops/pollers/.
+  Deploy poller code changes to the Portainer VM. Portainer GitOps auto-deploys within 5 minutes
+  of any push to the tracked branch. Use this skill for immediate manual deploys when you can't
+  wait, or when the user says "sync poller", "deploy poller", "redeploy home poller".
 ---
 
-# Sync Poller — Git to Docker via Portainer
+# Sync Poller -- Git to Docker via Portainer
 
-Poller code lives in `StakTrakr/devops/pollers/`. Changes deploy to the home VM via Portainer's
-git-based stack redeploy. No SSH file copying, no curl-update — Portainer pulls from the branch
-and rebuilds the container.
+Poller code lives in `StakTrakr/devops/pollers/`. Portainer has **GitOps enabled with a 5-minute
+polling interval** on all stacks. Push to the tracked branch and it auto-deploys. No SSH file
+copying, no curl-update.
 
-## Architecture Change (2026-03)
+## Deployment Model
 
-**Before:** Code lived in `StakTrakrApi`, was curl-downloaded onto the VM at `/opt/poller/`.
-Edits on the VM required manual sync back to the repo.
+**Primary (GitOps auto-deploy):** Commit, push to the tracked branch (usually `dev`). Portainer
+polls every 5 minutes, detects the change, pulls, rebuilds the image, and restarts the container.
+No manual action needed.
 
-**Now:** Code lives in `StakTrakr/devops/pollers/`. Portainer pulls from git, builds the Docker
-image, and deploys. The VM has no source files outside containers.
+**Manual (immediate deploy):** Use the Portainer API to trigger an immediate redeploy when you
+can't wait 5 minutes. See "Manual Redeploy" section below.
+
+## SSH Host
+
+The Portainer VM SSH host is `portainer` (LAN) or `portainer-ts` (Tailscale). User: `portainer`.
+
+```bash
+# Container status
+ssh -T portainer 'docker ps --filter network=staktrakr-net --format "table {{.Names}}\t{{.Status}}"'
+
+# Container logs
+ssh -T portainer 'docker logs --tail 30 staktrakr-home-poller'
+
+# Dashboard check
+ssh -T portainer 'curl -sf http://localhost:3010/ | head -c 100'
+```
 
 ## File Layout
 
@@ -50,7 +65,7 @@ devops/pollers/
     check-flyio.sh
     supervisord.conf
     docker-entrypoint.sh
-  remote-poller/           # Fly.io container (future)
+  remote-poller/           # Fly.io container
     Dockerfile
     fly.toml
     ...
@@ -59,23 +74,17 @@ devops/pollers/
   docker-compose.tinyproxy.yml
 ```
 
-## Deploy Workflow
+## Deploy Workflow (GitOps -- default)
 
-### Step 1 — Commit and push changes
+1. Work in a worktree branch, commit changes
+2. Push to origin (or merge PR to `dev`)
+3. Portainer detects the change within 5 minutes and redeploys
+4. Verify via SSH: `ssh -T portainer 'docker logs --tail 20 staktrakr-home-poller'`
 
-Work in the feature branch or `dev`. Push to origin:
+## Manual Redeploy (immediate)
 
-```bash
-cd /Volumes/DATA/GitHub/StakTrakr/.worktrees/feat-pollers  # or current worktree
-git add devops/pollers/
-git commit -m "fix: <description> (DEV-XX)"
-git push origin <branch>
-```
-
-### Step 2 — Redeploy via Portainer API
-
-The home-poller stack requires env vars on every redeploy. Fetch secrets from Infisical first
-(use `secrets` skill), then:
+Only needed when you can't wait for the 5-minute GitOps poll. The home-poller stack requires
+env vars on every manual redeploy. Fetch secrets from Infisical first (use `secrets` skill):
 
 ```bash
 PORTAINER_URL="https://192.168.1.81:9443"
@@ -83,7 +92,7 @@ PORTAINER_TOKEN="<from-infisical:PORTAINER_TOKEN>"
 STACK_ID=7
 ENDPOINT_ID=3
 
-ssh -T homepoller "curl -sk -X PUT \
+ssh -T portainer "curl -sk -X PUT \
   '${PORTAINER_URL}/api/stacks/${STACK_ID}/git/redeploy?endpointId=${ENDPOINT_ID}' \
   -H 'X-API-Key: ${PORTAINER_TOKEN}' \
   -H 'Content-Type: application/json' \
@@ -105,39 +114,12 @@ ssh -T homepoller "curl -sk -X PUT \
 For stacks without env vars (tailscale, tinyproxy):
 
 ```bash
-ssh -T homepoller "curl -sk -X PUT \
+ssh -T portainer "curl -sk -X PUT \
   '${PORTAINER_URL}/api/stacks/<STACK_ID>/git/redeploy?endpointId=${ENDPOINT_ID}' \
   -H 'X-API-Key: ${PORTAINER_TOKEN}' \
   -H 'Content-Type: application/json' \
   -d '{\"pullImage\": true, \"prune\": true}'"
 ```
-
-### Step 3 — Verify deployment
-
-```bash
-# Check container is running
-ssh -T homepoller 'docker ps --filter name=staktrakr-home-poller --format "{{.Status}}"'
-
-# Check logs for startup
-ssh -T homepoller 'docker logs --tail 20 staktrakr-home-poller'
-
-# Verify dashboard responds
-ssh -T homepoller 'curl -sf http://localhost:3010/ | head -c 100'
-
-# Check Turso connectivity
-ssh -T homepoller 'docker exec staktrakr-home-poller node -e "
-  const {createClient}=require(\"@libsql/client\");
-  const c=createClient({url:process.env.TURSO_DATABASE_URL,authToken:process.env.TURSO_AUTH_TOKEN});
-  c.execute(\"SELECT 1\").then(()=>console.log(\"Turso OK\")).catch(e=>console.error(e.message));
-"'
-```
-
-### Step 4 — Report
-
-Tell the user:
-- Which files changed
-- Redeploy result (success/failure)
-- Container status and dashboard reachable
 
 ## Stack IDs
 
@@ -150,8 +132,9 @@ Tell the user:
 
 ## Common Mistakes
 
-**Forgetting env vars on redeploy.** Portainer git-based stacks lose env vars on redeploy. If
-Turso queries fail after deploy, this is the cause. Always pass the full `env` array.
+**Forgetting env vars on manual redeploy.** Portainer git-based stacks lose env vars on manual
+redeploy. GitOps auto-deploy preserves them. If Turso queries fail after a manual deploy, this
+is the cause. Always pass the full `env` array for manual deploys.
 
 **Deploying from wrong branch.** Portainer pulls from the branch configured in the stack. After
 merging a feature PR, the stack should be pointed at `dev`. Check the Portainer UI if in doubt.

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -150,6 +150,24 @@ function getUptime() {
   }
 }
 
+const LOCK_FILES = [
+  { name: "Retail Poller", path: "/tmp/retail-poller.lock" },
+];
+
+function getLockStatus() {
+  return LOCK_FILES.map(({ name, path }) => {
+    if (!existsSync(path)) return { name, path, locked: false, age: null };
+    try {
+      const stat = execSync(`stat -c %Y "${path}" 2>/dev/null || stat -f %m "${path}"`, { timeout: 2000 }).toString().trim();
+      const mtime = parseInt(stat, 10);
+      const ageSec = Math.floor(Date.now() / 1000) - mtime;
+      return { name, path, locked: true, age: ageSec };
+    } catch {
+      return { name, path, locked: true, age: null };
+    }
+  });
+}
+
 function getSupervisordStatus() {
   try {
     const out = execSync("supervisorctl status 2>/dev/null", { timeout: 3000 }).toString();
@@ -684,7 +702,7 @@ function renderFailureTrendChart(trend) {
 }
 
 function renderMainPage(data) {
-  const { net, cpu, uptime, supervisord, systemd, logLines, tursoRuns, tursoError, tursoUp, flyioHealth, runStats, failureCount, coverageStats, spotCoverage, failureTrend, flyRuns, dockerContainers } = data;
+  const { net, cpu, uptime, supervisord, systemd, logLines, tursoRuns, tursoError, tursoUp, flyioHealth, runStats, failureCount, coverageStats, spotCoverage, failureTrend, flyRuns, dockerContainers, lockStatus } = data;
 
   const supRows = supervisord.map((s) => `
     <tr>
@@ -795,6 +813,33 @@ ${renderNav("home", failureCount)}
   <div class="card">
     <h2>Docker Containers</h2>
     <table><tbody>${dockerRows || '<tr><td colspan="3" class="no-data">Docker socket not available</td></tr>'}</tbody></table>
+  </div>
+
+  <div class="card${(lockStatus || []).some(l => l.locked) ? ' card-stale' : ''}">
+    <h2>Poller Locks</h2>
+    ${(lockStatus || []).map(l => {
+      const ageStr = l.age != null ? (l.age >= 3600 ? Math.floor(l.age / 3600) + 'h ' + Math.floor((l.age % 3600) / 60) + 'm' : l.age >= 60 ? Math.floor(l.age / 60) + 'm ' + (l.age % 60) + 's' : l.age + 's') : '?';
+      const stale = l.age != null && l.age > 900;
+      if (l.locked) {
+        return `<div class="stat-row">
+          <span>${escHtml(l.name)}</span>
+          <span>
+            <span class="badge" style="background:${stale ? '#ef4444' : '#f59e0b'}">${stale ? 'STALE' : 'LOCKED'}</span>
+            <span class="detail" style="margin-left:6px">${ageStr} ago</span>
+          </span>
+        </div>
+        <div style="margin-top:8px">
+          <button class="btn-clear-lock" data-path="${escHtml(l.path)}" data-name="${escHtml(l.name)}"
+            style="background:#7f1d1d;color:#fca5a5;padding:5px 12px;border-radius:6px;border:1px solid #991b1b;cursor:pointer;font-size:12px;font-weight:600;width:100%">
+            Clear Lock
+          </button>
+        </div>`;
+      }
+      return `<div class="stat-row">
+        <span>${escHtml(l.name)}</span>
+        <span><span class="badge" style="background:#22c55e">OK</span></span>
+      </div>`;
+    }).join("")}
   </div>
 
   ${renderFlyioCard(flyioHealth, flyRuns, tursoUp)}
@@ -920,6 +965,40 @@ document.querySelectorAll('.btn-browserbase').forEach(btn => {
     } finally {
       btn.disabled = false;
       btn.textContent = '\uD83C\uDF10 Browserbase';
+    }
+  });
+});
+
+// ── Clear lock button ────────────────────────────────────────────────────
+document.querySelectorAll('.btn-clear-lock').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    const lockPath = btn.dataset.path;
+    const lockName = btn.dataset.name;
+    if (!confirm('Clear the ' + lockName + ' lock file?\\n\\nThis will allow the next scheduled run to proceed.')) return;
+    btn.disabled = true;
+    btn.textContent = 'Clearing...';
+    try {
+      const r = await fetch('/api/clear-lock', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({ path: lockPath })
+      });
+      const j = await r.json();
+      if (j.ok) {
+        btn.textContent = 'Cleared!';
+        btn.style.background = '#14532d';
+        btn.style.color = '#86efac';
+        btn.style.borderColor = '#166534';
+        setTimeout(() => location.reload(), 1500);
+      } else {
+        alert('Failed: ' + (j.message || 'Unknown error'));
+        btn.disabled = false;
+        btn.textContent = 'Clear Lock';
+      }
+    } catch (err) {
+      alert('Request failed: ' + err.message);
+      btn.disabled = false;
+      btn.textContent = 'Clear Lock';
     }
   });
 });
@@ -2303,6 +2382,33 @@ async function handleRequest(req, res) {
     return;
   }
 
+  // ── POST /api/clear-lock — Remove a stale poller lock file ─────────────
+  if (req.method === "POST" && url === "/api/clear-lock") {
+    try {
+      const { path: lockPath } = JSON.parse(await readBody(req));
+      const allowed = LOCK_FILES.map(l => l.path);
+      if (!lockPath || !allowed.includes(lockPath)) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, message: "Invalid lock path" }));
+        return;
+      }
+      if (!existsSync(lockPath)) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, message: "Lock file does not exist (already cleared)" }));
+        return;
+      }
+      const { unlinkSync } = await import("node:fs");
+      unlinkSync(lockPath);
+      console.log(`[dashboard] Lock cleared: ${lockPath}`);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, message: `Cleared ${lockPath}` }));
+    } catch (err) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, message: err.message }));
+    }
+    return;
+  }
+
   // ── GET / (main dashboard) ─────────────────────────────────────────────
   if (req.method !== "GET" || (url !== "/" && url !== "/dashboard" && url !== "")) {
     res.writeHead(404);
@@ -2311,7 +2417,7 @@ async function handleRequest(req, res) {
   }
 
   const client = getTursoClient();
-  const [tursoResult, runStats, failureCount, net, cpu, uptime, supervisord, systemd, logLines, flyioHealth, coverageStats, spotCoverage, failureTrend, flyRuns, dockerContainers] = await Promise.all([
+  const [tursoResult, runStats, failureCount, net, cpu, uptime, supervisord, systemd, logLines, flyioHealth, coverageStats, spotCoverage, failureTrend, flyRuns, dockerContainers, lockStatus] = await Promise.all([
     fetchRunsFromTurso().then(rows => ({ rows, error: null })).catch(err => ({ rows: null, error: err.message })),
     client ? getRunStats(client).catch(() => null) : Promise.resolve(null),
     client ? getFailureCount(client) : Promise.resolve(0),
@@ -2327,6 +2433,7 @@ async function handleRequest(req, res) {
     client ? getFailureTrend(client).catch(() => []) : Promise.resolve([]),
     client ? fetchFlyioRuns(client).catch(() => null) : Promise.resolve(null),
     Promise.resolve(getDockerContainers()),
+    Promise.resolve(getLockStatus()),
   ]);
 
   const html = renderMainPage({
@@ -2341,6 +2448,7 @@ async function handleRequest(req, res) {
     failureTrend,
     flyRuns,
     dockerContainers,
+    lockStatus,
   });
 
   res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });


### PR DESCRIPTION
## GSD Session — Minor Fixes & Tweaks

### Changes
- Add "Poller Locks" status card to home poller dashboard with clear button for stale lock files
- Add `POST /api/clear-lock` endpoint with allowlist validation (prevents path traversal)
- Update `sync-poller` skill to reflect Portainer GitOps auto-deploy model (5-min polling)
- Fix SSH hostname from `homepoller` to `portainer` in skill docs

### Context
Home poller was stuck with "Previous run still active, skipping" due to a stale `/tmp/retail-poller.lock` left behind after a container restart. The clear button lets you fix this from the dashboard without SSH access.

Also discovered the Portainer stack was tracking a stale `feat/DEV-72-pollers-directory` branch (34 commits behind dev). User will fix the branch reference in Portainer UI.

### Notes
- No version bump — rolls into next patch release
- No Linear issue — casual fixes below spec threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)