### PR TITLE
chore: tinyproxy entrypoint waits for tailscale network

### DIFF
--- a/devops/pollers/tinyproxy/Dockerfile
+++ b/devops/pollers/tinyproxy/Dockerfile
@@ -1,9 +1,12 @@
 FROM alpine:3.20
 
-RUN apk add --no-cache tinyproxy
+RUN apk add --no-cache tinyproxy \
+    && mkdir -p /var/log/tinyproxy \
+    && chown tinyproxy:tinyproxy /var/log/tinyproxy
 
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY entrypoint.sh /entrypoint.sh
 
 EXPOSE 8888
 
-CMD ["tinyproxy", "-d"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/devops/pollers/tinyproxy/entrypoint.sh
+++ b/devops/pollers/tinyproxy/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# tinyproxy entrypoint — wait for shared network namespace from tailscale sidecar
+# network_mode: container:tailscale-staktrakr means we have no network if tailscale isn't up
+
+set -e
+
+# Ensure log directory exists (Alpine package may not create it)
+mkdir -p /var/log/tinyproxy
+chown tinyproxy:tinyproxy /var/log/tinyproxy
+
+# Wait for a routable (non-loopback) network interface
+# When sharing tailscale's network namespace, we need its interfaces to be up
+TIMEOUT=60
+ELAPSED=0
+echo "tinyproxy: waiting for network namespace..."
+while ! grep -q '00000000' /proc/net/route 2>/dev/null; do
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    echo "tinyproxy: ERROR — no routable interface after ${TIMEOUT}s. Is tailscale-staktrakr running?"
+    exit 1
+  fi
+done
+echo "tinyproxy: network ready after ${ELAPSED}s"
+
+exec tinyproxy -d


### PR DESCRIPTION
## GSD Session — Tinyproxy Crash Fix

### Changes
- Added `entrypoint.sh` that waits up to 60s for a routable network interface before starting tinyproxy
- Updated Dockerfile to use entrypoint instead of direct `CMD`
- Ensures `/var/log/tinyproxy/` exists at both build time and runtime

### Problem
`staktrakr-tinyproxy` exits with code 255 when the tailscale sidecar's network namespace isn't ready. Since tinyproxy uses `network_mode: container:tailscale-staktrakr`, it has no network of its own — if tailscale isn't fully up, tinyproxy crashes immediately.

### Solution
Entrypoint polls `/proc/net/route` for a default gateway (indicating the shared network namespace is ready) before `exec`ing tinyproxy.

- No version bump — devops infrastructure only
- No Linear issue — casual fix below spec threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)