### PR TITLE
v3.33.84 — Market price fixes (STAK-498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.84] - 2026-03-22
+
+### Fixed — Market price fixes (STAK-498)
+
+- **Fixed**: JM Bullion price extraction now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices (STAK-498)
+- **Fixed**: Goldback-g1 baseline reference no longer appears as a ghost card in market view (STAK-498)
+
+---
+
 ## [3.33.83] - 2026-03-22
 
 ### Fixed — Intraday chart 24h hourly view (STAK-498)

--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -628,6 +628,11 @@ async function main() {
     warn("Could not load providers from Turso or file — using slugs from DB only");
   }
 
+  // goldback-g1 is a baseline reference price (exported via goldback-spot.json),
+  // not a user-facing product. Exclude from the coins manifest so it doesn't
+  // render as a ghost card in the frontend market view (STAK-498 Task 7).
+  coinSlugs = coinSlugs.filter((s) => s !== "goldback-g1");
+
   log(`API export: ${coinSlugs.length} coins, latest window: ${latestWindow}`);
 
   // --------------------------------------------------------------------------
@@ -884,9 +889,11 @@ async function main() {
 
   // --------------------------------------------------------------------------
   // goldback-spot.json — generated from Turso goldback-g1 data; backward compat
-  // for api-health.js freshness check and denomination lookups
+  // for api-health.js freshness check and denomination lookups.
+  // goldback-g1 is excluded from coinSlugs (not a user-facing product) but
+  // still exported here as a standalone reference file (STAK-498 Task 7).
   // --------------------------------------------------------------------------
-  if (coinSlugs.includes("goldback-g1")) {
+  {
     const gbRows = readLatestPerVendor(db, "goldback-g1", 2);
     const gbVendors = vendorMap(gbRows);
     const g1Raw = gbVendors?.goldback?.price;

--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -846,6 +846,7 @@ async function main() {
   const coinsMeta = {};
   if (providersJson) {
     for (const [slug, coinData] of Object.entries(providersJson.coins || {})) {
+      if (slug === "goldback-g1") continue; // baseline ref, not a product
       coinsMeta[slug] = {
         name: coinData.name,
         metal: coinData.metal,

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -458,14 +458,18 @@ function extractPrice(markdown, metal, weightOz = 1, providerId = "") {
   }
 
   if (providerId === "jmbullion") {
-    // JM Bullion: pipe table → prose table ONLY. No "As Low As" fallback.
+    // JM Bullion: prose table → pipe table ONLY. No "As Low As" fallback.
+    // Prose parser is tried FIRST because it anchors to the "(e)Check/Wire" column
+    // header — guaranteed to return the eCheck price. The pipe-table parser
+    // (firstTableRowFirstPrice) is column-blind and can grab Card/PayPal when
+    // Firecrawl renders columns in non-standard order (STAK-498 Task 6).
     // "As Low As" is a volume discount (100+ units via ACH) — NOT the single-unit
     // retail price. Using it causes 10-90% price spread vs. actual retail (STAK-475 P2).
     // Better to return null (missed window) than record a volume discount.
-    const tblFirst = firstTableRowFirstPrice();
-    if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
     const proseTbl = jmPriceFromProseTable();
     if (proseTbl !== null) return { price: proseTbl, matchedBy: "jmProseTable" };
+    const tblFirst = firstTableRowFirstPrice();
+    if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
     // No asLowAs fallback — return null below.
   } else if (USES_AS_LOW_AS.has(providerId)) {
     // Reserved for vendors that have no pricing table, only "As Low As" display.

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Market Price Fixes (v3.33.84)**: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view (STAK-498).
 - **Intraday Chart Fix (v3.33.83)**: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets. API uses time-based 24h cutoff (STAK-498).
 - **Grid View Cleanup (v3.33.82)**: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473).
 - **Price Bounds Guard (v3.33.81)**: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496).

--- a/js/about.js
+++ b/js/about.js
@@ -247,6 +247,7 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.84 &ndash; Market Price Fixes</strong>: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view (STAK-498)</li>
     <li><strong>v3.33.83 &ndash; Intraday Chart Fix</strong>: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets (STAK-498)</li>
     <li><strong>v3.33.82 &ndash; Grid View Cleanup</strong>: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473)</li>
     <li><strong>v3.33.81 &ndash; Price Bounds Guard</strong>: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496)</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.83";
+const APP_VERSION = "3.33.84";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -99,11 +99,14 @@ let _manifestSlugs = null;
 let _manifestCoinMeta = null;
 let _manifestVendorMeta = null;
 
-/** Returns active slugs: manifest-driven (filtered to those with data) or hardcoded fallback */
+/** Returns active slugs: manifest-driven (filtered to those with data) or hardcoded fallback.
+ *  Excludes goldback-g1 — that slug is a baseline reference price for state-specific
+ *  goldback cards, not a user-facing product (STAK-498 Task 7). */
 const getActiveRetailSlugs = () => {
   if (!_manifestSlugs) return RETAIL_SLUGS;
   if (!retailPrices?.prices) return _manifestSlugs;
   return _manifestSlugs.filter((slug) => {
+    if (slug === "goldback-g1") return false;
     const entry = retailPrices.prices[slug];
     if (!entry) return false;
     if (entry.median_price != null || entry.lowest_price != null) return true;

--- a/js/retail.js
+++ b/js/retail.js
@@ -99,14 +99,16 @@ let _manifestSlugs = null;
 let _manifestCoinMeta = null;
 let _manifestVendorMeta = null;
 
+/** Slugs excluded from market card display — baseline references, not user-facing products. */
+const _HIDDEN_SLUGS = new Set(["goldback-g1"]);
+
 /** Returns active slugs: manifest-driven (filtered to those with data) or hardcoded fallback.
- *  Excludes goldback-g1 — that slug is a baseline reference price for state-specific
- *  goldback cards, not a user-facing product (STAK-498 Task 7). */
+ *  Excludes _HIDDEN_SLUGS on ALL return paths (STAK-498 Task 7). */
 const getActiveRetailSlugs = () => {
-  if (!_manifestSlugs) return RETAIL_SLUGS;
-  if (!retailPrices?.prices) return _manifestSlugs;
+  if (!_manifestSlugs) return RETAIL_SLUGS.filter((s) => !_HIDDEN_SLUGS.has(s));
+  if (!retailPrices?.prices) return _manifestSlugs.filter((s) => !_HIDDEN_SLUGS.has(s));
   return _manifestSlugs.filter((slug) => {
-    if (slug === "goldback-g1") return false;
+    if (_HIDDEN_SLUGS.has(slug)) return false;
     const entry = retailPrices.prices[slug];
     if (!entry) return false;
     if (entry.median_price != null || entry.lowest_price != null) return true;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.83-b1774151867';
+const CACHE_NAME = 'staktrakr-v3.33.84-b1774199560';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.83",
+  "version": "3.33.84",
   "releaseDate": "2026-03-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **JM Bullion eCheck fix**: Swapped extraction order so column-aware `jmPriceFromProseTable()` runs before column-blind `firstTableRowFirstPrice()` — prevents Card/PayPal prices from being recorded instead of eCheck/Wire
- **Goldback-g1 filter**: Excluded `goldback-g1` baseline slug from `getActiveRetailSlugs()` and `api-export.js` coin manifest — ghost card no longer appears in market view. `goldback-spot.json` export preserved as unconditional block.

## Vault Issues

- STAK-498: Intraday charts show multi-day data (Tasks 6-7 — market price follow-up fixes)

## Test Plan

- [ ] Market view: goldback-g1 card no longer appears
- [ ] Market view: state-specific goldback cards still show goldback.com reference price
- [ ] JM Bullion prices align with eCheck/Wire column (verify against jmbullion.com)
- [ ] No console errors on market page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)