### PR TITLE
v3.33.86 — What's New modal flash fix (STAK-500)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -144,6 +144,7 @@ Scripts load via `<script>` tags in `index.html` in strict dependency order. `fi
 **From `js/retail-view-modal.js`:**
 
 - `openRetailViewModal(slug)`, `closeRetailViewModal()` -- per-coin detail modal
+- `retailTrimTo24h(windows)` -- 24h time filter for intraday chart data (window bridge)
 
 **From `js/priceHistory.js`:**
 

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ devops/hub/
 
 # Git worktrees for isolated agent work — content dirs are transient, not project history
 .claude/worktrees/
+.worktrees/
 # Ignore spec-workflow transient data (specs, logs, approvals) but track user-templates, steering, and templates
 .spec-workflow/*
 !.spec-workflow/user-templates/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.86] - 2026-03-22
+
+### Fixed — What's New modal flash fix (STAK-500)
+
+- **Fixed**: What's New modal no longer flashes old content before showing current announcements — loadAnnouncements() race condition eliminated (STAK-500)
+
+---
+
 ## [3.33.84] - 2026-03-22
 
 ### Fixed — Market price fixes (STAK-498)

--- a/devops/pollers/home-poller/docker-entrypoint.sh
+++ b/devops/pollers/home-poller/docker-entrypoint.sh
@@ -17,10 +17,10 @@ chmod 600 /etc/environment
 mkdir -p /data/retail /data/api /data/hourly /data/logs
 
 # ── 3. Write cron schedule ──────────────────────────────────────────────
-# Home poller offsets from Fly.io to stagger Turso writes:
-#   Retail:  :30 (Fly.io runs at :00)
-#   Spot:    :15,:45 (Fly.io runs at :00,:30)
-#   Goldback: :31 (Fly.io runs at :01)
+# Home poller cron schedule (STAK-478: home is sole retail+goldback scraper):
+#   Retail:  :30 (home only — Fly.io does NOT scrape retail)
+#   Spot:    :15,:45 (staggered from Fly.io spot at :00,:30)
+#   Goldback: :31 (home only — Fly.io reads goldback from sqld)
 #   Provider export: every 5 min (same as Fly.io)
 #   Fly.io health check: every 5 min
 echo "[entrypoint] Writing cron schedule..."

--- a/devops/pollers/shared/README.md
+++ b/devops/pollers/shared/README.md
@@ -1,0 +1,24 @@
+# Shared Poller Code
+
+Shared JS modules used by **both** the Home Poller and Fly.io Remote Poller.
+
+## Current Architecture (STAK-478)
+
+**"Shared" does NOT mean both pollers run every file.** The current split:
+
+| File | Home Poller | Fly.io (Thin Publisher) |
+|------|:-----------:|:----------------------:|
+| `price-extract.js` | Yes (retail scraping) | **No** (retail disabled) |
+| `goldback-scraper.js` | Yes | **No** (reads from sqld) |
+| `cf-clearance.js` | Yes (Byparr sidecar) | **No** |
+| `spot-extract.js` | Yes | Yes |
+| `api-export.js` | Yes (local export) | Yes (publish to GitHub Pages) |
+| `db.js` | Yes | Yes |
+| `provider-db.js` | Yes | Yes |
+| `export-providers-json.js` | Yes | Yes |
+| `serve.js` | No | Yes (health endpoint) |
+
+**Deployment implications:**
+- Changes to `price-extract.js` or `goldback-scraper.js` only need a **Home Poller redeploy** (Portainer stack 7).
+- Changes to `api-export.js`, `db.js`, or `spot-extract.js` need **both** Home Poller redeploy AND `fly deploy`.
+- See DocVault: [[Home Poller]] and [[Remote Poller]] for deploy commands.

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,11 +1,10 @@
 ## What's New
 
+- **What's New Modal Fix (v3.33.86)**: What's New popup no longer flashes old content before showing current announcements on page load (STAK-500).
 - **Market Price Fixes (v3.33.84)**: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view (STAK-498).
 - **Intraday Chart Fix (v3.33.83)**: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets. API uses time-based 24h cutoff (STAK-498).
 - **Grid View Cleanup (v3.33.82)**: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473).
 - **Price Bounds Guard (v3.33.81)**: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496).
-- **Chart Accuracy Fix (v3.33.80)**: 7-day trend chart and trend badge now use live prices for today's data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483).
-- **Cloud Sync Image Fix (v3.33.79)**: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497).
 
 ## Development Roadmap
 

--- a/js/about.js
+++ b/js/about.js
@@ -247,12 +247,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.86 &ndash; What&rsquo;s New Modal Fix</strong>: What&rsquo;s New popup no longer flashes old content before showing current announcements on page load (STAK-500)</li>
     <li><strong>v3.33.84 &ndash; Market Price Fixes</strong>: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view (STAK-498)</li>
     <li><strong>v3.33.83 &ndash; Intraday Chart Fix</strong>: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets (STAK-498)</li>
     <li><strong>v3.33.82 &ndash; Grid View Cleanup</strong>: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473)</li>
     <li><strong>v3.33.81 &ndash; Price Bounds Guard</strong>: Retail poller now rejects implausible vendor prices at write time &mdash; prices &gt;+50% or &lt;-30% of spot-based melt value are flagged as failed. Per-vendor exemptions for legitimate outliers (STAK-496)</li>
-    <li><strong>v3.33.80 &ndash; Chart Accuracy Fix</strong>: 7-day trend chart and trend badge now use live prices for today&rsquo;s data point instead of a running daily average &mdash; no more confusing divergence from market card on volatile days (STAK-483)</li>
-    <li><strong>v3.33.79 &ndash; Cloud Sync Image Fix</strong>: Pushing from a device without photos no longer erases the image vault reference. Inventory hash now detects field-level changes (image URLs, numistaId). Image vault activity now visible in Activity Log (STAK-497)</li>
   `;
 };
 

--- a/js/about.js
+++ b/js/about.js
@@ -164,7 +164,7 @@ const showFullChangelog = () => {
   );
 };
 
-const showWhatsNewPopup = () => {
+const showWhatsNewPopup = async () => {
   const overlay = safeGetElement('whatsNewPopup');
   if (!overlay) return;
   // Populate version
@@ -172,8 +172,8 @@ const showWhatsNewPopup = () => {
   if (versionEl && typeof APP_VERSION !== 'undefined') {
     versionEl.textContent = `v${APP_VERSION} — Updated!`;
   }
-  // Load announcements into the popup's versionChanges list
-  if (typeof loadAnnouncements === 'function') loadAnnouncements();
+  // STAK-500: Load announcements BEFORE showing popup to prevent content flash
+  if (typeof loadAnnouncements === 'function') await loadAnnouncements();
   overlay.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 };

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.84";
+const APP_VERSION = "3.33.86";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/init.js
+++ b/js/init.js
@@ -414,7 +414,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       footerDomainEl.textContent = getFooterDomain();
     }
     // STAK-500: Removed redundant loadAnnouncements() call — it's called by
-    // showWhatsNewPopup() (awaited) and populateAboutTab() when those are needed
+    // showWhatsNewPopup() (which internally awaits loadAnnouncements()) and populateAboutTab() when those are needed
 
     // Phase 12: Data Initialization
     debugLog("Phase 12: Loading application data...");

--- a/js/init.js
+++ b/js/init.js
@@ -413,9 +413,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (footerDomainEl) {
       footerDomainEl.textContent = getFooterDomain();
     }
-    if (typeof loadAnnouncements === "function") {
-      loadAnnouncements();
-    }
+    // STAK-500: Removed redundant loadAnnouncements() call — it's called by
+    // showWhatsNewPopup() (awaited) and populateAboutTab() when those are needed
 
     // Phase 12: Data Initialization
     debugLog("Phase 12: Loading application data...");

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.84-b1774218501';
+const CACHE_NAME = 'staktrakr-v3.33.86-b1774218599';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.84-b1774199560';
+const CACHE_NAME = 'staktrakr-v3.33.84-b1774218501';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.86-b1774218599';
+const CACHE_NAME = 'staktrakr-v3.33.86-b1774219280';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.84",
+  "version": "3.33.86",
   "releaseDate": "2026-03-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: What's New modal no longer flashes old/stale content before showing current announcements on page load
- **Root cause**: `loadAnnouncements()` was called 3 times during init (fire-and-forget), creating a race condition where the popup became visible before the async fetch resolved
- **Fix**: Made `showWhatsNewPopup()` async — awaits `loadAnnouncements()` before showing overlay. Removed redundant call from `init.js` Phase 11

## Files Changed

- `js/about.js` — `showWhatsNewPopup()` now async, awaits content load before display
- `js/init.js` — removed redundant `loadAnnouncements()` call from Phase 11

## Issue

- STAK-500 / GitHub #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)