### PR TITLE
chore: slim Fly.io Dockerfile — thin publisher (STAK-478)

### DIFF
--- a/devops/pollers/remote-poller/Dockerfile
+++ b/devops/pollers/remote-poller/Dockerfile
@@ -1,158 +1,33 @@
 ############################################################
-# StakTrakr All-in-One Fly.io Container
-# ─────────────────────────────────────
-# Runs the full retail-poller pipeline in a single container:
-#   1. Redis           — Firecrawl queue + rate limiting
-#   2. RabbitMQ        — Firecrawl job queue
-#   3. PostgreSQL 17   — Firecrawl internal DB (pg_cron)
-#   4. Firecrawl API   — Scraping endpoint (port 3002)
-#   5. Firecrawl Worker + extract-worker + nuq-workers
-#   6. Playwright Svc  — Headless Chrome for Firecrawl (port 3003)
-#   7. Cron            — retail-poller 15-min cycle
-#   8. serve.js        — Public HTTP API (port 8080)
+# StakTrakr Thin Publisher — Fly.io Container
+# ─────────────────────────────────────────────
+# Lightweight publisher: reads from Turso, exports JSON,
+# pushes to GitHub Pages. No scraping, no browsers.
 #
-# All processes managed by supervisord.
+#   1. Cron            — spot poll + publish + provider export
+#   2. serve.js        — HTTP health endpoint (port 8080)
+#   3. Tailscale       — diagnostic VPN to home network
+#
+# Managed by supervisord. ~150MB image vs ~2GB all-in-one.
+# Full image archived as Dockerfile.full for rollback.
 ############################################################
 
-# ── Stage 1: Firecrawl app (API + workers) ──────────────
-FROM ghcr.io/firecrawl/firecrawl:latest@sha256:aef55fe8e15ed56eaac35e0ea3580c265134a89ac6f55cc1fe15bc49caa147c9 AS firecrawl
-
-# ── Stage 2: Playwright service ─────────────────────────
-FROM ghcr.io/firecrawl/playwright-service:latest@sha256:8e51d9b7880d6efc43f3a8adf7761bca1528fcafd9b6859150251182fd553f75 AS playwright-svc
-
-# ── Stage 3: Final all-in-one image ─────────────────────
 FROM node:20-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# System packages: git, cron, supervisor, redis, rabbitmq, postgres, chromium deps
+# System packages: git (for GitHub Pages push), cron, supervisor, curl
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     cron \
     ca-certificates \
     supervisor \
-    redis-server \
-    rabbitmq-server \
-    python3 \
-    make \
-    g++ \
     curl \
     gnupg \
     lsb-release \
-    # Chromium dependencies for Playwright service
-    libnss3 \
-    libnspr4 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libdrm2 \
-    libdbus-1-3 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxrandr2 \
-    libgbm1 \
-    libpango-1.0-0 \
-    libcairo2 \
-    libasound2 \
-    libatspi2.0-0 \
-    libwayland-client0 \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Block ad/tracker domains at OS level ──────────────────
-# Prevents Chromium from loading trackers during scrapes, reducing CPU and
-# bandwidth by ~30-50%. Domains resolve to 0.0.0.0 instantly (no TCP handshake).
-# Source: AdGuard base list + observed bullion dealer page trackers.
-# NOTE: /etc/hosts is read-only during Docker build (BuildKit restriction).
-# We write to a staging file here; docker-entrypoint.sh appends it at runtime.
-RUN printf '%s\n' \
-  '# --- Ad networks & trackers (blocked for scraper performance) ---' \
-  '0.0.0.0 www.googletagmanager.com' \
-  '0.0.0.0 googletagmanager.com' \
-  '0.0.0.0 www.google-analytics.com' \
-  '0.0.0.0 google-analytics.com' \
-  '0.0.0.0 ssl.google-analytics.com' \
-  '0.0.0.0 analytics.google.com' \
-  '0.0.0.0 www.googleadservices.com' \
-  '0.0.0.0 googleads.g.doubleclick.net' \
-  '0.0.0.0 pagead2.googlesyndication.com' \
-  '0.0.0.0 adservice.google.com' \
-  '0.0.0.0 pagead.l.doubleclick.net' \
-  '0.0.0.0 tpc.googlesyndication.com' \
-  '0.0.0.0 connect.facebook.net' \
-  '0.0.0.0 www.facebook.com' \
-  '0.0.0.0 pixel.facebook.com' \
-  '0.0.0.0 graph.facebook.com' \
-  '0.0.0.0 bat.bing.com' \
-  '0.0.0.0 clarity.ms' \
-  '0.0.0.0 www.clarity.ms' \
-  '0.0.0.0 cdn.klaviyo.com' \
-  '0.0.0.0 static.klaviyo.com' \
-  '0.0.0.0 a.klaviyo.com' \
-  '0.0.0.0 fast.a.klaviyo.com' \
-  '0.0.0.0 tr.snapchat.com' \
-  '0.0.0.0 sc-static.net' \
-  '0.0.0.0 px.ads.linkedin.com' \
-  '0.0.0.0 snap.licdn.com' \
-  '0.0.0.0 analytics.tiktok.com' \
-  '0.0.0.0 ct.pinterest.com' \
-  '0.0.0.0 static.hotjar.com' \
-  '0.0.0.0 script.hotjar.com' \
-  '0.0.0.0 vars.hotjar.com' \
-  '0.0.0.0 js.hs-analytics.net' \
-  '0.0.0.0 js.hs-scripts.com' \
-  '0.0.0.0 track.hubspot.com' \
-  '0.0.0.0 js.hsforms.net' \
-  '0.0.0.0 cdn.segment.com' \
-  '0.0.0.0 api.segment.io' \
-  '0.0.0.0 cdn.amplitude.com' \
-  '0.0.0.0 cdn.optimizely.com' \
-  '0.0.0.0 logx.optimizely.com' \
-  '0.0.0.0 cdn.heapanalytics.com' \
-  '0.0.0.0 cdn.mouseflow.com' \
-  '0.0.0.0 cdn.luckyorange.com' \
-  '0.0.0.0 cdn.onesignal.com' \
-  '0.0.0.0 widget.intercom.io' \
-  '0.0.0.0 js.intercomcdn.com' \
-  '0.0.0.0 static.doubleclick.net' \
-  '0.0.0.0 ad.doubleclick.net' \
-  '0.0.0.0 stats.g.doubleclick.net' \
-  '0.0.0.0 cm.g.doubleclick.net' \
-  '0.0.0.0 securepubads.g.doubleclick.net' \
-  '0.0.0.0 c.amazon-adsystem.com' \
-  '0.0.0.0 s.amazon-adsystem.com' \
-  '0.0.0.0 z-na.amazon-adsystem.com' \
-  '0.0.0.0 aax.amazon-adsystem.com' \
-  '0.0.0.0 fls-na.amazon-adsystem.com' \
-  '0.0.0.0 mads.amazon-adsystem.com' \
-  '0.0.0.0 aan.amazon.com' \
-  '0.0.0.0 ads.yahoo.com' \
-  '0.0.0.0 ads.pubmatic.com' \
-  '0.0.0.0 gum.criteo.com' \
-  '0.0.0.0 static.criteo.net' \
-  '0.0.0.0 bidder.criteo.com' \
-  '0.0.0.0 dis.criteo.com' \
-  '0.0.0.0 ib.adnxs.com' \
-  '0.0.0.0 secure.adnxs.com' \
-  '0.0.0.0 prebid.adnxs.com' \
-  '0.0.0.0 match.adsrvr.org' \
-  '0.0.0.0 insight.adsrvr.org' \
-  '0.0.0.0 js-agent.newrelic.com' \
-  '0.0.0.0 bam.nr-data.net' \
-  '0.0.0.0 consent.cookiebot.com' \
-  '0.0.0.0 cdn.cookielaw.org' \
-  '0.0.0.0 geolocation.onetrust.com' \
-  '0.0.0.0 tags.tiqcdn.com' \
-  '0.0.0.0 cdn.taboola.com' \
-  '0.0.0.0 trc.taboola.com' \
-  '0.0.0.0 widgets.outbrain.com' \
-  '0.0.0.0 log.outbrain.com' \
-  '0.0.0.0 assets.adobedtm.com' \
-  '0.0.0.0 dpm.demdex.net' \
-  > /tmp/tracker-blocklist.txt
-
-# Install Tailscale (stable Debian bookworm repo)
+# Install Tailscale (kept for diagnostics — free, no harm)
 RUN curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
       > /usr/share/keyrings/tailscale-archive-keyring.gpg \
     && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
@@ -161,74 +36,35 @@ RUN curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
     && apt-get install -y --no-install-recommends tailscale iptables \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PostgreSQL 17
-RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
-        > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-17 postgresql-17-cron \
-    && rm -rf /var/lib/apt/lists/*
-
-# ── Copy Firecrawl app ──────────────────────────────────
-COPY --from=firecrawl /app /opt/firecrawl
-# Firecrawl's node_modules are built for Node 22; our base is Node 20.
-# The compiled JS is compatible — only native addons would need a rebuild,
-# and Firecrawl has none (pure JS + the bundled go-html-to-md binary).
-
-# ── Copy Playwright service ─────────────────────────────
-COPY --from=playwright-svc /usr/src/app /opt/playwright-service
-# Copy Playwright browsers installed in the playwright-svc image
-COPY --from=playwright-svc /usr/local/share/playwright /usr/local/share/playwright
-
-# ── PostgreSQL init SQL ─────────────────────────────────
-COPY remote-poller/nuq-postgres-init.sql /opt/postgres/nuq.sql
-
-# ── Retail poller app ───────────────────────────────────
+# ── Poller app ────────────────────────────────────────────
 WORKDIR /app
-RUN mv /tmp/tracker-blocklist.txt /app/tracker-blocklist.txt
 
-# ── Shared poller code (single source of truth) ──────────
+# Shared poller code (single source of truth)
 COPY shared/package.json ./
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN npm install --omit=dev
-
-# Spot-poller Python deps
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
-    && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip install --no-cache-dir --break-system-packages "requests>=2.32.4" python-dotenv
 
 COPY shared/*.js ./
 
-# Spot-poller Python source
-COPY shared/spot-poller/ /app/spot-poller/
+# Remote-specific scripts (spot + publish only)
+COPY remote-poller/run-spot.sh remote-poller/run-publish.sh ./
+RUN chmod +x run-spot.sh run-publish.sh
 
-# ── Remote-specific files ─────────────────────────────────
-COPY remote-poller/run-local.sh remote-poller/run-goldback.sh remote-poller/run-spot.sh remote-poller/run-publish.sh remote-poller/run-retry.sh ./
-RUN chmod +x run-local.sh run-goldback.sh run-spot.sh run-publish.sh run-retry.sh
-
-# Git config for committing
+# Git config for committing to api branch
 RUN git config --global user.name "StakTrakr Poller" \
     && git config --global user.email "poller@staktrakr.local"
 
-# ── RabbitMQ setup (needs writable Erlang cookie + owned dirs) ──
-RUN mkdir -p /var/lib/rabbitmq /var/log/rabbitmq \
-    && echo "staktrakr-cookie" > /var/lib/rabbitmq/.erlang.cookie \
-    && chmod 600 /var/lib/rabbitmq/.erlang.cookie \
-    && chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /var/log/rabbitmq
-
-# ── Cron jobs ───────────────────────────────────────────
-RUN (echo "0 * * * * root . /etc/environment; /app/run-local.sh >> /var/log/retail-poller.log 2>&1"; \
-     echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1"; \
-     echo "20 * * * * root . /etc/environment; /app/run-goldback.sh >> /var/log/goldback-poller.log 2>&1"; \
+# ── Cron jobs (baked-in defaults — entrypoint overwrites) ──
+RUN (echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1"; \
+     echo "8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1"; \
      echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1") \
     > /etc/cron.d/retail-poller \
     && chmod 0644 /etc/cron.d/retail-poller
 
-# ── Supervisord config ──────────────────────────────────
-COPY remote-poller/supervisord.conf /etc/supervisor/conf.d/staktrakr.conf
+# ── Supervisord config ───────────────────────────────────
+COPY remote-poller/supervisord-slim.conf /etc/supervisor/conf.d/staktrakr.conf
 
-# ── Entrypoint ──────────────────────────────────────────
-COPY remote-poller/docker-entrypoint.sh /app/docker-entrypoint.sh
+# ── Entrypoint ────────────────────────────────────────────
+COPY remote-poller/docker-entrypoint-slim.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 8080

--- a/devops/pollers/remote-poller/Dockerfile
+++ b/devops/pollers/remote-poller/Dockerfile
@@ -16,7 +16,8 @@ FROM node:20-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# System packages: git (for GitHub Pages push), cron, supervisor, curl
+# System packages: git (GitHub Pages push), cron, supervisor, jq (publish logging),
+# python3/make/g++ (native addon compilation for better-sqlite3)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     cron \
@@ -24,7 +25,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     supervisor \
     curl \
     gnupg \
-    lsb-release \
+    jq \
+    python3 \
+    make \
+    g++ \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Tailscale (kept for diagnostics — free, no harm)
@@ -41,6 +45,7 @@ WORKDIR /app
 
 # Shared poller code (single source of truth)
 COPY shared/package.json ./
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN npm install --omit=dev
 
 COPY shared/*.js ./

--- a/devops/pollers/remote-poller/Dockerfile.full
+++ b/devops/pollers/remote-poller/Dockerfile.full
@@ -1,0 +1,237 @@
+############################################################
+# StakTrakr All-in-One Fly.io Container
+# ─────────────────────────────────────
+# Runs the full retail-poller pipeline in a single container:
+#   1. Redis           — Firecrawl queue + rate limiting
+#   2. RabbitMQ        — Firecrawl job queue
+#   3. PostgreSQL 17   — Firecrawl internal DB (pg_cron)
+#   4. Firecrawl API   — Scraping endpoint (port 3002)
+#   5. Firecrawl Worker + extract-worker + nuq-workers
+#   6. Playwright Svc  — Headless Chrome for Firecrawl (port 3003)
+#   7. Cron            — retail-poller 15-min cycle
+#   8. serve.js        — Public HTTP API (port 8080)
+#
+# All processes managed by supervisord.
+############################################################
+
+# ── Stage 1: Firecrawl app (API + workers) ──────────────
+FROM ghcr.io/firecrawl/firecrawl:latest@sha256:aef55fe8e15ed56eaac35e0ea3580c265134a89ac6f55cc1fe15bc49caa147c9 AS firecrawl
+
+# ── Stage 2: Playwright service ─────────────────────────
+FROM ghcr.io/firecrawl/playwright-service:latest@sha256:8e51d9b7880d6efc43f3a8adf7761bca1528fcafd9b6859150251182fd553f75 AS playwright-svc
+
+# ── Stage 3: Final all-in-one image ─────────────────────
+FROM node:20-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages: git, cron, supervisor, redis, rabbitmq, postgres, chromium deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    cron \
+    ca-certificates \
+    supervisor \
+    redis-server \
+    rabbitmq-server \
+    python3 \
+    make \
+    g++ \
+    curl \
+    gnupg \
+    lsb-release \
+    # Chromium dependencies for Playwright service
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libdbus-1-3 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libatspi2.0-0 \
+    libwayland-client0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Block ad/tracker domains at OS level ──────────────────
+# Prevents Chromium from loading trackers during scrapes, reducing CPU and
+# bandwidth by ~30-50%. Domains resolve to 0.0.0.0 instantly (no TCP handshake).
+# Source: AdGuard base list + observed bullion dealer page trackers.
+# NOTE: /etc/hosts is read-only during Docker build (BuildKit restriction).
+# We write to a staging file here; docker-entrypoint.sh appends it at runtime.
+RUN printf '%s\n' \
+  '# --- Ad networks & trackers (blocked for scraper performance) ---' \
+  '0.0.0.0 www.googletagmanager.com' \
+  '0.0.0.0 googletagmanager.com' \
+  '0.0.0.0 www.google-analytics.com' \
+  '0.0.0.0 google-analytics.com' \
+  '0.0.0.0 ssl.google-analytics.com' \
+  '0.0.0.0 analytics.google.com' \
+  '0.0.0.0 www.googleadservices.com' \
+  '0.0.0.0 googleads.g.doubleclick.net' \
+  '0.0.0.0 pagead2.googlesyndication.com' \
+  '0.0.0.0 adservice.google.com' \
+  '0.0.0.0 pagead.l.doubleclick.net' \
+  '0.0.0.0 tpc.googlesyndication.com' \
+  '0.0.0.0 connect.facebook.net' \
+  '0.0.0.0 www.facebook.com' \
+  '0.0.0.0 pixel.facebook.com' \
+  '0.0.0.0 graph.facebook.com' \
+  '0.0.0.0 bat.bing.com' \
+  '0.0.0.0 clarity.ms' \
+  '0.0.0.0 www.clarity.ms' \
+  '0.0.0.0 cdn.klaviyo.com' \
+  '0.0.0.0 static.klaviyo.com' \
+  '0.0.0.0 a.klaviyo.com' \
+  '0.0.0.0 fast.a.klaviyo.com' \
+  '0.0.0.0 tr.snapchat.com' \
+  '0.0.0.0 sc-static.net' \
+  '0.0.0.0 px.ads.linkedin.com' \
+  '0.0.0.0 snap.licdn.com' \
+  '0.0.0.0 analytics.tiktok.com' \
+  '0.0.0.0 ct.pinterest.com' \
+  '0.0.0.0 static.hotjar.com' \
+  '0.0.0.0 script.hotjar.com' \
+  '0.0.0.0 vars.hotjar.com' \
+  '0.0.0.0 js.hs-analytics.net' \
+  '0.0.0.0 js.hs-scripts.com' \
+  '0.0.0.0 track.hubspot.com' \
+  '0.0.0.0 js.hsforms.net' \
+  '0.0.0.0 cdn.segment.com' \
+  '0.0.0.0 api.segment.io' \
+  '0.0.0.0 cdn.amplitude.com' \
+  '0.0.0.0 cdn.optimizely.com' \
+  '0.0.0.0 logx.optimizely.com' \
+  '0.0.0.0 cdn.heapanalytics.com' \
+  '0.0.0.0 cdn.mouseflow.com' \
+  '0.0.0.0 cdn.luckyorange.com' \
+  '0.0.0.0 cdn.onesignal.com' \
+  '0.0.0.0 widget.intercom.io' \
+  '0.0.0.0 js.intercomcdn.com' \
+  '0.0.0.0 static.doubleclick.net' \
+  '0.0.0.0 ad.doubleclick.net' \
+  '0.0.0.0 stats.g.doubleclick.net' \
+  '0.0.0.0 cm.g.doubleclick.net' \
+  '0.0.0.0 securepubads.g.doubleclick.net' \
+  '0.0.0.0 c.amazon-adsystem.com' \
+  '0.0.0.0 s.amazon-adsystem.com' \
+  '0.0.0.0 z-na.amazon-adsystem.com' \
+  '0.0.0.0 aax.amazon-adsystem.com' \
+  '0.0.0.0 fls-na.amazon-adsystem.com' \
+  '0.0.0.0 mads.amazon-adsystem.com' \
+  '0.0.0.0 aan.amazon.com' \
+  '0.0.0.0 ads.yahoo.com' \
+  '0.0.0.0 ads.pubmatic.com' \
+  '0.0.0.0 gum.criteo.com' \
+  '0.0.0.0 static.criteo.net' \
+  '0.0.0.0 bidder.criteo.com' \
+  '0.0.0.0 dis.criteo.com' \
+  '0.0.0.0 ib.adnxs.com' \
+  '0.0.0.0 secure.adnxs.com' \
+  '0.0.0.0 prebid.adnxs.com' \
+  '0.0.0.0 match.adsrvr.org' \
+  '0.0.0.0 insight.adsrvr.org' \
+  '0.0.0.0 js-agent.newrelic.com' \
+  '0.0.0.0 bam.nr-data.net' \
+  '0.0.0.0 consent.cookiebot.com' \
+  '0.0.0.0 cdn.cookielaw.org' \
+  '0.0.0.0 geolocation.onetrust.com' \
+  '0.0.0.0 tags.tiqcdn.com' \
+  '0.0.0.0 cdn.taboola.com' \
+  '0.0.0.0 trc.taboola.com' \
+  '0.0.0.0 widgets.outbrain.com' \
+  '0.0.0.0 log.outbrain.com' \
+  '0.0.0.0 assets.adobedtm.com' \
+  '0.0.0.0 dpm.demdex.net' \
+  > /tmp/tracker-blocklist.txt
+
+# Install Tailscale (stable Debian bookworm repo)
+RUN curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
+      > /usr/share/keyrings/tailscale-archive-keyring.gpg \
+    && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
+      > /etc/apt/sources.list.d/tailscale.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends tailscale iptables \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PostgreSQL 17
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-17 postgresql-17-cron \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Copy Firecrawl app ──────────────────────────────────
+COPY --from=firecrawl /app /opt/firecrawl
+# Firecrawl's node_modules are built for Node 22; our base is Node 20.
+# The compiled JS is compatible — only native addons would need a rebuild,
+# and Firecrawl has none (pure JS + the bundled go-html-to-md binary).
+
+# ── Copy Playwright service ─────────────────────────────
+COPY --from=playwright-svc /usr/src/app /opt/playwright-service
+# Copy Playwright browsers installed in the playwright-svc image
+COPY --from=playwright-svc /usr/local/share/playwright /usr/local/share/playwright
+
+# ── PostgreSQL init SQL ─────────────────────────────────
+COPY remote-poller/nuq-postgres-init.sql /opt/postgres/nuq.sql
+
+# ── Retail poller app ───────────────────────────────────
+WORKDIR /app
+RUN mv /tmp/tracker-blocklist.txt /app/tracker-blocklist.txt
+
+# ── Shared poller code (single source of truth) ──────────
+COPY shared/package.json ./
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN npm install --omit=dev
+
+# Spot-poller Python deps
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m pip install --no-cache-dir --break-system-packages "requests>=2.32.4" python-dotenv
+
+COPY shared/*.js ./
+
+# Spot-poller Python source
+COPY shared/spot-poller/ /app/spot-poller/
+
+# ── Remote-specific files ─────────────────────────────────
+COPY remote-poller/run-local.sh remote-poller/run-goldback.sh remote-poller/run-spot.sh remote-poller/run-publish.sh remote-poller/run-retry.sh ./
+RUN chmod +x run-local.sh run-goldback.sh run-spot.sh run-publish.sh run-retry.sh
+
+# Git config for committing
+RUN git config --global user.name "StakTrakr Poller" \
+    && git config --global user.email "poller@staktrakr.local"
+
+# ── RabbitMQ setup (needs writable Erlang cookie + owned dirs) ──
+RUN mkdir -p /var/lib/rabbitmq /var/log/rabbitmq \
+    && echo "staktrakr-cookie" > /var/lib/rabbitmq/.erlang.cookie \
+    && chmod 600 /var/lib/rabbitmq/.erlang.cookie \
+    && chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /var/log/rabbitmq
+
+# ── Cron jobs ───────────────────────────────────────────
+RUN (echo "0 * * * * root . /etc/environment; /app/run-local.sh >> /var/log/retail-poller.log 2>&1"; \
+     echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1"; \
+     echo "20 * * * * root . /etc/environment; /app/run-goldback.sh >> /var/log/goldback-poller.log 2>&1"; \
+     echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1") \
+    > /etc/cron.d/retail-poller \
+    && chmod 0644 /etc/cron.d/retail-poller
+
+# ── Supervisord config ──────────────────────────────────
+COPY remote-poller/supervisord.conf /etc/supervisor/conf.d/staktrakr.conf
+
+# ── Entrypoint ──────────────────────────────────────────
+COPY remote-poller/docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/devops/pollers/remote-poller/docker-entrypoint-slim.sh
+++ b/devops/pollers/remote-poller/docker-entrypoint-slim.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+echo "[entrypoint] Starting StakTrakr thin publisher..."
+
+# ── 1. Export env vars for cron jobs (cron doesn't inherit Docker env) ──
+printenv | grep -v '^_=' > /etc/environment
+chmod 600 /etc/environment
+
+# ── 2. Configure git credentials ───────────────────────────────────────
+_GIT_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [ -n "$_GIT_TOKEN" ]; then
+  git config --global credential.helper store
+  printf 'https://x-access-token:%s@github.com\n' "$_GIT_TOKEN" > /root/.git-credentials
+  chmod 600 /root/.git-credentials
+fi
+
+# ── 3. Write cron schedule ─────────────────────────────────────────────
+echo "[entrypoint] Writing cron schedule (spot + publish + provider-export)..."
+: > /etc/cron.d/retail-poller
+echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1" >> /etc/cron.d/retail-poller
+echo "8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1" >> /etc/cron.d/retail-poller
+echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1" >> /etc/cron.d/retail-poller
+chmod 0644 /etc/cron.d/retail-poller
+
+# ── 4. Tailscale state directory (on persistent /data volume) ──────────
+mkdir -p /data/tailscale /var/run/tailscale /data/retail
+
+# ── 5. Create log files ────────────────────────────────────────────────
+touch /var/log/spot-poller.log /var/log/publish.log \
+      /var/log/http-server.log /var/log/provider-export.log
+
+echo "[entrypoint] Handing off to supervisord..."
+exec "$@"

--- a/devops/pollers/remote-poller/supervisord-slim.conf
+++ b/devops/pollers/remote-poller/supervisord-slim.conf
@@ -1,0 +1,49 @@
+; StakTrakr Thin Publisher — Supervisor Configuration
+; Only runs: Tailscale, cron (spot + publish), and HTTP health server.
+; No Redis, RabbitMQ, PostgreSQL, Firecrawl, or Playwright.
+
+; ── Tailscale (diagnostic VPN to home network) ──────────
+
+[program:tailscaled]
+command=tailscaled --state=/data/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscale.sock
+autorestart=true
+priority=4
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:tailscale-up]
+; Waits for tailscaled socket, then authenticates. Runs once on startup.
+command=bash -c "until tailscale --socket=/var/run/tailscale/tailscale.sock status >/dev/null 2>&1; do sleep 1; done && tailscale --socket=/var/run/tailscale/tailscale.sock up --authkey=%(ENV_TS_AUTHKEY)s --hostname=staktrakr-fly --accept-dns=false --accept-routes --reset"
+autorestart=false
+startsecs=0
+priority=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+; ── Cron (spot poll + publish + provider export) ─────────
+
+[program:cron]
+command=cron -f
+autorestart=true
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+; ── HTTP Health Server ───────────────────────────────────
+
+[program:http-server]
+command=node /app/serve.js
+directory=/app
+autorestart=true
+priority=10
+environment=API_EXPORT_DIR="/data/staktrakr-api-export"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
> **Draft — infrastructure change.** Merge to `dev`, then `fly deploy` to apply.

## Summary

- Replace all-in-one Dockerfile (~2GB: Redis, RabbitMQ, PostgreSQL, Firecrawl, Playwright) with thin publisher (~150MB: Node.js, git, cron, Tailscale)
- Only spot poll, publish (Turso → JSON → GitHub Pages), and provider export remain active
- Old Dockerfile archived as `Dockerfile.full` for rollback
- New slim entrypoint and supervisord config (3 services vs 12)
- VM stays at 1 CPU / 1GB to establish true baseline — can drop to 512MB later

## Context

Home poller has been sole retail + goldback source for 25+ hours with all feeds healthy. Current Fly.io container runs the full Firecrawl stack idle at 91% memory with constant WORKER STALLED errors. This change eliminates ~800MB of idle overhead.

## Vault Issues

- STAK-478: Slim Fly.io to thin publisher

## Deploy Plan

1. Merge to dev
2. `cd devops/pollers/remote-poller && fly deploy`
3. Monitor feeds for 30 min — all three should stay healthy
4. If issues: swap `Dockerfile.full` back to `Dockerfile`, redeploy

## Rollback

```bash
cp Dockerfile.full Dockerfile
fly deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)