### PR TITLE
fix: return Byparr HTML even without cf_clearance cookie

### DIFF
--- a/devops/pollers/shared/cf-clearance.js
+++ b/devops/pollers/shared/cf-clearance.js
@@ -20,11 +20,13 @@ const CF_CLEARANCE_ENABLED = process.env.CF_CLEARANCE_ENABLED ?? "1";
 const CF_CLEARANCE_TIMEOUT_MS = process.env.CF_CLEARANCE_TIMEOUT_MS ?? "30000";
 
 /**
- * Harvest a cf_clearance cookie from the Byparr sidecar for the given URL.
+ * Harvest a cf_clearance cookie (and pre-fetched HTML) from the Byparr sidecar.
  *
  * @param {string} url - Vendor product URL to solve CF challenge for
- * @returns {Promise<{ cfClearance: string, userAgent: string } | null>}
- *   Returns cookie+UA on success, null if disabled or sidecar unavailable.
+ * @returns {Promise<{ cfClearance: string|null, userAgent: string, responseHtml: string|null } | null>}
+ *   Returns solution on success (cfClearance may be null if Cloudflare didn't
+ *   set a cookie, but responseHtml may still contain usable page content).
+ *   Returns null only if disabled or sidecar unavailable.
  */
 export async function getCFClearanceCookie(url) {
   if (CF_CLEARANCE_ENABLED !== "1") {
@@ -56,12 +58,19 @@ export async function getCFClearanceCookie(url) {
 
     const cfCookie = data.solution.cookies?.find((c) => c.name === "cf_clearance");
     if (!cfCookie?.value) {
-      console.warn("[cf-clearance] no cf_clearance cookie in solution");
-      return null;
+      // Cloudflare may not set a cookie (managed challenge / Turnstile), but
+      // Byparr still fetched the page — return the HTML so the caller can
+      // extract prices directly without needing a cookie+Playwright round-trip.
+      if (data.solution.response) {
+        console.log("[cf-clearance] no cookie, but have response HTML — returning for direct extraction");
+      } else {
+        console.warn("[cf-clearance] no cf_clearance cookie and no response HTML");
+        return null;
+      }
     }
 
     return {
-      cfClearance: cfCookie.value,
+      cfClearance: cfCookie?.value ?? null,
       userAgent: data.solution.userAgent,
       // HTML Byparr already fetched — lets caller skip a second browser request
       responseHtml: data.solution.response ?? null,

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -598,7 +598,7 @@ async function scrapeViaCFClearance(url, providerId, coin) {
   log(`[cf-clearance] attempt: ${providerId} ${url}`);
   const cfData = await getCFClearanceCookie(url);
   if (!cfData) {
-    warn(`[cf-clearance] no cookie returned for ${providerId}`);
+    warn(`[cf-clearance] sidecar unavailable for ${providerId}`);
     return null;
   }
 
@@ -621,7 +621,12 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     return null;
   }
 
-  // Fallback: launch Playwright with the cookie if Byparr didn't return response HTML
+  // Fallback: launch Playwright with the cookie if Byparr didn't return response HTML.
+  // Requires a valid cf_clearance cookie — skip if Byparr didn't provide one.
+  if (!cfData.cfClearance) {
+    warn(`[cf-clearance] no cookie and no usable HTML for ${providerId}`);
+    return null;
+  }
   let browser;
   try {
     const cfg = providerCfg(providerId);


### PR DESCRIPTION
## Summary

- Byparr successfully bypasses Cloudflare and fetches page HTML (200 OK, 5-7s), but after VM migration Cloudflare stopped setting `cf_clearance` cookies
- `getCFClearanceCookie()` was returning `null` when no cookie was found, discarding the usable HTML that Byparr already fetched
- Now returns `responseHtml` even with `cfClearance: null`, so `scrapeViaCFClearance()` can extract prices directly from the pre-fetched HTML
- Added guard to skip Playwright fallback path when no cookie is available (it would fail anyway)
- Recovers ~20 bullionexchanges targets (146/166 → expected 166/166)

## Test plan

- [ ] Portainer GitOps picks up merge to `dev`
- [ ] Next hourly scan at :30 shows bullionexchanges prices returning
- [ ] Dashboard score returns to 166/166
- [ ] Byparr logs continue showing 200 OK for bullionexchanges
- [ ] Poller logs show `[cf-clearance] success (html)` instead of `no cookie returned`

🤖 Generated with [Claude Code](https://claude.com/claude-code)