### PR TITLE
fix: restore Fly.io proxy + route Byparr via Tailscale (STAK-468)

### DIFF
--- a/devops/pollers/shared/cf-clearance.js
+++ b/devops/pollers/shared/cf-clearance.js
@@ -14,8 +14,9 @@
 // Override URL via CF_CLEARANCE_SIDECAR_URL env var.
 // Docs: https://github.com/ThePhaseless/Byparr
 
+// Accept both SIDECAR_URL (canonical) and SCRAPER_URL (legacy Fly.io secret)
 const CF_CLEARANCE_SIDECAR_URL =
-  process.env.CF_CLEARANCE_SIDECAR_URL ?? "http://staktrakr-byparr:8191";
+  process.env.CF_CLEARANCE_SIDECAR_URL ?? process.env.CF_CLEARANCE_SCRAPER_URL ?? "http://staktrakr-byparr:8191";
 const CF_CLEARANCE_ENABLED = process.env.CF_CLEARANCE_ENABLED ?? "1";
 const CF_CLEARANCE_TIMEOUT_MS = process.env.CF_CLEARANCE_TIMEOUT_MS ?? "30000";
 

--- a/devops/pollers/tinyproxy/Dockerfile
+++ b/devops/pollers/tinyproxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-RUN apk add --no-cache tinyproxy iproute2 \
+RUN apk add --no-cache tinyproxy iproute2 socat \
     && mkdir -p /var/log/tinyproxy \
     && chown tinyproxy:tinyproxy /var/log/tinyproxy
 

--- a/devops/pollers/tinyproxy/entrypoint.sh
+++ b/devops/pollers/tinyproxy/entrypoint.sh
@@ -43,4 +43,13 @@ if ip addr 2>/dev/null | grep -q '100\.'; then
   echo "tinyproxy: Tailscale IP ${TS_IP} ready after ${ELAPSED}s"
 fi
 
+# Forward port 8191 from Tailscale namespace to Docker host → Byparr container.
+# Fly.io reaches Byparr at 100.112.198.50:8191 via Tailscale, socat routes to
+# the Docker bridge gateway (host port 8191 → staktrakr-byparr:8191).
+GATEWAY=$(ip route | grep default | awk '{print $3}')
+if [ -n "$GATEWAY" ]; then
+  echo "tinyproxy: starting socat port 8191 forwarder to gateway ${GATEWAY}"
+  socat TCP-LISTEN:8191,fork,reuseaddr TCP:${GATEWAY}:8191 &
+fi
+
 exec tinyproxy -d


### PR DESCRIPTION
## Summary
- **cf-clearance.js**: Accept both `CF_CLEARANCE_SIDECAR_URL` (canonical) and `CF_CLEARANCE_SCRAPER_URL` (legacy Fly.io secret) via `??` fallback chain — fixes env var mismatch that silently disabled CF bypass on Fly.io
- **tinyproxy Dockerfile**: Add `socat` package for port forwarding
- **tinyproxy entrypoint.sh**: Add socat forwarder that routes port 8191 from the Tailscale network namespace through the Docker bridge gateway to the Byparr container — enables Fly.io pollers to reach Byparr for CF bypass via Tailscale mesh

## Context
Follow-up to #840. These changes were committed after that PR merged. Together they complete the Fly.io → Tailscale → Byparr routing chain so remote pollers can solve Cloudflare challenges via the home sidecar.

## Test plan
- [ ] Portainer auto-deploys updated tinyproxy image (socat + port forwarder)
- [ ] Fly.io poller run shows improved price count (target: >100/166)
- [ ] `fly ssh console -C "curl -s http://100.112.198.50:8191/health"` returns Byparr health response
- [ ] Home poller CF-gated vendors (Bullion Exchanges) continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>