### PR TITLE
chore: disable dashed chart segments until API aggregates

### DIFF
--- a/js/retail.js
+++ b/js/retail.js
@@ -1486,10 +1486,11 @@ const _initMarketCardChart = (slug, detailsEl) => {
           pointBackgroundColor: (ctx) => interp[ctx.dataIndex] ? "transparent" : baseColor,
           tension: 0.3,
           spanGaps: true,
-          segment: {
-            borderDash: (ctx) => (interp[ctx.p0DataIndex] || interp[ctx.p1DataIndex]) ? [4, 3] : [],
-            borderColor: (ctx) => (interp[ctx.p0DataIndex] || interp[ctx.p1DataIndex]) ? baseColor + "50" : baseColor,
-          },
+          // TODO: re-enable dashed segments once API serves 30-min aggregates (STAK-474)
+          // segment: {
+          //   borderDash: (ctx) => (interp[ctx.p0DataIndex] || interp[ctx.p1DataIndex]) ? [4, 3] : [],
+          //   borderColor: (ctx) => (interp[ctx.p0DataIndex] || interp[ctx.p1DataIndex]) ? baseColor + "50" : baseColor,
+          // },
         };
       }).filter(Boolean)
     : [{
@@ -1604,10 +1605,11 @@ const _initMarketCardIntradayChart = (slug, detailsEl) => {
           tension: 0.2,
           spanGaps: true,
           _carriedIndices: carriedIndices,
-          segment: {
-            borderDash: (ctx) => (carriedIndices.has(ctx.p0DataIndex) || carriedIndices.has(ctx.p1DataIndex)) ? [4, 3] : [],
-            borderColor: (ctx) => (carriedIndices.has(ctx.p0DataIndex) || carriedIndices.has(ctx.p1DataIndex)) ? color + "50" : color,
-          },
+          // TODO: re-enable dashed segments once API serves 30-min aggregates (STAK-474)
+          // segment: {
+          //   borderDash: (ctx) => (carriedIndices.has(ctx.p0DataIndex) || carriedIndices.has(ctx.p1DataIndex)) ? [4, 3] : [],
+          //   borderColor: (ctx) => (carriedIndices.has(ctx.p0DataIndex) || carriedIndices.has(ctx.p1DataIndex)) ? color + "50" : color,
+          // },
         };
       })
     : [{

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773462717';
+const CACHE_NAME = 'staktrakr-v3.33.69-b1773516173';
 
 
 


### PR DESCRIPTION
## Summary
- Temporarily comments out `segment.borderDash` callbacks on both intraday and 7-day market card charts
- The dashed-line logic was rendering ~75% of chart lines as dotted because the API serves raw 15-min poll snapshots with sparse vendor coverage (1-3 vendors per window instead of all 9)
- Will re-enable once the API delivers pre-aggregated 30-min windows with full vendor data (STAK-474)

## Test plan
- [ ] Sync retail prices and open any market card chart — all lines should be solid
- [ ] Verify intraday and 7-day charts both render solid lines
- [ ] Confirm no JS errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)