### PR TITLE
⚡ Bolt: Use DocumentFragment for filter chips

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 **Finding:** Instantiating `Intl.NumberFormat` is a known expensive operation in JavaScript.
 **Learning:** Functions like `formatCurrency` and `getCurrencySymbol` in `js/utils.js` were instantiating `Intl.NumberFormat` on every call. For large dataset renderings (e.g. lists of items), this initialization overhead can add up significantly.
 **Action:** Caching these instances in a `Map` using a combination of the locale and the currency code (e.g., `'default-USD'`) reduces the overhead of formatting operations from ~1ms to <0.1ms per call. When formatting strings or dates, always look for opportunities to cache and reuse `Intl` instances.
+
+## 2026-03-17 - Batching DOM Appends with DocumentFragment
+**Learning:** The `renderActiveFilters` function in `js/filters.js` iterated over many active chips, calling `container.appendChild(chip)` repeatedly. This repetitive appending forces the browser to reflow and repaint multiple times, creating unnecessary rendering overhead when appending multiple elements dynamically.
+**Action:** When generating and appending multiple DOM elements at once, use `document.createDocumentFragment()`. Append all newly generated elements to the fragment first, and then append the complete fragment to the target DOM container. This reduces reflows and repaints from O(N) to O(1).

--- a/js/filters.js
+++ b/js/filters.js
@@ -499,6 +499,8 @@ const renderActiveFilters = () => {
   
   container.style.display = '';
 
+  const fragment = document.createDocumentFragment();
+
   chips.forEach((f, i) => {
     const chip = document.createElement('span');
     chip.className = 'filter-chip';
@@ -666,7 +668,7 @@ const renderActiveFilters = () => {
       }
     };
 
-    container.appendChild(chip);
+    fragment.appendChild(chip);
   });
 
   // Add clear button if there are any chips (check for both active and summary chips)
@@ -678,8 +680,10 @@ const renderActiveFilters = () => {
     clearButton.onclick = () => {
       clearAllFilters();
     };
-    container.appendChild(clearButton);
+    fragment.appendChild(clearButton);
   }
+
+  container.appendChild(fragment);
 };
 
 /**


### PR DESCRIPTION
💡 What: 
Refactored `renderActiveFilters` in `js/filters.js` to use `document.createDocumentFragment()` to batch append operations for filter chips.

🎯 Why: 
The function previously iterated over active filters and appended each chip individually to the live DOM (`container.appendChild(chip)`). This forces the browser to recalculate layouts (reflow) and repaint multiple times, creating rendering overhead and potential layout thrashing when dynamically adding multiple chips.

📊 Impact: 
Reduces DOM reflows and repaints in `renderActiveFilters` from O(N) (one per active filter chip) to O(1) (a single bulk insertion). This yields smoother, faster UI updates when users apply multiple grouped filters or searches.

🔬 Measurement: 
Can be verified using Chrome DevTools Performance tab. Record an interaction where multiple filter chips are generated simultaneously (e.g. by applying a grouped name filter or complex search) and observe that only a single "Recalculate Style" and "Layout" task occurs for the chip container insertion.

---
*PR created automatically by Jules for task [1647977924962709308](https://jules.google.com/task/1647977924962709308) started by @lbruton*