### PR TITLE
feat: add intraday trend toggle to Market Prices cards (STAK-464)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -12331,6 +12331,9 @@ th {
   align-items: center;
   gap: 10px;
 }
+.market-header-view-row {
+  margin-top: 8px;
+}
 .market-header-controls-right {
   display: flex;
   align-items: center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -12334,6 +12334,37 @@ th {
 .market-header-view-row {
   margin-top: 8px;
 }
+/* STAK-464: Intraday trend toggle pill */
+.market-trend-toggle {
+  display: inline-flex;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid var(--border, var(--bs-border-color));
+}
+.market-trend-toggle-btn {
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--text-muted, #6c757d);
+}
+.market-trend-toggle-btn:hover {
+  color: var(--text-primary, var(--bs-body-color));
+}
+.market-trend-toggle-btn--active {
+  background: var(--primary, #4a9eff);
+  color: #fff;
+}
+/* Expand/Collapse icon button */
+.market-expand-btn {
+  padding: 4px 8px;
+  line-height: 1;
+}
+.market-expand-btn svg {
+  display: block;
+}
 .market-header-controls-right {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -257,26 +257,33 @@
       /* STAK-464: Intraday trend toggle pill */
       .market-trend-toggle {
         display: inline-flex;
-        border-radius: 6px;
+        border-radius: 14px;
         overflow: hidden;
-        border: 1px solid var(--border-color, #374151);
+        border: 1px solid var(--border, var(--bs-border-color));
       }
       .market-trend-toggle-btn {
-        padding: 3px 10px;
-        font-size: 0.75rem;
+        padding: 4px 12px;
+        font-size: 11px;
         font-weight: 500;
         cursor: pointer;
         border: none;
-        background: var(--bg-secondary, #1f2937);
+        background: transparent;
         color: var(--text-muted, #6c757d);
-        transition: none;
       }
       .market-trend-toggle-btn:hover {
-        color: var(--text-primary, #e5e7eb);
+        color: var(--text-primary, var(--bs-body-color));
       }
       .market-trend-toggle-btn--active {
         background: var(--primary, #4a9eff);
         color: #fff;
+      }
+      /* Expand/Collapse icon button */
+      .market-expand-btn {
+        padding: 4px 8px;
+        line-height: 1;
+      }
+      .market-expand-btn svg {
+        display: block;
       }
 
     </style>
@@ -3754,6 +3761,18 @@
                     <input type="search" id="marketSearchInput" class="market-search"
                            placeholder="Search items, metals, vendors..." autocomplete="off"
                            aria-label="Search market items">
+                    <div class="market-sort-wrap">
+                      <span class="market-header-btn market-sort-label">Sort: Name <span class="btn-chevron">&#9662;</span></span>
+                      <select id="marketSortSelect" aria-label="Sort market items">
+                        <option value="name" selected>Name</option>
+                        <option value="metal">Metal</option>
+                        <option value="price-low">Price: Low</option>
+                        <option value="price-high">Price: High</option>
+                        <option value="trend">Trend</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="market-header-controls-row market-header-view-row">
                     <div class="market-filter-pills" id="marketFilterPills">
                       <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>
                       <button class="market-filter-pill" data-metal="silver" type="button" aria-pressed="false">Silver</button>
@@ -3763,17 +3782,9 @@
                       <button class="market-filter-pill" data-metal="palladium" type="button" aria-pressed="false">Palladium</button>
                     </div>
                     <div class="market-header-controls-right">
-                      <div class="market-sort-wrap">
-                        <span class="market-header-btn market-sort-label">Sort: Name <span class="btn-chevron">&#9662;</span></span>
-                        <select id="marketSortSelect" aria-label="Sort market items">
-                          <option value="name" selected>Name</option>
-                          <option value="metal">Metal</option>
-                          <option value="price-low">Price: Low</option>
-                          <option value="price-high">Price: High</option>
-                          <option value="trend">Trend</option>
-                        </select>
-                      </div>
-                      <button class="market-header-btn" id="marketExpandAllBtn" type="button">Expand All</button>
+                      <button class="market-header-btn market-expand-btn" id="marketExpandAllBtn" type="button" title="Expand All">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+                      </button>
                     </div>
                   </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -254,6 +254,31 @@
         }
       }
 
+      /* STAK-464: Intraday trend toggle pill */
+      .market-trend-toggle {
+        display: inline-flex;
+        border-radius: 6px;
+        overflow: hidden;
+        border: 1px solid var(--border-color, #374151);
+      }
+      .market-trend-toggle-btn {
+        padding: 3px 10px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        cursor: pointer;
+        border: none;
+        background: var(--bg-secondary, #1f2937);
+        color: var(--text-muted, #6c757d);
+        transition: none;
+      }
+      .market-trend-toggle-btn:hover {
+        color: var(--text-primary, #e5e7eb);
+      }
+      .market-trend-toggle-btn--active {
+        background: var(--primary, #4a9eff);
+        color: #fff;
+      }
+
     </style>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -254,37 +254,6 @@
         }
       }
 
-      /* STAK-464: Intraday trend toggle pill */
-      .market-trend-toggle {
-        display: inline-flex;
-        border-radius: 14px;
-        overflow: hidden;
-        border: 1px solid var(--border, var(--bs-border-color));
-      }
-      .market-trend-toggle-btn {
-        padding: 4px 12px;
-        font-size: 11px;
-        font-weight: 500;
-        cursor: pointer;
-        border: none;
-        background: transparent;
-        color: var(--text-muted, #6c757d);
-      }
-      .market-trend-toggle-btn:hover {
-        color: var(--text-primary, var(--bs-body-color));
-      }
-      .market-trend-toggle-btn--active {
-        background: var(--primary, #4a9eff);
-        color: #fff;
-      }
-      /* Expand/Collapse icon button */
-      .market-expand-btn {
-        padding: 4px 8px;
-        line-height: 1;
-      }
-      .market-expand-btn svg {
-        display: block;
-      }
 
     </style>
   </head>
@@ -3782,7 +3751,7 @@
                       <button class="market-filter-pill" data-metal="palladium" type="button" aria-pressed="false">Palladium</button>
                     </div>
                     <div class="market-header-controls-right">
-                      <button class="market-header-btn market-expand-btn" id="marketExpandAllBtn" type="button" title="Expand All">
+                      <button class="market-header-btn market-expand-btn" id="marketExpandAllBtn" type="button" title="Expand All" aria-label="Expand All">
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
                       </button>
                     </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -730,7 +730,7 @@ const RETAIL_MANIFEST_COIN_META_KEY = "retailManifestCoinMeta";
 /** @constant {string} RETAIL_MANIFEST_VENDOR_META_KEY - LocalStorage key for cached manifest vendor display metadata */
 const RETAIL_MANIFEST_VENDOR_META_KEY = "retailManifestVendorMeta";
 
-/** @constant {string} RETAIL_TREND_MODE_KEY - LocalStorage key for retail trend display mode (intraday vs last-sync) */
+/** @constant {string} RETAIL_TREND_MODE_KEY - LocalStorage key for retail trend display mode; stored values: "7d" or "intraday" */
 const RETAIL_TREND_MODE_KEY = "retailTrendMode";
 
 // =============================================================================
@@ -944,7 +944,7 @@ const ALLOWED_STORAGE_KEYS = [
   RETAIL_MANIFEST_SLUGS_KEY,       // JSON array: cached manifest coin slug list
   RETAIL_MANIFEST_COIN_META_KEY,   // JSON object: cached manifest coin metadata (canonical names)
   RETAIL_MANIFEST_VENDOR_META_KEY, // JSON object: cached manifest vendor display metadata
-  RETAIL_TREND_MODE_KEY,           // string: retail trend display mode (intraday | last-sync)
+  RETAIL_TREND_MODE_KEY,           // string: retail trend display mode (7d | intraday)
   "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54) — legacy, migrated to layoutSectionConfig
   "layoutSectionConfig",      // JSON array: ordered section config [{ id, label, enabled }] (STACK-54)
   LAST_VERSION_CHECK_KEY,     // timestamp: last remote version check (STACK-67)

--- a/js/constants.js
+++ b/js/constants.js
@@ -730,6 +730,9 @@ const RETAIL_MANIFEST_COIN_META_KEY = "retailManifestCoinMeta";
 /** @constant {string} RETAIL_MANIFEST_VENDOR_META_KEY - LocalStorage key for cached manifest vendor display metadata */
 const RETAIL_MANIFEST_VENDOR_META_KEY = "retailManifestVendorMeta";
 
+/** @constant {string} RETAIL_TREND_MODE_KEY - LocalStorage key for retail trend display mode (intraday vs last-sync) */
+const RETAIL_TREND_MODE_KEY = "retailTrendMode";
+
 // =============================================================================
 // IMAGE PROCESSOR DEFAULTS (STACK-95)
 // =============================================================================
@@ -941,6 +944,7 @@ const ALLOWED_STORAGE_KEYS = [
   RETAIL_MANIFEST_SLUGS_KEY,       // JSON array: cached manifest coin slug list
   RETAIL_MANIFEST_COIN_META_KEY,   // JSON object: cached manifest coin metadata (canonical names)
   RETAIL_MANIFEST_VENDOR_META_KEY, // JSON object: cached manifest vendor display metadata
+  RETAIL_TREND_MODE_KEY,           // string: retail trend display mode (intraday | last-sync)
   "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54) — legacy, migrated to layoutSectionConfig
   "layoutSectionConfig",      // JSON array: ordered section config [{ id, label, enabled }] (STACK-54)
   LAST_VERSION_CHECK_KEY,     // timestamp: last remote version check (STACK-67)
@@ -1905,6 +1909,7 @@ if (typeof window !== "undefined") {
   window.RETAIL_MANIFEST_SLUGS_KEY = RETAIL_MANIFEST_SLUGS_KEY;
   window.RETAIL_MANIFEST_COIN_META_KEY = RETAIL_MANIFEST_COIN_META_KEY;
   window.RETAIL_MANIFEST_VENDOR_META_KEY = RETAIL_MANIFEST_VENDOR_META_KEY;
+  window.RETAIL_TREND_MODE_KEY = RETAIL_TREND_MODE_KEY;
   window.RETAIL_ANOMALY_THRESHOLD = RETAIL_ANOMALY_THRESHOLD;
   window.RETAIL_SPIKE_NEIGHBOR_TOLERANCE = RETAIL_SPIKE_NEIGHBOR_TOLERANCE;
   // Disposition types for realized gains (STAK-72)

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -757,6 +757,10 @@ if (typeof window !== "undefined") {
   window._forwardFillVendors = _forwardFillVendors;
   window._flagAnomalies = _flagAnomalies;
   window._buildIntradayTable = _buildIntradayTable;
+  window.retailBucketWindows = _bucketWindows;
+  window.retailForwardFillVendors = _forwardFillVendors;
+  window.retailFlagAnomalies = _flagAnomalies;
+  window.retailFmtIntradayTime = _fmtIntradayTime;
 }
 
 // =============================================================================

--- a/js/retail.js
+++ b/js/retail.js
@@ -1720,10 +1720,11 @@ const _renderMarketListView = () => {
 
   // Reset expand button before any early-return path
   const expandBtn = safeGetElement("marketExpandAllBtn");
-  if (expandBtn) expandBtn.textContent = "Expand All";
+  if (expandBtn) expandBtn.title = "Expand All";
 
-  // Trend mode toggle pill (STAK-464)
-  const controlsRight = listHeader ? listHeader.querySelector(".market-header-controls-right") : null;
+  // Trend mode toggle pill (STAK-464) — inject into view-row controls-right
+  const viewRow = listHeader ? listHeader.querySelector(".market-header-view-row") : null;
+  const controlsRight = viewRow ? viewRow.querySelector(".market-header-controls-right") : null;
   if (controlsRight) {
     const existing = controlsRight.querySelector(".market-trend-toggle");
     if (existing) existing.remove();
@@ -1737,12 +1738,7 @@ const _renderMarketListView = () => {
       btn.addEventListener("click", () => _setRetailTrendMode(mode));
       trendToggle.appendChild(btn);
     });
-    const sortWrap = controlsRight.querySelector(".market-sort-wrap");
-    if (sortWrap) {
-      controlsRight.insertBefore(trendToggle, sortWrap);
-    } else {
-      controlsRight.prepend(trendToggle);
-    }
+    controlsRight.insertBefore(trendToggle, controlsRight.firstChild);
   }
 
   if (_retailSyncInProgress) {
@@ -1841,7 +1837,7 @@ const _initMarketListViewListeners = () => {
       else d.setAttribute("open", "");
       d.dispatchEvent(new Event("toggle"));
     });
-    expandBtn.textContent = allOpen ? "Expand All" : "Collapse All";
+    expandBtn.title = allOpen ? "Expand All" : "Collapse All";
   });
 
   const pillContainer = safeGetElement("marketFilterPills");

--- a/js/retail.js
+++ b/js/retail.js
@@ -171,6 +171,22 @@ let _retailSyncError = false;
 /** Active sparkline Chart instances keyed by slug — destroyed before re-render to prevent Canvas reuse errors */
 const _retailSparklines = new Map();
 
+/** Current trend display mode: "7d" (default) or "intraday" */
+let _retailTrendMode = "7d";
+
+const _loadRetailTrendMode = () => {
+  const stored = loadDataSync(RETAIL_TREND_MODE_KEY, null);
+  if (stored === "intraday") _retailTrendMode = "intraday";
+};
+
+const _setRetailTrendMode = (mode) => {
+  _retailTrendMode = mode;
+  saveDataSync(RETAIL_TREND_MODE_KEY, mode);
+  _marketChartInstances.forEach((chart) => chart.destroy());
+  _marketChartInstances.clear();
+  _renderMarketListView();
+};
+
 // ---------------------------------------------------------------------------
 // Persistence
 // ---------------------------------------------------------------------------
@@ -729,6 +745,24 @@ const _computeRetailTrend = (slug) => {
   return { dir: "flat", pct: "0.0" };
 };
 
+const _computeIntradayTrend = (slug) => {
+  const intraday = retailIntradayData[slug];
+  if (!intraday || !Array.isArray(intraday.windows_24h) || intraday.windows_24h.length < 2) return null;
+  const windows = intraday.windows_24h;
+  const earliest = Number(windows[0].median);
+  const latest = Number(windows[windows.length - 1].median);
+  if (!isFinite(earliest) || !isFinite(latest) || earliest === 0) return null;
+  const change = ((latest - earliest) / earliest) * 100;
+  const pct = Math.abs(change).toFixed(1);
+  if (change > 0.2) return { dir: "up", pct };
+  if (change < -0.2) return { dir: "down", pct };
+  return { dir: "flat", pct: "0.0" };
+};
+
+const _getActiveTrend = (slug) => {
+  return _retailTrendMode === "intraday" ? _computeIntradayTrend(slug) : _computeRetailTrend(slug);
+};
+
 
 /**
  * Builds a single coin price card element.
@@ -1082,7 +1116,7 @@ const _buildMarketListCard = (slug, meta, priceData, historyData) => {
   card.appendChild(statsCol);
 
   // === Trend badge — playground: .market-card-trend .up/.down/.flat ===
-  const trend = _computeRetailTrend(slug);
+  const trend = _getActiveTrend(slug);
   const trendDir = trend ? trend.dir : "flat";
   const trendCol = document.createElement("div");
   trendCol.className = `market-card-trend ${trendDir}`;
@@ -1178,12 +1212,15 @@ const _buildMarketListCard = (slug, meta, priceData, historyData) => {
   const tArrow = trend ? ({ up: "\u2191", down: "\u2193", flat: "\u2192" }[trend.dir]) : "\u2192";
   const tSign = trend ? (trend.dir === "up" ? "+" : trend.dir === "down" ? "\u2212" : "") : "";
   const tPct = trend ? trend.pct : "0.0";
-  summary.textContent = `7-Day Trend \u00A0${tArrow} ${tSign}${tPct}%`;
+  const trendLabel = _retailTrendMode === "intraday" ? "Intraday Trend" : "7-Day Trend";
+  summary.textContent = `${trendLabel} \u00A0${tArrow} ${tSign}${tPct}%`;
   details.appendChild(summary);
   const chartContainer = document.createElement("div");
   chartContainer.className = "market-chart-container";
   const history = retailPriceHistory[slug];
-  if (!history || history.length < 2) {
+  const intradayWindows = retailIntradayData[slug] && Array.isArray(retailIntradayData[slug].windows_24h) ? retailIntradayData[slug].windows_24h : [];
+  const hasChartData = (history && history.length >= 2) || intradayWindows.length >= 2;
+  if (!hasChartData) {
     const msg = document.createElement("p");
     msg.className = "text-muted market-chart-empty";
     msg.textContent = "Not enough data for chart";
@@ -1196,7 +1233,11 @@ const _buildMarketListCard = (slug, meta, priceData, historyData) => {
   details.appendChild(chartContainer);
   details.addEventListener("toggle", () => {
     if (details.open) {
-      _initMarketCardChart(slug, details);
+      if (_retailTrendMode === "intraday") {
+        _initMarketCardIntradayChart(slug, details);
+      } else {
+        _initMarketCardChart(slug, details);
+      }
     } else if (_marketChartInstances.has(slug)) {
       _marketChartInstances.get(slug).destroy();
       _marketChartInstances.delete(slug);
@@ -1488,6 +1529,99 @@ const _initMarketCardChart = (slug, detailsEl) => {
   _marketChartInstances.set(slug, chart);
 };
 
+const _initMarketCardIntradayChart = (slug, detailsEl) => {
+  if (typeof Chart === "undefined") return;
+  if (_marketChartInstances.has(slug)) return;
+  const canvas = detailsEl.querySelector(`#market-chart-${slug}`);
+  if (!(canvas instanceof HTMLCanvasElement)) return;
+
+  if (typeof window.retailBucketWindows !== "function") return;
+
+  const intraday = retailIntradayData[slug];
+  const windows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
+  if (windows.length < 2) return;
+
+  const filled = window.retailForwardFillVendors(window.retailBucketWindows(windows));
+  let bucketed;
+  try {
+    bucketed = window.retailFlagAnomalies(filled);
+  } catch (e) {
+    debugLog("[retail] _flagAnomalies threw — anomaly detection skipped: " + e.message, "warn");
+    bucketed = filled;
+  }
+  if (bucketed.length < 2) return;
+
+  const labels = bucketed.map((w) => {
+    const d = w.window ? new Date(w.window) : null;
+    return typeof window.retailFmtIntradayTime === "function" ? window.retailFmtIntradayTime(d) : (d ? d.toISOString().slice(11, 16) : "");
+  });
+
+  const knownVendors = typeof RETAIL_VENDOR_NAMES !== "undefined" ? Object.keys(RETAIL_VENDOR_NAMES) : [];
+  const activeVendors = knownVendors.filter((v) =>
+    bucketed.some((w) => (w.vendors && w.vendors[v] != null) || (w._anomalyOriginals && w._anomalyOriginals[v] != null))
+  );
+
+  const datasets = activeVendors.length > 0
+    ? activeVendors.map((vendorId) => {
+        const _vd = getVendorDisplay(vendorId);
+        const color = RETAIL_VENDOR_COLORS[vendorId] || "#94a3b8";
+        const carriedIndices = new Set();
+        bucketed.forEach((w, i) => {
+          if (w._carriedVendors && w._carriedVendors.has(vendorId)) carriedIndices.add(i);
+        });
+        return {
+          label: _vd.name,
+          data: bucketed.map((w) => (w.vendors && w.vendors[vendorId] != null ? w.vendors[vendorId] : null)),
+          borderColor: color,
+          backgroundColor: "transparent",
+          borderWidth: 1.5,
+          pointRadius: 0,
+          pointHoverRadius: 3,
+          tension: 0.2,
+          spanGaps: true,
+          _carriedIndices: carriedIndices,
+        };
+      })
+    : [{
+        label: "Median",
+        data: bucketed.map((w) => w.median),
+        borderColor: "#3b82f6",
+        backgroundColor: "transparent",
+        borderWidth: 1.5,
+        pointRadius: 0,
+        pointHoverRadius: 3,
+        tension: 0.3,
+      }];
+
+  const chart = new Chart(canvas, {
+    type: "line",
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label: (ctx) => {
+              if (ctx.raw == null) return null;
+              const carried = ctx.dataset._carriedIndices && ctx.dataset._carriedIndices.has(ctx.dataIndex);
+              return `${ctx.dataset.label}: ${carried ? "~" : ""}$${Number(ctx.raw).toFixed(2)}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: { ticks: { maxTicksLimit: 12, autoSkip: true, maxRotation: 0, font: { size: 10 } } },
+        y: { ticks: { callback: (v) => `$${Number(v).toFixed(0)}` } },
+      },
+      animation: false,
+    },
+  });
+  _marketChartInstances.set(slug, chart);
+};
+
 /**
  * Filters and sorts the slug list for market list view.
  * @param {string} query - Search query (case-insensitive substring)
@@ -1539,8 +1673,8 @@ const _getFilteredSortedSlugs = (query, sortKey) => {
         return pb - pa;
       }
       case "trend": {
-        const ta = _computeRetailTrend(a);
-        const tb = _computeRetailTrend(b);
+        const ta = _getActiveTrend(a);
+        const tb = _getActiveTrend(b);
         const va = ta ? parseFloat(ta.pct) * (ta.dir === "down" ? -1 : 1) : 0;
         const vb = tb ? parseFloat(tb.pct) * (tb.dir === "down" ? -1 : 1) : 0;
         return vb - va;
@@ -1587,6 +1721,29 @@ const _renderMarketListView = () => {
   // Reset expand button before any early-return path
   const expandBtn = safeGetElement("marketExpandAllBtn");
   if (expandBtn) expandBtn.textContent = "Expand All";
+
+  // Trend mode toggle pill (STAK-464)
+  const controlsRight = listHeader ? listHeader.querySelector(".market-header-controls-right") : null;
+  if (controlsRight) {
+    const existing = controlsRight.querySelector(".market-trend-toggle");
+    if (existing) existing.remove();
+    const trendToggle = document.createElement("div");
+    trendToggle.className = "market-trend-toggle";
+    ["7d", "intraday"].forEach((mode) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "market-trend-toggle-btn" + (_retailTrendMode === mode ? " market-trend-toggle-btn--active" : "");
+      btn.textContent = mode === "7d" ? "7-Day" : "Intraday";
+      btn.addEventListener("click", () => _setRetailTrendMode(mode));
+      trendToggle.appendChild(btn);
+    });
+    const sortWrap = controlsRight.querySelector(".market-sort-wrap");
+    if (sortWrap) {
+      controlsRight.insertBefore(trendToggle, sortWrap);
+    } else {
+      controlsRight.prepend(trendToggle);
+    }
+  }
 
   if (_retailSyncInProgress) {
     emptyState.style.display = "none";
@@ -1900,6 +2057,7 @@ const initRetailPrices = () => {
   loadRetailPrices();
   loadRetailPriceHistory();
   loadRetailIntradayData();
+  _loadRetailTrendMode();
   loadRetailProviders();
   loadRetailAvailability();
   _initMarketListViewListeners();

--- a/js/retail.js
+++ b/js/retail.js
@@ -748,9 +748,12 @@ const _computeRetailTrend = (slug) => {
 const _computeIntradayTrend = (slug) => {
   const intraday = retailIntradayData[slug];
   if (!intraday || !Array.isArray(intraday.windows_24h) || intraday.windows_24h.length < 2) return null;
-  const windows = intraday.windows_24h;
-  const earliest = Number(windows[0].median);
-  const latest = Number(windows[windows.length - 1].median);
+  // Use the same pipeline as the chart for consistency
+  if (typeof window.retailBucketWindows !== "function") return null;
+  const bucketed = window.retailBucketWindows(intraday.windows_24h);
+  if (bucketed.length < 2) return null;
+  const earliest = Number(bucketed[0].median);
+  const latest = Number(bucketed[bucketed.length - 1].median);
   if (!isFinite(earliest) || !isFinite(latest) || earliest === 0) return null;
   const change = ((latest - earliest) / earliest) * 100;
   const pct = Math.abs(change).toFixed(1);
@@ -1535,7 +1538,9 @@ const _initMarketCardIntradayChart = (slug, detailsEl) => {
   const canvas = detailsEl.querySelector(`#market-chart-${slug}`);
   if (!(canvas instanceof HTMLCanvasElement)) return;
 
-  if (typeof window.retailBucketWindows !== "function") return;
+  if (typeof window.retailBucketWindows !== "function" ||
+      typeof window.retailForwardFillVendors !== "function" ||
+      typeof window.retailFlagAnomalies !== "function") return;
 
   const intraday = retailIntradayData[slug];
   const windows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
@@ -1605,7 +1610,7 @@ const _initMarketCardIntradayChart = (slug, detailsEl) => {
         tooltip: {
           callbacks: {
             label: (ctx) => {
-              if (ctx.raw == null) return null;
+              if (ctx.raw === null) return `${ctx.dataset.label}: Out of stock`;
               const carried = ctx.dataset._carriedIndices && ctx.dataset._carriedIndices.has(ctx.dataIndex);
               return `${ctx.dataset.label}: ${carried ? "~" : ""}$${Number(ctx.raw).toFixed(2)}`;
             },
@@ -1734,6 +1739,7 @@ const _renderMarketListView = () => {
       const btn = document.createElement("button");
       btn.type = "button";
       btn.className = "market-trend-toggle-btn" + (_retailTrendMode === mode ? " market-trend-toggle-btn--active" : "");
+      btn.setAttribute("aria-pressed", _retailTrendMode === mode ? "true" : "false");
       btn.textContent = mode === "7d" ? "7-Day" : "Intraday";
       btn.addEventListener("click", () => _setRetailTrendMode(mode));
       trendToggle.appendChild(btn);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773443770';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773449491';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773449944';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773453028';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773449502';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773449555';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773449491';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773449502';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773449555';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773449944';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773453028';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773456231';
 
 
 


### PR DESCRIPTION
## Summary

- Add a global **7-Day / Intraday** toggle pill to the Market Prices panel header
- When set to Intraday, cards show per-vendor intraday chart (12h of 15-min windowed data) instead of 7-day history
- Trend badge and sort-by-trend respond to the active mode
- Toggle preference persists across page reloads via localStorage

## Changes

| File | Lines | Change |
|------|-------|--------|
| `js/constants.js` | +5 | `RETAIL_TREND_MODE_KEY` constant + ALLOWED_STORAGE_KEYS + window export |
| `js/retail-view-modal.js` | +4 | Window exports for `retailBucketWindows`, `retailForwardFillVendors`, `retailFlagAnomalies`, `retailFmtIntradayTime` |
| `index.html` | +25 | CSS for `.market-trend-toggle` pill (theme-compatible) |
| `js/retail.js` | +170/-7 | State management, toggle UI, `_computeIntradayTrend`, `_getActiveTrend`, `_initMarketCardIntradayChart`, card builder + sort mods |

## Spec

- **Issue:** STAK-464 / GH #822
- **Spec path:** `.spec-workflow/specs/STAK-464-intraday-trend-toggle/`
- **Phases:** Requirements ✓ → Design ✓ → Tasks ✓ → Readiness Gate ✓ → Implementation ✓ (4/4 tasks)

## Test plan

- [ ] Toggle pill renders in market panel header
- [ ] Clicking "Intraday" switches all card badges to intraday trend
- [ ] Expanding a card in Intraday mode shows per-vendor intraday chart
- [ ] Switching back to "7-Day" restores original behavior
- [ ] Toggle preference persists across reload
- [ ] Sort-by-trend uses the active mode
- [ ] No regression on retail-view-modal intraday tab
- [ ] Theme compatibility (dark, light, sepia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)