### PR TITLE
⚡ Bolt: Use DocumentFragment for batched DOM updates in renderActiveFilters

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -499,6 +499,10 @@ const renderActiveFilters = () => {
   
   container.style.display = '';
 
+  // ⚡ Bolt: Use DocumentFragment to batch DOM insertions for filter chips.
+  // Instead of triggering a reflow/repaint for every single chip appended to the container,
+  // we build them off-DOM in a fragment and append them all at once. O(N) -> O(1) reflows.
+  const fragment = document.createDocumentFragment();
   chips.forEach((f, i) => {
     const chip = document.createElement('span');
     chip.className = 'filter-chip';
@@ -666,7 +670,7 @@ const renderActiveFilters = () => {
       }
     };
 
-    container.appendChild(chip);
+    fragment.appendChild(chip);
   });
 
   // Add clear button if there are any chips (check for both active and summary chips)
@@ -678,8 +682,10 @@ const renderActiveFilters = () => {
     clearButton.onclick = () => {
       clearAllFilters();
     };
-    container.appendChild(clearButton);
+    fragment.appendChild(clearButton);
   }
+
+  container.appendChild(fragment);
 };
 
 /**


### PR DESCRIPTION
💡 **What:** Modified `renderActiveFilters` in `js/filters.js` to batch append DOM elements using `DocumentFragment`.
🎯 **Why:** To reduce browser reflows/repaints when rendering a large number of filter chips. Previously, the code appended each filter chip individually into the live DOM container.
📊 **Impact:** Reduces O(N) reflows (where N is the number of chips + clear button) to O(1) by building the entire list of filter chips inside an off-screen DocumentFragment and attaching it to the live DOM container in a single operation.
🔬 **Measurement:** Open the app, type a multi-word search string, and enable several filter options to generate 5+ chips. Observe the DOM rendering time.

---
*PR created automatically by Jules for task [7538517980512011825](https://jules.google.com/task/7538517980512011825) started by @lbruton*