### PR TITLE
v3.33.67 — STAK-467: Fix Phase 0 price extraction false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.67] - 2026-03-10
+
+### Fixed — STAK-467: Phase 0 price extraction false positives
+
+- **Fixed**: Strip `nav/header/footer` from page before capturing `innerText` in Phase 0 Playwright direct — prevents spot price tickers in site headers (e.g. Provident Metals gold ticker ~$5,320) from being matched instead of the actual product price (STAK-467)
+- **Fixed**: Hero Bullion moved to Firecrawl path — Phase 0 plain text lacks pipe characters so `firstTableRowFirstPrice` always returns null, falling through to `firstInRangePriceProse` which matched the "As Low As" bulk discount price instead of the 1-unit table price (STAK-467)
+- **Fixed**: Gainesville Coins moved to Firecrawl path — Phase 0 Playwright direct always times out (15s wasted per coin per run); Firecrawl succeeds reliably (STAK-467)
+
+---
+
 ## [3.33.66] - 2026-03-10
 
 ### Fixed — STAK-462: Fix cf-clearance.js endpoint for Byparr sidecar

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -512,8 +512,16 @@ const PROVIDER_CONFIG = {
     waitUntil: "domcontentloaded",  // fast — no need for networkidle
   },
   herobullion: {
-    waitUntil: "domcontentloaded",  // fast — no need for networkidle
-    waitAfter: 2_000,              // light JS hydration wait
+    phase: "firecrawl",            // Phase 0 innerText loses pipe-table structure →
+                                   // firstTableRowFirstPrice() returns null → firstInRangePriceProse()
+                                   // grabs "As Low As" bulk price before the 1-unit table price.
+                                   // Firecrawl markdown has | pipe | tables — extraction works correctly.
+    waitFor: 3_000,
+  },
+  gainesvillecoins: {
+    phase: "firecrawl",            // Phase 0 Playwright direct always times out (15s wasted per coin).
+                                   // Firecrawl succeeds reliably — skip Phase 0 entirely.
+    waitFor: 3_000,
   },
   summitmetals: {
     // defaults are fine — phase0 + networkidle
@@ -818,10 +826,18 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
       await page.waitForTimeout(phase0Wait);
     }
 
-    const [text, jsonLdScripts] = await page.evaluate(() => [
-      document.body.innerText,
-      Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
-    ]);
+    // Strip nav/header/footer before capturing innerText — same as scrapeViaCFClearance Phase 2.
+    // Site-wide navigation on many vendors (Provident, SDB, etc.) contains a spot price ticker
+    // (e.g. Gold $5,320.00) that appears before the product price in the text stream.
+    // firstInRangePriceProse() would otherwise match the spot ticker instead of the product price.
+    const [text, jsonLdScripts] = await page.evaluate(() => {
+      document.querySelectorAll("nav, header, footer, [role='navigation'], [role='banner']")
+        .forEach(el => el.remove());
+      return [
+        document.body.innerText,
+        Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
+      ];
+    });
     const cleaned = preprocessMarkdown(text, providerId);
     const stock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
 

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -648,17 +648,18 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     });
     await page.goto(url, { waitUntil: "networkidle", timeout: cfg.timeout || 40000 });
     if (cfg.waitFor > 0) await page.waitForTimeout(cfg.waitFor);
-    // Capture JSON-LD BEFORE closing browser — evaluate returns once page is ready.
-    // Strip nav/header/footer first (same effect as Firecrawl onlyMainContent:true)
-    // to avoid spot tickers and site-wide navigation being included in innerText,
-    // which causes firstInRangePriceProse() to grab wrong prices on BE pages.
+    // Capture JSON-LD BEFORE removing nav elements — some vendors embed
+    // <script type="application/ld+json"> inside <header>/<footer>; removing first
+    // would make querySelectorAll return empty. Strip nav/header/footer after capturing
+    // to prevent spot tickers from polluting innerText (Firecrawl onlyMainContent equivalent).
     const [text, jsonLdScripts] = await page.evaluate(() => {
+      const scripts = Array.from(
+        document.querySelectorAll('script[type="application/ld+json"]'),
+        s => s.textContent
+      );
       document.querySelectorAll("nav, header, footer, [role='navigation'], [role='banner']")
         .forEach(el => el.remove());
-      return [
-        document.body.innerText,
-        Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
-      ];
+      return [document.body.innerText, scripts];
     });
     await browser.close();
     browser = null;
@@ -826,17 +827,19 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
       await page.waitForTimeout(phase0Wait);
     }
 
-    // Strip nav/header/footer before capturing innerText — same as scrapeViaCFClearance Phase 2.
-    // Site-wide navigation on many vendors (Provident, SDB, etc.) contains a spot price ticker
-    // (e.g. Gold $5,320.00) that appears before the product price in the text stream.
-    // firstInRangePriceProse() would otherwise match the spot ticker instead of the product price.
+    // Capture JSON-LD BEFORE removing nav elements (same as scrapeViaCFClearance Phase 2).
+    // Some vendors embed <script type="application/ld+json"> inside <header>/<footer>;
+    // removing those elements first would return empty scripts. After capturing, strip
+    // nav/header/footer to prevent spot tickers from polluting innerText and causing
+    // firstInRangePriceProse() to match the spot price instead of the product price.
     const [text, jsonLdScripts] = await page.evaluate(() => {
+      const scripts = Array.from(
+        document.querySelectorAll('script[type="application/ld+json"]'),
+        s => s.textContent
+      );
       document.querySelectorAll("nav, header, footer, [role='navigation'], [role='banner']")
         .forEach(el => el.remove());
-      return [
-        document.body.innerText,
-        Array.from(document.querySelectorAll('script[type="application/ld+json"]'), s => s.textContent),
-      ];
+      return [document.body.innerText, scripts];
     });
     const cleaned = preprocessMarkdown(text, providerId);
     const stock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Retail Price Accuracy (v3.33.67)**: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk "As Low As" price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467).
 - **Retail Price Reliability (v3.33.61&ndash;v3.33.66)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462).
 - **Market Price Chart Fixes (v3.33.62)**: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463).
 - **DiffModal Complete Overhaul (v3.33.56&ndash;v3.33.60)**: Full card-based cloud sync review — summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457).
 - **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449).
-- **Market View Improvements (v3.33.52, v3.33.57)**: Mobile search bar and controls layout fixed; metal filter pills (All / Silver / Gold / Goldback / Platinum / Palladium) added; Australian coins (Kangaroo, Koala, Kookaburra) now display correctly (STAK-433, STAK-434, STAK-452).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.67 &ndash; Retail Price Accuracy</strong>: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467)</li>
     <li><strong>v3.33.61&ndash;v3.33.66 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462)</li>
     <li><strong>v3.33.62 &ndash; Market Price Chart Fixes</strong>: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463)</li>
     <li><strong>v3.33.60 &ndash; DiffModal Complete Overhaul</strong>: Full card-based cloud sync review &mdash; summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457)</li>
     <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449)</li>
-    <li><strong>v3.33.57 &ndash; Market View Improvements</strong>: Mobile search bar and controls layout fixed; metal filter pills (All / Silver / Gold / Goldback / Platinum / Palladium) added; Australian coins (Kangaroo, Koala, Kookaburra) now display correctly (STAK-433, STAK-434, STAK-452)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.66";
+const APP_VERSION = "3.33.67";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.66-b1773111077';
+const CACHE_NAME = 'staktrakr-v3.33.67-b1773127104';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.66",
+  "version": "3.33.67",
   "releaseDate": "2026-03-10",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/fly-container.md
+++ b/wiki/fly-container.md
@@ -2,7 +2,7 @@
 title: Fly.io Container
 category: infrastructure
 owner: staktrakr
-lastUpdated: v3.33.66
+lastUpdated: v3.33.67
 date: 2026-03-10
 sourceFiles:
   - devops/pollers/remote-poller/Dockerfile

--- a/wiki/home-poller.md
+++ b/wiki/home-poller.md
@@ -2,7 +2,7 @@
 title: Home Poller (Docker/Portainer)
 category: infrastructure
 owner: staktrakr
-lastUpdated: v3.33.66
+lastUpdated: v3.33.67
 date: 2026-03-10
 sourceFiles:
   - devops/pollers/shared/price-extract.js
@@ -167,12 +167,17 @@ Phase 2 calls `getCFClearanceCookie(url)` from `shared/cf-clearance.js`, which P
 
 After scraping, `price-extract.js` extracts the wire/ACH price via:
 
-1. **JSON-LD first** — `extractJsonLdPrice()` reads `<script type="application/ld+json">` Product schemas (`offers.price`). This is the authoritative price set by the merchant and avoids spot ticker / related-product false positives. Applies in Phase 0 (Playwright direct) and Phase 2 (CF-clearance) paths.
-2. **Pipe-table first row** — `firstTableRowFirstPrice()` — standard pricing grid layout.
+1. **JSON-LD first** — `extractJsonLdPrice()` reads `<script type="application/ld+json">` Product schemas (`offers.price`). Authoritative price set by the merchant; avoids spot ticker / related-product false positives. Applies in Phase 0 and Phase 2.
+2. **Pipe-table first row** — `firstTableRowFirstPrice()` — standard pricing grid layout. Only matches Firecrawl markdown (which produces `| $price |` pipe tables). Phase 0 plain `innerText` has no pipe characters — vendors that need table-based extraction must use `phase: "firecrawl"` in `PROVIDER_CONFIG`.
 3. **Prose price scan** — `firstInRangePriceProse()` — first `$XX.XX` value in the metal's price range (SPA fallback).
 4. **As Low As** — `asLowAsPrices()` — bulk-discount price as last resort.
 
-**Known false-positive risk:** APMEX spot ticker shows daily price *changes* (e.g. palladium ±$11) which can fall in the goldback range ($5–$25). Provident's spot ticker gold price ($5,100+) falls within the platinum range ($500–$6,000). JSON-LD extraction resolves both by reading the authoritative `offers.price` before scanning prose.
+**Nav stripping (Phase 0 + Phase 2):** Before capturing `innerText`, Phase 0 (`scrapeWithPlaywrightDirect`) removes `nav, header, footer, [role='navigation'], [role='banner']` from the DOM — the same treatment applied in Phase 2 (`scrapeViaCFClearance`). This prevents site-wide spot price tickers (e.g. Provident Metals gold ticker ~$5,320) from appearing before the product price in the text stream and being matched by `firstInRangePriceProse`.
+
+**Vendor routing (PROVIDER_CONFIG):** Vendors where Phase 0 `innerText` extraction is structurally insufficient use `phase: "firecrawl"`:
+- `herobullion` — "As Low As" bulk price appears before the 1-unit table; pipe-table extraction via Firecrawl returns the correct 1-unit price.
+- `gainesvillecoins` — Phase 0 Playwright always times out; Firecrawl succeeds reliably.
+- `apmex`, `monumentmetals`, `jmbullion`, `bullionexchanges` — already Firecrawl-preferred (JS-rendering, bot-detection, or table-parsing requirements).
 
 ### Enabling / Disabling
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after QA passes. Do NOT target main.

## Changes

Three related extraction failures fixed in `devops/pollers/shared/price-extract.js`:

- **Strip nav/header/footer in Phase 0** — `scrapeWithPlaywrightDirect` now removes `nav, header, footer, [role='navigation'], [role='banner']` before capturing `innerText`, same as the Phase 2 cf-clearance path. Prevents site-wide spot price tickers (e.g. Provident Metals gold ticker ~$5,320) from appearing before the product price and being matched by `firstInRangePriceProse`.

- **Hero Bullion → `phase: "firecrawl"`** — Phase 0 plain `innerText` has no pipe characters; `firstTableRowFirstPrice` always returns null, silently falling through to `firstInRangePriceProse` which matched the "As Low As" bulk discount price. Firecrawl markdown tables allow `firstTableRowFirstPrice` to correctly extract the 1-unit wire price.

- **Gainesville Coins → `phase: "firecrawl"`** — Phase 0 Playwright direct always times out (15s wasted per coin per run). Firecrawl succeeds reliably.

## Linear Issues

- [STAK-467](https://linear.app/lbruton/issue/STAK-467) — Fix Phase 0 price extraction false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)