### PR TITLE
chore: GSD session 2026-03-21 — goldback sqld routing (STAK-491)

### DIFF
--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -910,6 +910,41 @@ async function main() {
         confidence: "high",
       });
     }
+
+    // goldback-{YYYY}.json — daily history from DB (replaces file-based append)
+    const gbAllRows = db
+      .prepare(`
+        SELECT scraped_at, price
+        FROM price_snapshots
+        WHERE coin_slug = 'goldback-g1' AND vendor = 'goldback' AND price IS NOT NULL
+        ORDER BY scraped_at DESC
+      `)
+      .all();
+
+    // Aggregate: one entry per date (latest scrape wins)
+    const byDate = {};
+    for (const row of gbAllRows) {
+      const date = row.scraped_at.slice(0, 10);
+      if (!byDate[date]) {
+        byDate[date] = { date, g1_usd: Math.round(row.price * 100) / 100, scraped_at: row.scraped_at };
+      }
+    }
+
+    // Group by year and write each year file
+    const byYear = {};
+    for (const entry of Object.values(byDate)) {
+      const year = entry.date.slice(0, 4);
+      if (!byYear[year]) byYear[year] = [];
+      byYear[year].push(entry);
+    }
+    for (const [year, entries] of Object.entries(byYear)) {
+      entries.sort((a, b) => b.date.localeCompare(a.date)); // newest first
+      const histPath = join(DATA_DIR, `goldback-${year}.json`);
+      if (!DRY_RUN) {
+        writeFileSync(histPath, JSON.stringify(entries, null, 2) + "\n");
+        log(`Wrote ${histPath} (${entries.length} entries)`);
+      }
+    }
   }
 
   log(`API export complete: ${coinSlugs.length} coin(s), ${windowCount} window(s) in history`);

--- a/devops/pollers/shared/goldback-scraper.js
+++ b/devops/pollers/shared/goldback-scraper.js
@@ -4,14 +4,17 @@
  * =======================================
  * Scrapes goldback.com/goldback-value/ for the current G1 USD exchange rate.
  * Writes:
- *   DATA_DIR/api/goldback-spot.json   -- latest rate (overwritten each day)
- *   DATA_DIR/goldback-{YYYY}.json     -- rolling daily log (appended)
+ *   sqld price_snapshots table        -- coin_slug="goldback-g1", vendor="goldback"
+ *   DATA_DIR/api/goldback-spot.json   -- latest rate (local backup, overwritten each day)
+ *   DATA_DIR/goldback-{YYYY}.json     -- rolling daily log (local backup, appended)
  *
  * Usage:
  *   DATA_DIR=/path/to/data node goldback-scraper.js
  *
  * Environment:
  *   DATA_DIR            Path to repo data/ folder (default: ../../data)
+ *   TURSO_DATABASE_URL  sqld/Turso connection string
+ *   TURSO_AUTH_TOKEN    sqld/Turso auth token
  *   FIRECRAWL_BASE_URL  Self-hosted Firecrawl (default: http://firecrawl:3002)
  *   FIRECRAWL_API_KEY   Cloud Firecrawl only (omit for self-hosted)
  *   DRY_RUN             Set to "1" to skip writes
@@ -20,6 +23,7 @@
 import { writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { openTursoDb, writeSnapshot, windowFloor } from "./db.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -195,6 +199,27 @@ async function main() {
   }
 
   log(`G1 rate: $${g1Rate}`);
+
+  // Write to sqld so Fly.io publisher can export goldback-spot.json
+  try {
+    const client = await openTursoDb();
+    await writeSnapshot(client, {
+      scrapedAt,
+      windowStart: windowFloor(now),
+      coinSlug: "goldback-g1",
+      vendor: "goldback",
+      price: g1Rate,
+      source: "firecrawl",
+      isFailed: false,
+    });
+    client.close();
+    log("Wrote goldback rate to sqld");
+  } catch (err) {
+    // DB write failure is non-fatal — local files still get written
+    warn(`sqld write failed (non-fatal): ${err.message}`);
+  }
+
+  // Local file writes (backup on home poller, primary on Fly.io legacy path)
   writeLatestJson(g1Rate, dateStr, scrapedAt);
   appendHistoryJson(g1Rate, dateStr, scrapedAt);
   log("Done.");


### PR DESCRIPTION
## GSD Session — Goldback Publish Gap Fix

### Problem
After STAK-478 moved goldback scraping to the home poller, the goldback data was being
scraped but never published. The old Fly.io `run-goldback.sh` (git commit+push) was the
only publish path and is now disabled (`GOLDBACK_ENABLED=0`).

### Changes
- **`goldback-scraper.js`**: Now writes to sqld as `coin_slug=goldback-g1`, `vendor=goldback`
  (in addition to local files as backup). DB write is non-fatal — scraper still writes local
  files if sqld is unreachable.
- **`api-export.js`**: Added `goldback-{YYYY}.json` history file export from DB. The
  `goldback-spot.json` export already existed (lines 888-913).

### Data Flow (After)
```
Home poller (:31) → scrape goldback.com → write to sqld
Fly.io publisher (:08/:23/:38/:53) → api-export.js reads sqld → writes goldback-spot.json + goldback-{YYYY}.json → git push → GitHub Pages
```

### Manual Steps Taken
- Backfilled 2026-03-21 goldback rate ($9.11) directly to api branch
- Seeded `goldback-g1` row in sqld for immediate pickup

### Notes
- No version bump — rolls into next release
- Vault issue: STAK-491
- `run-goldback.sh` on Fly.io can be removed in a future cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)