### PR TITLE
v3.33.74 — Graceful SW update — auto-reload on cache miss (STAK-485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.74] - 2026-03-21
+
+### Fixed — Graceful SW update — auto-reload on cache miss
+
+- **Fixed**: Network-first navigation prevents stale HTML after file-restructuring deploys (STAK-485)
+- **Fixed**: Smart error recovery detects stale cache ReferenceErrors and auto-reloads instead of showing a scary error dialog (STAK-485)
+- **Fixed**: Cloud sync guard prevents data corruption during SW cache transitions (STAK-485)
+
+---
+
 ## [3.33.73] - 2026-03-20
 
 ### Fixed — Stored URLs as single source of truth for images

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,9 +1,9 @@
 ## What's New
 
+- **Graceful SW Update (v3.33.74)**: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss instead of showing scary error dialogs. Cloud sync guard prevents data corruption during transitions (STAK-485).
 - **Image URL Consistency (v3.33.73)**: Stored URLs are now the single source of truth for images everywhere &mdash; view modal no longer fetches from Numista API independently. Fill Fields now overwrites existing image URLs when checkbox is checked (STAK-488, STAK-489).
 - **Numista Metadata Fix (v3.33.72)**: Numista metadata fields (KM Reference, country, etc.) can now be cleared and saved as empty &mdash; previously clearing a field would restore the old value on save (STAK-487).
 - **Codebase Modularization (v3.33.71)**: Shared chart utility library eliminates 11 duplicate Chart.js patterns. Inventory split: 4,504 &rarr; 1,744 lines across 4 focused modules. Convention sweep: 53 getElementById, 5 localStorage, 23 var fixes (STAK-484).
-- **Intraday Trends &amp; Reliability (v3.33.70)**: Intraday trend toggle on Market Prices cards. Aggregation fixes stop data loss from UNIQUE constraint and carry forward vendor prices across 30-min windows. CF bypass hardened with Byparr-first phase and shm_size fix (STAK-464, STAK-474, STAK-475, STAK-476, STAK-477).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -237,6 +237,7 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.74 &ndash; Graceful SW Update</strong>: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss. Cloud sync guard prevents data corruption during transitions (STAK-485)</li>
     <li><strong>v3.33.73 &ndash; Image URL Consistency</strong>: Stored URLs are now the single source of truth for images everywhere &mdash; view modal no longer fetches from Numista API independently. Fill Fields now overwrites existing image URLs when checkbox is checked (STAK-488, STAK-489)</li>
     <li><strong>v3.33.72 &ndash; Numista Metadata Fix</strong>: Numista metadata fields (KM Reference, country, etc.) can now be cleared and saved as empty &mdash; previously clearing a field would restore the old value on save (STAK-487)</li>
     <li><strong>v3.33.71 &ndash; Codebase Modularization</strong>: Shared chart utility library eliminates 11 duplicate Chart.js patterns. Inventory split: 4,504 &rarr; 1,744 lines across 4 focused modules (STAK-484)</li>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -1014,6 +1014,11 @@ async function buildAndUploadManifest(token, password, syncId) {
  * Skips silently if not connected or sync is disabled.
  */
 async function pushSyncVault() {
+  // Guard: skip sync if app initialization failed (STAK-485)
+  if (window._initFailed) {
+    console.warn('[CloudSync] Skipping push — app initialization failed');
+    return;
+  }
   debugLog('[CloudSync] pushSyncVault called. enabled:', syncIsEnabled(), 'provider:', _syncProvider);
 
   if (!syncIsEnabled()) {
@@ -1548,6 +1553,11 @@ async function pushSyncVault() {
  * Skips silently if not connected or sync is disabled.
  */
 async function pollForRemoteChanges() {
+  // Guard: skip sync if app initialization failed (STAK-485)
+  if (window._initFailed) {
+    console.warn('[CloudSync] Skipping poll — app initialization failed');
+    return;
+  }
   if (!syncIsEnabled()) return;
   if (!_syncIsLeader) {
     debugLog('cloud-sync', 'Not leader tab — skipping poll');
@@ -2817,6 +2827,11 @@ function stopSyncPoller() {
  * @param {string} [provider='dropbox']
  */
 async function enableCloudSync(provider) {
+  // Guard: skip sync if app initialization failed (STAK-485)
+  if (window._initFailed) {
+    console.warn('[CloudSync] Skipping enable — app initialization failed');
+    return;
+  }
   _syncProvider = provider || 'dropbox';
   try { localStorage.setItem('cloud_sync_enabled', 'true'); } catch (_) { /* ignore */ }
 
@@ -2897,6 +2912,11 @@ function disableCloudSync() {
  * Creates the debounced push function and starts the poller if sync was enabled.
  */
 function initCloudSync() {
+  // Guard: skip sync if app initialization failed (STAK-485)
+  if (window._initFailed) {
+    console.warn('[CloudSync] Skipping init — app initialization failed');
+    return;
+  }
   // Initialize multi-tab coordination (Layer 7)
   initSyncTabCoordination();
 
@@ -2992,6 +3012,11 @@ document.addEventListener('visibilitychange', function () {
  * Ensures a valid password exists before attempting any sync operations.
  */
 async function syncNow() {
+  // Guard: skip sync if app initialization failed (STAK-485)
+  if (window._initFailed) {
+    console.warn('[CloudSync] Skipping syncNow — app initialization failed');
+    return;
+  }
   // Ensure we have a password before attempting sync.  If no silent password
   // is available, prompt the user interactively.
   var pw = getSyncPasswordSilent();

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.73";
+const APP_VERSION = "3.33.74";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/init.js
+++ b/js/init.js
@@ -36,6 +36,16 @@ function safeGetElement(id, required = false) {
   return element || createDummyElement();
 }
 
+// Auto-reload when a new service worker takes control (STAK-485)
+if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!document._swReloading) {
+      document._swReloading = true;
+      window.location.reload();
+    }
+  });
+}
+
 /**
  * Main application initialization function
  *
@@ -700,12 +710,31 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     }, 250);
 
+    // Clear stale-cache recovery flag on successful init (STAK-485)
+    sessionStorage.removeItem('sw-recovery-attempted');
+
   } catch (error) {
     console.error("=== CRITICAL INITIALIZATION ERROR ===");
     console.error("Error:", error.message);
     console.error("Stack:", error.stack);
 
-    // Try to show a user-friendly error message
+    // Flag init failure for cloud sync guard (STAK-485)
+    window._initFailed = true;
+
+    // Detect stale SW cache: ReferenceError for a function that should exist
+    const isStaleCache = error instanceof ReferenceError
+      && 'serviceWorker' in navigator
+      && !sessionStorage.getItem('sw-recovery-attempted');
+
+    if (isStaleCache) {
+      sessionStorage.setItem('sw-recovery-attempted', '1');
+      console.warn('[Init] Stale cache detected — reloading for new version');
+      document.body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:system-ui;color:#ccc;background:#0f172a"><p>Updating to new version\u2026</p></div>';
+      setTimeout(() => window.location.reload(), 800);
+      return;
+    }
+
+    // Standard error dialog for non-cache errors
     setTimeout(() => {
       appAlert(
         `Application initialization failed: ${error.message}\n\nPlease refresh the page and try again. If the problem persists, check the browser console for more details.`,

--- a/js/init.js
+++ b/js/init.js
@@ -727,6 +727,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       && !sessionStorage.getItem('sw-recovery-attempted');
 
     if (isStaleCache) {
+      document._swReloading = true;
       sessionStorage.setItem('sw-recovery-attempted', '1');
       console.warn('[Init] Stale cache detected — reloading for new version');
       document.body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:system-ui;color:#ccc;background:#0f172a"><p>Updating to new version\u2026</p></div>';

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.73-b1774059572';
+const CACHE_NAME = 'staktrakr-v3.33.73-b1774059625';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.73-b1774059675';
+const CACHE_NAME = 'staktrakr-v3.33.74-b1774059927';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.73-b1774059625';
+const CACHE_NAME = 'staktrakr-v3.33.73-b1774059675';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.73-b1774045883';
+const CACHE_NAME = 'staktrakr-v3.33.73-b1774059572';
 
 
 
@@ -176,23 +176,21 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Navigation requests (PWA launch, page reload) — serve cached app shell
+  // Navigation requests (PWA launch, page reload) — network-first for fresh HTML
   if (event.request.mode === 'navigate' && url.origin === self.location.origin) {
     event.respondWith(
-      caches.match('./')
-        .then((cached) => {
-          if (cached) return cached;
-          console.log('[SW] Cache miss for ./, fetching from network');
-          return fetchAndCache(event.request);
-        })
+      fetch(event.request)
         .then((response) => {
-          if (response) return response;
-          console.warn('[SW] No response from cache or network, serving offline page');
-          return offlineResponse();
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put('./', clone))
+              .catch((err) => console.warn('[SW] Nav cache put failed:', err));
+          }
+          return response;
         })
-        .catch((err) => {
-          console.error('[SW] Navigation handler failed:', err);
-          return offlineResponse();
+        .catch(() => {
+          return caches.match('./')
+            .then((cached) => cached || offlineResponse());
         })
     );
     return;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.74-b1774059927';
+const CACHE_NAME = 'staktrakr-v3.33.74-b1774061557';
 
 
 
@@ -185,12 +185,15 @@ self.addEventListener('fetch', (event) => {
             const clone = response.clone();
             caches.open(CACHE_NAME).then((cache) => cache.put('./', clone))
               .catch((err) => console.warn('[SW] Nav cache put failed:', err));
+            return response;
           }
-          return response;
+          // Non-OK response (4xx/5xx) — fall back to cache instead of serving error
+          return caches.match('./').then((cached) => cached || response);
         })
         .catch(() => {
           return caches.match('./')
-            .then((cached) => cached || offlineResponse());
+            .then((cached) => cached || offlineResponse())
+            .catch(() => offlineResponse());
         })
     );
     return;

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.73",
-  "releaseDate": "2026-03-20",
+  "version": "3.33.74",
+  "releaseDate": "2026-03-21",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Network-first navigation** in `sw.js` — prevents stale HTML after file-restructuring deploys
- **`controllerchange` auto-reload** in `js/init.js` — refreshes page when new SW takes control mid-session
- **Smart error recovery** in `js/init.js` — detects stale cache `ReferenceError`s, shows "Updating..." and auto-reloads with `sessionStorage` loop guard
- **Cloud sync guard** in `js/cloud-sync.js` — blocks sync when `window._initFailed` is set, preventing data corruption during SW transitions

## Issue

- STAK-485: UX: Graceful service worker update — auto-reload on cache miss

## Spec

- `.spec-workflow/specs/STAK-485-graceful-sw-update/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)