### PR TITLE
chore: GSD session 2026-03-13 — CodeQL warnings cleanup

### DIFF
--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1040,7 +1040,7 @@ const loadCatalogHistory = () => {
 const purgeCatalogHistory = (days = 180) => {
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - days);
-  const cutoffStr = cutoff.toISOString().slice(0, 10).replace(/-/g, "-");
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
   catalogHistory = catalogHistory.filter(
     (e) => e.timestamp >= cutoffStr
   );

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -396,10 +396,10 @@ const renderSpotLookupEmpty = (container, metalName, dateStr) => {
   if (avail.available) {
     if (avail.withinLimit) {
       html += `<button class="btn secondary spot-lookup-fetch-btn" type="button" `
-           + `data-metal="${metalName}" data-date="${dateStr}">`;
-      html += `Fetch from ${avail.providerName}</button>`;
+           + `data-metal="${escapeHtml(metalName)}" data-date="${escapeHtml(dateStr)}">`;
+      html += `Fetch from ${escapeHtml(avail.providerName)}</button>`;
     } else {
-      html += `<p class="spot-lookup-hint">Date is beyond ${avail.providerName}'s ${avail.maxDays}-day history limit.</p>`;
+      html += `<p class="spot-lookup-hint">Date is beyond ${escapeHtml(avail.providerName)}'s ${escapeHtml(avail.maxDays)}-day history limit.</p>`;
     }
   } else {
     html += '<p class="spot-lookup-hint">Configure an API key in Settings to fetch historical prices.</p>';

--- a/js/utils.js
+++ b/js/utils.js
@@ -94,9 +94,9 @@ const getAppTitle = (baseTitle = "StakTrakr") => {
  */
 const getFooterDomain = () => {
   const host = window.location.hostname.toLowerCase();
-  if (host.includes("staktrakr.com")) return "staktrakr.com";
-  if (host.includes("stackrtrackr.com")) return "stackrtrackr.com";
-  if (host.includes("stackertrackr.com")) return "stackertrackr.com";
+  if (host === "staktrakr.com" || host.endsWith(".staktrakr.com")) return "staktrakr.com";
+  if (host === "stackrtrackr.com" || host.endsWith(".stackrtrackr.com")) return "stackrtrackr.com";
+  if (host === "stackertrackr.com" || host.endsWith(".stackertrackr.com")) return "stackertrackr.com";
   return "staktrakr.com";
 };
 
@@ -894,15 +894,17 @@ const stripNonAlphanumeric = (str = "", { allowHyphen = false, allowSlash = fals
  * @param {string} str - Input string
  * @returns {string} Cleaned string
  */
-const cleanString = (str = "") =>
-  str
-    .toString()
-    .replace(/<[^>]*>/g, "")
+const cleanString = (str = "") => {
+  let s = str.toString();
+  let prev;
+  do { prev = s; s = s.replace(/<[^>]*>/g, ''); } while (s !== prev);
+  return s
     .normalize("NFD")
     .replace(/\p{Diacritic}/gu, "")
     .replace(/[\u0000-\u001F\u007F]/g, "")
     .replace(/\s+/g, " ")
     .trim();
+};
 
 /**
  * Sanitizes all string properties of an object by stripping non-alphanumeric characters.
@@ -1211,10 +1213,11 @@ const sanitizeImportedItem = (item) => {
 
   // Normalize and sanitize string fields
   const basicFields = ['name', 'type', 'purchaseLocation', 'storageLocation'];
-  const cleanMultilineString = (str = '') =>
-    str
-      .toString()
-      .replace(/<[^>]*>/g, '')
+  const cleanMultilineString = (str = '') => {
+    let s = str.toString();
+    let prev;
+    do { prev = s; s = s.replace(/<[^>]*>/g, ''); } while (s !== prev);
+    return s
       .normalize('NFD')
       .replace(/\p{Diacritic}/gu, '')
       .replace(/[\u0000-\u0008\u000B-\u001F\u007F]/g, '')
@@ -1222,6 +1225,7 @@ const sanitizeImportedItem = (item) => {
       .replace(/[ \t]+/g, ' ')
       .replace(/ *\n */g, '\n')
       .trim();
+  };
   for (const field of basicFields) {
     sanitized[field] = cleanString(sanitized[field]);
   }

--- a/playground/market-card-playground.html
+++ b/playground/market-card-playground.html
@@ -1191,7 +1191,7 @@ function renderAll() {
     </div>
   </div>`;
 
-  inner.innerHTML = html;
+  inner.innerHTML = html; // lgtm[js/xss-through-dom] — playground-only, no user input
 
   // Wire live search/sort
   const searchEl = document.getElementById('liveSearch');

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773301355';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773441488';
 
 
 


### PR DESCRIPTION
## GSD Session — CodeQL Tech Debt (STAK-460)

### Changes
- **`js/utils.js`**: Loop HTML tag stripping in `cleanString()` and `cleanMultilineString()` to handle nested injection (`<scr<script>ipt>`)
- **`js/utils.js`**: `getFooterDomain()` uses exact domain match + `endsWith()` instead of `includes()` to prevent subdomain spoofing
- **`js/spotLookup.js`**: Escape `metalName`, `dateStr`, `providerName` in `renderSpotLookupEmpty()` innerHTML template
- **`js/catalog-api.js`**: Remove no-op `.replace(/-/g, "-")` in `purgeCatalogHistory()`
- **`playground/market-card-playground.html`**: Suppress non-production innerHTML warning

### CodeQL Rules Resolved
| Rule | Files | Fix |
|------|-------|-----|
| `js/incomplete-multi-character-sanitization` | utils.js | Loop until stable |
| `js/incomplete-url-substring-sanitization` | utils.js | Exact match + endsWith |
| `js/xss-through-dom` | spotLookup.js, playground | escapeHtml() / suppress |
| `js/identity-replacement` | catalog-api.js | Remove no-op |

### Notes
- No version bump — rolls into next patch release
- Resolves STAK-460 / GH #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)