### PR TITLE
v3.33.83 — Intraday chart 24h hourly view (STAK-498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.83] - 2026-03-22
+
+### Fixed — Intraday chart 24h hourly view (STAK-498)
+
+- **Fixed**: Intraday charts now show exactly 24 hourly data points instead of 2-3 days of multi-day data with excessive dotted lines (STAK-498)
+- **Fixed**: Dotted chart lines only appear for genuinely missing data (2+ consecutive hour gaps), not for normal hourly polling jitter (STAK-498)
+- **Fixed**: Out-of-stock vendors excluded from intraday chart datasets — no more phantom lines for vendors with zero real prices (STAK-498)
+- **Fixed**: API `readRecentWindows()` uses time-based 24h cutoff instead of row-count over-fetch spanning multiple days (STAK-498)
+
+---
+
 ## [3.33.82] - 2026-03-22
 
 ### Removed — Remove decommissioned grid/card view code (STAK-473)

--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -807,7 +807,7 @@ async function main() {
       }
     }
 
-    // 24h windows time series — aggregate into 60-min (hourly) buckets
+    // 24h windows time series — time-bound to 24h from latest snapshot, aggregated into 60-min buckets
     // Merges both pollers (:00 Fly.io + :30 home) into one bucket with all vendors (STAK-476)
     const recentRows = readRecentWindows(db, slug, 96);
     const windows24h = aggregateWindows(recentRows, 60);

--- a/devops/pollers/shared/db.js
+++ b/devops/pollers/shared/db.js
@@ -262,7 +262,7 @@ export function readRecentWindows(db, coinSlug, windowCount = 96, cutoffHours = 
     "SELECT MAX(window_start) as latest FROM price_snapshots WHERE coin_slug = ? AND price IS NOT NULL"
   ).get(coinSlug);
   if (!latest || !latest.latest) return [];
-  const cutoff = new Date(new Date(latest.latest).getTime() - cutoffHours * 60 * 60 * 1000).toISOString();
+  const cutoff = new Date(new Date(latest.latest).getTime() - cutoffHours * 60 * 60 * 1000).toISOString().replace(".000Z", "Z");
   return db.prepare(`
       SELECT *
       FROM price_snapshots

--- a/devops/pollers/shared/db.js
+++ b/devops/pollers/shared/db.js
@@ -248,24 +248,29 @@ export function readWindow(db, windowStart) {
 }
 
 /**
- * Returns per-window rows for a specific coin over the past N windows (chronological).
- * Used for building the 24h time series in api-export.
+ * Returns per-window rows for a specific coin within cutoffHours of the latest
+ * snapshot (chronological). Used for building the 24h time series in api-export.
  *
  * @param {Database.Database} db
  * @param {string} coinSlug
- * @param {number} [windowCount=96]  default 96 = 24h worth of 15-min windows
+ * @param {number} [windowCount=96]  safety-cap LIMIT (default 96 × 20 rows)
+ * @param {number} [cutoffHours=24]  only return rows within this many hours of the latest window
  * @returns {Array<object>}
  */
-export function readRecentWindows(db, coinSlug, windowCount = 96) {
-  return db
-    .prepare(`
+export function readRecentWindows(db, coinSlug, windowCount = 96, cutoffHours = 24) {
+  const latest = db.prepare(
+    "SELECT MAX(window_start) as latest FROM price_snapshots WHERE coin_slug = ? AND price IS NOT NULL"
+  ).get(coinSlug);
+  if (!latest || !latest.latest) return [];
+  const cutoff = new Date(new Date(latest.latest).getTime() - cutoffHours * 60 * 60 * 1000).toISOString();
+  return db.prepare(`
       SELECT *
       FROM price_snapshots
-      WHERE coin_slug = ? AND price IS NOT NULL
+      WHERE coin_slug = ? AND price IS NOT NULL AND window_start >= ?
       ORDER BY window_start DESC
       LIMIT ?
     `)
-    .all(coinSlug, windowCount * 20) // over-fetch then aggregate in JS
+    .all(coinSlug, cutoff, windowCount * 20)
     .reverse();
 }
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,10 @@
 ## What's New
 
+- **Intraday Chart Fix (v3.33.83)**: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets. API uses time-based 24h cutoff (STAK-498).
 - **Grid View Cleanup (v3.33.82)**: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473).
 - **Price Bounds Guard (v3.33.81)**: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496).
 - **Chart Accuracy Fix (v3.33.80)**: 7-day trend chart and trend badge now use live prices for today's data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483).
 - **Cloud Sync Image Fix (v3.33.79)**: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497).
-- **Retail Scraper + OOS Pipeline (v3.33.78)**: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -247,11 +247,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.83 &ndash; Intraday Chart Fix</strong>: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets (STAK-498)</li>
     <li><strong>v3.33.82 &ndash; Grid View Cleanup</strong>: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473)</li>
     <li><strong>v3.33.81 &ndash; Price Bounds Guard</strong>: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496)</li>
     <li><strong>v3.33.80 &ndash; Chart Accuracy Fix</strong>: 7-day trend chart and trend badge now use live prices for today&rsquo;s data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483)</li>
     <li><strong>v3.33.79 &ndash; Cloud Sync Image Fix</strong>: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497)</li>
-    <li><strong>v3.33.78 &ndash; Retail Scraper + OOS Pipeline</strong>: JM Bullion no longer grabs volume discount prices. Soft 404 detection for React SPAs. OOS vendors shown dimmed with strikethrough on retail cards (STAK-475, STAK-495)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.82";
+const APP_VERSION = "3.33.83";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -125,13 +125,15 @@ const _buildVendorLegend = (slug) => {
   });
 };
 
-/**
- * Buckets raw windows_24h into 30-min aligned slots (HH:00 and HH:30).
- * For each slot, picks the most recent window whose timestamp falls within it.
- * Returns up to 48 entries covering the 24h window, oldest first.
- * @param {Array} windows - raw windows_24h from API
- * @returns {Array}
- */
+const _trimTo24h = (windows) => {
+  if (!windows || windows.length === 0) return [];
+  const validWindows = windows.filter(w => w && w.window);
+  if (validWindows.length === 0) return [];
+  const maxTs = Math.max(...validWindows.map(w => new Date(w.window).getTime()));
+  const cutoff = maxTs - 24 * 60 * 60 * 1000;
+  return validWindows.filter(w => new Date(w.window).getTime() >= cutoff);
+};
+
 const _bucketWindows = (windows) => {
   if (!windows || windows.length === 0) return [];
   // Build a map: slotKey (ISO :00 or :30) → most recent window in that slot
@@ -141,7 +143,7 @@ const _bucketWindows = (windows) => {
     const d = new Date(w.window);
     if (isNaN(d.getTime())) continue;
     // Round down to nearest 30-min boundary
-    const mins = d.getUTCMinutes() >= 30 ? 30 : 0;
+    const mins = 0;
     const slotDate = new Date(Date.UTC(
       d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
       d.getUTCHours(), mins, 0, 0
@@ -301,7 +303,7 @@ const _buildIntradayTable = (slug, bucketed) => {
   if (!bucketed) {
     const intraday = typeof retailIntradayData !== "undefined" ? retailIntradayData[slug] : null;
     const windows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
-    const filled = _forwardFillVendors(_bucketWindows(windows));
+    const filled = _forwardFillVendors(_bucketWindows(_trimTo24h(windows)));
     try {
       bucketed = _flagAnomalies(filled);
     } catch (e) {
@@ -421,7 +423,7 @@ const _buildIntradayChart = (slug) => {
 
   const intraday = typeof retailIntradayData !== "undefined" ? retailIntradayData[slug] : null;
   const windows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
-  const filled = _forwardFillVendors(_bucketWindows(windows));
+  const filled = _forwardFillVendors(_bucketWindows(_trimTo24h(windows)));
   let bucketed;
   try {
     bucketed = _flagAnomalies(filled);
@@ -727,6 +729,7 @@ if (typeof window !== "undefined") {
   window.retailForwardFillVendors = _forwardFillVendors;
   window.retailFlagAnomalies = _flagAnomalies;
   window.retailFmtIntradayTime = _fmtIntradayTime;
+  window.retailTrimTo24h = _trimTo24h;
 }
 
 // =============================================================================

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -142,7 +142,7 @@ const _bucketWindows = (windows) => {
     if (!w.window) continue;
     const d = new Date(w.window);
     if (isNaN(d.getTime())) continue;
-    // Round down to nearest 30-min boundary
+    // Round down to nearest 60-min (hourly) boundary
     const mins = 0;
     const slotDate = new Date(Date.UTC(
       d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
@@ -451,8 +451,15 @@ const _buildIntradayChart = (slug) => {
     ...knownOrder.filter((v) => vendorSet.has(v)),
     ...[...vendorSet].filter((v) => !knownOrder.includes(v)).sort(),
   ];
+  // Exclude OOS vendors with zero real (non-carried) prices
+  const qualifiedVendors = activeVendors.filter((vendorId) =>
+    bucketed.some((w) =>
+      w.vendors && w.vendors[vendorId] != null &&
+      !(w._carriedVendors && w._carriedVendors.has(vendorId))
+    )
+  );
   // Fall back to median+low when windows predate the per-vendor format
-  const useVendorLines = activeVendors.length > 0;
+  const useVendorLines = qualifiedVendors.length > 0;
 
   if (bucketed.length >= 2 && canvas instanceof HTMLCanvasElement && typeof Chart !== "undefined") {
     const labels = bucketed.map((w) => {
@@ -461,16 +468,21 @@ const _buildIntradayChart = (slug) => {
     });
 
     // Build carried-index sets for each active vendor
-    const carriedSets = activeVendors.map((vendorId) => {
+    // Multi-hop only: mark carried when previous window also carried (2+ consecutive hours missing)
+    const carriedSets = qualifiedVendors.map((vendorId) => {
       const s = new Set();
       bucketed.forEach((w, i) => {
-        if (w._carriedVendors && w._carriedVendors.has(vendorId)) s.add(i);
+        if (w._carriedVendors && w._carriedVendors.has(vendorId)) {
+          if (i === 0 || (bucketed[i - 1]._carriedVendors && bucketed[i - 1]._carriedVendors.has(vendorId))) {
+            s.add(i);
+          }
+        }
       });
       return s;
     });
 
     const datasets = useVendorLines
-      ? buildVendorDatasets(activeVendors, bucketed,
+      ? buildVendorDatasets(qualifiedVendors, bucketed,
           (w, vendorId) => (w.vendors && w.vendors[vendorId] != null ? w.vendors[vendorId] : null),
           {
             labelFn: (vendorId) => (typeof RETAIL_VENDOR_NAMES !== "undefined" && RETAIL_VENDOR_NAMES[vendorId]) || vendorId,

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -129,9 +129,11 @@ const _trimTo24h = (windows) => {
   if (!windows || windows.length === 0) return [];
   const validWindows = windows.filter(w => w && w.window);
   if (validWindows.length === 0) return [];
-  const maxTs = Math.max(...validWindows.map(w => new Date(w.window).getTime()));
+  const timestamps = validWindows.map(w => new Date(w.window).getTime()).filter(t => !isNaN(t));
+  if (timestamps.length === 0) return [];
+  const maxTs = Math.max(...timestamps);
   const cutoff = maxTs - 24 * 60 * 60 * 1000;
-  return validWindows.filter(w => new Date(w.window).getTime() >= cutoff);
+  return validWindows.filter(w => { const t = new Date(w.window).getTime(); return !isNaN(t) && t >= cutoff; });
 };
 
 const _bucketWindows = (windows) => {

--- a/js/retail.js
+++ b/js/retail.js
@@ -251,7 +251,7 @@ const loadRetailIntradayData = () => {
 };
 
 const saveRetailIntradayData = () => {
-  // STAK-300: cap windows_24h to last 96 entries per slug (24h of 15-min data)
+  // STAK-300: cap windows_24h to last 96 entries per slug (24h of hourly data)
   // to prevent localStorage quota overflow on large collections
   const pruned = {};
   for (const [slug, entry] of Object.entries(retailIntradayData)) {
@@ -1296,7 +1296,8 @@ const _initMarketCardIntradayChart = (slug, detailsEl) => {
       typeof window.retailFlagAnomalies !== "function") return;
 
   const intraday = retailIntradayData[slug];
-  const windows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
+  const raw = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
+  const windows = typeof window.retailTrimTo24h === "function" ? window.retailTrimTo24h(raw) : raw;
   if (windows.length < 2) return;
 
   const filled = window.retailForwardFillVendors(window.retailBucketWindows(windows));
@@ -1327,17 +1328,30 @@ const _initMarketCardIntradayChart = (slug, detailsEl) => {
     ...[...vendorSet].filter((v) => !knownOrder.includes(v)).sort(),
   ];
 
+  // Exclude OOS vendors with zero real (non-carried) prices
+  const qualifiedVendors = activeVendors.filter((vendorId) =>
+    bucketed.some((w) =>
+      w.vendors && w.vendors[vendorId] != null &&
+      !(w._carriedVendors && w._carriedVendors.has(vendorId))
+    )
+  );
+
   // Pre-compute carried indices per vendor for buildVendorDatasets
-  const carriedPerVendor = activeVendors.map((vendorId) => {
+  // Multi-hop only: mark carried when previous window also carried (2+ consecutive hours missing)
+  const carriedPerVendor = qualifiedVendors.map((vendorId) => {
     const carried = new Set();
     bucketed.forEach((w, i) => {
-      if (w._carriedVendors && w._carriedVendors.has(vendorId)) carried.add(i);
+      if (w._carriedVendors && w._carriedVendors.has(vendorId)) {
+        if (i === 0 || (bucketed[i - 1]._carriedVendors && bucketed[i - 1]._carriedVendors.has(vendorId))) {
+          carried.add(i);
+        }
+      }
     });
     return carried;
   });
 
-  const datasets = activeVendors.length > 0
-    ? buildVendorDatasets(activeVendors, bucketed, (w, vendorId) => {
+  const datasets = qualifiedVendors.length > 0
+    ? buildVendorDatasets(qualifiedVendors, bucketed, (w, vendorId) => {
         return w.vendors && w.vendors[vendorId] != null ? w.vendors[vendorId] : null;
       }, {
         colorMap: RETAIL_VENDOR_COLORS,

--- a/js/retail.js
+++ b/js/retail.js
@@ -1371,7 +1371,7 @@ const _initMarketCardIntradayChart = (slug, detailsEl) => {
       }];
 
   // Augment vendor datasets with carried-aware dashed segments (STAK-474)
-  if (activeVendors.length > 0) {
+  if (qualifiedVendors.length > 0) {
     datasets.forEach((ds, idx) => {
       const carried = carriedPerVendor[idx];
       ds.pointRadius = 0;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.82-b1774148840';
+const CACHE_NAME = 'staktrakr-v3.33.83-b1774149261';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.82-b1774145412';
+const CACHE_NAME = 'staktrakr-v3.33.82-b1774148413';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.82-b1774148413';
+const CACHE_NAME = 'staktrakr-v3.33.82-b1774148840';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.83-b1774149261';
+const CACHE_NAME = 'staktrakr-v3.33.83-b1774151867';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.82",
+  "version": "3.33.83",
   "releaseDate": "2026-03-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Summary

- **Fixed**: Intraday charts now show exactly 24 hourly data points instead of 2-3 days of multi-day data with excessive dotted lines
- **Fixed**: Dotted chart lines only appear for genuinely missing data (2+ consecutive hour gaps), not for normal hourly polling jitter
- **Fixed**: Out-of-stock vendors excluded from intraday chart datasets
- **Fixed**: API `readRecentWindows()` uses time-based 24h cutoff instead of row-count over-fetch

## Changes

### Frontend (`js/retail-view-modal.js`)
- New `_trimTo24h()` function trims raw API windows to last 24h by timestamp (relative to newest data point, not `Date.now()`)
- `_bucketWindows()` changed from 30-min to 60-min hourly slots
- Both `_buildIntradayChart()` and `_buildIntradayTable()` pipelines updated

### Frontend (`js/retail.js`)
- `_initMarketCardIntradayChart()` applies `retailTrimTo24h()` before bucketing
- Multi-hop carry detection: single-hop carry (1 hour) = solid line, 2+ consecutive hours = dotted
- `qualifiedVendors` filter excludes vendors with zero real prices from chart datasets

### API (`devops/pollers/shared/db.js`)
- `readRecentWindows()` now accepts optional `cutoffHours` parameter (default 24)
- Uses subquery to find latest window, computes time-based cutoff, adds WHERE clause
- LIMIT safety cap preserved for backward compatibility

## Vault Issues

- STAK-498: Intraday charts show multi-day data with excessive dotted lines instead of clean 24h hourly view

🤖 Generated with [Claude Code](https://claude.com/claude-code)