### PR TITLE
chore: expose byparr port 8191 for Fly.io → Tailscale CF bypass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ When you change a file, update every wiki page listed in its row.
 
 ## API Infrastructure
 
-> **Poller code ownership:** All poller scripts live in `StakTrakr/devops/pollers/` (shared core + home-poller + remote-poller). Home VM deploys via Portainer API from git. Fly.io container still deploys from `StakTrakrApi/devops/fly-poller/` (transitioning). See `repo-boundaries` skill for full ownership map.
+> **Poller code ownership:** All poller scripts live in `StakTrakr/devops/pollers/` (shared core + home-poller + remote-poller). Home VM deploys via Portainer API from git. Fly.io deploys from `devops/pollers/remote-poller/` in this same repo — `StakTrakrApi/devops/fly-poller/` no longer exists. See `repo-boundaries` skill for full ownership map.
 
 **Runbook:** See wiki/ for current runbooks: [`health.md`](wiki/health.md), [`fly-container.md`](wiki/fly-container.md), [`spot-pipeline.md`](wiki/spot-pipeline.md).
 

--- a/devops/pollers/docker-compose.home.yml
+++ b/devops/pollers/docker-compose.home.yml
@@ -52,6 +52,8 @@ services:
     restart: unless-stopped
     environment:
       LOG_LEVEL: info
+    ports:
+      - "8191:8191"   # Exposed for Fly.io → Tailscale → Byparr CF bypass
     volumes:
       - /dev/shm:/dev/shm
     logging:

--- a/devops/pollers/remote-poller/fly.toml
+++ b/devops/pollers/remote-poller/fly.toml
@@ -6,6 +6,9 @@ primary_region = 'iad'
 
 [build]
   dockerfile = "Dockerfile"
+  # Build context is parent dir (devops/pollers/) so Dockerfile can reach
+  # both shared/ and remote-poller/ as sibling directories.
+  context = ".."
 
 [env]
   POLLER_ID = "api"


### PR DESCRIPTION
## Summary

- Adds `ports: - "8191:8191"` to the `byparr` service in `docker-compose.home.yml`
- Enables Fly.io to reach the home Byparr (CF clearance sidecar) over Tailscale at `100.112.198.50:8191`
- Fly.io secrets (`CF_CLEARANCE_SCRAPER_URL`, `CF_CLEARANCE_ENABLED`, `CF_CLEARANCE_TIMEOUT_MS`) set separately via `fly secrets set`

## Context

The STAK-466 CF clearance bypass was confirmed working on the home poller. This completes the Fly.io side of that integration — Fly.io can now use the same Byparr instance via the home VM's Tailscale IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)