### PR TITLE
chore: mitigate reverse tabnabbing on all window.open() popups

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -2049,11 +2049,12 @@ const setupNoteAndModalListeners = () => {
 
   optionalListener(document.getElementById('goldbackExchangeRateLink'), "click", (e) => {
     e.preventDefault();
-    window.open(
+    const popup = window.open(
       'https://www.goldback.com/exchange-rates/',
       'goldback_rates',
       'width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no',
     );
+    if (popup) popup.opener = null;
   }, "Goldback exchange rates link");
 
   optionalListener(document.getElementById('spotLookupCloseBtn'), "click", () => {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -4185,6 +4185,7 @@ document.addEventListener('click', (e) => {
       if (!popup) {
         appAlert(`Popup blocked! Please allow popups or manually visit:\n${url}`);
       } else {
+        popup.opener = null;
         popup.focus();
       }
     }
@@ -4207,6 +4208,7 @@ document.addEventListener('click', (e) => {
       if (!popup) {
         appAlert(`Popup blocked! Please allow popups or manually visit:\n${url}`);
       } else {
+        popup.opener = null;
         popup.focus();
       }
     }

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -100,7 +100,8 @@ const _buildVendorLegend = (slug) => {
       item.addEventListener("click", (e) => {
         e.preventDefault();
         const popup = window.open(vendorUrl, `retail_vendor_${vendorId}`, "width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no");
-        if (!popup) window.open(vendorUrl, "_blank");
+        if (popup) popup.opener = null;
+        else window.open(vendorUrl, "_blank", "noopener,noreferrer");
       });
     }
 

--- a/js/retail.js
+++ b/js/retail.js
@@ -876,7 +876,8 @@ const _buildRetailCard = (slug, meta, priceData) => {
         link.addEventListener("click", (e) => {
           e.preventDefault();
           const popup = window.open(vendorUrl, `retail_vendor_${key}`, "width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no");
-          if (!popup) window.open(vendorUrl, "_blank");
+          if (popup) popup.opener = null;
+          else window.open(vendorUrl, "_blank", "noopener,noreferrer");
         });
         nameEl.appendChild(link);
       } else {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773442959';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773443770';
 
 
 


### PR DESCRIPTION
## Summary
- Add `popup.opener = null` to 5 external popup call sites that were missing it
- Correctly replaces the approach in Sentinel PR #853 (closed), which used `noopener` in the features string — that breaks `window.open()` return value, causing false "Popup blocked!" alerts and double-opens

## Files changed
- `js/inventory.js` — PCGS CoinFacts + cert verification popups
- `js/retail.js` — vendor link popups in retail cards
- `js/retail-view-modal.js` — vendor legend popups
- `js/events.js` — Goldback exchange rate link

## Why not `noopener` in the features string?
`window.open(url, name, 'noopener')` returns `null` per the HTML spec. Multiple call sites check `if (!popup)` to detect blocked popups — using `noopener` would trigger false alerts and double-opens. Setting `popup.opener = null` post-creation achieves the same security without breaking return value semantics.

## Notes
- No version bump — rolls into next patch
- `cloud-storage.js` OAuth popup intentionally excluded — requires `window.opener` for OAuth redirect flow
- `about.js` changelog link already had `noopener,noreferrer` (no return value used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)