### PR TITLE
v3.33.62 — STAK-463: fix 7-day trend chart endpoint spikes and OOS roll-forward drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.62] - 2026-03-10
+
+### Fixed — STAK-463: 7-Day Trend Chart Endpoint Spike Detection and Roll-Forward Drift
+
+- **Fixed**: Endpoint spikes (day 0 / day 6) in the 7-day trend chart now caught by lookahead/lookback peer comparison (10% threshold), preventing anomalous first/last data points from distorting the chart (STAK-463)
+- **Fixed**: Cross-vendor median guard lowered from 3 to 2 vendors for endpoint slots, with stricter 20% threshold, so sparse endpoint coverage no longer lets outliers slip through (STAK-463)
+- **Fixed**: OOS carry-forward no longer drifts — when a vendor is out-of-stock but the scraper still returns a price, the last in-stock price is used as the carry anchor instead, keeping dotted lines flat (STAK-463)
+
+---
+
 ## [3.33.60] - 2026-03-08
 
 ### Fixed — STAK-457: ZIP Backup Restore Routes Through DiffModal

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Market Price Chart Fixes (v3.33.62)**: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463).
 - **DiffModal Complete Overhaul (v3.33.56&ndash;v3.33.60)**: Full card-based cloud sync review — summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449).
 - **Market View Improvements (v3.33.52, v3.33.57)**: Mobile search bar and controls layout fixed; metal filter pills (All / Silver / Gold / Goldback / Platinum / Palladium) added; Australian coins (Kangaroo, Koala, Kookaburra) now display correctly (STAK-433, STAK-434, STAK-452).
 - **Numista N# Search Fixes (v3.33.53)**: Image URLs and metal types now auto-populated when adding items via Numista N# search — no more manual re-download workaround needed (STAK-431).
-- **Date Sort Fix (v3.33.54)**: Items without a purchase date now sort as oldest rather than always appearing at the bottom regardless of sort direction (STAK-448).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.62 &ndash; Market Price Chart Fixes</strong>: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463)</li>
     <li><strong>v3.33.60 &ndash; DiffModal Complete Overhaul</strong>: Full card-based cloud sync review &mdash; summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449)</li>
     <li><strong>v3.33.57 &ndash; Market View Improvements</strong>: Mobile search bar and controls layout fixed; metal filter pills (All / Silver / Gold / Goldback / Platinum / Palladium) added; Australian coins (Kangaroo, Koala, Kookaburra) now display correctly (STAK-433, STAK-434, STAK-452)</li>
     <li><strong>v3.33.53 &ndash; Numista N# Search Fixes</strong>: Image URLs and metal types now auto-populated when adding items via Numista N# search &mdash; no more manual re-download workaround needed (STAK-431)</li>
-    <li><strong>v3.33.54 &ndash; Date Sort Fix</strong>: Items without a purchase date now sort as oldest rather than always appearing at the bottom regardless of sort direction (STAK-448)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.60";
+const APP_VERSION = "3.33.62";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -1254,10 +1254,11 @@ const _filterHistorySpikes = (entries, vendorIds) => {
         prices[vid][t] = lastKnown;
         estimated[vid][t] = true;
       } else if (val != null && isOOS) {
-        // OOS but has a price (e.g. last scraped) — use it, mark estimated
-        prices[vid][t] = val;
+        // OOS but scraper returned a price — prefer last in-stock anchor for carry-forward
+        // so the dotted line stays flat at the last real price, not drifting with OOS prices
+        prices[vid][t] = lastKnown != null ? lastKnown : val;
         estimated[vid][t] = true;
-        lastKnown = val;
+        // Do NOT update lastKnown — keep last in-stock price as the carry anchor
       } else {
         // No data at all
         prices[vid][t] = null;
@@ -1290,12 +1291,53 @@ const _filterHistorySpikes = (entries, vendorIds) => {
     }
   }
 
+  // Pass 1b: Endpoint spike detection (t=0 and t=length-1 have no symmetric neighbors)
+  // Compare each endpoint against the average of the nearest 2 real interior data points.
+  // Uses 2× the neighbor tolerance (10%) since we're comparing one side only.
+  const endpointTol = neighborTol * 2;
+  for (const vid of vendorIds) {
+    const arr = prices[vid];
+    const est = estimated[vid];
+    const n = arr.length;
+    // Leading endpoint (t=0): look ahead for 2 real non-estimated data points
+    if (!est[0] && arr[0] != null) {
+      const peers = [];
+      for (let j = 1; j < n && peers.length < 2; j++) {
+        if (!est[j] && arr[j] != null) peers.push(arr[j]);
+      }
+      if (peers.length >= 2) {
+        const peerAvg = (peers[0] + peers[1]) / 2;
+        if (peerAvg !== 0 && Math.abs(arr[0] - peerAvg) / peerAvg > endpointTol) {
+          arr[0] = null;
+          est[0] = false;
+        }
+      }
+    }
+    // Trailing endpoint (t=n-1): look back for 2 real non-estimated data points
+    if (!est[n - 1] && arr[n - 1] != null) {
+      const peers = [];
+      for (let j = n - 2; j >= 0 && peers.length < 2; j--) {
+        if (!est[j] && arr[j] != null) peers.push(arr[j]);
+      }
+      if (peers.length >= 2) {
+        const peerAvg = (peers[0] + peers[1]) / 2;
+        if (peerAvg !== 0 && Math.abs(arr[n - 1] - peerAvg) / peerAvg > endpointTol) {
+          arr[n - 1] = null;
+          est[n - 1] = false;
+        }
+      }
+    }
+  }
+
   // Pass 2: Cross-vendor median consensus (only on non-estimated points)
   for (let t = 0; t < entries.length; t++) {
+    const isEndpoint = (t === 0 || t === entries.length - 1);
     const valid = vendorIds
       .map((vid) => ({ vid, price: prices[vid][t], est: estimated[vid][t] }))
       .filter((x) => x.price != null && !x.est);
-    if (valid.length < 3) continue;
+    // Endpoints: allow 2 vendors and tighter threshold (20%); interior: 3 vendors, 40%
+    if (valid.length < (isEndpoint ? 2 : 3)) continue;
+    const threshold = isEndpoint ? medianThreshold * 0.5 : medianThreshold;
     const sorted = valid.map((x) => x.price).sort((a, b) => a - b);
     const mid = Math.floor(sorted.length / 2);
     const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
@@ -1303,7 +1345,7 @@ const _filterHistorySpikes = (entries, vendorIds) => {
     let flagged = 0;
     const candidates = [];
     for (const { vid, price } of valid) {
-      if (Math.abs(price - median) / median > medianThreshold) {
+      if (Math.abs(price - median) / median > threshold) {
         candidates.push(vid);
         flagged++;
       }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.60-b1773090355';
+const CACHE_NAME = 'staktrakr-v3.33.62-b1773103214';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.60",
-  "releaseDate": "2026-03-08",
+  "version": "3.33.62",
+  "releaseDate": "2026-03-10",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/retail-modal.md
+++ b/wiki/retail-modal.md
@@ -2,8 +2,8 @@
 title: Retail Modal
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.60
-date: 2026-03-09
+lastUpdated: v3.33.62
+date: 2026-03-10
 sourceFiles:
   - js/retail-view-modal.js
   - js/retail.js
@@ -265,6 +265,8 @@ Two-pass anomaly filter that nulls scraper spike prices before charting. Preserv
 
 **Pass 2 — Cross-vendor median consensus (safety net):** For each window with 3+ vendors, any vendor deviating more than `RETAIL_ANOMALY_THRESHOLD` (default 40%) from the median is nulled. Guard: if all vendors would be flagged, none are (prevents false consensus collapse).
 
+> **Note:** `_flagAnomalies` is the intraday-only pipeline. The 7-day trend card charts in `retail.js` use a separate `_filterHistorySpikes()` function with its own three-pass logic — see the **7-Day Trend Card Chart** section below.
+
 Anomalous chart prices are set to `null` so Chart.js gaps over them via `spanGaps: true`. Table cells with anomalous values render with strikethrough at reduced opacity.
 
 ### `_buildIntradayChart(slug)`
@@ -427,6 +429,56 @@ Both `_retailViewModalChart` and `_retailViewIntradayChart` must be explicitly d
 `openRetailViewModal` reads `RETAIL_COIN_META[slug]` and returns early if not found. Dynamic slugs (Goldbacks, manifest-added coins) are resolved via `getRetailCoinMeta(slug)` in `retail.js`, but the modal uses the raw `RETAIL_COIN_META` constant directly. If a new slug from the manifest is not in that constant and has no Goldback pattern match, the modal will silently refuse to open.
 
 As of v3.33.57, `RETAIL_COIN_META` includes 15 hardcoded entries covering all standard coins plus the three Australian silver coins (Kangaroo, Koala, Kookaburra). The manifest's `coins_meta` field provides runtime metadata but is not persisted to localStorage — on page reload before the manifest re-fetches, only the hardcoded entries are available.
+
+---
+
+---
+
+## 7-Day Trend Card Chart (`retail.js`)
+
+The **market card** expanded view renders a 7-day per-vendor trend chart using `_initMarketCardChart(slug, detailsEl)`. This is separate from the retail-view-modal history tab — it lives entirely in `retail.js` and operates on `retailPriceHistory[slug]`.
+
+### Pipeline
+
+```
+retailPriceHistory[slug].slice(-7)     -> last7[]  (7 daily entries, oldest first)
+         |
+         v
+  _filterHistorySpikes(last7, vendors) -> { prices, estimated }
+  (three-pass spike + OOS filter)
+         |
+         v
+  _interpolateGaps(prices[vid], estimated[vid])  -> { filled, interp }
+  (linear interpolation for null gaps only;
+   OOS carry-forward values are already present and are NOT re-interpolated)
+         |
+         v
+  Chart.js line chart  (dashed/dimmed segments where interp[i] === true)
+```
+
+### `_filterHistorySpikes(entries, vendorIds)`
+
+Three-pass filter applied before chart rendering:
+
+**Pass 0 — OOS carry-forward (data extraction):** For each vendor per day:
+- In-stock with price → real data point; updates `lastKnown`
+- OOS with prior in-stock price → carry `lastKnown` forward, mark `estimated = true`; **`lastKnown` is NOT updated** — the carry anchor always remains the last confirmed in-stock price, keeping dotted lines flat
+- OOS with no prior in-stock price → use scraped price as fallback (no `lastKnown` available)
+- No data → `null`
+
+**Pass 1 — Temporal spike detection:** For `t=1` to `t=length-2` (interior points only), flags points deviating more than `RETAIL_SPIKE_NEIGHBOR_TOLERANCE` (5%) from the average of stable neighbors. Skips estimated (OOS carry) points.
+
+**Pass 1b — Endpoint spike detection (v3.33.62+):** For `t=0` and `t=length-1`, compares against the average of the nearest 2 real interior data points. Threshold: `2× RETAIL_SPIKE_NEIGHBOR_TOLERANCE` (10%). Catches anomalous first/last data points that Pass 1 cannot reach.
+
+**Pass 2 — Cross-vendor median consensus:** For interior positions: requires 3+ vendors, 40% threshold. For endpoint positions: requires 2+ vendors, 20% threshold (stricter, to catch edge spikes that slipped Pass 1b due to single-vendor coverage).
+
+### `_interpolateGaps(data, preEstimated)`
+
+Linearly interpolates only `null` entries in the price array. OOS carry-forward values are already non-null after Pass 0, so they are preserved as flat. Trailing/leading nulls (vendor not present on those days) are left as-is — no extrapolation beyond the vendor's known data range.
+
+### Dotted line rendering
+
+Chart.js `segment.borderDash` callback: if either endpoint of a segment has `interp[i] === true`, the segment renders dashed (`[4, 3]`) at 50% opacity. This applies to both OOS carry-forward and linearly interpolated gap fills.
 
 ---
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Endpoint spikes (day 0 / day 6) now detected via lookahead/lookback peer comparison (10% threshold) — bad scrapes at the start or end of the 7-day window no longer distort the full chart line
- **Fixed**: Cross-vendor median guard for endpoint slots lowered from 3 to 2 vendors with stricter 20% threshold — sparse endpoint coverage no longer lets outliers through
- **Fixed**: OOS carry-forward no longer drifts — when a vendor is OOS but the scraper returns a price, the last confirmed **in-stock** price is used as the carry anchor instead, keeping dotted lines flat

## Root Cause

`_filterHistorySpikes()` in `retail.js`:
1. Temporal spike check loop ran `t=1` to `t<length-1`, skipping endpoints entirely
2. Cross-vendor median guard required 3+ vendors — single/dual-vendor endpoint slots escaped
3. The `val != null && isOOS` branch was updating `lastKnown` with the OOS price, causing carry-forward to drift as the OOS price changed day-to-day

## Linear Issues

- STAK-463: Fix 7-day trend chart endpoint spike detection and roll-forward drift — https://linear.app/lbruton/issue/STAK-463

🤖 Generated with [Claude Code](https://claude.com/claude-code)