### PR TITLE
v3.33.81 — Price bounds guard for retail poller (STAK-496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.81] - 2026-03-21
+
+### Added — Price bounds guard for retail poller (STAK-496)
+
+- **Added**: Dynamic price bounds check in `writeSnapshot()` rejects vendor prices >+50% or <-30% of spot-based melt value — prevents data pollution from wrong product pages, multi-packs, and scraper failures (STAK-496)
+- **Added**: Goldback baseline from `goldback-spot.json` G1 rate with gold spot fallback — denomination-aware for G1 through G50 (STAK-496)
+- **Added**: Per-vendor `skip_bounds` exemption in `provider_vendors` table for legitimate outliers like limited edition Goldbacks (STAK-496)
+
+---
+
 ## [3.33.80] - 2026-03-21
 
 ### Fixed — Chart daily average diverges from current price on volatile days (STAK-483)

--- a/devops/pollers/shared/db.js
+++ b/devops/pollers/shared/db.js
@@ -125,6 +125,32 @@ function appendPriceLog(row) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// STAK-496: Price bounds guard — reject implausible prices at write time.
+// If row.baseline is provided (spot-based melt value or goldback G1 rate),
+// prices outside the reject threshold are written as is_failed=1, price=null.
+// ---------------------------------------------------------------------------
+const BOUNDS_REJECT_HIGH = 1.50;  // > +50% above baseline
+const BOUNDS_REJECT_LOW  = 0.70;  // < -30% below baseline
+
+/**
+ * Check whether a price is within plausible bounds of its baseline.
+ * @param {number} price
+ * @param {number} baseline
+ * @returns {{ ok: boolean, ratio: number, reason?: string }}
+ */
+function checkPriceBounds(price, baseline) {
+  if (baseline <= 0 || !isFinite(baseline)) return { ok: true, ratio: 0 };
+  const ratio = price / baseline;
+  if (ratio > BOUNDS_REJECT_HIGH) {
+    return { ok: false, ratio, reason: `${((ratio - 1) * 100).toFixed(1)}% above baseline ($${price.toFixed(2)} vs $${baseline.toFixed(2)})` };
+  }
+  if (ratio < BOUNDS_REJECT_LOW) {
+    return { ok: false, ratio, reason: `${((1 - ratio) * 100).toFixed(1)}% below baseline ($${price.toFixed(2)} vs $${baseline.toFixed(2)})` };
+  }
+  return { ok: true, ratio };
+}
+
 /**
  * Insert a single price snapshot row.
  *
@@ -139,9 +165,24 @@ function appendPriceLog(row) {
  * @param {number|null} [row.confidence]  populated later by merge step
  * @param {boolean} [row.isFailed]  true if this scrape returned no price
  * @param {boolean} [row.inStock]   false if product is out of stock (defaults to true)
+ * @param {number|null} [row.baseline]  dynamic baseline for bounds check (STAK-496)
+ * @param {boolean} [row.skipPriceBounds]  true to exempt from bounds check
  */
 export async function writeSnapshot(client, row) {
-  appendPriceLog(row);
+  let price = row.price;
+  let isFailed = row.isFailed ? 1 : 0;
+
+  // STAK-496: Bounds check — reject implausible prices
+  if (price != null && row.baseline != null && !row.skipPriceBounds) {
+    const bounds = checkPriceBounds(price, row.baseline);
+    if (!bounds.ok) {
+      console.warn(`[bounds-guard] REJECTED ${row.coinSlug}/${row.vendor}: ${bounds.reason}`);
+      price = null;
+      isFailed = 1;
+    }
+  }
+
+  appendPriceLog({ ...row, price, isFailed: isFailed === 1 });
 
   await client.execute({
     sql: `
@@ -155,10 +196,10 @@ export async function writeSnapshot(client, row) {
       row.windowStart,
       row.coinSlug,
       row.vendor,
-      row.price,
+      price,
       row.source,
       row.confidence || null,
-      row.isFailed ? 1 : 0,
+      isFailed,
       row.inStock === false ? 0 : 1,
     ],
   });

--- a/devops/pollers/shared/db.js
+++ b/devops/pollers/shared/db.js
@@ -140,7 +140,8 @@ const BOUNDS_REJECT_LOW  = 0.70;  // < -30% below baseline
  * @returns {{ ok: boolean, ratio: number, reason?: string }}
  */
 function checkPriceBounds(price, baseline) {
-  if (baseline <= 0 || !isFinite(baseline)) return { ok: true, ratio: 0 };
+  if (!isFinite(price) || price <= 0) return { ok: false, ratio: NaN, reason: `non-finite or non-positive price (${price})` };
+  if (baseline <= 0 || !isFinite(baseline)) return { ok: true, ratio: 1 };
   const ratio = price / baseline;
   if (ratio > BOUNDS_REJECT_HIGH) {
     return { ok: false, ratio, reason: `${((ratio - 1) * 100).toFixed(1)}% above baseline ($${price.toFixed(2)} vs $${baseline.toFixed(2)})` };

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1008,7 +1008,7 @@ async function main() {
     try {
       const spotRows = await readSpotCurrent(db);
       for (const row of spotRows) {
-        if (row.metal && row.price != null) _spotByMetal[row.metal] = Number(row.price);
+        if (row.metal && row.spot != null) _spotByMetal[row.metal] = Number(row.spot);
       }
       log(`[bounds-guard] Spot prices loaded: ${Object.entries(_spotByMetal).map(([m, p]) => `${m}=$${p}`).join(", ") || "none"}`);
     } catch (err) {

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -22,7 +22,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { openTursoDb, writeSnapshot, windowFloor, startRunLog, finishRunLog, recordFailure } from "./db.js";
+import { openTursoDb, writeSnapshot, windowFloor, startRunLog, finishRunLog, recordFailure, readSpotCurrent } from "./db.js";
 import { loadProviders } from "./provider-db.js";
 import { getCFClearanceCookie } from "./cf-clearance.js";
 
@@ -1000,6 +1000,54 @@ async function main() {
   const scrapedAt = new Date().toISOString();
   const winStart = windowFloor();
 
+  // STAK-496: Load spot prices + goldback baseline for price bounds guard.
+  // Computed once at startup — used by safeWriteSnapshot for each target.
+  const _spotByMetal = {};  // { gold: 2650.00, silver: 31.50, ... }
+  let _goldbackG1 = null;   // goldback.com G1 rate in USD
+  if (db) {
+    try {
+      const spotRows = await readSpotCurrent(db);
+      for (const row of spotRows) {
+        if (row.metal && row.price != null) _spotByMetal[row.metal] = Number(row.price);
+      }
+      log(`[bounds-guard] Spot prices loaded: ${Object.entries(_spotByMetal).map(([m, p]) => `${m}=$${p}`).join(", ") || "none"}`);
+    } catch (err) {
+      warn(`[bounds-guard] Spot prices unavailable (non-fatal): ${err.message.slice(0, 80)}`);
+    }
+    try {
+      const gbPath = join(DATA_DIR, "api", "goldback-spot.json");
+      if (existsSync(gbPath)) {
+        const gb = JSON.parse(readFileSync(gbPath, "utf-8"));
+        if (gb.g1_usd > 0) _goldbackG1 = gb.g1_usd;
+      }
+      if (_goldbackG1 == null && _spotByMetal.gold) {
+        _goldbackG1 = _spotByMetal.gold * 0.003085;  // fallback: gold spot × G1 weight
+      }
+      if (_goldbackG1) log(`[bounds-guard] Goldback G1 baseline: $${_goldbackG1.toFixed(2)}`);
+    } catch (err) {
+      warn(`[bounds-guard] Goldback baseline unavailable (non-fatal): ${err.message.slice(0, 80)}`);
+    }
+  }
+
+  /**
+   * Compute the dynamic price baseline for a given coin.
+   * @param {string} coinSlug
+   * @param {object} coin  { metal, weight_oz }
+   * @returns {number|null}  baseline price in USD, or null if unavailable
+   */
+  function computeBaseline(coinSlug, coin) {
+    if (coin.metal === "goldback") {
+      // Goldback denominations: G1, G5, G10, G25, G50
+      if (!_goldbackG1) return null;
+      const denomMatch = coinSlug.match(/goldback-.*?-?g(\d+)$/i) || coinSlug.match(/goldback-g(\d+)/i);
+      const multiplier = denomMatch ? Number(denomMatch[1]) : 1;
+      return _goldbackG1 * multiplier;
+    }
+    const spot = _spotByMetal[coin.metal];
+    if (!spot || !coin.weight_oz) return null;
+    return spot * coin.weight_oz;
+  }
+
   // Start run log entry in Turso.
   // First, mark any orphaned "running" rows from previous crashed runs as "error".
   let runId = null;
@@ -1023,6 +1071,10 @@ async function main() {
   for (let targetIdx = 0; targetIdx < targets.length; targetIdx++) {
     const { coinSlug, coin, provider, urls } = targets[targetIdx];
     log(`Scraping ${coinSlug}/${provider.id}${urls.length > 1 ? ` (${urls.length} URL(s))` : ""}`);
+
+    // STAK-496: Per-target bounds check params
+    const _baseline = computeBaseline(coinSlug, coin);
+    const _skipBounds = provider.skipPriceBounds === true;
 
     let price = null;
     let source = "firecrawl";
@@ -1054,6 +1106,7 @@ async function main() {
             scrapedAt, windowStart: winStart, coinSlug,
             vendor: provider.id, price, source,
             isFailed: false, inStock,
+            baseline: _baseline, skipPriceBounds: _skipBounds,
           });
         }
         if (targetIdx < targets.length - 1) { await jitter(); }
@@ -1072,6 +1125,7 @@ async function main() {
             scrapedAt, windowStart: winStart, coinSlug,
             vendor: provider.id, price: null, source: cfResult.source,
             isFailed: false, inStock: false,
+            baseline: _baseline, skipPriceBounds: _skipBounds,
           });
         }
         if (targetIdx < targets.length - 1) { await jitter(); }
@@ -1112,6 +1166,7 @@ async function main() {
             scrapedAt, windowStart: winStart, coinSlug,
             vendor: provider.id, price, source,
             isFailed: false, inStock,
+            baseline: _baseline, skipPriceBounds: _skipBounds,
           });
         }
         if (targetIdx < targets.length - 1) { await jitter(); }
@@ -1306,6 +1361,7 @@ async function main() {
         price,
         source,
         isFailed:  price === null && inStock,  // Only failed if in stock but no price
+        baseline: _baseline, skipPriceBounds: _skipBounds,
         inStock,
       });
 

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1020,7 +1020,7 @@ async function main() {
         const gb = JSON.parse(readFileSync(gbPath, "utf-8"));
         if (gb.g1_usd > 0) _goldbackG1 = gb.g1_usd;
       }
-      if (_goldbackG1 == null && _spotByMetal.gold) {
+      if (_goldbackG1 == null && typeof _spotByMetal.gold === "number" && isFinite(_spotByMetal.gold)) {
         _goldbackG1 = _spotByMetal.gold * 0.003085;  // fallback: gold spot × G1 weight
       }
       if (_goldbackG1) log(`[bounds-guard] Goldback G1 baseline: $${_goldbackG1.toFixed(2)}`);

--- a/devops/pollers/shared/provider-db.js
+++ b/devops/pollers/shared/provider-db.js
@@ -43,6 +43,7 @@ const CREATE_PROVIDER_VENDORS = `
     enabled     INTEGER NOT NULL DEFAULT 1,
     selector    TEXT,
     hints       TEXT,
+    skip_bounds INTEGER NOT NULL DEFAULT 0,
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(coin_slug, vendor_id)
@@ -68,6 +69,12 @@ export async function initProviderSchema(client) {
   for (const sql of CREATE_INDEXES) {
     await client.execute(sql);
   }
+  // STAK-496: Add skip_bounds column if missing (migration for existing DBs)
+  try {
+    await client.execute("ALTER TABLE provider_vendors ADD COLUMN skip_bounds INTEGER NOT NULL DEFAULT 0");
+  } catch {
+    // Column already exists — expected on subsequent runs
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +94,7 @@ export async function getProviders(client) {
     "SELECT slug, metal, name, weight_oz, fbp_url, notes, enabled FROM provider_coins ORDER BY slug"
   );
   const vendorsResult = await client.execute(
-    "SELECT coin_slug, vendor_id, vendor_name, url, enabled, selector, hints FROM provider_vendors ORDER BY coin_slug, vendor_id"
+    "SELECT coin_slug, vendor_id, vendor_name, url, enabled, selector, hints, skip_bounds FROM provider_vendors ORDER BY coin_slug, vendor_id"
   );
 
   // Index vendors by coin_slug for fast lookup
@@ -102,6 +109,7 @@ export async function getProviders(client) {
       url: row.url || undefined,
       ...(row.selector ? { selector: row.selector } : {}),
       ...(row.hints ? { hints: row.hints } : {}),
+      ...(row.skip_bounds === 1 ? { skipPriceBounds: true } : {}),
     });
   }
 
@@ -129,7 +137,7 @@ export async function getProviders(client) {
  */
 export async function getProvidersByCoin(client, coinSlug) {
   const result = await client.execute({
-    sql: "SELECT vendor_id, vendor_name, url, enabled, selector, hints FROM provider_vendors WHERE coin_slug = ? ORDER BY vendor_id",
+    sql: "SELECT vendor_id, vendor_name, url, enabled, selector, hints, skip_bounds FROM provider_vendors WHERE coin_slug = ? ORDER BY vendor_id",
     args: [coinSlug],
   });
   return result.rows.map((row) => ({
@@ -139,6 +147,7 @@ export async function getProvidersByCoin(client, coinSlug) {
     enabled: row.enabled === 1,
     ...(row.selector ? { selector: row.selector } : {}),
     ...(row.hints ? { hints: row.hints } : {}),
+    ...(row.skip_bounds === 1 ? { skipPriceBounds: true } : {}),
   }));
 }
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Price Bounds Guard (v3.33.81)**: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496).
 - **Chart Accuracy Fix (v3.33.80)**: 7-day trend chart and trend badge now use live prices for today's data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483).
 - **Cloud Sync Image Fix (v3.33.79)**: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497).
 - **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495).
 - **Numista Search Fix (v3.33.77)**: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494).
-- **Cloud Sync Field Fix (v3.33.75)**: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items (STAK-493).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -247,11 +247,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.81 &ndash; Price Bounds Guard</strong>: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496)</li>
     <li><strong>v3.33.80 &ndash; Chart Accuracy Fix</strong>: 7-day trend chart and trend badge now use live prices for today&rsquo;s data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483)</li>
     <li><strong>v3.33.79 &ndash; Cloud Sync Image Fix</strong>: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497)</li>
     <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495)</li>
     <li><strong>v3.33.77 &ndash; Numista Search Fix</strong>: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494)</li>
-    <li><strong>v3.33.75 &ndash; Cloud Sync Field Fix</strong>: Cloud sync now compares all item fields during merge &mdash; previously image URLs, numistaId, grading, disposition, and 15+ other fields were silently dropped on matched items (STAK-493)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.80";
+const APP_VERSION = "3.33.81";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.80-b1774140938';
+const CACHE_NAME = 'staktrakr-v3.33.81-b1774142223';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.80",
+  "version": "3.33.81",
   "releaseDate": "2026-03-21",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Changes

- **Added**: Dynamic price bounds check in `writeSnapshot()` — prices >+50% or <-30% of spot-based melt value are rejected (written as `is_failed=1, price=null`)
- **Added**: Baseline computation at scrape startup: spot prices via `readSpotCurrent()` for standard coins, `goldback-spot.json` G1 rate (with gold×0.003085 fallback) for Goldbacks
- **Added**: Denomination-aware Goldback baselines — parses G1/G5/G10/G25/G50 multiplier from coin slug
- **Added**: `skip_bounds` column on `provider_vendors` table with idempotent migration — per coin-vendor exemption for legitimate outliers (e.g. limited edition Goldbacks at 60% premium)
- **Added**: `[bounds-guard] REJECTED` warning logs for every rejected price — full audit trail

## Files Changed

- `devops/pollers/shared/db.js` — `checkPriceBounds()` utility + bounds check in `writeSnapshot()`
- `devops/pollers/shared/price-extract.js` — spot/goldback baseline loading, `computeBaseline()`, pass baseline to all 4 `safeWriteSnapshot` call sites
- `devops/pollers/shared/provider-db.js` — `skip_bounds` column in schema, migration, surfaced in reads

## Vault Issues

- STAK-496: Price bounds guard — reject implausible vendor prices at write time

## Test Plan

- [ ] Verify poller starts and logs spot prices + goldback baseline
- [ ] Verify a normal price within bounds is written successfully
- [ ] Verify a price >+50% above melt is rejected with `[bounds-guard] REJECTED` log
- [ ] Verify `skip_bounds=1` vendor bypasses the check
- [ ] Verify goldback denomination multiplier works (G5 baseline = 5× G1)
- [ ] Verify graceful degradation when spot prices unavailable (no baseline → no check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)