### PR TITLE
v3.33.79 — Fix cloud sync image vault erasure on cross-device push (STAK-497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.79] - 2026-03-21
+
+### Fixed — Cloud sync image vault erasure on cross-device push (STAK-497)
+
+- **Fixed**: Cloud sync preserves image vault metadata when pushing device has no photos — prevents erasing uploaded images from other devices (STAK-497)
+- **Fixed**: Inventory hash now includes content fingerprint (image URLs, numistaId, grade, disposition) — prevents silent poll skip when items have same keys but different field values (STAK-497)
+- **Fixed**: Image vault push/pull now logs all outcomes (success, skipped, fail) to Activity Log — previously only failures were visible (STAK-497)
+
+---
+
 ## [3.33.78] - 2026-03-21
 
 ### Fixed — Retail scraper consistency + OOS availability pipeline (STAK-475, STAK-495)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
-- **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards. Intraday charts now render dashed lines for carried/stale prices (STAK-475, STAK-495).
+- **Cloud Sync Image Fix (v3.33.79)**: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497).
+- **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495).
 - **Numista Search Fix (v3.33.77)**: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494).
-- **Image Popover Fix (v3.33.76)**: Image thumbnail popovers now open correctly in table and card view. Previously clicking a thumbnail crashed silently due to a dummy DOM element missing `.remove()` (STAK-492).
-- **Cloud Sync Field Fix (v3.33.75)**: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items. Manifest add path also fixed (STAK-493).
-- **Graceful SW Update (v3.33.74)**: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss instead of showing scary error dialogs. Cloud sync guard prevents data corruption during transitions (STAK-485).
+- **Cloud Sync Field Fix (v3.33.75)**: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items (STAK-493).
+- **Graceful SW Update (v3.33.74)**: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss instead of showing scary error dialogs (STAK-485).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -247,10 +247,10 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards. Intraday charts now render dashed lines for carried/stale prices (STAK-475, STAK-495)</li>
+    <li><strong>v3.33.79 &ndash; Cloud Sync Image Fix</strong>: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497)</li>
+    <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495)</li>
     <li><strong>v3.33.77 &ndash; Numista Search Fix</strong>: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494)</li>
-    <li><strong>v3.33.76 &ndash; Image Popover Fix</strong>: Image thumbnail popovers now open correctly in table and card view. Previously clicking a thumbnail crashed silently due to a dummy DOM element missing .remove() (STAK-492)</li>
-    <li><strong>v3.33.75 &ndash; Cloud Sync Field Fix</strong>: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, year, grading, disposition, and 10+ other fields were silently dropped on matched items. Manifest add path also fixed (STAK-493)</li>
+    <li><strong>v3.33.75 &ndash; Cloud Sync Field Fix</strong>: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items (STAK-493)</li>
     <li><strong>v3.33.74 &ndash; Graceful SW Update</strong>: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss. Cloud sync guard prevents data corruption during transitions (STAK-485)</li>
   `;
 };

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -113,7 +113,17 @@ async function computeInventoryHash(items) {
     var arr = Array.isArray(items) ? items : [];
     var keys = [];
     for (var i = 0; i < arr.length; i++) {
-      keys.push(typeof DiffEngine !== 'undefined' ? DiffEngine.computeItemKey(arr[i]) : String(i));
+      var item = arr[i];
+      var itemKey = typeof DiffEngine !== 'undefined' ? DiffEngine.computeItemKey(item) : String(i);
+      // Include a content fingerprint so field-level changes (image URLs,
+      // numistaId, grade, disposition) produce a different hash even when
+      // the item key (name+metal+weight+date) is unchanged.
+      var contentSample = (item.obverseImageUrl || '') + '|'
+        + (item.reverseImageUrl || '') + '|'
+        + (item.numistaId || '') + '|'
+        + (item.grade || '') + '|'
+        + (item.disposition ? JSON.stringify(item.disposition) : '');
+      keys.push(itemKey + '::' + contentSample);
     }
     keys.sort();
     var joined = keys.join('|');
@@ -1059,6 +1069,7 @@ async function pushSyncVault() {
   _syncPushInFlight = true;
   updateSyncStatusIndicator('syncing');
   var pushStart = Date.now();
+  var _remoteImageVaultMeta = null; // Preserve remote image vault reference across pushes
 
   try {
     // -----------------------------------------------------------------------
@@ -1224,6 +1235,13 @@ async function pushSyncVault() {
       // Only fail-open for network errors; log prominently so we can diagnose
       console.warn('[CloudSync] Pre-push check: EXCEPTION (fail-open):', prePushErr.message);
       debugLog('[CloudSync] Pre-push remote check failed (non-blocking):', prePushErr.message);
+    }
+
+    // Capture remote imageVault metadata so we can preserve it when this
+    // device has no local photos (prevents erasing another device's uploads).
+    if (typeof prePushMeta !== 'undefined' && prePushMeta && prePushMeta.imageVault) {
+      _remoteImageVaultMeta = prePushMeta.imageVault;
+      debugLog('[CloudSync] Pre-push: remote has image vault —', _remoteImageVaultMeta.imageCount, 'photos, hash:', _remoteImageVaultMeta.hash);
     }
 
     // -----------------------------------------------------------------------
@@ -1408,10 +1426,12 @@ async function pushSyncVault() {
             if (!imgResp.ok) throw new Error('Image vault upload failed: ' + imgResp.status);
             imageVaultMeta = { imageCount: imgData.imageCount, hash: imgData.hash };
             debugLog('[CloudSync] Image vault uploaded:', imgData.imageCount, 'photos');
+            logCloudSyncActivity('image_vault_push', 'success', imgData.imageCount + ' photos, ' + Math.round(imageBytes.byteLength / 1024) + ' KB');
           } else {
             // Hash unchanged — carry forward existing meta so other devices can still detect it
             imageVaultMeta = lastImageHash ? { imageCount: imgData.imageCount, hash: imgData.hash } : null;
             debugLog('[CloudSync] Image vault unchanged — skipping upload');
+            logCloudSyncActivity('image_vault_push', 'skipped', 'Hash unchanged — ' + imgData.imageCount + ' photos');
           }
         } else if (lastImageHash) {
           // STAK-426: All local photos deleted — propagate deletion to remote
@@ -1427,6 +1447,7 @@ async function pushSyncVault() {
             });
             if (delResp.ok || delResp.status === 409) {
               debugLog('[CloudSync] Remote image vault deleted (all local photos removed)');
+              logCloudSyncActivity('image_vault_push', 'success', 'All local photos removed — remote vault deleted');
             } else {
               debugLog('[CloudSync] Image vault deletion returned status:', delResp.status);
             }
@@ -1434,6 +1455,19 @@ async function pushSyncVault() {
             debugLog('[CloudSync] Image vault deletion failed (non-blocking):', delErr.message);
           }
           // imageVaultMeta stays null → imageHash cleared in pushMeta
+        } else {
+          // No local images and no previous hash — carry forward remote
+          // image vault metadata if another device uploaded photos. Without
+          // this, a push from a device with no photos erases the imageVault
+          // pointer from the sync metadata, making the image file on Dropbox
+          // invisible to future pulls.
+          if (_remoteImageVaultMeta) {
+            imageVaultMeta = _remoteImageVaultMeta;
+            debugLog('[CloudSync] No local photos — preserving remote image vault reference:', _remoteImageVaultMeta.imageCount, 'photos');
+            logCloudSyncActivity('image_vault_push', 'skipped', 'No local photos — preserved remote reference (' + _remoteImageVaultMeta.imageCount + ' photos)');
+          } else {
+            logCloudSyncActivity('image_vault_push', 'skipped', 'No user photos on this device');
+          }
         }
       }
     } catch (imgErr) {
@@ -1883,6 +1917,7 @@ async function pullSyncVault(remoteMeta) {
             var restoredCount = await vaultDecryptAndRestoreImages(imgBytes, password);
             pulledImageHash = remoteMeta.imageVault.hash;
             debugLog('[CloudSync] Image vault restored:', restoredCount, 'photos');
+            logCloudSyncActivity('image_vault_pull', 'success', restoredCount + ' photos restored');
           } else if (imgPullResp.status === 404) {
             // File not yet uploaded (fresh account or first push in progress) — not an error.
             // Set hash sentinel to stop retry loop until manifest changes.
@@ -2321,13 +2356,15 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
                 });
                 if (_dvImgResp.ok) {
                   var _dvImgBytes = new Uint8Array(await _dvImgResp.arrayBuffer());
-                  await vaultDecryptAndRestoreImages(_dvImgBytes, password);
+                  var _dvRestoredCount = await vaultDecryptAndRestoreImages(_dvImgBytes, password);
                   debugLog('[CloudSync] Manifest-path: image vault restored');
+                  logCloudSyncActivity('image_vault_pull', 'success', (_dvRestoredCount || '?') + ' photos restored (manifest path)');
                 }
               }
             }
           } catch (_dvImgErr) {
             debugLog('[CloudSync] Manifest-path image restore failed (non-blocking):', _dvImgErr.message);
+            logCloudSyncActivity('image_vault_pull', 'fail', 'Manifest path: ' + _dvImgErr.message);
           }
 
           return;

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.78";
+const APP_VERSION = "3.33.79";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.78-b1774127088';
+const CACHE_NAME = 'staktrakr-v3.33.79-b1774127160';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.78-b1774118152';
+const CACHE_NAME = 'staktrakr-v3.33.78-b1774127088';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.78",
+  "version": "3.33.79",
   "releaseDate": "2026-03-21",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

P1 bug fix — cloud sync was silently erasing image vault metadata when a device without user-uploaded photos pushed to Dropbox, making uploaded images from other devices invisible to future pulls.

### Three bugs fixed:

1. **Image vault metadata erasure** — When device A pushes without photos, `imageVaultMeta` stayed null and the sync metadata omitted the `imageVault` pointer, erasing the reference to images device B uploaded. Fix: capture remote imageVault from pre-push metadata and carry it forward.

2. **Key-only inventory hash** — `computeInventoryHash` only hashed item keys (`name+metal+weight+date`), ignoring field values. Items with different image URLs, numistaId, grade, or disposition produced identical hashes, causing polls to silently skip pulls. Fix: include content fingerprint in hash.

3. **No Activity Log visibility** — Image vault push/pull success and skip paths used `debugLog()` (console-only). Fix: added `logCloudSyncActivity()` for all outcomes — success, skipped, and fail — on both push and pull paths.

### Root cause timeline

| Version | Change | Impact |
|---------|--------|--------|
| v3.32.0 | Image vault sync added (STAK-181) | Image blobs sync via separate file |
| v3.33.19 | DiffModal selective merge (STAK-190) | Full overwrite → field-level apply |
| v3.33.75 | STAK-493 adds image URLs to DIFF_FIELDS | Diff engine can now detect image URL changes |
| v3.33.78 | Cross-device push erases imageVault pointer | **This bug — metadata reference lost** |

## Test plan

- [ ] Push from device with user-uploaded photos → verify `image_vault_push: success` in Activity Log
- [ ] Push from device WITHOUT photos → verify `image_vault_push: skipped — preserved remote reference` in Activity Log
- [ ] Verify remote metadata still contains `imageVault` after push from device without photos
- [ ] Pull on second device → verify `image_vault_pull: success` in Activity Log
- [ ] Modify image URLs on device A, push, verify device B poll detects change (content-aware hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)