### PR TITLE
v3.33.68 — STAK-469: Fix Catalog Data not saving without Numista number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.68] - 2026-03-11
+
+### Fixed — STAK-469: Catalog Data not saving for items without Numista number
+
+- **Fixed**: Catalog Data fields (diameter, thickness, country, composition, shape, etc.) silently discarded on save for any item without a Numista number — removed overly aggressive early return in `parseNumistaDataFields()` that wiped all metadata when the N# field was empty, even for items that never had one (STAK-469)
+
+---
+
 ## [3.33.67] - 2026-03-10
 
 ### Fixed — STAK-467: Phase 0 price extraction false positives

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Catalog Data Fix (v3.33.68)**: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469).
 - **Retail Price Accuracy (v3.33.67)**: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk "As Low As" price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467).
 - **Retail Price Reliability (v3.33.61&ndash;v3.33.66)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462).
 - **Market Price Chart Fixes (v3.33.62)**: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463).
 - **DiffModal Complete Overhaul (v3.33.56&ndash;v3.33.60)**: Full card-based cloud sync review — summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457).
-- **Dropbox Multi-Account UX (v3.33.55)**: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.68 &ndash; Catalog Data Fix</strong>: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469)</li>
     <li><strong>v3.33.67 &ndash; Retail Price Accuracy</strong>: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467)</li>
     <li><strong>v3.33.61&ndash;v3.33.66 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462)</li>
     <li><strong>v3.33.62 &ndash; Market Price Chart Fixes</strong>: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463)</li>
     <li><strong>v3.33.60 &ndash; DiffModal Complete Overhaul</strong>: Full card-based cloud sync review &mdash; summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457)</li>
-    <li><strong>v3.33.55 &ndash; Dropbox Multi-Account UX</strong>: Connected Dropbox account email and display name shown in Cloud settings. New Switch Account button forces re-authentication to prevent auto-connecting the wrong account (STAK-449)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.67";
+const APP_VERSION = "3.33.68";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -1040,9 +1040,6 @@ const parseItemFormFields = (isEditing, existingItem) => {
  * @returns {Object} Numista data fields with source tracking
  */
 const parseNumistaDataFields = (isEditing, existingItem, catalog = '') => {
-  // When N# is being cleared while editing, wipe all Numista metadata (STAK-309)
-  if (isEditing && !catalog) return {};
-
   const get = (id) => (document.getElementById(id)?.value?.trim() ?? '');
   const prev = (isEditing && existingItem?.numistaData) ? existingItem.numistaData : {};
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.67-b1773127104';
+const CACHE_NAME = 'staktrakr-v3.33.68-b1773214250';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.67",
-  "releaseDate": "2026-03-10",
+  "version": "3.33.68",
+  "releaseDate": "2026-03-11",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Catalog Data fields (diameter, thickness, country, composition, shape, etc.) silently discarded on save for any item without a Numista number
- Removed overly aggressive early return in `parseNumistaDataFields()` (line 1044 of `js/events.js`) that was added for STAK-309 — it wiped all metadata when the N# field was empty, even for items that never had one
- The form fields already handle data correctly: if fields are empty, the cleanup loop strips them; if fields have values, they persist

## Root Cause

```javascript
// REMOVED — this early return wiped catalog data for items without N#
if (isEditing && !catalog) return {};
```

## Reproduction

Confirmed on both staktrakr.com (main) and beta.staktrakr.com (dev) v3.33.67 via Browserbase:
1. Open any item without a Numista number (e.g., Palladium Bar)
2. Enter values in Catalog Data fields (diameter, thickness, country)
3. Click Save Changes — modal closes successfully
4. Re-open the item — all Catalog Data fields are empty

## Linear Issues

- [STAK-469: Bug: Catalog Data fields silently wiped on save for items without Numista number](https://linear.app/lbruton/issue/STAK-469)

🤖 Generated with [Claude Code](https://claude.com/claude-code)