### PR TITLE
v3.33.72 — Fix Numista metadata field clearing (STAK-487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.72] - 2026-03-20
+
+### Fixed — Allow clearing Numista metadata fields
+
+- **Fixed**: Numista metadata fields (KM Reference, country, denomination, etc.) can now be cleared and saved as empty — previously the `||` fallback chain treated empty strings as falsy and restored the previous value, making it impossible to delete incorrect data (STAK-487)
+
+---
+
 ## [3.33.71] - 2026-03-18
 
 ### Added — Modularize large JS files: chart-utils, inventory split, convention migration

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **Numista Metadata Fix (v3.33.72)**: Numista metadata fields (KM Reference, country, etc.) can now be cleared and saved as empty &mdash; previously clearing a field would restore the old value on save (STAK-487).
 - **Codebase Modularization (v3.33.71)**: Shared chart utility library eliminates 11 duplicate Chart.js patterns. Inventory split: 4,504 &rarr; 1,744 lines across 4 focused modules. Convention sweep: 53 getElementById, 5 localStorage, 23 var fixes (STAK-484).
 - **Intraday Trends &amp; Reliability (v3.33.70)**: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477).
 - **Storage &amp; Sync Hygiene (v3.33.69)**: Fixed disposed filter preference resetting on every page reload. Version upgrades no longer trigger phantom cloud sync diff popups &mdash; settings-only key diffs from new versions are auto-merged silently (STAK-470).
 - **Catalog Data Fix (v3.33.68)**: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469).
-- **Retail Price Accuracy (v3.33.67)**: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467).
-- **Retail Price Reliability (v3.33.61&ndash;v3.33.66)**: Improved scraping success rate for Bullion Exchanges and JM Bullion &mdash; Cloudflare-blocked requests now fall back to a Byparr (Camoufox) cookie-based bypass (STAK-462).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -283,11 +283,11 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.72 &ndash; Numista Metadata Fix</strong>: Numista metadata fields (KM Reference, country, etc.) can now be cleared and saved as empty &mdash; previously clearing a field would restore the old value on save (STAK-487)</li>
     <li><strong>v3.33.71 &ndash; Codebase Modularization</strong>: Shared chart utility library eliminates 11 duplicate Chart.js patterns. Inventory split: 4,504 &rarr; 1,744 lines across 4 focused modules. Convention sweep: 53 getElementById, 5 localStorage, 23 var fixes (STAK-484)</li>
     <li><strong>v3.33.70 &ndash; Intraday Trends &amp; Reliability</strong>: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477)</li>
     <li><strong>v3.33.69 &ndash; Storage &amp; Sync Hygiene</strong>: Fixed disposed filter preference resetting on every page reload. Version upgrades no longer trigger phantom cloud sync diff popups &mdash; settings-only key diffs from new versions are auto-merged silently (STAK-470)</li>
     <li><strong>v3.33.68 &ndash; Catalog Data Fix</strong>: Fixed a bug where Catalog Data fields (diameter, thickness, country, etc.) were silently discarded on save for items without a Numista number (STAK-469)</li>
-    <li><strong>v3.33.67 &ndash; Retail Price Accuracy</strong>: Fixed Provident Metals picking up spot ticker instead of product price; fixed Hero Bullion returning bulk &ldquo;As Low As&rdquo; price instead of 1-unit table price; Gainesville Coins no longer wastes 15s on a Playwright timeout per coin (STAK-467)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.71";
+const APP_VERSION = "3.33.72";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -1050,26 +1050,34 @@ const parseItemFormFields = (isEditing, existingItem) => {
  * @returns {Object} Numista data fields with source tracking
  */
 const parseNumistaDataFields = (isEditing, existingItem, catalog = '') => {
-  const get = (id) => (document.getElementById(id)?.value?.trim() ?? '');
   const prev = (isEditing && existingItem?.numistaData) ? existingItem.numistaData : {};
 
+  // STAK-487: Respect intentional clearing — if the form element exists, trust its
+  // value (even empty string). Only fall back to previous data when the element is
+  // absent from the DOM. Previous || fallback treated '' as falsy, making it
+  // impossible for users to clear metadata fields.
+  const getOrPrev = (id, prevVal) => {
+    const el = document.getElementById(id);
+    return el ? el.value.trim() : (prevVal ?? '');
+  };
+
   const fields = {
-    country: get('numistaCountry') || prev.country || '',
-    denomination: get('numistaDenomination') || prev.denomination || '',
-    composition: get('numistaComposition') || prev.composition || '',
-    shape: get('numistaShape') || prev.shape || '',
-    diameter: get('numistaDiameter') || prev.diameter || '',
-    thickness: get('numistaThickness') || prev.thickness || '',
-    orientation: get('numistaOrientation') || prev.orientation || '',
-    technique: get('numistaTechnique') || prev.technique || '',
-    mintage: get('numistaMintage') || prev.mintage || '',
-    rarityIndex: get('numistaRarity') || prev.rarityIndex || '',
-    kmRef: get('numistaKmRef') || prev.kmRef || '',
+    country: getOrPrev('numistaCountry', prev.country),
+    denomination: getOrPrev('numistaDenomination', prev.denomination),
+    composition: getOrPrev('numistaComposition', prev.composition),
+    shape: getOrPrev('numistaShape', prev.shape),
+    diameter: getOrPrev('numistaDiameter', prev.diameter),
+    thickness: getOrPrev('numistaThickness', prev.thickness),
+    orientation: getOrPrev('numistaOrientation', prev.orientation),
+    technique: getOrPrev('numistaTechnique', prev.technique),
+    mintage: getOrPrev('numistaMintage', prev.mintage),
+    rarityIndex: getOrPrev('numistaRarity', prev.rarityIndex),
+    kmRef: getOrPrev('numistaKmRef', prev.kmRef),
     commemorative: document.getElementById('numistaCommemorative')?.checked || false,
-    commemorativeDesc: get('numistaCommemorativeDesc') || prev.commemorativeDesc || '',
-    obverseDesc: get('numistaObverseDesc') || prev.obverseDesc || '',
-    reverseDesc: get('numistaReverseDesc') || prev.reverseDesc || '',
-    edgeDesc: get('numistaEdgeDesc') || prev.edgeDesc || '',
+    commemorativeDesc: getOrPrev('numistaCommemorativeDesc', prev.commemorativeDesc),
+    obverseDesc: getOrPrev('numistaObverseDesc', prev.obverseDesc),
+    reverseDesc: getOrPrev('numistaReverseDesc', prev.reverseDesc),
+    edgeDesc: getOrPrev('numistaEdgeDesc', prev.edgeDesc),
   };
 
   // Track data source: 'user' if any field was manually changed from the API value,

--- a/js/events.js
+++ b/js/events.js
@@ -1057,7 +1057,7 @@ const parseNumistaDataFields = (isEditing, existingItem, catalog = '') => {
   // absent from the DOM. Previous || fallback treated '' as falsy, making it
   // impossible for users to clear metadata fields.
   const getOrPrev = (id, prevVal) => {
-    const el = document.getElementById(id);
+    const el = safeGetElement(id);
     return el ? el.value.trim() : (prevVal ?? '');
   };
 
@@ -1073,7 +1073,7 @@ const parseNumistaDataFields = (isEditing, existingItem, catalog = '') => {
     mintage: getOrPrev('numistaMintage', prev.mintage),
     rarityIndex: getOrPrev('numistaRarity', prev.rarityIndex),
     kmRef: getOrPrev('numistaKmRef', prev.kmRef),
-    commemorative: document.getElementById('numistaCommemorative')?.checked || false,
+    commemorative: (() => { const el = safeGetElement('numistaCommemorative'); return el ? el.checked : (prev.commemorative ?? false); })(),
     commemorativeDesc: getOrPrev('numistaCommemorativeDesc', prev.commemorativeDesc),
     obverseDesc: getOrPrev('numistaObverseDesc', prev.obverseDesc),
     reverseDesc: getOrPrev('numistaReverseDesc', prev.reverseDesc),

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.72-b1774036202';
+const CACHE_NAME = 'staktrakr-v3.33.72-b1774036509';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.71-b1773966921';
+const CACHE_NAME = 'staktrakr-v3.33.71-b1774036152';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.71-b1774036152';
+const CACHE_NAME = 'staktrakr-v3.33.72-b1774036202';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.71",
-  "releaseDate": "2026-03-18",
+  "version": "3.33.72",
+  "releaseDate": "2026-03-20",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

### STAK-487: Numista metadata fields can now be cleared
- **Fixed**: `parseNumistaDataFields` used `||` fallback that treated empty strings as falsy, silently restoring previous values when user cleared fields. New `getOrPrev()` helper checks DOM element existence — trusts form value (even empty) when element exists, falls back to stored data only when absent.
- **Fixed**: `commemorative` checkbox now uses the same DOM-existence fallback pattern (was missing, could lose `true` state)
- Uses `safeGetElement` per project convention

### STAK-489: View modal no longer fetches images from Numista API
- **Fixed**: Removed on-the-fly Numista image fetch from view modal. Stored URLs are now the single source of truth for images everywhere. API fetch retained only for metadata enrichment.
- **Fixed**: Eliminates the "paste one URL kills the other image" behavior — the boolean `imagesLoaded` flag no longer gates API fallback since there is no API image fallback.

### STAK-488: Image URL fill improvements
- **Fixed**: Removed `!el.value.trim()` guard on image URL fill — the field picker checkbox is the user's control for overwrite, not a hidden code guard. Editing items with existing URLs can now update images via Numista search.
- **Fixed**: URL input wrappers now become visible after Fill Fields, giving visual feedback that URLs were populated.

## Issues

- STAK-487: Numista metadata fields cannot be cleared
- STAK-488: Numista search image URLs not persisting + cross-image preview bug
- STAK-489: Remove on-the-fly Numista image fetch from view modal

## Test Plan

- [ ] Edit an item, clear KM Reference field, save → field stays empty on reopen
- [ ] Edit an item, don't touch metadata fields, save → all metadata preserved
- [ ] Add new item via Numista search → Fill Fields → save → image URLs persist, thumbnails show in table
- [ ] View modal for item WITHOUT stored images → no images shown (no API fetch)
- [ ] View modal for item WITH stored URLs → images show normally
- [ ] Edit an item with existing image URLs, search Numista, fill fields with image checkbox checked → URLs updated
- [ ] After Fill Fields, URL input wrappers are visible in the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)