### PR TITLE
fix: JSON-LD price extraction before firstInRangePriceProse (STAK-466)

### DIFF
--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -616,10 +616,17 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     await page.goto(url, { waitUntil: "networkidle", timeout: cfg.timeout || 40000 });
     if (cfg.waitFor > 0) await page.waitForTimeout(cfg.waitFor);
     // Capture JSON-LD BEFORE closing browser — evaluate returns once page is ready.
-    const [text, jsonLdScripts] = await page.evaluate(() => [
-      document.body.innerText,
-      Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
-    ]);
+    // Strip nav/header/footer first (same effect as Firecrawl onlyMainContent:true)
+    // to avoid spot tickers and site-wide navigation being included in innerText,
+    // which causes firstInRangePriceProse() to grab wrong prices on BE pages.
+    const [text, jsonLdScripts] = await page.evaluate(() => {
+      document.querySelectorAll("nav, header, footer, [role='navigation'], [role='banner']")
+        .forEach(el => el.remove());
+      return [
+        document.body.innerText,
+        Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
+      ];
+    });
     await browser.close();
     browser = null;
     const cleaned = preprocessMarkdown(text, providerId);

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -248,6 +248,43 @@ function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "") {
 }
 
 /**
+ * Extract price from JSON-LD Product schema (`offers.price`).
+ *
+ * Checks first — before any regex-based extraction — because JSON-LD is
+ * the authoritative structured price set by the merchant, and avoids
+ * false positives from spot ticker values appearing earlier in innerText.
+ *
+ * @param {string[]} jsonLdScripts  textContent of each ld+json script tag
+ * @param {string}   metal
+ * @param {number}   weightOz
+ * @returns {number|null}
+ */
+function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1) {
+  if (!jsonLdScripts || jsonLdScripts.length === 0) return null;
+  const perOz = METAL_PRICE_RANGE_PER_OZ[metal];
+  if (!perOz) return null;
+  const min = perOz.min * weightOz;
+  const max = perOz.max * weightOz;
+  for (const script of jsonLdScripts) {
+    try {
+      const data = JSON.parse(script);
+      const items = Array.isArray(data) ? data : [data];
+      for (const item of items) {
+        if (item["@type"] !== "Product") continue;
+        const offers = item.offers;
+        if (!offers) continue;
+        const offerList = Array.isArray(offers) ? offers : [offers];
+        for (const offer of offerList) {
+          const price = parseFloat(offer.price);
+          if (!isNaN(price) && price >= min && price <= max) return price;
+        }
+      }
+    } catch { /* invalid JSON — skip */ }
+  }
+  return null;
+}
+
+/**
  * Extract the lowest plausible per-coin price from scraped markdown.
  *
  * Strategy order varies by provider to avoid picking up related-product prices:
@@ -578,11 +615,21 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     });
     await page.goto(url, { waitUntil: "networkidle", timeout: cfg.timeout || 40000 });
     if (cfg.waitFor > 0) await page.waitForTimeout(cfg.waitFor);
-    const text = await page.innerText("body");
+    // Capture JSON-LD BEFORE closing browser — evaluate returns once page is ready.
+    const [text, jsonLdScripts] = await page.evaluate(() => [
+      document.body.innerText,
+      Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
+    ]);
     await browser.close();
     browser = null;
     const cleaned = preprocessMarkdown(text, providerId);
     const inStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
+    // JSON-LD is authoritative — avoids related-product / spot ticker false positives.
+    const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
+    if (jsonLdPrice !== null) {
+      log(`[cf-clearance] success via jsonLd: ${providerId} price=${jsonLdPrice}`);
+      return { price: jsonLdPrice, inStock: inStock.inStock, source: "cf-clearance" };
+    }
     const price = extractPrice(cleaned, coin.metal, coin.weight_oz || 1, providerId);
     if (price !== null) {
       log(`[cf-clearance] success: ${providerId} price=${price.price}`);
@@ -739,9 +786,21 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
       await page.waitForTimeout(phase0Wait);
     }
 
-    const text = await page.evaluate(() => document.body.innerText);
+    const [text, jsonLdScripts] = await page.evaluate(() => [
+      document.body.innerText,
+      Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
+    ]);
     const cleaned = preprocessMarkdown(text, providerId);
     const stock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
+
+    // JSON-LD is authoritative — check before regex fallbacks to avoid
+    // grabbing spot ticker deltas or related-product prices from innerText.
+    const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
+    if (jsonLdPrice !== null) {
+      log(`  extractPrice ${providerId}: matched=jsonLd price=$${jsonLdPrice.toFixed(2)}`);
+      return { price: jsonLdPrice, inStock: stock.inStock, source: "playwright-direct" };
+    }
+
     const extracted = extractPrice(cleaned, coin.metal, coin.weight_oz || 1, providerId);
     const price = extracted ? extracted.price : null;
     if (extracted) log(`  extractPrice ${providerId}: matched=${extracted.matchedBy} price=$${extracted.price.toFixed(2)}`);

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -270,12 +270,16 @@ function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1) {
       const data = JSON.parse(script);
       const items = Array.isArray(data) ? data : [data];
       for (const item of items) {
-        if (item["@type"] !== "Product") continue;
+        // @type may be a string or an array per JSON-LD spec
+        const typeVal = item["@type"];
+        const types = Array.isArray(typeVal) ? typeVal : [typeVal];
+        if (!types.includes("Product")) continue;
         const offers = item.offers;
         if (!offers) continue;
         const offerList = Array.isArray(offers) ? offers : [offers];
         for (const offer of offerList) {
-          const price = parseFloat(offer.price);
+          // Strip thousands separators before parsing — "1,200.00" must not become 1
+          const price = parseFloat(String(offer.price ?? "").replace(/,/g, ""));
           if (!isNaN(price) && price >= min && price <= max) return price;
         }
       }

--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -2,9 +2,10 @@
 title: Home Poller (Docker/Portainer)
 category: infrastructure
 owner: staktrakr
-lastUpdated: v3.33.63
+lastUpdated: v3.33.66
 date: 2026-03-10
 sourceFiles:
+  - devops/pollers/shared/price-extract.js
   - devops/pollers/docker-compose.home.yml
   - devops/pollers/home-poller/Dockerfile
   - devops/pollers/home-poller/dashboard.js
@@ -157,6 +158,17 @@ The Tailscale sidecar (`tailscale-staktrakr`) runs in its own container. Tinypro
 | 2 | CF sidecar + Playwright with cookie | Phase 0/1 return HTTP 403 |
 
 Phase 2 calls `getCFClearanceCookie(url)` from `shared/cf-clearance.js`, injects the returned `cf_clearance` cookie and matching `User-Agent` into a Playwright browser context, then re-scrapes. Results written to Turso with `source: "cf-clearance"`.
+
+### Price Extraction Strategy (`extractPrice` + JSON-LD)
+
+After scraping, `price-extract.js` extracts the wire/ACH price via:
+
+1. **JSON-LD first** — `extractJsonLdPrice()` reads `<script type="application/ld+json">` Product schemas (`offers.price`). This is the authoritative price set by the merchant and avoids spot ticker / related-product false positives. Applies in Phase 0 (Playwright direct) and Phase 2 (CF-clearance) paths.
+2. **Pipe-table first row** — `firstTableRowFirstPrice()` — standard pricing grid layout.
+3. **Prose price scan** — `firstInRangePriceProse()` — first `$XX.XX` value in the metal's price range (SPA fallback).
+4. **As Low As** — `asLowAsPrices()` — bulk-discount price as last resort.
+
+**Known false-positive risk:** APMEX spot ticker shows daily price *changes* (e.g. palladium ±$11) which can fall in the goldback range ($5–$25). Provident's spot ticker gold price ($5,100+) falls within the platinum range ($500–$6,000). JSON-LD extraction resolves both by reading the authoritative `offers.price` before scanning prose.
 
 ### Enabling / Disabling
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes.

## Problem

`firstInRangePriceProse()` grabs the first `$XX.XX` in the metal's price range from page `innerText`. Two confirmed false positives:

- **APMEX goldbacks (~$11 vs ~$10.70):** APMEX spot ticker shows daily price *changes* (palladium ±$11.30 falls in goldback range $5–$25). Phase 0 Playwright grabs this delta before reaching the product price.
- **Provident APE (~$5,176 vs ~$2,477):** Gold spot price ($5,185) appears first in innerText and falls within platinum range ($500–$6,000).

## Fix

Added `extractJsonLdPrice(jsonLdScripts, metal, weightOz)` — parses `<script type="application/ld+json">` Product schemas and returns `offers.price` if it falls in the metal's valid range.

Both `scrapeWithPlaywrightDirect` and `scrapeViaCFClearance` now:
1. Capture JSON-LD scripts alongside `innerText` via `page.evaluate()`
2. Check JSON-LD price **first** before falling through to regex extraction chain
3. JSON-LD extraction also fires on CF-clearance path (may improve Bullion Exchanges accuracy if React app injects schema after hydration)

## Files changed

- `devops/pollers/shared/price-extract.js` — +61/-2 lines
- `wiki/home-poller.md` — sourceFiles + Price Extraction Strategy section

## Linear

- STAK-466

🤖 Generated with [Claude Code](https://claude.com/claude-code)