### PR TITLE
v3.33.65 — STAK-462: Byparr Phase 2 fires on CF invisible challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.65] - 2026-03-10
+
+### Fixed — STAK-462: Byparr Phase 2 fallback for CF invisible challenge
+
+- **Fixed**: Price scraper now triggers Byparr CF bypass when Firecrawl returns a 200 Cloudflare JS-challenge page (no price) — previously only fired on 403. Covers bullionexchanges and jmbullion invisible-challenge pattern (STAK-462)
+
+---
+
 ## [3.33.64] - 2026-03-10
 
 ### Fixed — STAK-462: Switch Byparr to upstream GHCR image

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1019,6 +1019,34 @@ async function main() {
       }
     }
 
+    // ── Phase 2 fallback: CF-clearance for invisible Cloudflare challenges ──────
+    // Cloudflare's JS challenge returns 200 (not 403), so the in-scrapeUrl 403
+    // trigger never fires. If Phase 0+1 both returned no price for a
+    // cf_clearance_fallback vendor, attempt Byparr now as a last resort.
+    if (price === null && inStock) {
+      const cfg = providerCfg(provider.id);
+      if (cfg.cf_clearance_fallback && CF_CLEARANCE_ENABLED_FLAG) {
+        log(`  [cf-clearance] ${provider.id}: no price from Phase 0/1 — trying Byparr bypass`);
+        cfAttempts++;
+        try {
+          const phase2 = await scrapeViaCFClearance(urls[0], provider.id, coin);
+          if (phase2 !== null) {
+            price = phase2.price;
+            source = phase2.source;
+            inStock = phase2.inStock;
+            finalUrl = urls[0];
+            cfSuccess++;
+            log(`  ✓ ${coinSlug}/${provider.id}: $${price.toFixed(2)} (${source})`);
+          } else {
+            cfFailures++;
+          }
+        } catch (cfErr) {
+          cfFailures++;
+          warn(`  ✗ ${provider.id} cf-clearance error: ${cfErr.message.slice(0, 100)}`);
+        }
+      }
+    }
+
     // Log terminal state if not already logged
     if (price === null && inStock) {
       warn(`  ? ${coinSlug}/${provider.id}: all URLs exhausted, no price found`);

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,6 @@
 ## What's New
 
-- **Retail Price Reliability (v3.33.61&ndash;v3.33.64)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass, reducing missed prices from these vendors (STAK-462).
+- **Retail Price Reliability (v3.33.61&ndash;v3.33.65)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass, reducing missed prices from these vendors (STAK-462).
 - **Market Price Chart Fixes (v3.33.62)**: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463).
 - **DiffModal Complete Overhaul (v3.33.56&ndash;v3.33.60)**: Full card-based cloud sync review — summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449).

--- a/js/about.js
+++ b/js/about.js
@@ -283,7 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.33.61&ndash;v3.33.64 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass, reducing missed prices from these vendors (STAK-462)</li>
+    <li><strong>v3.33.61&ndash;v3.33.65 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass, reducing missed prices from these vendors (STAK-462)</li>
     <li><strong>v3.33.62 &ndash; Market Price Chart Fixes</strong>: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463)</li>
     <li><strong>v3.33.60 &ndash; DiffModal Complete Overhaul</strong>: Full card-based cloud sync review &mdash; summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449)</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.64";
+const APP_VERSION = "3.33.65";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.64-b1773107841';
+const CACHE_NAME = 'staktrakr-v3.33.65-b1773109578';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.64",
+  "version": "3.33.65",
   "releaseDate": "2026-03-10",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes.

## Changes

- Added post-Phase-1 CF bypass fallback in \`price-extract.js\`: when \`cf_clearance_fallback: true\` and both Phase 0 + Phase 1 return no price, Byparr is now called as a last resort
- Previously Phase 2 only fired on Firecrawl HTTP 403 — but Cloudflare's JS challenge returns 200 with a challenge page (no price), so the 403 trigger never activated for bullionexchanges/jmbullion
- Covers the invisible challenge pattern that was silently dropping all BE/JMB prices

## Linear Issues

- STAK-462: CF-Clearance-Scraper sidecar integration for home poller

🤖 Generated with [Claude Code](https://claude.com/claude-code)