### PR TITLE
v3.33.61 — STAK-462: CF-Clearance-Scraper sidecar for home poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.61] - 2026-03-10
+
+### Added — STAK-462: CF-Clearance-Scraper sidecar for home poller
+
+- **Added**: CF-Clearance-Scraper Docker sidecar as Phase 2 fallback in home poller scraping pipeline — Cloudflare-blocked vendors (Bullion Exchanges, JM Bullion) now attempt a Zendriver-based cookie bypass before recording terminal 403 failures (STAK-462)
+
+---
+
 ## [3.33.60] - 2026-03-08
 
 ### Fixed — STAK-457: ZIP Backup Restore Routes Through DiffModal

--- a/devops/pollers/.env.home.example
+++ b/devops/pollers/.env.home.example
@@ -18,3 +18,8 @@ GEMINI_API_KEY=
 # Fly.io health check
 FLYIO_TAILSCALE_IP=100.90.171.110
 FLYIO_HTTP_URL=https://api2.staktrakr.com/data/retail/providers.json
+
+# CF-Clearance-Scraper sidecar (Cloudflare bypass for 403 vendors)
+CF_CLEARANCE_SCRAPER_URL=http://cf-clearance-scraper:5000  # Internal URL of the sidecar — no change needed when running on staktrakr-net
+CF_CLEARANCE_ENABLED=1                                      # Set to 0 to disable CF fallback entirely (all 403s remain terminal)
+CF_CLEARANCE_TIMEOUT_MS=30000                               # Max ms to wait for the sidecar to solve a CF challenge

--- a/devops/pollers/docker-compose.home.yml
+++ b/devops/pollers/docker-compose.home.yml
@@ -30,6 +30,9 @@ services:
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - FLYIO_TAILSCALE_IP=${FLYIO_TAILSCALE_IP:-100.90.171.110}
       - FLYIO_HTTP_URL=${FLYIO_HTTP_URL:-https://api2.staktrakr.com/data/retail/providers.json}
+      - CF_CLEARANCE_SCRAPER_URL=${CF_CLEARANCE_SCRAPER_URL:-http://cf-clearance-scraper:5000}
+      - CF_CLEARANCE_ENABLED=${CF_CLEARANCE_ENABLED:-1}
+      - CF_CLEARANCE_TIMEOUT_MS=${CF_CLEARANCE_TIMEOUT_MS:-30000}
     ports:
       - "3010:3010"   # Dashboard (HTTP)
       - "3011:3011"   # Dashboard (HTTPS for iframe embed)
@@ -37,6 +40,20 @@ services:
     volumes:
       - poller-data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  cf-clearance-scraper:
+    image: ghcr.io/xewdy444/cf-clearance-scraper:latest
+    container_name: staktrakr-cf-clearance
+    restart: unless-stopped
+    environment:
+      LOG_LEVEL: info
+    volumes:
+      - /dev/shm:/dev/shm
     logging:
       driver: json-file
       options:

--- a/devops/pollers/shared/cf-clearance.js
+++ b/devops/pollers/shared/cf-clearance.js
@@ -1,0 +1,67 @@
+// CF-Clearance-Scraper sidecar client
+// =====================================
+// Communicates with the ghcr.io/xewdy444/cf-clearance-scraper container.
+//
+// Verified endpoint (2026-03-09):
+//   POST /cf-clearance-tokens
+//   Body:    { "url": "https://..." }
+//   Returns: { "cf_clearance": "<cookie-value>", "user_agent": "<ua-string>" }
+//   Health:  GET / → 200 OK
+//
+// Source: design.md for STAK-462 (spec-verified schema).
+// Live container pull was attempted during implementation but the GHCR registry
+// was unavailable from the build machine. Endpoint confirmed via spec design.md
+// which documents the upstream API contract. Adapt field mapping if the live
+// container returns different field names.
+
+const CF_CLEARANCE_SCRAPER_URL =
+  process.env.CF_CLEARANCE_SCRAPER_URL ?? "http://cf-clearance-scraper:5000";
+const CF_CLEARANCE_ENABLED = process.env.CF_CLEARANCE_ENABLED ?? "1";
+const CF_CLEARANCE_TIMEOUT_MS = process.env.CF_CLEARANCE_TIMEOUT_MS ?? "30000";
+
+/**
+ * Harvest a cf_clearance cookie from the sidecar for the given URL.
+ *
+ * @param {string} url - Vendor product URL to solve CF challenge for
+ * @returns {Promise<{ cfClearance: string, userAgent: string } | null>}
+ *   Returns cookie+UA on success, null if disabled or sidecar unavailable.
+ */
+export async function getCFClearanceCookie(url) {
+  if (CF_CLEARANCE_ENABLED !== "1") {
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    Number(CF_CLEARANCE_TIMEOUT_MS)
+  );
+
+  try {
+    const response = await fetch(
+      `${CF_CLEARANCE_SCRAPER_URL}/cf-clearance-tokens`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+        signal: controller.signal,
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${text.slice(0, 120)}`);
+    }
+
+    const data = await response.json();
+    return {
+      cfClearance: data.cf_clearance,
+      userAgent: data.user_agent,
+    };
+  } catch (err) {
+    console.warn("[cf-clearance] sidecar error: " + err.message);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/devops/pollers/shared/cf-clearance.js
+++ b/devops/pollers/shared/cf-clearance.js
@@ -54,6 +54,10 @@ export async function getCFClearanceCookie(url) {
     }
 
     const data = await response.json();
+    if (!data.cf_clearance) {
+      console.warn("[cf-clearance] unexpected response shape:", JSON.stringify(data).slice(0, 200));
+      return null;
+    }
     return {
       cfClearance: data.cf_clearance,
       userAgent: data.user_agent,

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -24,6 +24,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { openTursoDb, writeSnapshot, windowFloor, startRunLog, finishRunLog, recordFailure } from "./db.js";
 import { loadProviders } from "./provider-db.js";
+import { getCFClearanceCookie } from "./cf-clearance.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -42,6 +43,10 @@ const PLAYWRIGHT_LAUNCH = process.env.PLAYWRIGHT_LAUNCH === "1";
 const DATA_DIR = resolve(process.env.DATA_DIR || join(__dirname, "../../data"));
 const DRY_RUN = process.env.DRY_RUN === "1";
 const COIN_FILTER = process.env.COINS ? process.env.COINS.split(",").map(s => s.trim()) : null;
+const CF_CLEARANCE_ENABLED_FLAG = process.env.CF_CLEARANCE_ENABLED !== "0";
+let cfAttempts = 0;
+let cfSuccess = 0;
+let cfFailures = 0;
 // Cox WiFi tinyproxy (port 8888) — residential proxy via Tailscale.
 // Set as Fly.io secret: fly secrets set HOME_PROXY_URL=http://100.112.198.50:8888
 const HOME_PROXY_URL = process.env.HOME_PROXY_URL || null;
@@ -426,6 +431,7 @@ const PROVIDER_DEFAULTS = {
   onlyMainContent: true,       // Firecrawl onlyMainContent flag
   retryOn408: true,            // allow retry on Firecrawl 408 timeout
   fractionalExempt: false,     // skip fractional_weight nav false-positive check
+  cf_clearance_fallback: false, // attempt Phase 2 CF-clearance sidecar on 403
   proxy: {},                   // per-poller proxy routing
 };
 
@@ -447,6 +453,7 @@ const PROVIDER_CONFIG = {
     timeout: 40_000,
     onlyMainContent: false,     // React pages return empty with onlyMainContent
     retryOn408: false,          // retrying won't help — skip to save ~40s
+    cf_clearance_fallback: true,
     fractionalExempt: true,     // mega-menu lists fractional coins on every page
   },
   bullionexchanges: {
@@ -454,6 +461,7 @@ const PROVIDER_CONFIG = {
     waitFor: 15_000,            // React pricing grid needs 12-15s to fully hydrate
     timeout: 70_000,            // extended timeout for 15s waitFor + round-trip
     fractionalExempt: true,     // Related Products section lists fractional variants
+    cf_clearance_fallback: true,
     proxy: {
       home: null,               // home poller is on residential IP — no proxy needed
       fly: null,                // Fly.io uses its own IP (93%+ success rate)
@@ -537,7 +545,60 @@ async function scrapeViaProxy(url, waitFor = 15000, timeout = 40000) {
   }
 }
 
-async function scrapeUrl(url, providerId = "", attempt = 1) {
+async function scrapeViaCFClearance(url, providerId, coin) {
+  log(`[cf-clearance] attempt: ${providerId} ${url}`);
+  const cfData = await getCFClearanceCookie(url);
+  if (!cfData) {
+    warn(`[cf-clearance] no cookie returned for ${providerId}`);
+    return null;
+  }
+  let browser;
+  try {
+    const cfg = providerCfg(providerId);
+    const { chromium } = await import("playwright-core");
+    browser = await chromium.launch({ args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"] });
+    const context = await browser.newContext({
+      userAgent: cfData.userAgent,
+      extraHTTPHeaders: { "Accept-Language": "en-US,en;q=0.9" },
+    });
+    const urlObj = new URL(url);
+    await context.addCookies([{
+      name: "cf_clearance",
+      value: cfData.cfClearance,
+      domain: urlObj.hostname,
+      path: "/",
+      httpOnly: false,
+      secure: true,
+    }]);
+    const page = await context.newPage();
+    await page.route("**/*", (route) => {
+      const type = route.request().resourceType();
+      if (["image", "font", "stylesheet", "media"].includes(type)) route.abort();
+      else route.continue();
+    });
+    await page.goto(url, { waitUntil: "networkidle", timeout: cfg.timeout || 40000 });
+    if (cfg.waitFor > 0) await page.waitForTimeout(cfg.waitFor);
+    const text = await page.innerText("body");
+    await browser.close();
+    browser = null;
+    const cleaned = preprocessMarkdown(text, providerId);
+    const inStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
+    const price = extractPrice(cleaned, coin.metal, coin.weight_oz || 1, providerId);
+    if (price !== null) {
+      log(`[cf-clearance] success: ${providerId} price=${price.price}`);
+      return { price: price.price, inStock: inStock.inStock, source: "cf-clearance" };
+    }
+    warn(`[cf-clearance] no price extracted for ${providerId}`);
+    return null;
+  } catch (err) {
+    warn(`[cf-clearance] failure: ${providerId} error=${err.message}`);
+    return null;
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+async function scrapeUrl(url, providerId = "", attempt = 1, coin = null) {
   const controller = new AbortController();
   const scrapeTimeout = providerCfg(providerId).timeout;
   const timer = setTimeout(() => controller.abort(), scrapeTimeout);
@@ -571,6 +632,16 @@ async function scrapeUrl(url, providerId = "", attempt = 1) {
       // 403 = bot detection / IP block. Retrying Firecrawl (same IP) won't help;
       // skip retries — terminal failure for this target.
       if (response.status === 403) {
+        const cfg = providerCfg(providerId);
+        if (cfg.cf_clearance_fallback && CF_CLEARANCE_ENABLED_FLAG) {
+          cfAttempts++;
+          const phase2 = await scrapeViaCFClearance(url, providerId, coin);
+          if (phase2 !== null) {
+            cfSuccess++;
+            return phase2;
+          }
+          cfFailures++;
+        }
         throw Object.assign(
           new Error(`HTTP 403 (blocked): ${text.slice(0, 200)}`),
           { skipRetry: true }
@@ -599,7 +670,7 @@ async function scrapeUrl(url, providerId = "", attempt = 1) {
     if (!err.skipRetry && attempt < RETRY_ATTEMPTS) {
       warn(`Retry ${attempt}/${RETRY_ATTEMPTS} for ${url}: ${err.message}`);
       await sleep(RETRY_DELAY_MS * attempt);
-      return scrapeUrl(url, providerId, attempt + 1);
+      return scrapeUrl(url, providerId, attempt + 1, coin);
     }
     throw err;
   } finally {
@@ -855,7 +926,17 @@ async function main() {
               warn(`  \u2717 ${provider.id} fly-proxy error: ${proxyErr.message.slice(0, 80)}, falling back`);
             }
           }
-          markdown = await scrapeUrl(url, provider.id);
+          const scrapeResult = await scrapeUrl(url, provider.id, 1, coin);
+          // Phase 2 (CF-clearance) returns an object directly — short-circuit markdown path
+          if (scrapeResult !== null && typeof scrapeResult === "object") {
+            price = scrapeResult.price;
+            source = scrapeResult.source;
+            inStock = scrapeResult.inStock;
+            finalUrl = url;
+            log(`  ✓ ${coinSlug}/${provider.id}: $${price.toFixed(2)} (${source})`);
+            break;
+          }
+          markdown = scrapeResult;
           const cleaned = preprocessMarkdown(markdown, provider.id);
           const stock = detectStockStatus(cleaned, coin.weight_oz || 1, provider.id);
 
@@ -894,7 +975,17 @@ async function main() {
             log(`  ↻ ${coinSlug}/${provider.id} [url${i}]: retrying with extended waitFor...`);
             await jitter();
             try {
-              const retryMd = await scrapeUrl(url, provider.id, 1);
+              const retryRaw = await scrapeUrl(url, provider.id, 1, coin);
+              // Phase 2 result object — short-circuit retry markdown path
+              if (retryRaw !== null && typeof retryRaw === "object") {
+                price = retryRaw.price;
+                source = retryRaw.source;
+                inStock = retryRaw.inStock;
+                finalUrl = url;
+                log(`  ✓ ${coinSlug}/${provider.id}: $${price.toFixed(2)} (${source})`);
+                break;
+              }
+              const retryMd = retryRaw;
               const retryCleaned = preprocessMarkdown(retryMd, provider.id);
               const retryStock = detectStockStatus(retryCleaned, coin.weight_oz || 1, provider.id);
               const retryExtracted = extractPrice(retryCleaned, coin.metal, coin.weight_oz || 1, provider.id);
@@ -983,7 +1074,7 @@ async function main() {
   const ok = scrapeResults.filter(r => r.ok).length;
   const fail = scrapeResults.length - ok;
 
-  log(`Done: ${ok}/${scrapeResults.length} prices captured, ${fail} failures`);
+  log(`Done: ${ok}/${scrapeResults.length} prices captured, ${fail} failures, cf-clearance: ${cfAttempts} attempts ${cfSuccess} ok ${cfFailures} failed`);
 
   // Finish run log entry in Turso
   if (db && runId) {

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Retail Price Reliability (v3.33.61)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a cookie-based bypass, reducing missed prices from these vendors (STAK-462).
 - **DiffModal Complete Overhaul (v3.33.56&ndash;v3.33.60)**: Full card-based cloud sync review — summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449).
 - **Market View Improvements (v3.33.52, v3.33.57)**: Mobile search bar and controls layout fixed; metal filter pills (All / Silver / Gold / Goldback / Platinum / Palladium) added; Australian coins (Kangaroo, Koala, Kookaburra) now display correctly (STAK-433, STAK-434, STAK-452).
 - **Numista N# Search Fixes (v3.33.53)**: Image URLs and metal types now auto-populated when adding items via Numista N# search — no more manual re-download workaround needed (STAK-431).
-- **Date Sort Fix (v3.33.54)**: Items without a purchase date now sort as oldest rather than always appearing at the bottom regardless of sort direction (STAK-448).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.61 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a cookie-based bypass, reducing missed prices from these vendors (STAK-462)</li>
     <li><strong>v3.33.60 &ndash; DiffModal Complete Overhaul</strong>: Full card-based cloud sync review &mdash; summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449)</li>
     <li><strong>v3.33.57 &ndash; Market View Improvements</strong>: Mobile search bar and controls layout fixed; metal filter pills (All / Silver / Gold / Goldback / Platinum / Palladium) added; Australian coins (Kangaroo, Koala, Kookaburra) now display correctly (STAK-433, STAK-434, STAK-452)</li>
     <li><strong>v3.33.53 &ndash; Numista N# Search Fixes</strong>: Image URLs and metal types now auto-populated when adding items via Numista N# search &mdash; no more manual re-download workaround needed (STAK-431)</li>
-    <li><strong>v3.33.54 &ndash; Date Sort Fix</strong>: Items without a purchase date now sort as oldest rather than always appearing at the bottom regardless of sort direction (STAK-448)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.60";
+const APP_VERSION = "3.33.61";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.60-b1773090355';
+const CACHE_NAME = 'staktrakr-v3.33.61-b1773102305';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.60",
-  "releaseDate": "2026-03-08",
+  "version": "3.33.61",
+  "releaseDate": "2026-03-10",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -2,8 +2,8 @@
 title: Home Poller (Docker/Portainer)
 category: infrastructure
 owner: staktrakr
-lastUpdated: v3.33.57
-date: 2026-03-07
+lastUpdated: v3.33.61
+date: 2026-03-10
 sourceFiles:
   - devops/pollers/docker-compose.home.yml
   - devops/pollers/home-poller/Dockerfile
@@ -22,7 +22,7 @@ relatedPages:
 
 # Home Poller (Docker/Portainer)
 
-> **Last verified:** 2026-03-07 — Docker containers on Ubuntu 24.04 LXC at 192.168.1.81, managed by Portainer. Four stacks on `staktrakr-net` bridge network.
+> **Last verified:** 2026-03-10 — Docker containers on Ubuntu 24.04 LXC at 192.168.1.81, managed by Portainer. Five stacks on `staktrakr-net` bridge network.
 
 ---
 
@@ -60,11 +60,12 @@ See `portainer` skill for full API reference.
 
 ## Docker Stacks
 
-Four Portainer-managed stacks on the `staktrakr-net` bridge network:
+Five Portainer-managed stacks on the `staktrakr-net` bridge network:
 
 | Stack | Container | Purpose | Ports | Stack ID |
 |-------|-----------|---------|-------|----------|
 | home-poller | `staktrakr-home-poller` | Retail/spot/goldback pollers + dashboard + metrics | 3010, 3011, 9100 | 7 |
+| cf-clearance-scraper | `staktrakr-cf-clearance` | Cloudflare bypass sidecar (Zendriver, returns `cf_clearance` cookie) | internal only | — |
 | firecrawl | `firecrawl-api` + workers | Web scraping engine (Firecrawl self-hosted) | 3002 | 4 |
 | tinyproxy | `tinyproxy-staktrakr` | HTTP proxy for Fly.io residential IP routing | 8888 | 5 |
 | tailscale | `tailscale-staktrakr` | Tailscale network namespace (tinyproxy shares it) | — | 8 |
@@ -130,6 +131,36 @@ The Fly.io container routes scraper traffic through this proxy for residential I
 | Fly.io container (`staktrakr-fly`) | 100.90.171.110 |
 
 The Tailscale sidecar (`tailscale-staktrakr`) runs in its own container. Tinyproxy shares its network namespace. The home-poller container does NOT share the Tailscale network — it uses the standard Docker bridge. Tailscale is only needed for the proxy path from Fly.io.
+
+---
+
+## CF-Clearance-Scraper Sidecar
+
+`staktrakr-cf-clearance` runs `ghcr.io/xewdy444/cf-clearance-scraper:latest` — a headless Chromium sidecar (Zendriver fork) that solves Cloudflare challenges and returns a valid `cf_clearance` cookie.
+
+| Property | Value |
+|----------|-------|
+| Image | `ghcr.io/xewdy444/cf-clearance-scraper:latest` |
+| Internal URL | `http://cf-clearance-scraper:5000` (Docker DNS, no host ports) |
+| Purpose | Phase 2 fallback for CF-protected vendors (Bullion Exchanges, JM Bullion) |
+| Network | `staktrakr-net` bridge only — not exposed to host |
+| Shared memory | `/dev/shm` mounted from host (required by Chromium) |
+
+### 3-Phase Scraping Pipeline
+
+`shared/price-extract.js` uses a 3-phase fallback cascade for vendors with `cf_clearance_fallback: true` in `PROVIDER_CONFIG`:
+
+| Phase | Method | Triggers When |
+|-------|--------|--------------|
+| 0 | Playwright direct | Always attempted first |
+| 1 | Firecrawl | Phase 0 fails or returns empty |
+| 2 | CF sidecar + Playwright with cookie | Phase 0/1 return HTTP 403 |
+
+Phase 2 calls `getCFClearanceCookie(url)` from `shared/cf-clearance.js`, injects the returned `cf_clearance` cookie and matching `User-Agent` into a Playwright browser context, then re-scrapes. Results written to Turso with `source: "cf-clearance"`.
+
+### Enabling / Disabling
+
+Controlled by `CF_CLEARANCE_ENABLED` env var on the home-poller container. Set to `0` to disable Phase 2 without stopping the sidecar container.
 
 ---
 
@@ -202,6 +233,9 @@ Injected via Portainer stack env vars (must be passed on every redeploy):
 | `FLYIO_HTTP_URL` | Yes | `https://api2.staktrakr.com/data/retail/providers.json` |
 | `GEMINI_API_KEY` | No | Enables vision pipeline |
 | `VISION_ENABLED` | No | Set to `1` to enable vision pipeline |
+| `CF_CLEARANCE_SCRAPER_URL` | No | Defaults to `http://cf-clearance-scraper:5000` (Docker DNS) |
+| `CF_CLEARANCE_ENABLED` | No | Set to `1` (default) to enable Phase 2; `0` to disable |
+| `CF_CLEARANCE_TIMEOUT_MS` | No | Sidecar request timeout; defaults to `30000` (30 s) |
 
 ---
 
@@ -306,3 +340,6 @@ rm -f /tmp/retail-poller.lock
 | Container crash loop | `docker logs --tail 50 staktrakr-home-poller` — check entrypoint errors |
 | Tailscale sidecar down | `docker logs tailscale-staktrakr` — check for auth issues |
 | Tinyproxy unreachable from Fly.io | Verify tailscale sidecar is up, tinyproxy shares its network namespace |
+| CF sidecar not resolving 403s | Check `CF_CLEARANCE_ENABLED=1` on home-poller; `docker logs staktrakr-cf-clearance` for Zendriver errors |
+| CF sidecar crashes on start | Verify `/dev/shm` volume is mounted in compose; container needs shared memory for Chromium |
+| Phase 2 never attempted | Confirm vendor has `cf_clearance_fallback: true` in `PROVIDER_CONFIG` (`shared/price-extract.js`) |

--- a/wiki/release-workflow.md
+++ b/wiki/release-workflow.md
@@ -2,8 +2,8 @@
 title: Release Workflow
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.59
-date: 2026-03-07
+lastUpdated: v3.33.61
+date: 2026-03-10
 sourceFiles:
   - .claude/skills/release/SKILL.md
   - .claude/skills/ship/SKILL.md


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **feat**: Add `staktrakr-cf-clearance` sidecar service to `docker-compose.home.yml` — Zendriver-based Cloudflare bypass container (no host ports, internal bridge only, `/dev/shm` mounted)
- **feat**: Add `shared/cf-clearance.js` — `getCFClearanceCookie(url)` client module; calls sidecar, returns `{ cfClearance, userAgent }` with AbortController timeout
- **feat**: Add Phase 2 CF fallback to `shared/price-extract.js` — vendors with `cf_clearance_fallback: true` (Bullion Exchanges, JM Bullion) now attempt a cookie-injected Playwright scrape when Phase 0/1 return 403; results written to Turso with `source: "cf-clearance"`
- **chore**: Add `CF_CLEARANCE_SCRAPER_URL`, `CF_CLEARANCE_ENABLED`, `CF_CLEARANCE_TIMEOUT_MS` env vars to compose and `.env.home.example`
- **docs**: Update `wiki/home-poller.md` — CF sidecar stack entry, 3-phase pipeline table, env vars, diagnosing entries

## Linear Issues

- [STAK-462: CF-Clearance-Scraper sidecar integration for home poller](https://linear.app/staktrakr/issue/STAK-462)

## Trial Verification (Task 4 — Human Gate)

After this PR deploys to the QA preview, redeploy the home-poller stack on Portainer with the new `cf-clearance-scraper` service added. Then run via Portainer Console:

```bash
COINS=silver-eagle CF_CLEARANCE_ENABLED=1 node shared/price-extract.js
```

Verify:
- `[cf-clearance]` log lines appear for bullionexchanges and/or jmbullion
- Turso `price_snapshots` table has rows with `source = 'cf-clearance'` for those vendors
- No crash / exception in the sidecar container (`docker logs staktrakr-cf-clearance`)

> **Note:** The sidecar API endpoint `/cf-clearance-tokens` and response schema `{ cf_clearance, user_agent }` are sourced from the project spec. Verify against live container during trial — a comment in `cf-clearance.js` flags this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)