### PR TITLE
chore(wiki): log inaccuracy in service-worker.md API_HOSTS array

### DIFF
--- a/wiki/.nightwatch-log.json
+++ b/wiki/.nightwatch-log.json
@@ -1,5 +1,5 @@
 {
-  "nextIndex": 7,
+  "nextIndex": 8,
   "rotation": [
     "api-consumption.md",
     "backup-restore.md",
@@ -46,6 +46,14 @@
       "verified": [
         "patch/3.33.61"
       ]
+    },
+    {
+      "date": "2026-03-09",
+      "page": "service-worker.md",
+      "track": "frontend",
+      "status": "inaccuracy_found",
+      "finding": "Wiki lists External API hosts as metalpriceapi.com, metals-api.com, gold-api.com, numista.com but sw.js API_HOSTS array contains subdomains: api.metalpriceapi.com, metals-api.com, api.gold-api.com, en.numista.com",
+      "verified": []
     }
   ]
 }


### PR DESCRIPTION
Found and recorded an inaccuracy in `wiki/service-worker.md` where the `API_HOSTS` list in the "Cache Strategy" section documented domains like `metalpriceapi.com` and `numista.com`, while the actual codebase in `sw.js` uses subdomains like `api.metalpriceapi.com` and `en.numista.com`.

Updates `wiki/.nightwatch-log.json` to record the finding, increments `nextIndex`, and wraps up the wiki accuracy hunt.

---
*PR created automatically by Jules for task [7267173131322714410](https://jules.google.com/task/7267173131322714410) started by @lbruton*