### PR TITLE
v3.33.78 — Retail scraper consistency + OOS availability pipeline (STAK-475, STAK-495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.78] - 2026-03-21
+
+### Fixed — Retail scraper consistency + OOS availability pipeline (STAK-475, STAK-495)
+
+- **Fixed**: JM Bullion extraction removes "As Low As" fallback — volume discount prices (10-90% below retail) no longer recorded (STAK-475 P2)
+- **Fixed**: Soft 404 detection for React SPAs — Monument Metals and similar sites now correctly flag OOS instead of scraping nav ticker spot prices (STAK-475)
+- **Fixed**: Monument Metals header/nav spot tickers stripped before price extraction to prevent false matches (STAK-475)
+- **Fixed**: Intraday chart carry-forward removed from API export — frontend `_forwardFillVendors()` now detects gaps and renders dashed lines for carried/stale prices (STAK-495-B)
+- **Added**: OOS vendor indicators on retail cards — dimmed rows with strikethrough price and "(OOS)" label, sorted below in-stock vendors (STAK-495-C)
+
+---
+
 ## [3.33.77] - 2026-03-21
 
 ### Fixed — Numista search on names with special characters (STAK-494)

--- a/css/styles.css
+++ b/css/styles.css
@@ -11948,6 +11948,15 @@ th {
   font-weight: 600;
 }
 
+/* STAK-495: OOS vendor visual indicator */
+.retail-vendor-row--oos {
+  opacity: 0.5;
+}
+.retail-vendor-row--oos .retail-vendor-price {
+  text-decoration: line-through;
+  font-style: italic;
+}
+
 .retail-vendor-details { margin-top: 0.25rem; }
 
 /* STAK-217: Loading skeleton shimmer */

--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -172,22 +172,19 @@ function aggregateWindows(allRows, bucketMinutes = 30) {
     }
   }
 
-  // Step 2: Sort buckets chronologically, then carry forward
+  // Step 2: Sort buckets chronologically — NO carry-forward.
+  // Carry-forward is handled by the frontend's _forwardFillVendors() which
+  // marks carried prices in _carriedVendors → triggers dashed-line rendering.
+  // Pre-filling here made all prices look fresh to the frontend (STAK-495-B).
   const sortedKeys = [...byBucket.keys()].sort();
-  const lastSeen = {};  // vendorId → { price, scraped_at }
 
   const result = [];
   for (const bucket of sortedKeys) {
     const { vendors } = byBucket.get(bucket);
 
-    // Update lastSeen with any fresh data in this bucket
-    for (const [vendorId, data] of Object.entries(vendors)) {
-      lastSeen[vendorId] = data;
-    }
-
-    // Build the full vendor map: fresh data + carried-forward
+    // Only include vendors with fresh data in this bucket
     const vendorPrices = {};
-    for (const [vendorId, data] of Object.entries(lastSeen)) {
+    for (const [vendorId, data] of Object.entries(vendors)) {
       vendorPrices[vendorId] = data.price;
     }
 

--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -137,16 +137,16 @@ function vendorMap(rows) {
  * Excludes out-of-stock vendors (in_stock = 0).
  */
 /**
- * Aggregate raw snapshot rows into consensus time-bucket windows with
- * carry-forward so every window has all vendors.
+ * Aggregate raw snapshot rows into sparse time-bucket windows.
+ * Only vendors with fresh data in each bucket are included.
  *
  * 1. Bucket rows by time (30-min default) — merge both pollers.
- * 2. Walk buckets chronologically, carrying forward each vendor's last
- *    known price into any window where that vendor has no new data.
- * 3. Recompute median/low from the FULL vendor set (carried + fresh).
+ * 2. Emit only fresh data per bucket — NO carry-forward.
+ * 3. Compute median/low from fresh vendors only.
  *
- * Result: every window always has all vendors. Fresh data overwrites
- * carried data. The API serves complete, clean consensus windows.
+ * The frontend's _forwardFillVendors() handles carry-forward and marks
+ * carried vendors in _carriedVendors for dashed-line chart rendering.
+ * Pre-filling here made all prices look fresh to the frontend (STAK-495-B).
  *
  * @param {Array} allRows  Raw price_snapshots rows (must include scraped_at)
  * @param {number} bucketMinutes  Bucket size in minutes: 15, 30, or 60

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -140,11 +140,11 @@ const OUT_OF_STOCK_PATTERNS = [
 // Soft 404 patterns — React SPAs return HTTP 200 but render "not found" content.
 // When detected, the scraper should record inStock=false and price=null (STAK-475).
 const SOFT_404_PATTERNS = [
-  /page\s*(not|can.t be)\s*found/i,
+  /page\s*(not|can['\u2019]?t be|cannot be)\s*found/i,
   /product\s*(not|no longer)\s*(found|available)/i,
   /404\s*[-–—]\s*(page|not found)/i,
-  /this\s+page\s+(doesn.t|does not)\s+exist/i,
-  /we\s+couldn.t\s+find/i,
+  /this\s+page\s+(doesn['\u2019]?t|does not)\s+exist/i,
+  /we\s+couldn['\u2019]?t\s+find/i,
   /the\s+page\s+you\s+(requested|are looking for)/i,
   /no\s+longer\s+available/i,
   /has\s+been\s+(removed|discontinued)/i,

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -137,6 +137,19 @@ const OUT_OF_STOCK_PATTERNS = [
   /pre-?order/i,
 ];
 
+// Soft 404 patterns — React SPAs return HTTP 200 but render "not found" content.
+// When detected, the scraper should record inStock=false and price=null (STAK-475).
+const SOFT_404_PATTERNS = [
+  /page\s*(not|can.t be)\s*found/i,
+  /product\s*(not|no longer)\s*(found|available)/i,
+  /404\s*[-–—]\s*(page|not found)/i,
+  /this\s+page\s+(doesn.t|does not)\s+exist/i,
+  /we\s+couldn.t\s+find/i,
+  /the\s+page\s+you\s+(requested|are looking for)/i,
+  /no\s+longer\s+available/i,
+  /has\s+been\s+(removed|discontinued)/i,
+];
+
 // Providers whose "Pre-Order" / "Presale" items still show live purchasable prices.
 // For these, skip the pre-?order OOS pattern — treat presale as in-stock.
 const PREORDER_TOLERANT_PROVIDERS = new Set(["jmbullion", "monumentmetals"]);
@@ -167,6 +180,10 @@ const MARKDOWN_HEADER_SKIP_PATTERNS = {
   // followed by the nav mega-menu. The product area starts after the nav.
   // We skip past the spot ticker to avoid false gold-price matches.
   jmbullion: /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},\s+\d{4}\s+at\s+\d{1,2}:\d{2}\s+[A-Z]{2,4}/,
+  // Monument Metals (React SPA) — nav has spot tickers like "Gold $3,120.50 Silver $32.10".
+  // Skip past the header/nav area to avoid firstInRangeProse grabbing spot prices.
+  // The product title typically follows a breadcrumb containing "Home >" or the product name.
+  monumentmetals: /(?:Home\s*>|Bullion\s*>|Coins?\s*>)/,
 };
 
 function preprocessMarkdown(markdown, providerId) {
@@ -211,6 +228,18 @@ function preprocessMarkdown(markdown, providerId) {
 function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "") {
   if (!markdown) {
     return { inStock: true, reason: "no_markdown", detectedText: null };
+  }
+
+  // Check for soft 404 pages (React SPAs returning HTTP 200 with "not found" content)
+  for (const pattern of SOFT_404_PATTERNS) {
+    const match = markdown.match(pattern);
+    if (match) {
+      return {
+        inStock: false,
+        reason: "soft_404",
+        detectedText: match[0]
+      };
+    }
   }
 
   // Check for out-of-stock text patterns
@@ -429,19 +458,15 @@ function extractPrice(markdown, metal, weightOz = 1, providerId = "") {
   }
 
   if (providerId === "jmbullion") {
-    // JM Bullion: pipe table → prose table → "As Low As" fallback.
-    // Silver pages often render pipe tables; gold pages render as plain text.
-    // jmPriceFromProseTable() handles the plain-text layout:
-    //   "(e)Check/Wire" header → "1-9" qty tier → first dollar amount.
-    // NOTE: firstInRangePriceProse() is intentionally NOT used here — JMBullion's
-    // mega-menu (after nav stripping) can contain goldback category prices in the
-    // $5-$25 range that appear before the product price and produce false matches.
+    // JM Bullion: pipe table → prose table ONLY. No "As Low As" fallback.
+    // "As Low As" is a volume discount (100+ units via ACH) — NOT the single-unit
+    // retail price. Using it causes 10-90% price spread vs. actual retail (STAK-475 P2).
+    // Better to return null (missed window) than record a volume discount.
     const tblFirst = firstTableRowFirstPrice();
     if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
     const proseTbl = jmPriceFromProseTable();
     if (proseTbl !== null) return { price: proseTbl, matchedBy: "jmProseTable" };
-    const ala = asLowAsPrices();
-    if (ala.length > 0) return { price: Math.min(...ala), matchedBy: "asLowAs" };
+    // No asLowAs fallback — return null below.
   } else if (USES_AS_LOW_AS.has(providerId)) {
     // Reserved for vendors that have no pricing table, only "As Low As" display.
     // Currently empty — all vendors now use table-first extraction.

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards. Intraday charts now render dashed lines for carried/stale prices (STAK-475, STAK-495).
 - **Numista Search Fix (v3.33.77)**: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494).
 - **Image Popover Fix (v3.33.76)**: Image thumbnail popovers now open correctly in table and card view. Previously clicking a thumbnail crashed silently due to a dummy DOM element missing `.remove()` (STAK-492).
 - **Cloud Sync Field Fix (v3.33.75)**: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items. Manifest add path also fixed (STAK-493).
 - **Graceful SW Update (v3.33.74)**: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss instead of showing scary error dialogs. Cloud sync guard prevents data corruption during transitions (STAK-485).
-- **Image URL Consistency (v3.33.73)**: Stored URLs are now the single source of truth for images everywhere &mdash; view modal no longer fetches from Numista API independently. Fill Fields now overwrites existing image URLs when checkbox is checked (STAK-488, STAK-489).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -247,11 +247,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards. Intraday charts now render dashed lines for carried/stale prices (STAK-475, STAK-495)</li>
     <li><strong>v3.33.77 &ndash; Numista Search Fix</strong>: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494)</li>
     <li><strong>v3.33.76 &ndash; Image Popover Fix</strong>: Image thumbnail popovers now open correctly in table and card view. Previously clicking a thumbnail crashed silently due to a dummy DOM element missing .remove() (STAK-492)</li>
     <li><strong>v3.33.75 &ndash; Cloud Sync Field Fix</strong>: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, year, grading, disposition, and 10+ other fields were silently dropped on matched items. Manifest add path also fixed (STAK-493)</li>
     <li><strong>v3.33.74 &ndash; Graceful SW Update</strong>: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss. Cloud sync guard prevents data corruption during transitions (STAK-485)</li>
-    <li><strong>v3.33.73 &ndash; Image URL Consistency</strong>: Stored URLs are now the single source of truth for images everywhere &mdash; view modal no longer fetches from Numista API independently. Fill Fields now overwrites existing image URLs when checkbox is checked (STAK-488, STAK-489)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.77";
+const APP_VERSION = "3.33.78";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -860,17 +860,19 @@ const _buildRetailCard = (slug, meta, priceData) => {
       ...Object.keys(availability),
     ]);
 
-    // Sort: high-confidence in-stock vendors (≥60) by price asc, then low-confidence, then OOS vendors
+    // Sort: in-stock vendors by price asc, then OOS vendors by last-known price asc
     const sortedVendorEntries = Array.from(allVendorKeys)
       .map((key) => {
         const vendorData = vendorMap[key];
         const isAvailable = availability[key] !== false; // default true if not specified
         const price = vendorData ? vendorData.price : null;
+        // OOS vendors with no current price: use last-known price for display (STAK-495)
+        const displayPrice = price ?? (lastKnownPrices[key] ?? null);
         const score = vendorData ? vendorData.confidence : null;
         const label = getVendorDisplay(key).name;
-        return { key, label, price, score, isAvailable };
+        return { key, label, price: displayPrice, score, isAvailable };
       })
-      .filter(({ price }) => price != null) // show only vendors with a price
+      .filter(({ price }) => price != null) // show only vendors with a displayable price
       .sort((a, b) => {
         // In-stock vendors first (by price asc), then OOS vendors (by price asc)
         if (a.isAvailable !== b.isAvailable) return a.isAvailable ? -1 : 1;

--- a/js/retail.js
+++ b/js/retail.js
@@ -871,14 +871,21 @@ const _buildRetailCard = (slug, meta, priceData) => {
         return { key, label, price, score, isAvailable };
       })
       .filter(({ price }) => price != null) // show only vendors with a price
-      .sort((a, b) => a.price - b.price); // sort by price ascending
+      .sort((a, b) => {
+        // In-stock vendors first (by price asc), then OOS vendors (by price asc)
+        if (a.isAvailable !== b.isAvailable) return a.isAvailable ? -1 : 1;
+        return a.price - b.price;
+      });
 
-    // Award medals to top 3 vendors by price
-    const top3 = sortedVendorEntries.slice(0, 3).map(({ key }) => key);
+    // Award medals to top 3 IN-STOCK vendors by price (STAK-495)
+    const top3 = sortedVendorEntries
+      .filter(({ isAvailable }) => isAvailable)
+      .slice(0, 3).map(({ key }) => key);
 
-    sortedVendorEntries.forEach(({ key, label, price }) => {
+    sortedVendorEntries.forEach(({ key, label, price, isAvailable }) => {
       const row = document.createElement("div");
       row.className = "retail-vendor-row";
+      if (!isAvailable) row.classList.add("retail-vendor-row--oos");
       const medalIndex = top3.indexOf(key);
       if (medalIndex !== -1) {
         row.classList.add(`retail-vendor-row--medal-${medalIndex + 1}`);
@@ -894,7 +901,7 @@ const _buildRetailCard = (slug, meta, priceData) => {
       if (vendorUrl) {
         const link = document.createElement("a");
         link.href = "#";
-        link.textContent = label;
+        link.textContent = !isAvailable ? `${label} (OOS)` : label;
         link.className = "retail-vendor-link";
         if (vendorColor) link.style.color = vendorColor;
         link.addEventListener("click", (e) => {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.77-b1774116902';
+const CACHE_NAME = 'staktrakr-v3.33.78-b1774117126';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.78-b1774117126';
+const CACHE_NAME = 'staktrakr-v3.33.78-b1774118152';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.77-b1774113527';
+const CACHE_NAME = 'staktrakr-v3.33.77-b1774116902';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.77",
+  "version": "3.33.78",
   "releaseDate": "2026-03-21",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — poller code change.** Merge to `dev`, then redeploy home-poller to apply.

## Summary

- **JM Bullion**: Remove `asLowAs` fallback from extraction chain — it grabs volume discounts (100+ unit ACH price), not single-unit retail. Eliminates 10-90% price spread on gold items and $5.99 phantom prices on Goldbacks
- **Soft 404 detection**: New `SOFT_404_PATTERNS` catch React SPAs (Monument Metals) that return HTTP 200 with "page not found" content — records `inStock=false` instead of scraping nav tickers
- **Monument Metals header skip**: New `MARKDOWN_HEADER_SKIP_PATTERNS` entry strips spot price tickers from nav to prevent `firstInRangeProse` from grabbing spot as product price
- **Koala URL fix**: Updated `koala-silver` URL in Turso DB from 2026 → 2025 (correct product page)

## Data Evidence (48h analysis)

| Issue | Affected Items | Before | After |
|-------|---------------|--------|-------|
| JM asLowAs gold | age, buffalo, ape, maple-gold, krugerrand-gold | 55-90% spread | null (missed) → retry gets jsonLd |
| JM asLowAs Goldback | dc, nevada, SD, utah, wyoming | $5.99 phantom | null → correctly flagged |
| JM asLowAs silver | all silver coins | 8-15% below retail | null → retry gets table/prose |
| Monument soft 404 | koala-silver (old URL) | spot price ($67.86) as retail | inStock=false, price=null |
| Monument nav ticker | koala, kookaburra, generic-round | spot leakage via firstInRangeProse | header stripped before extraction |

## Vault Issues

- STAK-475: Retail scraper problem children — vendor/item triage list

## Deploy Plan

1. Merge to dev
2. Redeploy home-poller: `docker --context homepoller compose -f docker-compose.home.yml up --build -d`
3. Monitor next scrape run (`:00` or `:30`) — verify JM asLowAs entries stop appearing
4. Check Monument koala URL produces real prices or proper OOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)