### PR TITLE
fix: resilient DB writes + Fly.io cron toggles (STAK-478)

### DIFF
--- a/devops/pollers/remote-poller/docker-entrypoint.sh
+++ b/devops/pollers/remote-poller/docker-entrypoint.sh
@@ -53,20 +53,31 @@ fi
 # API repo is no longer cloned at entrypoint — stateless clone in run-local.sh
 
 # ── 5.5. Dynamic cron schedule (overrides Dockerfile baked-in crontab) ──
+# ENV toggles: set RETAIL_ENABLED=0 or GOLDBACK_ENABLED=0 to disable those crons.
+# When retail is disabled, retry is also skipped (no retail data to retry).
+RETAIL_ENABLED="${RETAIL_ENABLED:-1}"
+GOLDBACK_ENABLED="${GOLDBACK_ENABLED:-1}"
 CRON_SCHEDULE="${CRON_SCHEDULE:-15,45}"
-if ! echo "$CRON_SCHEDULE" | grep -qE '^[0-9*/,\-]+$'; then
+if [ "$RETAIL_ENABLED" = "1" ] && ! echo "$CRON_SCHEDULE" | grep -qE '^[0-9*/,\-]+$'; then
   echo "[entrypoint] ERROR: Invalid CRON_SCHEDULE '${CRON_SCHEDULE}' — aborting." >&2
   exit 1
 fi
-echo "[entrypoint] Writing cron schedule: ${CRON_SCHEDULE}"
-(echo "${CRON_SCHEDULE} * * * * root . /etc/environment; /app/run-local.sh >> /var/log/retail-poller.log 2>&1"; \
- echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1"; \
- echo "8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1"; \
- echo "15 * * * * root . /etc/environment; /app/run-retry.sh >> /var/log/retail-retry.log 2>&1"; \
- echo "1 * * * * root . /etc/environment; /app/run-goldback.sh >> /var/log/goldback-poller.log 2>&1"; \
- echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1"; \
-) \
-  > /etc/cron.d/retail-poller
+echo "[entrypoint] Writing cron schedule (retail=${RETAIL_ENABLED}, goldback=${GOLDBACK_ENABLED})..."
+: > /etc/cron.d/retail-poller
+if [ "$RETAIL_ENABLED" = "1" ]; then
+  echo "${CRON_SCHEDULE} * * * * root . /etc/environment; /app/run-local.sh >> /var/log/retail-poller.log 2>&1" >> /etc/cron.d/retail-poller
+  echo "15 * * * * root . /etc/environment; /app/run-retry.sh >> /var/log/retail-retry.log 2>&1" >> /etc/cron.d/retail-poller
+else
+  echo "[entrypoint] Retail + retry crons DISABLED"
+fi
+echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1" >> /etc/cron.d/retail-poller
+echo "8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1" >> /etc/cron.d/retail-poller
+if [ "$GOLDBACK_ENABLED" = "1" ]; then
+  echo "1 * * * * root . /etc/environment; /app/run-goldback.sh >> /var/log/goldback-poller.log 2>&1" >> /etc/cron.d/retail-poller
+else
+  echo "[entrypoint] Goldback cron DISABLED"
+fi
+echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1" >> /etc/cron.d/retail-poller
 chmod 0644 /etc/cron.d/retail-poller
 
 # ── 5.6. Tailscale state directory (on persistent /data volume) ───────

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -90,6 +90,20 @@ function warn(msg) {
   console.warn(`[${new Date().toISOString().slice(11, 19)}] WARN: ${msg}`);
 }
 
+/** Wrapper around writeSnapshot that catches DB errors so a single failed
+ *  write doesn't crash the entire run. Returns true on success. */
+let _dbWriteFailures = 0;
+async function safeWriteSnapshot(db, row) {
+  try {
+    await writeSnapshot(db, row);
+    return true;
+  } catch (err) {
+    _dbWriteFailures++;
+    warn(`DB write failed for ${row.coinSlug}/${row.vendor} (non-fatal): ${err.message.slice(0, 100)}`);
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Price extraction from Firecrawl markdown
 // ---------------------------------------------------------------------------
@@ -1011,7 +1025,7 @@ async function main() {
           price, source, inStock, ok: true, error: null,
         });
         if (db) {
-          await writeSnapshot(db, {
+          await safeWriteSnapshot(db, {
             scrapedAt, windowStart: winStart, coinSlug,
             vendor: provider.id, price, source,
             isFailed: false, inStock,
@@ -1029,7 +1043,7 @@ async function main() {
           price: null, source: cfResult.source, inStock: false, ok: true, error: null,
         });
         if (db) {
-          await writeSnapshot(db, {
+          await safeWriteSnapshot(db, {
             scrapedAt, windowStart: winStart, coinSlug,
             vendor: provider.id, price: null, source: cfResult.source,
             isFailed: false, inStock: false,
@@ -1069,7 +1083,7 @@ async function main() {
           price, source, inStock, ok: true, error: null,
         });
         if (db) {
-          await writeSnapshot(db, {
+          await safeWriteSnapshot(db, {
             scrapedAt, windowStart: winStart, coinSlug,
             vendor: provider.id, price, source,
             isFailed: false, inStock,
@@ -1259,7 +1273,7 @@ async function main() {
 
     // Record to Turso
     if (db) {
-      await writeSnapshot(db, {
+      await safeWriteSnapshot(db, {
         scrapedAt,
         windowStart: winStart,
         coinSlug,
@@ -1295,18 +1309,21 @@ async function main() {
   const ok = scrapeResults.filter(r => r.ok).length;
   const fail = scrapeResults.length - ok;
 
-  log(`Done: ${ok}/${scrapeResults.length} prices captured, ${fail} failures, cf-clearance: ${cfAttempts} attempts ${cfSuccess} ok ${cfFailures} failed`);
+  log(`Done: ${ok}/${scrapeResults.length} prices captured, ${fail} failures, ${_dbWriteFailures} DB write errors, cf-clearance: ${cfAttempts} attempts ${cfSuccess} ok ${cfFailures} failed`);
 
   // Finish run log entry in Turso
   if (db && runId) {
     try {
+      const errorMsg = ok === 0 ? "All scrapes failed"
+        : _dbWriteFailures > 0 ? `${_dbWriteFailures} DB write(s) failed`
+        : null;
       await finishRunLog(db, {
         runId,
         finishedAt: new Date().toISOString(),
         captured: ok,
         failures: fail,
         fbpFilled: 0,
-        error: ok === 0 ? "All scrapes failed" : null,
+        error: errorMsg,
       });
     } catch (err) {
       warn(`Run log finish failed (non-fatal): ${err.message.slice(0, 80)}`);


### PR DESCRIPTION
## Summary

- **`safeWriteSnapshot` wrapper** — all 4 `writeSnapshot` call sites in `price-extract.js` are now wrapped in try-catch. A single DB write failure (SQLITE_BUSY, network error, etc.) no longer crashes the entire run. Failed writes are logged, counted, and reported in `finishRunLog`. The run always completes and properly records its status.

- **`RETAIL_ENABLED` / `GOLDBACK_ENABLED` ENV toggles** in `remote-poller/docker-entrypoint.sh`. Setting either to `0` disables those cron jobs while keeping spot, publish, and provider-export active. When retail is disabled, retry is also skipped (no retail data to retry). Defaults to `1` (backwards compatible).

## Context

The home poller handles all retail scraping. The Fly.io container's retail/goldback crons are redundant and expensive (4GB / 8 shared CPUs). This PR adds the toggles needed to disable them, enabling a future scale-down to `shared-cpu-1x:512MB` (~$3-5/mo vs current ~$20/mo).

## Next Steps (after merge)

1. `fly secrets set RETAIL_ENABLED=0 GOLDBACK_ENABLED=0 --app staktrakr`
2. `fly deploy` (picks up entrypoint changes)
3. `fly scale vm shared-cpu-1x --memory 512 --app staktrakr`
4. Monitor for 48h — verify spot + publish still flowing

## Test plan

- [ ] Verify `RETAIL_ENABLED=0` produces a cron file without retail/retry lines
- [ ] Verify `GOLDBACK_ENABLED=0` produces a cron file without goldback line
- [ ] Verify default behavior (both `1`) is unchanged
- [ ] Verify `safeWriteSnapshot` logs errors but doesn't crash the run
- [ ] Verify `finishRunLog` reports DB write failure count

🤖 Generated with [Claude Code](https://claude.com/claude-code)