### PR TITLE
v3.33.80 — Fix chart daily average divergence on volatile days (STAK-483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.80] - 2026-03-21
+
+### Fixed — Chart daily average diverges from current price on volatile days (STAK-483)
+
+- **Fixed**: 7-day trend chart and trend badge now use live vendor prices for today's data point instead of a running daily average — eliminates visible divergence from market card on volatile days (STAK-483)
+
+---
+
 ## [3.33.79] - 2026-03-21
 
 ### Fixed — Cloud sync image vault erasure on cross-device push (STAK-497)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Chart Accuracy Fix (v3.33.80)**: 7-day trend chart and trend badge now use live prices for today's data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483).
 - **Cloud Sync Image Fix (v3.33.79)**: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497).
 - **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495).
 - **Numista Search Fix (v3.33.77)**: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494).
 - **Cloud Sync Field Fix (v3.33.75)**: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items (STAK-493).
-- **Graceful SW Update (v3.33.74)**: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss instead of showing scary error dialogs (STAK-485).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -247,11 +247,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.80 &ndash; Chart Accuracy Fix</strong>: 7-day trend chart and trend badge now use live prices for today&rsquo;s data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483)</li>
     <li><strong>v3.33.79 &ndash; Cloud Sync Image Fix</strong>: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497)</li>
     <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495)</li>
     <li><strong>v3.33.77 &ndash; Numista Search Fix</strong>: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494)</li>
     <li><strong>v3.33.75 &ndash; Cloud Sync Field Fix</strong>: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items (STAK-493)</li>
-    <li><strong>v3.33.74 &ndash; Graceful SW Update</strong>: Network-first navigation prevents stale HTML after deploys. Smart error recovery auto-reloads on cache miss. Cloud sync guard prevents data corruption during transitions (STAK-485)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.79";
+const APP_VERSION = "3.33.80";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -415,6 +415,28 @@ const _processSlugResult = (slug, latest, hist30) => {
   result.lastKnownPriceBySite = latest.last_known_price_by_site || null;
   result.lastAvailableDateBySite = latest.last_available_date_by_site || null;
 
+  // STAK-483: Patch today's history entry with live prices so chart/trend
+  // match the current market card instead of lagging behind a daily average.
+  if (result.history30 && latest.window_start && latest.vendors) {
+    const today = latest.window_start.slice(0, 10);
+    const todayEntry = result.history30.find((e) => e.date === today);
+    if (todayEntry) {
+      const livePrices = [];
+      const patchedVendors = {};
+      for (const [vid, vdata] of Object.entries(latest.vendors)) {
+        const p = vdata.price != null ? Number(vdata.price) : null;
+        if (p != null && isFinite(p)) livePrices.push(p);
+        patchedVendors[vid] = { avg: p, inStock: vdata.in_stock !== false };
+      }
+      if (livePrices.length > 0) {
+        const sorted = [...livePrices].sort((a, b) => a - b);
+        todayEntry.avg_median = Math.round(sorted[Math.floor(sorted.length / 2)] * 100) / 100;
+        todayEntry.avg_low = Math.round(Math.min(...livePrices) * 100) / 100;
+        todayEntry.vendors = patchedVendors;
+      }
+    }
+  }
+
   return result;
 };
 

--- a/js/retail.js
+++ b/js/retail.js
@@ -424,9 +424,9 @@ const _processSlugResult = (slug, latest, hist30) => {
       const livePrices = [];
       const patchedVendors = {};
       for (const [vid, vdata] of Object.entries(latest.vendors)) {
-        const p = vdata.price != null ? Number(vdata.price) : null;
-        if (p != null && isFinite(p)) livePrices.push(p);
-        patchedVendors[vid] = { avg: p, inStock: vdata.in_stock !== false };
+        const p = (vdata.price !== null && vdata.price !== undefined && vdata.price > 0 && isFinite(vdata.price)) ? Number(vdata.price) : null;
+        if (p !== null) livePrices.push(p);
+        patchedVendors[vid] = { avg: p, inStock: vdata.inStock !== false };
       }
       if (livePrices.length > 0) {
         const sorted = [...livePrices].sort((a, b) => a - b);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.79-b1774135104';
+const CACHE_NAME = 'staktrakr-v3.33.80-b1774139830';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.80-b1774139830';
+const CACHE_NAME = 'staktrakr-v3.33.80-b1774140938';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.79",
+  "version": "3.33.80",
   "releaseDate": "2026-03-21",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: 7-day trend chart and trend badge now use live vendor prices for today's data point instead of a running daily average
- On volatile days (gold swings $50+), the daily AVG from `history-30d.json` diverged visibly from the current price on the market card — this patch overlays today's history entry with current `latest.json` prices at fetch time
- Median recalculated from live prices using the same algorithm as the poller's `aggregateDailyRows`

## Vault Issues

- STAK-483: Chart daily average diverges from current price on volatile days

## Test Plan

- [ ] Open Market view on a volatile day — verify chart's rightmost point matches the card price
- [ ] Toggle between 7-Day and Intraday trend modes — both should reflect current prices
- [ ] Check trend badge direction matches visual chart direction
- [ ] Verify historical days (not today) still show daily averages unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)