### PR TITLE
v3.33.69 — STAK-470: Fix disposedFilterMode storage + silent settings-only sync merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.69] - 2026-03-11
+
+### Fixed — STAK-470: Storage hygiene + silent settings-only sync merge
+
+- **Fixed**: `disposedFilterMode` not registered in `ALLOWED_STORAGE_KEYS` — `cleanupStorage()` silently deleted the disposed filter preference on every page reload, resetting it to "hide" (STAK-470)
+- **Fixed**: Raw `localStorage` calls for disposed filter in `events.js` replaced with `loadDataSync`/`saveDataSync` to follow project storage conventions (STAK-470)
+- **Fixed**: Version upgrades that add new `SYNC_SCOPE_KEYS` no longer trigger a phantom DiffModal — one-sided settings key diffs (key exists on only one side) are now auto-merged silently during cloud sync polling, with a push scheduled to propagate local-only keys back to the remote (STAK-470)
+
+---
+
 ## [3.33.68] - 2026-03-11
 
 ### Fixed — STAK-469: Catalog Data not saving for items without Numista number

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Storage &amp; Sync Hygiene (v3.33.69)**: Fixed disposed filter preference resetting on every page reload. Version upgrades no longer trigger phantom cloud sync diff popups &mdash; settings-only key diffs from new versions are auto-merged silently (STAK-470).
 - **Catalog Data Fix (v3.33.68)**: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469).
 - **Retail Price Accuracy (v3.33.67)**: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk "As Low As" price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467).
 - **Retail Price Reliability (v3.33.61&ndash;v3.33.66)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462).

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.69 &ndash; Storage &amp; Sync Hygiene</strong>: Fixed disposed filter preference resetting on every page reload. Version upgrades no longer trigger phantom cloud sync diff popups &mdash; settings-only key diffs from new versions are auto-merged silently (STAK-470)</li>
     <li><strong>v3.33.68 &ndash; Catalog Data Fix</strong>: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469)</li>
     <li><strong>v3.33.67 &ndash; Retail Price Accuracy</strong>: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467)</li>
     <li><strong>v3.33.61&ndash;v3.33.66 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462)</li>
     <li><strong>v3.33.62 &ndash; Market Price Chart Fixes</strong>: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463)</li>
-    <li><strong>v3.33.60 &ndash; DiffModal Complete Overhaul</strong>: Full card-based cloud sync review &mdash; summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457)</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2422,6 +2422,39 @@ async function pullWithPreview(remoteMeta) {
             return;
           }
 
+          // STAK-470: If inventory has no changes but settings changes are ALL
+          // one-sided (key exists on only one side), this is a version upgrade —
+          // one device has newer SYNC_SCOPE_KEYS the other doesn't know about.
+          // Auto-merge silently: apply remote-only keys locally, keep local-only
+          // keys (they'll be pushed on next sync). No DiffModal needed.
+          if (_mNoChanges && !_mNoSettingsChanges) {
+            var _allOneSided = manifestSettingsDiff.changed.every(function(c) {
+              return c.localVal === null || c.remoteVal === null;
+            });
+            if (_allOneSided) {
+              var _appliedCount = 0;
+              for (var _si = 0; _si < manifestSettingsDiff.changed.length; _si++) {
+                var _sc = manifestSettingsDiff.changed[_si];
+                if (_sc.remoteVal !== null && _sc.localVal === null) {
+                  try { localStorage.setItem(_sc.key, _sc.remoteVal); _appliedCount++; } catch (_) { /* ignore */ }
+                }
+              }
+              syncSetLastPull({
+                syncId: remoteMeta ? remoteMeta.syncId : null,
+                timestamp: remoteMeta ? remoteMeta.timestamp : Date.now(),
+                rev: remoteMeta ? remoteMeta.rev : null,
+              });
+              console.warn('[CloudSync] STAK-470: Version-upgrade settings diff — auto-merged ' + _appliedCount + ' remote-only keys, ' + (manifestSettingsDiff.changed.length - _appliedCount) + ' local-only keys kept');
+              logCloudSyncActivity('auto_sync_pull', 'success', 'Version-upgrade settings merged silently (' + _appliedCount + ' applied, ' + (manifestSettingsDiff.changed.length - _appliedCount) + ' local-only)');
+              updateSyncStatusIndicator('idle', 'just now');
+              // Push to update remote manifest with local-only keys
+              if (_appliedCount < manifestSettingsDiff.changed.length && typeof scheduleSyncPush === 'function') {
+                scheduleSyncPush();
+              }
+              return;
+            }
+          }
+
           // STAK-402 + STAK-412: Verify the manifest diff is complete by checking
           // whether the expected post-apply count matches the remote item count.
           // The manifest changelog only records changes the pushing device made — it

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2422,39 +2422,6 @@ async function pullWithPreview(remoteMeta) {
             return;
           }
 
-          // STAK-470: If inventory has no changes but settings changes are ALL
-          // one-sided (key exists on only one side), this is a version upgrade —
-          // one device has newer SYNC_SCOPE_KEYS the other doesn't know about.
-          // Auto-merge silently: apply remote-only keys locally, keep local-only
-          // keys (they'll be pushed on next sync). No DiffModal needed.
-          if (_mNoChanges && !_mNoSettingsChanges) {
-            var _allOneSided = manifestSettingsDiff.changed.every(function(c) {
-              return c.localVal === null || c.remoteVal === null;
-            });
-            if (_allOneSided) {
-              var _appliedCount = 0;
-              for (var _si = 0; _si < manifestSettingsDiff.changed.length; _si++) {
-                var _sc = manifestSettingsDiff.changed[_si];
-                if (_sc.remoteVal !== null && _sc.localVal === null) {
-                  try { localStorage.setItem(_sc.key, _sc.remoteVal); _appliedCount++; } catch (_) { /* ignore */ }
-                }
-              }
-              syncSetLastPull({
-                syncId: remoteMeta ? remoteMeta.syncId : null,
-                timestamp: remoteMeta ? remoteMeta.timestamp : Date.now(),
-                rev: remoteMeta ? remoteMeta.rev : null,
-              });
-              console.warn('[CloudSync] STAK-470: Version-upgrade settings diff — auto-merged ' + _appliedCount + ' remote-only keys, ' + (manifestSettingsDiff.changed.length - _appliedCount) + ' local-only keys kept');
-              logCloudSyncActivity('auto_sync_pull', 'success', 'Version-upgrade settings merged silently (' + _appliedCount + ' applied, ' + (manifestSettingsDiff.changed.length - _appliedCount) + ' local-only)');
-              updateSyncStatusIndicator('idle', 'just now');
-              // Push to update remote manifest with local-only keys
-              if (_appliedCount < manifestSettingsDiff.changed.length && typeof scheduleSyncPush === 'function') {
-                scheduleSyncPush();
-              }
-              return;
-            }
-          }
-
           // STAK-402 + STAK-412: Verify the manifest diff is complete by checking
           // whether the expected post-apply count matches the remote item count.
           // The manifest changelog only records changes the pushing device made — it
@@ -2467,6 +2434,55 @@ async function pullWithPreview(remoteMeta) {
           if (_mExpectedAfterApply !== _mRemoteCount) {
             debugLog('[CloudSync] Manifest diff incomplete: expected ' + _mExpectedAfterApply + ' items after apply but remote has ' + _mRemoteCount + ' (' + _mLocalCount + ' local + ' + manifestDiff.added.length + ' added - ' + manifestDiff.deleted.length + ' deleted) — using vault-first');
             throw new Error('Manifest stale: post-apply count mismatch');
+          }
+
+          // STAK-470: If inventory has no changes but settings changes are ALL
+          // one-sided (key exists on only one side), this is a version upgrade —
+          // one device has newer SYNC_SCOPE_KEYS the other doesn't know about.
+          // Auto-merge silently: apply remote-only keys locally, keep local-only
+          // keys (they'll be pushed on next sync). No DiffModal needed.
+          // Placed AFTER the manifest completeness guard so a stale manifest
+          // cannot cause this branch to skip real inventory changes.
+          if (_mNoChanges && !_mNoSettingsChanges) {
+            var _allOneSided = manifestSettingsDiff.changed.every(function(c) {
+              return c.localVal === null || c.remoteVal === null;
+            });
+            if (_allOneSided) {
+              var _appliedCount = 0;
+              var _failedCount = 0;
+              for (var _si = 0; _si < manifestSettingsDiff.changed.length; _si++) {
+                var _sc = manifestSettingsDiff.changed[_si];
+                // Guard: only apply keys in the ALLOWED_STORAGE_KEYS allowlist
+                if (typeof ALLOWED_STORAGE_KEYS !== 'undefined' && ALLOWED_STORAGE_KEYS.indexOf(_sc.key) === -1) {
+                  continue;
+                }
+                if (_sc.remoteVal !== null && _sc.localVal === null) {
+                  // Write raw localStorage value directly — remoteVal is the exact
+                  // stored form from the remote device (may include JSON encoding or
+                  // compression from saveDataSync). Re-encoding via saveDataSync
+                  // would double-encode.
+                  try { localStorage.setItem(_sc.key, _sc.remoteVal); _appliedCount++; } catch (_e) { _failedCount++; }
+                }
+              }
+              // Only record the pull if all writes succeeded — if any failed
+              // (e.g. QuotaExceededError), leave lastPull stale so the next
+              // poll cycle retries
+              if (_failedCount === 0) {
+                syncSetLastPull({
+                  syncId: remoteMeta ? remoteMeta.syncId : null,
+                  timestamp: remoteMeta ? remoteMeta.timestamp : Date.now(),
+                  rev: remoteMeta ? remoteMeta.rev : null,
+                });
+              }
+              console.warn('[CloudSync] STAK-470: Version-upgrade settings diff — auto-merged ' + _appliedCount + ' remote-only keys, ' + (manifestSettingsDiff.changed.length - _appliedCount) + ' local-only keys kept' + (_failedCount > 0 ? ', ' + _failedCount + ' failed' : ''));
+              logCloudSyncActivity('auto_sync_pull', _failedCount > 0 ? 'partial' : 'success', 'Version-upgrade settings merged silently (' + _appliedCount + ' applied, ' + (manifestSettingsDiff.changed.length - _appliedCount) + ' local-only' + (_failedCount > 0 ? ', ' + _failedCount + ' failed' : '') + ')');
+              updateSyncStatusIndicator('idle', 'just now');
+              // Push to update remote manifest with local-only keys
+              if (_appliedCount < manifestSettingsDiff.changed.length && typeof scheduleSyncPush === 'function') {
+                scheduleSyncPush();
+              }
+              return;
+            }
           }
 
           // Stash pull metadata

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.68";
+const APP_VERSION = "3.33.69";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -911,6 +911,7 @@ const ALLOWED_STORAGE_KEYS = [
   "providerPriority",
   "filterChipCategoryConfig",
   "chipSortOrder",
+  "disposedFilterMode",                    // string: "hide"|"show"|"only" — disposed items filter preference (STAK-388)
   GOLDBACK_PRICES_KEY,
   GOLDBACK_PRICE_HISTORY_KEY,
   RETAIL_PRICES_KEY,

--- a/js/events.js
+++ b/js/events.js
@@ -694,7 +694,17 @@ const setupSearchAndChipListeners = () => {
   }
 
   // Disposed filter three-state toggle (STAK-388, STAK-470)
-  const savedDisposedMode = (typeof loadDataSync === 'function' ? loadDataSync('disposedFilterMode', 'hide') : 'hide') || 'hide';
+  // Migration shim: pre-v3.33.69 stored raw strings ("hide"/"show"/"only") via
+  // localStorage.setItem. loadDataSync JSON.parse fails on these, silently
+  // resetting to default. Detect raw strings and re-encode via saveDataSync.
+  var _rawDisposed = localStorage.getItem('disposedFilterMode');
+  var savedDisposedMode = 'hide';
+  if (_rawDisposed === 'hide' || _rawDisposed === 'show' || _rawDisposed === 'only') {
+    savedDisposedMode = _rawDisposed;
+    if (typeof saveDataSync === 'function') saveDataSync('disposedFilterMode', _rawDisposed);
+  } else if (typeof loadDataSync === 'function') {
+    savedDisposedMode = loadDataSync('disposedFilterMode', 'hide') || 'hide';
+  }
   document.querySelectorAll('#disposedFilterGroup .chip-sort-btn').forEach(function(b) {
     b.classList.toggle('active', b.dataset.disposedMode === savedDisposedMode);
   });

--- a/js/events.js
+++ b/js/events.js
@@ -693,8 +693,8 @@ const setupSearchAndChipListeners = () => {
     wireChipSortToggle('chipSortOrder', 'settingsChipSortOrder');
   }
 
-  // Disposed filter three-state toggle (STAK-388)
-  const savedDisposedMode = localStorage.getItem('disposedFilterMode') || 'hide';
+  // Disposed filter three-state toggle (STAK-388, STAK-470)
+  const savedDisposedMode = (typeof loadDataSync === 'function' ? loadDataSync('disposedFilterMode', 'hide') : 'hide') || 'hide';
   document.querySelectorAll('#disposedFilterGroup .chip-sort-btn').forEach(function(b) {
     b.classList.toggle('active', b.dataset.disposedMode === savedDisposedMode);
   });
@@ -706,7 +706,7 @@ const setupSearchAndChipListeners = () => {
       b.classList.remove('active');
     });
     btn.classList.add('active');
-    localStorage.setItem('disposedFilterMode', btn.dataset.disposedMode);
+    if (typeof saveDataSync === 'function') saveDataSync('disposedFilterMode', btn.dataset.disposedMode);
     if (typeof renderTable === 'function') renderTable();
     if (typeof renderActiveFilters === 'function') renderActiveFilters();
   });

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.68-b1773214250';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773270317';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773270317';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773273031';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.68",
+  "version": "3.33.69",
   "releaseDate": "2026-03-11",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }

--- a/wiki/data-model.md
+++ b/wiki/data-model.md
@@ -2,8 +2,8 @@
 title: Data Model
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.59
-date: 2026-03-07
+lastUpdated: v3.33.69
+date: 2026-03-11
 sourceFiles:
   - js/constants.js
   - js/utils.js
@@ -14,7 +14,7 @@ relatedPages:
 ---
 # Data Model
 
-> **Last updated:** v3.33.59 — 2026-03-07
+> **Last updated:** v3.33.69 — 2026-03-11
 > **Source files:** `js/constants.js`, `js/utils.js`, `js/types.js`
 
 ## Overview
@@ -331,6 +331,7 @@ All keys currently registered in `js/constants.js`. `cleanupStorage()` enforces 
 | `chipBlacklist` | JSON array | Hidden chip values |
 | `inlineChipConfig` | JSON object | Inline chip display configuration |
 | `chipSortOrder` | String | Chip sort order preference |
+| `disposedFilterMode` | String | `"hide"` \| `"show"` \| `"only"` — three-state toggle for disposed/sold items visibility in the inventory table (STAK-388) |
 | `apiProviderOrder` | JSON array | API provider display order |
 | `providerPriority` | JSON object | API provider priority map |
 | `filterChipCategoryConfig` | JSON object | Filter chip category configuration |

--- a/wiki/storage-patterns.md
+++ b/wiki/storage-patterns.md
@@ -2,8 +2,8 @@
 title: Storage Patterns
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.59
-date: 2026-03-07
+lastUpdated: v3.33.69
+date: 2026-03-11
 sourceFiles:
   - js/utils.js
   - js/constants.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Storage Patterns
 
-> **Last updated:** v3.33.59 — 2026-03-07
+> **Last updated:** v3.33.69 — 2026-03-11
 > **Source files:** `js/utils.js`, `js/constants.js`
 
 ## Overview
@@ -242,6 +242,7 @@ All permitted keys are defined in `ALLOWED_STORAGE_KEYS` in `js/constants.js`. A
 | `"inlineChipConfig"` | JSON array | Inline chip display config |
 | `"filterChipCategoryConfig"` | JSON array | Filter chip category config |
 | `"chipSortOrder"` | string | Chip sort order |
+| `"disposedFilterMode"` | string | `"hide"` \| `"show"` \| `"only"` — disposed items filter preference (STAK-388) |
 | `"chipMinCount"` | number string | Min count for filter chips |
 | `"chipMaxCount"` | number string | Max count for filter chips |
 | `"chipCustomGroups"` | JSON object | Custom chip groupings |

--- a/wiki/sync-cloud.md
+++ b/wiki/sync-cloud.md
@@ -2,8 +2,8 @@
 title: Cloud Sync
 category: frontend
 owner: staktrakr
-lastUpdated: v3.33.59
-date: 2026-03-07
+lastUpdated: v3.33.69
+date: 2026-03-11
 sourceFiles:
   - js/cloud-sync.js
   - js/cloud-storage.js
@@ -13,7 +13,7 @@ relatedPages:
 ---
 # Cloud Sync
 
-> **Last updated:** v3.33.59 — 2026-03-07
+> **Last updated:** v3.33.69 — 2026-03-11
 > **Source files:** `js/cloud-sync.js`, `js/cloud-storage.js`
 
 ---
@@ -255,6 +255,20 @@ pullWithPreview(remoteMeta)
   ├─ Manifest-first path (preferred):
   │    ├─ Download /sync/staktrakr-sync.stmanifest
   │    ├─ decryptManifest() → build diff from changelog entries
+  │    ├─ Compare settings: DiffEngine.compareSettings(localSettings, manifest.settings)
+  │    │
+  │    ├─ STAK-387: No item changes AND no settings changes
+  │    │    → syncSetLastPull() + return silently (no vault download, no modal)
+  │    │
+  │    ├─ STAK-470: No item changes BUT settings changes are ALL one-sided
+  │    │    (every changed key has localVal === null OR remoteVal === null)
+  │    │    → auto-merge silently:
+  │    │         · remote-only keys (remoteVal set, localVal null) → localStorage.setItem()
+  │    │         · local-only keys (localVal set, remoteVal null) → kept as-is
+  │    │    → syncSetLastPull() + updateSyncStatusIndicator('idle')
+  │    │    → if any local-only keys remain → scheduleSyncPush() to propagate them
+  │    │    → return (no DiffModal shown)
+  │    │
   │    ├─ await new Promise(resolveModal):
   │    │    DiffModal.show() with manifest diff
   │    │    └─ onApply: _deferredVaultRestore().finally(resolveModal)
@@ -302,6 +316,11 @@ Runs as part of push and pull, non-fatally:
 ## Conflict Resolution
 
 **Default: DiffModal always shown** — `handleRemoteChange()` routes all remote changes directly to `pullWithPreview()`, which presents the DiffModal. The user chooses Apply or Cancel regardless of whether the local device has unsaved changes.
+
+**Exceptions — silent auto-merge (no DiffModal):** Two cases inside the manifest-first path resolve without user interaction:
+
+1. **STAK-387 — no changes at all:** Manifest confirms no item changes and no settings changes. Pull is recorded silently; no vault download.
+2. **STAK-470 — version-upgrade settings drift:** No item changes, but every settings difference is one-sided (the key exists on only one side). This pattern indicates one device has a newer `SYNC_SCOPE_KEYS` set from a version upgrade. Remote-only keys are applied to localStorage immediately; local-only keys are kept and a `scheduleSyncPush()` is queued to propagate them to the remote. No DiffModal is shown. If any changed key has a genuine value on both sides (a real conflict), the STAK-470 branch is skipped and the DiffModal is shown normally.
 
 `syncHasLocalChanges()` returns true if `lastPush.timestamp > lastPull.timestamp` — meaning the local device has pushed changes that predated the remote update, so both sides have diverged. This flag is checked internally within the pull/preview flow.
 
@@ -540,6 +559,23 @@ scheduleSyncPush(); // for inventory changes
 **Root cause:** The Layer 0 pre-push check (added in STAK-398) downloads and inspects remote metadata before every push. When the user chose to overwrite, the resulting `pushSyncVault()` call hit Layer 0, detected the same unacknowledged remote change the user had just dismissed, and re-routed to `handleRemoteChange()` — triggering the conflict flow again in a loop.
 
 **Fix (v3.33.32):** A module-level one-shot flag `_syncConflictUserOverride` is set `true` at call sites that represent explicit user intent to overwrite. At the start of the Layer 0 try block the flag is snapshot-and-cleared; if the snapshot is `true` the conflict check is bypassed and the push proceeds. See the "Keep Mine / Push My Data — conflict bypass flag" section under Conflict Resolution for full details.
+
+---
+
+## Version-Upgrade Settings Drift Auto-Merge (STAK-470, v3.33.69)
+
+**Symptom:** After a version upgrade, the DiffModal appeared on first sync showing only settings changes with no inventory differences. Every listed change was one-sided: a key introduced by the new version existed on one device but not the other. The user had to manually click Apply to proceed even though no meaningful conflict existed.
+
+**Root cause:** `pullWithPreview()` fell through both the STAK-387 silent-return block (which required no settings changes at all) and straight into DiffModal. There was no path to handle the specific case where all settings diffs are the result of `SYNC_SCOPE_KEYS` additions or removals introduced by a version bump.
+
+**Fix (STAK-470, v3.33.69):** A new branch between the STAK-387 block and the DiffModal check inspects the settings diff when there are no item changes. If every entry in `manifestSettingsDiff.changed` is one-sided (`localVal === null` or `remoteVal === null`), the diff is classified as version-upgrade drift and resolved automatically:
+
+- Remote-only keys (`remoteVal` set, `localVal` null) are written to localStorage.
+- Local-only keys (`localVal` set, `remoteVal` null) are kept. If any local-only keys remain, `scheduleSyncPush()` is called to propagate them to the remote manifest.
+- `syncSetLastPull()` is called and the status indicator is updated to `'idle'`.
+- No DiffModal is shown.
+
+If any key has genuine values on both sides (a real conflict), `_allOneSided` is `false` and the branch is skipped entirely — the DiffModal shows as usual.
 
 ---
 


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: `disposedFilterMode` not registered in `ALLOWED_STORAGE_KEYS` — `cleanupStorage()` silently deleted the disposed filter preference on every page reload, resetting it to "hide" (STAK-470)
- **Fixed**: Raw `localStorage` calls for disposed filter in `events.js` replaced with `loadDataSync`/`saveDataSync` to follow project storage conventions (STAK-470)
- **Fixed**: Version upgrades that add new `SYNC_SCOPE_KEYS` no longer trigger a phantom DiffModal — one-sided settings key diffs (key exists on only one side) are now auto-merged silently during cloud sync polling, with a push scheduled to propagate local-only keys back to the remote (STAK-470)

## Files Changed

- `js/constants.js` — added `disposedFilterMode` to `ALLOWED_STORAGE_KEYS`
- `js/events.js` — replaced raw `localStorage.getItem/setItem` with `loadDataSync`/`saveDataSync`
- `js/cloud-sync.js` — added silent merge logic in `pullWithPreview()` manifest-first path for version-upgrade settings diffs
- `wiki/storage-patterns.md`, `wiki/data-model.md`, `wiki/sync-cloud.md` — updated

## Linear Issues

- STAK-470: Fix disposedFilterMode storage + silent settings-only sync merge — https://linear.app/lbruton/issue/STAK-470

🤖 Generated with [Claude Code](https://claude.com/claude-code)