### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in pattern rule settings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Mutation XSS (mXSS) risk from using custom DOM-based HTML escaping (`div.textContent = str; return div.innerHTML;`).
 **Learning:** Browsers can mutate HTML during the parsing process, introducing mXSS vulnerabilities when using properties like `innerHTML` and `textContent` sequentially. The regex-based `escapeHtml` function provided globally in `js/utils.js` prevents these parsing anomalies.
 **Prevention:** Avoid custom DOM-based HTML escaping. Always use the globally available, regex-based `escapeHtml` function defined in `js/utils.js`.
+
+## 2026-06-25 - XSS via Insufficient Attribute Escaping in innerHTML
+**Vulnerability:** XSS vulnerability caused by manually escaping quotes (`.replace(/"/g, '&quot;')`) instead of using a comprehensive HTML escaping utility when injecting user-controlled data into HTML attributes via `innerHTML`.
+**Learning:** When using template literals and `innerHTML` to construct HTML with dynamic attributes, escaping only double quotes is insufficient. Attackers can inject payloads if they break out of the context or use other HTML special characters.
+**Prevention:** Always use robust HTML escaping functions (like the regex-based `escapeHtml` utility in `js/utils.js`) for *all* dynamic content interpolated into HTML strings, particularly when setting HTML element attributes. Even better, avoid `innerHTML` entirely and use DOM methods (`createElement` and `value` property assignment) for dynamically constructing inputs.

--- a/js/settings.js
+++ b/js/settings.js
@@ -1672,8 +1672,8 @@ const renderCustomPatternRules = async () => {
     editForm.style.display = 'none';
     editForm.innerHTML = `
       <div class="edit-form-fields">
-        <label>Pattern <input type="text" class="edit-pattern" value="${rule.pattern.replace(/"/g, '&quot;')}" /></label>
-        <label>Replacement <input type="text" class="edit-replacement" value="${(rule.replacement || '').replace(/"/g, '&quot;')}" /></label>
+        <label>Pattern <input type="text" class="edit-pattern" value="${escapeHtml(rule.pattern)}" /></label>
+        <label>Replacement <input type="text" class="edit-replacement" value="${escapeHtml(rule.replacement || '')}" /></label>
         <label>Obverse <input type="file" class="edit-obverse" accept="image/*" /></label>
         <label>Reverse <input type="file" class="edit-reverse" accept="image/*" /></label>
       </div>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When rendering custom pattern rules in the settings modal (`js/settings.js`), the application manually escaped double quotes (`.replace(/"/g, '&quot;')`) before injecting the values into HTML attributes via `innerHTML`. This manual escaping is insufficient and could allow an attacker to inject an XSS payload if they break out of the context or use other HTML special characters.
🎯 Impact: An attacker could potentially inject malicious JavaScript that executes in the context of the user's browser, leading to session hijacking, data theft, or unauthorized actions if they can control the input to these fields.
🔧 Fix: Replaced the inadequate `.replace` logic with the robust, regex-based `escapeHtml` utility from `js/utils.js` which correctly escapes `<`, `>`, `&`, `"`, and `'`.
✅ Verification: Ran `npm run lint` successfully. Due to missing `@playwright/test` dependencies in the test runner environment (the repo uses a separate Browserbase suite), verified the behavior manually via a standalone Node.js DOM simulation and by starting a local python server and capturing the DOM state via Playwright using `page.evaluate`. Evaluated the DOM string visually to confirm inputs are securely escaped. Reverted an accidental `package-lock.json` change.

---
*PR created automatically by Jules for task [13821028059011716449](https://jules.google.com/task/13821028059011716449) started by @lbruton*