### PR TITLE
v3.33.77 — Fix Numista search on names with special characters (STAK-494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.77] - 2026-03-21
+
+### Fixed — Numista search on names with special characters (STAK-494)
+
+- **Fixed**: Numista search now strips operator characters (hyphens, parentheses, quotes, plus) from queries before sending to the API — items with official Numista-style names like "1 Dollar - Charles III (1st Portrait - Australian Kookaburra)" no longer timeout or return empty results (STAK-494)
+
+---
+
 ## [3.33.76] - 2026-03-21
 
 ### Fixed — Image thumbnail popover crash (STAK-492)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Numista Search Fix (v3.33.77)**: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494).
 - **Image Popover Fix (v3.33.76)**: Image thumbnail popovers now open correctly in table and card view. Previously clicking a thumbnail crashed silently due to a dummy DOM element missing `.remove()` (STAK-492).
 - **Cloud Sync Field Fix (v3.33.75)**: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items. Manifest add path also fixed (STAK-493).
 - **Graceful SW Update (v3.33.74)**: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss instead of showing scary error dialogs. Cloud sync guard prevents data corruption during transitions (STAK-485).

--- a/js/about.js
+++ b/js/about.js
@@ -247,6 +247,7 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.77 &ndash; Numista Search Fix</strong>: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494)</li>
     <li><strong>v3.33.76 &ndash; Image Popover Fix</strong>: Image thumbnail popovers now open correctly in table and card view. Previously clicking a thumbnail crashed silently due to a dummy DOM element missing .remove() (STAK-492)</li>
     <li><strong>v3.33.75 &ndash; Cloud Sync Field Fix</strong>: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, year, grading, disposition, and 10+ other fields were silently dropped on matched items. Manifest add path also fixed (STAK-493)</li>
     <li><strong>v3.33.74 &ndash; Graceful SW Update</strong>: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss. Cloud sync guard prevents data corruption during transitions (STAK-485)</li>

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -507,9 +507,11 @@ class NumistaProvider extends CatalogProvider {
    * @returns {Promise<Array>} Array of standardized item data
    */
   async searchItems(query, filters = {}) {
+    if (!query || typeof query !== 'string') return [];
     // STAK-494: Strip characters the Numista API interprets as search operators
     // - hyphens are negation, parentheses are grouping, plus is required-term
     const sanitized = query.replace(/[-()+"]/g, ' ').replace(/\s{2,}/g, ' ').trim();
+    if (!sanitized) return [];
     const params = new URLSearchParams({
       q: sanitized,
       count: Math.min(filters.limit || 20, 50),

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -507,8 +507,11 @@ class NumistaProvider extends CatalogProvider {
    * @returns {Promise<Array>} Array of standardized item data
    */
   async searchItems(query, filters = {}) {
+    // STAK-494: Strip characters the Numista API interprets as search operators
+    // - hyphens are negation, parentheses are grouping, plus is required-term
+    const sanitized = query.replace(/[-()+"]/g, ' ').replace(/\s{2,}/g, ' ').trim();
     const params = new URLSearchParams({
-      q: query,
+      q: sanitized,
       count: Math.min(filters.limit || 20, 50),
       lang: 'en'
     });

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.76";
+const APP_VERSION = "3.33.77";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.77-b1774112608';
+const CACHE_NAME = 'staktrakr-v3.33.77-b1774113527';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.76-b1774108988';
+const CACHE_NAME = 'staktrakr-v3.33.76-b1774112528';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.76-b1774112528';
+const CACHE_NAME = 'staktrakr-v3.33.77-b1774112608';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.76",
+  "version": "3.33.77",
   "releaseDate": "2026-03-21",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: Numista search now strips operator characters (`-`, `(`, `)`, `+`, `"`) from queries before sending to the API
- Items with official Numista-style names like "1 Dollar - Charles III (1st Portrait - Australian Kookaburra)" no longer timeout or return empty results
- The sanitization is scoped to `NumistaProvider.searchItems()` only — `lookupItem` (N#) and `LocalProvider` are unaffected

## Vault Issues

- STAK-494: Numista search fails on item names with special characters — GH #891

## Test Plan

- [ ] Edit an item with hyphens/parentheses in the name (e.g., "1 Dollar - Charles III (1st Portrait - Australian Kookaburra)")
- [ ] Click the magnifying glass search icon next to the Name field
- [ ] Verify Numista search returns results (no timeout)
- [ ] Verify N# lookup still works (enter a Numista number, click N# search)
- [ ] Verify plain-text name search still works (no special chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)