### PR TITLE
v3.33.73 — Stored URLs as single source of truth for images (STAK-488, STAK-489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.73] - 2026-03-20
+
+### Fixed — Stored URLs as single source of truth for images
+
+- **Fixed**: View modal no longer independently fetches images from Numista API — stored URLs and user uploads are the single source of truth for images everywhere (STAK-489)
+- **Fixed**: Numista search "Fill Fields" now always writes image URLs when checkbox is checked, even when editing items with existing images (STAK-488)
+- **Fixed**: Image URL input wrappers now become visible after Fill Fields, giving visual feedback that URLs were populated (STAK-488)
+
+---
+
 ## [3.33.72] - 2026-03-20
 
 ### Fixed — Allow clearing Numista metadata fields

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Image URL Consistency (v3.33.73)**: Stored URLs are now the single source of truth for images everywhere &mdash; view modal no longer fetches from Numista API independently. Fill Fields now overwrites existing image URLs when checkbox is checked (STAK-488, STAK-489).
 - **Numista Metadata Fix (v3.33.72)**: Numista metadata fields (KM Reference, country, etc.) can now be cleared and saved as empty &mdash; previously clearing a field would restore the old value on save (STAK-487).
 - **Codebase Modularization (v3.33.71)**: Shared chart utility library eliminates 11 duplicate Chart.js patterns. Inventory split: 4,504 &rarr; 1,744 lines across 4 focused modules. Convention sweep: 53 getElementById, 5 localStorage, 23 var fixes (STAK-484).
 - **Intraday Trends &amp; Reliability (v3.33.70)**: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477).

--- a/js/about.js
+++ b/js/about.js
@@ -283,6 +283,7 @@ const setupAckModalEvents = () => {
  */
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.73 &ndash; Image URL Consistency</strong>: Stored URLs are now the single source of truth for images everywhere &mdash; view modal no longer fetches from Numista API independently. Fill Fields now overwrites existing image URLs when checkbox is checked (STAK-488, STAK-489)</li>
     <li><strong>v3.33.72 &ndash; Numista Metadata Fix</strong>: Numista metadata fields (KM Reference, country, etc.) can now be cleared and saved as empty &mdash; previously clearing a field would restore the old value on save (STAK-487)</li>
     <li><strong>v3.33.71 &ndash; Codebase Modularization</strong>: Shared chart utility library eliminates 11 duplicate Chart.js patterns. Inventory split: 4,504 &rarr; 1,744 lines across 4 focused modules. Convention sweep: 53 getElementById, 5 localStorage, 23 var fixes (STAK-484)</li>
     <li><strong>v3.33.70 &ndash; Intraday Trends &amp; Reliability</strong>: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477)</li>

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -1643,13 +1643,15 @@ const fillFormFromNumistaResult = () => {
         break;
       }
       case 'obverseImage': {
+        // STAK-488: Always write the URL when checkbox is checked — the user controls
+        // whether to overwrite via the field picker checkbox, not this guard.
         const el = elements.itemObverseImageUrl || safeGetElement('itemObverseImageUrl');
-        if (el && !el.value.trim()) el.value = val;
+        if (el) el.value = val;
         break;
       }
       case 'reverseImage': {
         const el = elements.itemReverseImageUrl || safeGetElement('itemReverseImageUrl');
-        if (el && !el.value.trim()) el.value = val;
+        if (el) el.value = val;
         break;
       }
       case 'metal': {
@@ -1661,6 +1663,13 @@ const fillFormFromNumistaResult = () => {
         break;
       }
     }
+  });
+
+  // STAK-488: Show URL input wrappers if we just filled image URLs (they're hidden by default)
+  ['Obv', 'Rev'].forEach(suffix => {
+    const wrap = document.getElementById('itemImageUrlInput' + suffix);
+    const field = suffix === 'Obv' ? elements.itemObverseImageUrl : elements.itemReverseImageUrl;
+    if (wrap && field && field.value.trim()) wrap.style.display = '';
   });
 
   // Auto-populate Numista Data fields from the selected result (STAK-173)

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.72";
+const APP_VERSION = "3.33.73";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -71,15 +71,13 @@ async function showViewModal(index) {
   modal.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 
-  // Load images and Numista data asynchronously after modal is visible
-  // Share a single API result to avoid duplicate calls
+  // Load images from stored URLs / user uploads only — no API fallback.
+  // STAK-489: Stored URLs are the single source of truth for images everywhere.
+  // Users populate images via Search → Fill Fields or manual URL entry in the edit form.
   const catalogId = item.numistaId || '';
   let apiResult = null;
 
-  // Try loading images from cache/item first
-  const cacheResult = await loadViewImages(item, body);
-  const imagesLoaded = cacheResult.loaded;
-  const imageSource = cacheResult.source;
+  await loadViewImages(item, body);
 
   // Check whether metadata is already cached in IndexedDB
   let metaCached = false;
@@ -90,29 +88,12 @@ async function showViewModal(index) {
     } catch { /* ignore */ }
   }
 
-  // Only hit the API when images are missing OR metadata is not in cache
-  if (catalogId && (!imagesLoaded || !metaCached)) {
+  // Fetch API result only for metadata enrichment — not for images
+  if (catalogId && !metaCached) {
     apiResult = await _fetchNumistaResult(catalogId);
   }
 
-  // Fill images from API result when no images were loaded at all
-  const shouldReplaceWithApi = !imagesLoaded;
-
-  if (shouldReplaceWithApi && apiResult && (apiResult.imageUrl || apiResult.reverseImageUrl)) {
-    const section = body.querySelector('#viewImageSection');
-    if (section) {
-      const slots = section.querySelectorAll('.view-image-slot');
-      if (apiResult.imageUrl) _setSlotImage(slots[0], apiResult.imageUrl);
-      if (apiResult.reverseImageUrl) _setSlotImage(slots[1], apiResult.reverseImageUrl);
-    }
-  }
-
-  // Do NOT persist CDN URLs from the view modal back to the inventory item (STAK-311).
-  // Writing here bypasses the save-path image priority cascade and can stick URLs to
-  // items that the user has deliberately cleared. URLs are written only via the edit
-  // form save path and the bulk-sync operation.
-
-  // Load Numista enrichment section
+  // Load Numista enrichment section (country, denomination, composition, etc.)
   await loadViewNumistaData(item, body, apiResult);
 }
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.72-b1774036509';
+const CACHE_NAME = 'staktrakr-v3.33.72-b1774038680';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.72-b1774038680';
+const CACHE_NAME = 'staktrakr-v3.33.73-b1774038725';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.72",
+  "version": "3.33.73",
   "releaseDate": "2026-03-20",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

### STAK-489: View modal no longer fetches images from Numista API
- Removed on-the-fly Numista API image fetch from view modal. Stored URLs and user uploads are the single source of truth for images everywhere. API fetch retained only for metadata enrichment (country, denomination, etc.).
- This eliminates the confusing disconnect where images appeared in the view popup but not in the table, card view, or edit form — and fixes the "paste one URL kills the other image" behavior caused by the boolean `imagesLoaded` flag.

### STAK-488: Image URL fill improvements
- Removed `!el.value.trim()` guard on image URL fill — the field picker checkbox is the user's control for whether to overwrite, not a hidden code guard. Editing items with existing URLs can now update images via Numista search.
- URL input wrappers now become visible after Fill Fields, giving user feedback that URLs were populated.

## Issues

- STAK-488: Numista search image URLs not persisting + cross-image preview bug
- STAK-489: Remove on-the-fly Numista image fetch from view modal

## Test Plan

- [ ] View modal for item WITHOUT stored images → no images shown (no API fetch)
- [ ] View modal for item WITH stored URLs → images show normally
- [ ] Add new item via Numista search → Fill Fields → save → image URLs persist, thumbnails show
- [ ] Edit item with existing images, search Numista, Fill Fields with checkbox checked → URLs updated
- [ ] After Fill Fields, URL input wrappers are visible in the form
- [ ] Paste one image URL into edit form → other image is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)