### PR TITLE
v3.33.70 — Intraday trends, aggregation fixes, CF bypass hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.70] - 2026-03-18
+
+### Added — Intraday trends, aggregation fixes, CF bypass hardening
+
+- **Added**: Intraday trend toggle for Market Prices cards — pill button switches between current price and hourly % change (STAK-464)
+- **Added**: Chart polish — dashed line segments for OOS vendors + 7-day Goldback baseline on spot charts (STAK-474)
+- **Fixed**: aggregateWindows data merge — dropped UNIQUE constraint that caused data loss, upsert cache rows, 30-min consensus buckets carry forward vendor prices across windows (STAK-476)
+- **Fixed**: Retail scraper CF bypass — Byparr before Firecrawl phase, JSON-LD price=0 treated as OOS, Camoufox shm_size 1g for shared memory (STAK-475)
+- **Fixed**: Goldback cron staggered from :01 to :20 to avoid Fly.io overlap (STAK-477)
+- **Changed**: Removed wiki/ after DocVault migration (STAK-471)
+- **Changed**: CodeQL warnings cleanup — pre-existing issues resolved (STAK-460)
+- **Changed**: Cache Intl.NumberFormat instances for faster rendering
+- **Changed**: Reverse tabnabbing mitigation on all window.open() calls
+- **Changed**: Vault-based issue tracking replaces Linear section
+
+---
+
 ## [3.33.69] - 2026-03-11
 
 ### Fixed — STAK-470: Storage hygiene + silent settings-only sync merge

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,16 +1,15 @@
 ## What's New
 
+- **Intraday Trends &amp; Reliability (v3.33.70)**: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477).
 - **Storage &amp; Sync Hygiene (v3.33.69)**: Fixed disposed filter preference resetting on every page reload. Version upgrades no longer trigger phantom cloud sync diff popups &mdash; settings-only key diffs from new versions are auto-merged silently (STAK-470).
 - **Catalog Data Fix (v3.33.68)**: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469).
-- **Retail Price Accuracy (v3.33.67)**: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk "As Low As" price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467).
-- **Retail Price Reliability (v3.33.61&ndash;v3.33.66)**: Improved scraping success rate for Bullion Exchanges and JM Bullion — Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462).
-- **Market Price Chart Fixes (v3.33.62)**: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463).
-- **DiffModal Complete Overhaul (v3.33.56&ndash;v3.33.60)**: Full card-based cloud sync review — summary dashboard, per-item conflict cards with click-to-pick field resolution, 7 settings categories with rich chip renderers, and ZIP backup restore now routes through DiffModal instead of silently overwriting (STAK-451, STAK-454, STAK-455, STAK-457).
+- **Retail Price Accuracy (v3.33.67)**: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467).
+- **Retail Price Reliability (v3.33.61&ndash;v3.33.66)**: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass (STAK-462).
 
 ## Development Roadmap
 
 ### Next Up
 
+- **Settings Redesign (STAK-436&ndash;447)**: 12-issue suite covering Appearance, Filters, and API settings tabs
 - **Market Page Phase 3**: Inventory-to-market linking with auto-update retail prices
 - **Cloud Backup Conflict Detection (STAK-150)**: Smarter conflict resolution using item count direction, not just timestamps
-- **Accessible Table Mode (STAK-144)**: Style D with horizontal scroll, long-press to edit, 300% zoom support

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.70 &ndash; Intraday Trends &amp; Reliability</strong>: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477)</li>
     <li><strong>v3.33.69 &ndash; Storage &amp; Sync Hygiene</strong>: Fixed disposed filter preference resetting on every page reload. Version upgrades no longer trigger phantom cloud sync diff popups &mdash; settings-only key diffs from new versions are auto-merged silently (STAK-470)</li>
     <li><strong>v3.33.68 &ndash; Catalog Data Fix</strong>: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469)</li>
     <li><strong>v3.33.67 &ndash; Retail Price Accuracy</strong>: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467)</li>
-    <li><strong>v3.33.61&ndash;v3.33.66 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass. Fixed sidecar API endpoint so CF cookies are actually retrieved (STAK-462)</li>
-    <li><strong>v3.33.62 &ndash; Market Price Chart Fixes</strong>: 7-day trend charts now correctly detect anomalous first/last data points and carry OOS prices as flat dotted lines instead of drifting trends (STAK-463)</li>
+    <li><strong>v3.33.61&ndash;v3.33.66 &ndash; Retail Price Reliability</strong>: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass (STAK-462)</li>
   `;
 };
 
@@ -297,9 +297,9 @@ const getEmbeddedWhatsNew = () => {
  */
 const getEmbeddedRoadmap = () => {
   return `
+    <li><strong>Settings Redesign (STAK-436&ndash;447)</strong>: 12-issue suite covering Appearance, Filters, and API settings tabs</li>
     <li><strong>Market Page Phase 3</strong>: Inventory-to-market linking with auto-update retail prices</li>
     <li><strong>Cloud Backup Conflict Detection (STAK-150)</strong>: Smarter conflict resolution using item count direction, not just timestamps</li>
-    <li><strong>Accessible Table Mode (STAK-144)</strong>: Style D with horizontal scroll, long-press to edit, 300% zoom support</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.69";
+const APP_VERSION = "3.33.70";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.69-b1773516173';
+const CACHE_NAME = 'staktrakr-v3.33.70-b1773841922';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.69",
-  "releaseDate": "2026-03-11",
+  "version": "3.33.70",
+  "releaseDate": "2026-03-18",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Added**: Intraday trend toggle for Market Prices cards — pill button switches between current price and hourly % change (STAK-464)
- **Added**: Chart polish — dashed line segments for OOS vendors + 7-day Goldback baseline on spot charts (STAK-474)
- **Fixed**: aggregateWindows data merge — dropped UNIQUE constraint that caused data loss, upsert cache rows, 30-min consensus buckets carry forward vendor prices across windows (STAK-476)
- **Fixed**: Retail scraper CF bypass — Byparr before Firecrawl phase, JSON-LD price=0 treated as OOS, Camoufox shm_size 1g for shared memory (STAK-475)
- **Fixed**: Goldback cron staggered from :01 to :20 to avoid Fly.io overlap (STAK-477)
- **Changed**: Removed wiki/ after DocVault migration (STAK-471)
- **Changed**: CodeQL warnings cleanup — pre-existing issues resolved (STAK-460)
- **Changed**: Cache Intl.NumberFormat instances for faster rendering
- **Changed**: Reverse tabnabbing mitigation on all window.open() calls
- **Changed**: Vault-based issue tracking replaces Linear section

## Vault Issues

- STAK-464: Intraday trend toggle
- STAK-474: Chart polish — dashed gaps + Goldback baseline
- STAK-475: Retail scraper CF bypass hardening
- STAK-476: aggregateWindows data merge fixes
- STAK-477: Goldback cron stagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)