### PR TITLE
v3.33.82 — Remove decommissioned grid/card view code (STAK-473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.82] - 2026-03-22
+
+### Removed — Remove decommissioned grid/card view code (STAK-473)
+
+- **Removed**: Dead grid/card view rendering code from retail.js (~260 lines) — `_buildRetailCard()`, `_renderRetailSparkline()`, `_retailSparklines` Map, and grid branch of `renderRetailCards()` (STAK-473)
+- **Removed**: `MARKET_LIST_VIEW` feature flag from constants.js — list view is now unconditional (STAK-473)
+- **Removed**: Orphaned `.retail-card-footer` and `.retail-sparkline` CSS rules (STAK-473)
+
+---
+
 ## [3.33.81] - 2026-03-21
 
 ### Added — Price bounds guard for retail poller (STAK-496)

--- a/css/styles.css
+++ b/css/styles.css
@@ -11773,15 +11773,6 @@ th {
   font-size: 0.9rem;
 }
 
-.retail-card-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 0.75rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--border-color-subtle, var(--bs-border-color));
-}
-
 .retail-card-date {
   font-size: 0.75rem;
   color: var(--text-muted, var(--bs-secondary-color));
@@ -11880,9 +11871,6 @@ th {
   color: var(--text-muted, var(--bs-secondary-color));
   font-style: italic;
 }
-
-/* Reset footer margin — gap on .retail-price-card handles spacing */
-.retail-price-card > .retail-card-footer { margin-top: 0; }
 
 /* STAK-217: Metal badge color coding */
 .retail-metal-badge {
@@ -12006,13 +11994,6 @@ th {
 }
 .retail-sync-cta:hover { opacity: 0.85; }
 
-
-/* STAK-217: Sparkline micro-chart */
-.retail-sparkline {
-  display: block;
-  margin-left: auto;
-  opacity: 0.75;
-}
 
 /* History table in Activity Log */
 .retail-history-controls {

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Grid View Cleanup (v3.33.82)**: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473).
 - **Price Bounds Guard (v3.33.81)**: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496).
 - **Chart Accuracy Fix (v3.33.80)**: 7-day trend chart and trend badge now use live prices for today's data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483).
 - **Cloud Sync Image Fix (v3.33.79)**: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497).
 - **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495).
-- **Numista Search Fix (v3.33.77)**: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494).
 
 ## Development Roadmap
 

--- a/index.html
+++ b/index.html
@@ -3621,7 +3621,7 @@
             <!-- ===== MARKET PRICES ===== -->
             <div id="settingsPanel_market" class="settings-section-panel" style="display: none">
 
-              <!-- Market List View header (hidden by default, shown by JS when MARKET_LIST_VIEW enabled) -->
+              <!-- Market List View header -->
               <div id="marketListHeader" style="display:none">
                 <div class="market-header">
                   <div class="market-header-row">
@@ -3665,7 +3665,7 @@
                 </div>
               </div>
 
-              <!-- Original grid header (shown when MARKET_LIST_VIEW is disabled) -->
+              <!-- Legacy grid header (hidden when list view active) -->
               <div id="marketGridHeader">
                 <h3 style="margin-bottom:0.75rem;">Market Prices</h3>
                 <div style="display:flex; align-items:center; justify-content:space-between; gap:0.75rem; margin-bottom:0.5rem;">

--- a/js/about.js
+++ b/js/about.js
@@ -247,11 +247,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.82 &ndash; Grid View Cleanup</strong>: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473)</li>
     <li><strong>v3.33.81 &ndash; Price Bounds Guard</strong>: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496)</li>
     <li><strong>v3.33.80 &ndash; Chart Accuracy Fix</strong>: 7-day trend chart and trend badge now use live prices for today&rsquo;s data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483)</li>
     <li><strong>v3.33.79 &ndash; Cloud Sync Image Fix</strong>: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497)</li>
     <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495)</li>
-    <li><strong>v3.33.77 &ndash; Numista Search Fix</strong>: Numista search now strips operator characters from queries &mdash; items with official names containing hyphens and parentheses no longer timeout or return empty results (STAK-494)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -1415,13 +1415,6 @@ const FEATURE_FLAGS = {
     description: "Coin image caching and item view modal",
     phase: "beta"
   },
-  MARKET_LIST_VIEW: {
-    enabled: true,
-    urlOverride: true,
-    userToggle: true,
-    description: "New single-row market card layout with search, sort, and inline charts",
-    phase: "beta"
-  },
   MARKET_DASHBOARD_ITEMS: {
     enabled: false,
     urlOverride: true,

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.81";
+const APP_VERSION = "3.33.82";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -174,9 +174,6 @@ let _retailSyncInProgress = false;
 /** True when the last sync attempt failed — drives error display in grid/list views */
 let _retailSyncError = false;
 
-/** Active sparkline Chart instances keyed by slug — destroyed before re-render to prevent Canvas reuse errors */
-const _retailSparklines = new Map();
-
 /** Current trend display mode: "7d" (default) or "intraday" */
 let _retailTrendMode = "7d";
 
@@ -648,32 +645,6 @@ const _buildSkeletonCard = () => {
   return card;
 };
 
-/**
- * Renders a 15-min intraday sparkline on a card's canvas (last 48 windows = 12h).
- * Falls back to 7-day daily history if no intraday data is available.
- * Destroys any prior Chart instance first to prevent Canvas reuse errors.
- * @param {string} slug
- */
-const _renderRetailSparkline = (slug) => {
-  const canvas = safeGetElement(`retail-spark-${slug}`);
-  if (!(canvas instanceof HTMLCanvasElement) || typeof Chart === "undefined") return;
-  const intraday = retailIntradayData[slug];
-  let data;
-  if (intraday && Array.isArray(intraday.windows_24h) && intraday.windows_24h.length >= 2) {
-    data = intraday.windows_24h.slice(-48).map((w) => Number(w.median)).filter((v) => isFinite(v));
-  } else {
-    // Fallback: 7-day daily history
-    data = (retailPriceHistory[slug] || []).slice(0, 7).reverse()
-      .map((e) => Number(e.avg_median ?? e.average_price)).filter((v) => isFinite(v));
-  }
-  if (data.length < 2) return;
-  if (_retailSparklines.has(slug)) {
-    _retailSparklines.get(slug).destroy();
-  }
-  const chart = createSparkline(canvas, data);
-  if (chart) _retailSparklines.set(slug, chart);
-};
-
 /** Updates the sync timestamp element based on current sync state. Shared by grid and list views. */
 const _updateLastSyncEl = (el) => {
   if (_retailSyncError) {
@@ -691,46 +662,7 @@ const _updateLastSyncEl = (el) => {
 
 /** Called on market section open and after each sync. */
 const renderRetailCards = () => {
-  // Market list view branch (feature flag)
-  if (typeof isFeatureEnabled === "function" && isFeatureEnabled("MARKET_LIST_VIEW")) {
-    _renderMarketListView();
-    return;
-  }
-
-  const grid = safeGetElement("retailCardsGrid");
-  const lastSyncEl = safeGetElement("retailLastSync");
-  const disclaimer = safeGetElement("retailDisclaimer");
-
-  // Ensure grid header is visible when using grid view
-  const listHeader = safeGetElement("marketListHeader");
-  const gridHeader = safeGetElement("marketGridHeader");
-  if (listHeader) listHeader.style.display = "none";
-  if (gridHeader) gridHeader.style.display = "";
-  grid.classList.remove("market-list-mode");
-
-  _updateLastSyncEl(lastSyncEl);
-
-  grid.innerHTML = "";
-  if (_retailSyncInProgress) {
-    disclaimer.style.display = "";
-    safeGetElement("retailEmptyState").style.display = "none";
-    getActiveRetailSlugs().forEach(() => grid.appendChild(_buildSkeletonCard()));
-    return;
-  }
-
-  const emptyState = safeGetElement("retailEmptyState");
-  const hasData = retailPrices && retailPrices.prices && Object.keys(retailPrices.prices).length > 0;
-  emptyState.style.display = hasData ? "none" : "";
-  disclaimer.style.display = hasData ? "" : "none";
-  if (!hasData) return;
-
-  const activeSlugs = getActiveRetailSlugs();
-  activeSlugs.forEach((slug) => {
-    const meta = getRetailCoinMeta(slug);
-    const priceData = retailPrices && retailPrices.prices ? retailPrices.prices[slug] || null : null;
-    grid.appendChild(_buildRetailCard(slug, meta, priceData));
-  });
-  activeSlugs.forEach((slug) => _renderRetailSparkline(slug));
+  _renderMarketListView();
 };
 
 /** Metal emoji icons keyed by metal name */
@@ -776,221 +708,6 @@ const _getActiveTrend = (slug) => {
 };
 
 
-/**
- * Builds a single coin price card element.
- * @param {string} slug
- * @param {{name:string, weight:number, metal:string}} meta
- * @param {Object|null} priceData
- * @returns {HTMLElement}
- */
-const _buildRetailCard = (slug, meta, priceData) => {
-  const card = document.createElement("div");
-  card.className = "retail-price-card";
-  card.dataset.slug = slug;
-
-  const header = document.createElement("div");
-  header.className = "retail-card-header";
-
-  const nameSpan = document.createElement("span");
-  nameSpan.className = "retail-coin-name";
-  nameSpan.textContent = meta.name;
-
-  const badge = document.createElement("span");
-  badge.className = `retail-metal-badge retail-metal-badge--${meta.metal}`;
-  const emoji = RETAIL_METAL_EMOJI[meta.metal];
-  const metalLabel = meta.metal === "platinum" ? "PLAT" : meta.metal.toUpperCase();
-  badge.textContent = emoji ? `${emoji} ${metalLabel}` : metalLabel;
-
-  header.appendChild(nameSpan);
-  header.appendChild(badge);
-  card.appendChild(header);
-
-  const weightEl = document.createElement("div");
-  weightEl.className = "retail-coin-weight";
-  weightEl.textContent = `${meta.weight} troy oz`;
-  card.appendChild(weightEl);
-
-  if (!priceData) {
-    const noData = document.createElement("div");
-    noData.className = "retail-no-data";
-    noData.textContent = "No data — click Sync";
-    card.appendChild(noData);
-  } else {
-    const summary = document.createElement("div");
-    summary.className = "retail-summary-row";
-    [["Med", priceData.median_price], ["Low", priceData.lowest_price]].forEach(([label, val]) => {
-      const item = document.createElement("span");
-      item.className = "retail-summary-item";
-      const lbl = document.createElement("span");
-      lbl.className = "retail-label";
-      lbl.textContent = label;
-      const valSpan = document.createElement("span");
-      valSpan.className = "retail-summary-value";
-      valSpan.textContent = _fmtRetailPrice(val);
-      item.appendChild(lbl);
-      item.appendChild(valSpan);
-      summary.appendChild(item);
-    });
-
-    // Add trend chip to the right side of the summary row
-    const trend = _computeRetailTrend(slug);
-    if (trend) {
-      const trendEl = document.createElement("span");
-      const arrow = { up: "\u2191", down: "\u2193", flat: "\u2192" }[trend.dir];
-      const sign  = trend.dir === "up" ? "+" : trend.dir === "down" ? "-" : "";
-      trendEl.className = `retail-trend retail-trend--${trend.dir}`;
-      trendEl.textContent = `${arrow} ${sign}${trend.pct}%`;
-      summary.appendChild(trendEl);
-    }
-
-    card.appendChild(summary);
-
-    const vendorDetails = document.createElement("div");
-    vendorDetails.className = "retail-vendor-details";
-
-    const vendors = document.createElement("div");
-    vendors.className = "retail-vendors";
-
-    // Goldback vendor reference price (grid view)
-    if (typeof getGoldbackVendorPrice === "function") {
-      const gbPrice = getGoldbackVendorPrice(slug);
-      if (gbPrice) {
-        const gbRow = document.createElement("div");
-        gbRow.className = "retail-vendor-row";
-        if (gbPrice.isStale) gbRow.style.opacity = "0.6";
-        const gbName = document.createElement("span");
-        gbName.className = "retail-vendor-name";
-        gbName.style.color = "#d4a017";
-        gbName.textContent = "Goldback";
-        gbRow.appendChild(gbName);
-        const gbVal = document.createElement("span");
-        gbVal.className = "retail-vendor-price";
-        gbVal.textContent = _fmtRetailPrice(gbPrice.price) + (gbPrice.isStale ? " (stale)" : "");
-        gbRow.appendChild(gbVal);
-        vendors.appendChild(gbRow);
-      }
-    }
-
-    const vendorMap = priceData.vendors || {};
-    const availability = retailAvailability[slug] || {};
-    const lastKnownPrices = retailLastKnownPrices[slug] || {};
-    const lastKnownDates = retailLastAvailableDates[slug] || {};
-
-    // Build list of all vendors (in-stock and OOS)
-    const allVendorKeys = new Set([
-      ...Object.keys(vendorMap),
-      ...Object.keys(availability),
-    ]);
-
-    // Sort: in-stock vendors by price asc, then OOS vendors by last-known price asc
-    const sortedVendorEntries = Array.from(allVendorKeys)
-      .map((key) => {
-        const vendorData = vendorMap[key];
-        const isAvailable = availability[key] !== false; // default true if not specified
-        const price = vendorData ? vendorData.price : null;
-        // OOS vendors with no current price: use last-known price for display (STAK-495)
-        const displayPrice = price ?? (lastKnownPrices[key] ?? null);
-        const score = vendorData ? vendorData.confidence : null;
-        const label = getVendorDisplay(key).name;
-        return { key, label, price: displayPrice, score, isAvailable };
-      })
-      .filter(({ price }) => price != null) // show only vendors with a displayable price
-      .sort((a, b) => {
-        // In-stock vendors first (by price asc), then OOS vendors (by price asc)
-        if (a.isAvailable !== b.isAvailable) return a.isAvailable ? -1 : 1;
-        return a.price - b.price;
-      });
-
-    // Award medals to top 3 IN-STOCK vendors by price (STAK-495)
-    const top3 = sortedVendorEntries
-      .filter(({ isAvailable }) => isAvailable)
-      .slice(0, 3).map(({ key }) => key);
-
-    sortedVendorEntries.forEach(({ key, label, price, isAvailable }) => {
-      const row = document.createElement("div");
-      row.className = "retail-vendor-row";
-      if (!isAvailable) row.classList.add("retail-vendor-row--oos");
-      const medalIndex = top3.indexOf(key);
-      if (medalIndex !== -1) {
-        row.classList.add(`retail-vendor-row--medal-${medalIndex + 1}`);
-      }
-
-      const nameEl = document.createElement("span");
-      nameEl.className = "retail-vendor-name";
-      const _vd = getVendorDisplay(key);
-      const vendorColor = _vd.color;
-      // Prefer specific product page from providers.json; fall back to vendor homepage
-      const vendorUrl = (retailProviders && retailProviders[slug] && retailProviders[slug][key])
-        || _vd.url;
-      if (vendorUrl) {
-        const link = document.createElement("a");
-        link.href = "#";
-        link.textContent = !isAvailable ? `${label} (OOS)` : label;
-        link.className = "retail-vendor-link";
-        if (vendorColor) link.style.color = vendorColor;
-        link.addEventListener("click", (e) => {
-          e.preventDefault();
-          const popup = window.open(vendorUrl, `retail_vendor_${key}`, "width=1250,height=800,scrollbars=yes,resizable=yes,toolbar=no,location=no,menubar=no,status=no");
-          if (popup) popup.opener = null;
-          else window.open(vendorUrl, "_blank", "noopener,noreferrer");
-        });
-        nameEl.appendChild(link);
-      } else {
-        nameEl.textContent = label;
-        if (vendorColor) nameEl.style.color = vendorColor;
-      }
-
-      const priceEl = document.createElement("span");
-      priceEl.className = "retail-vendor-price";
-      priceEl.textContent = _fmtRetailPrice(price);
-
-      row.appendChild(nameEl);
-      row.appendChild(priceEl);
-      vendors.appendChild(row);
-    });
-
-    vendorDetails.appendChild(vendors);
-    card.appendChild(vendorDetails);
-
-    const footer = document.createElement("div");
-    footer.className = "retail-card-footer";
-    const dateSpan = document.createElement("span");
-    dateSpan.className = "retail-data-date";
-    dateSpan.textContent = retailPrices && retailPrices.window_start ? "today" : "—";
-    footer.appendChild(dateSpan);
-    const sparkCanvas = document.createElement("canvas");
-    sparkCanvas.id = `retail-spark-${slug}`;
-    sparkCanvas.className = "retail-sparkline";
-    sparkCanvas.width = 80;
-    sparkCanvas.height = 28;
-    footer.appendChild(sparkCanvas);
-    card.appendChild(footer);
-  }
-
-  const btnRow = document.createElement("div");
-  btnRow.className = "retail-card-btn-row";
-
-  const viewBtn = document.createElement("button");
-  viewBtn.className = "retail-card-action retail-view-btn";
-  viewBtn.type = "button";
-  viewBtn.dataset.retailViewSlug = slug;
-  viewBtn.textContent = "View";
-  btnRow.appendChild(viewBtn);
-
-  const histBtn = document.createElement("button");
-  histBtn.className = "retail-card-action retail-history-btn";
-  histBtn.type = "button";
-  histBtn.dataset.retailHistorySlug = slug;
-  histBtn.textContent = "History";
-  btnRow.appendChild(histBtn);
-
-  card.appendChild(btnRow);
-
-  return card;
-};
-
-// ---------------------------------------------------------------------------
-// Market List View (MARKET_LIST_VIEW feature flag)
 // ---------------------------------------------------------------------------
 
 /** Medal text labels and CSS classes for top-3 vendors (matches playground) */
@@ -1728,7 +1445,7 @@ const _getFilteredSortedSlugs = (query, sortKey) => {
 };
 
 /**
- * Renders the market list view when MARKET_LIST_VIEW is enabled.
+ * Renders the market list view.
  * Shows list header, iterates filtered+sorted slugs, builds cards.
  */
 const _renderMarketListView = () => {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.81-b1774144951';
+const CACHE_NAME = 'staktrakr-v3.33.81-b1774145063';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.81-b1774142223';
+const CACHE_NAME = 'staktrakr-v3.33.81-b1774144866';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.81-b1774145063';
+const CACHE_NAME = 'staktrakr-v3.33.81-b1774145091';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.81-b1774145091';
+const CACHE_NAME = 'staktrakr-v3.33.82-b1774145412';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.81-b1774144866';
+const CACHE_NAME = 'staktrakr-v3.33.81-b1774144951';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.81",
-  "releaseDate": "2026-03-21",
+  "version": "3.33.82",
+  "releaseDate": "2026-03-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Removed**: Dead grid/card view rendering code from `retail.js` (~260 lines) — `_buildRetailCard()`, `_renderRetailSparkline()`, `_retailSparklines` Map, and grid branch of `renderRetailCards()` (STAK-473)
- **Removed**: `MARKET_LIST_VIEW` feature flag from `constants.js` — list view is now unconditional (STAK-473)
- **Removed**: Orphaned `.retail-card-footer` and `.retail-sparkline` CSS rules (STAK-473)
- **Updated**: Stale HTML comments in `index.html` referencing grid/list toggle (STAK-473)

## Vault Issues

- STAK-473: Remove decommissioned grid/card view code from retail.js

## Test Plan

- [ ] Market Prices list view renders normally
- [ ] Skeleton cards appear during retail sync
- [ ] History and View buttons work on market cards
- [ ] No console errors related to missing functions
- [ ] `/bb-test sections=05` passes against preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)