### PR TITLE
fix: resolve startup quota regression and stabilize market ticker loop (STAK-481)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -12904,14 +12904,19 @@ th {
 }
 
 .ticker-track {
-  display: flex;
+  display: inline-flex;
   flex-wrap: nowrap;
-  animation: ticker-scroll 45s linear infinite;
+  align-items: center;
+  width: max-content;
+  min-width: max-content;
+  animation: ticker-scroll var(--ticker-duration, 45s) linear infinite;
   will-change: transform;
 }
 
 .ticker-track.static {
   animation: none;
+  width: 100%;
+  min-width: 0;
   justify-content: center;
 }
 
@@ -12919,17 +12924,23 @@ th {
   display: flex;
   flex-shrink: 0;
   flex-wrap: nowrap;
+  align-items: center;
+  width: max-content;
+  min-width: max-content;
   padding: 0 20px;
   gap: 10px;
 }
 
 @keyframes ticker-scroll {
-  0%   { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
+  0%   { transform: translate3d(0, 0, 0); }
+  100% { transform: translate3d(calc(-1 * var(--ticker-loop-distance, 50%)), 0, 0); }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ticker-track { animation: none; }
+  .ticker-track {
+    animation: none;
+    transform: none;
+  }
 }
 
 .ticker-item {

--- a/js/constants.js
+++ b/js/constants.js
@@ -886,6 +886,8 @@ const SYNC_SCOPE_KEYS = [
   'metalApiConfig',            // API_KEY_STORAGE_KEY — Numista/PCGS/spot provider keys
 ];
 
+const SPOT_HISTORY_RUNTIME_WINDOW_DAYS = 180;
+
 const ALLOWED_STORAGE_KEYS = [
   LS_KEY,
   SERIAL_KEY,
@@ -964,6 +966,7 @@ const ALLOWED_STORAGE_KEYS = [
   LATEST_REMOTE_URL_KEY,      // string: cached latest remote release URL (STACK-67)
   "ff_migration_fuzzy_autocomplete", // one-time migration flag (v3.26.01)
   "migration_hourlySource",          // one-time migration flag: re-tag StakTrakr hourly entries
+  "migration_seedHistoryMerge",      // one-time migration flag: skip redundant seed-history merge writes
   "numistaLookupRules",              // custom Numista search lookup rules (JSON array)
   "numistaViewFields",               // view modal Numista field visibility config (JSON object)
   TIMEZONE_KEY,                        // string: "auto" | "UTC" | IANA zone (STACK-63)
@@ -1838,6 +1841,7 @@ if (typeof window !== "undefined") {
   window.disableFeature = disableFeature;
   window.toggleFeature = toggleFeature;
   window.ALLOWED_STORAGE_KEYS = ALLOWED_STORAGE_KEYS;
+  window.SPOT_HISTORY_RUNTIME_WINDOW_DAYS = SPOT_HISTORY_RUNTIME_WINDOW_DAYS;
   // STAK-149: Cloud auto-sync constants
   window.SYNC_POLL_INTERVAL = SYNC_POLL_INTERVAL;
   window.SYNC_PUSH_DEBOUNCE = SYNC_PUSH_DEBOUNCE;

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -101,13 +101,14 @@ const _ensureManifest = async () => {
 // Ticker
 // ---------------------------------------------------------------------------
 
-const TICKER_PIXELS_PER_SECOND = 127;
+const TICKER_SPEED_PIXELS_PER_SECOND = 127;
+const MIN_TICKER_DURATION_SECONDS = 20;
 
 const _buildTickerSignature = (items) => items.map((item) => [
   item.slug,
   item.bestVid,
   Number(item.bestPrice || 0).toFixed(2),
-  item.premium == null ? '' : item.premium.toFixed(3),
+  Number.isFinite(item.premium) ? item.premium.toFixed(3) : '',
 ].join('|')).join('||');
 
 const _getTickerLoopPhase = (track) => {
@@ -149,7 +150,7 @@ const _finalizeTickerTrack = (container, track, primaryBlock, phase = 0, previou
     track.style.removeProperty('--ticker-duration');
     track.style.removeProperty('animation-delay');
   } else {
-    const durationSeconds = Math.max(20, loopWidth / TICKER_PIXELS_PER_SECOND);
+    const durationSeconds = Math.max(MIN_TICKER_DURATION_SECONDS, loopWidth / TICKER_SPEED_PIXELS_PER_SECOND);
     track.dataset.loopWidth = String(loopWidth);
     track.style.setProperty('--ticker-loop-distance', `${loopWidth}px`);
     track.style.setProperty('--ticker-duration', `${durationSeconds.toFixed(3)}s`);

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -101,6 +101,68 @@ const _ensureManifest = async () => {
 // Ticker
 // ---------------------------------------------------------------------------
 
+const TICKER_PIXELS_PER_SECOND = 127;
+
+const _buildTickerSignature = (items) => items.map((item) => [
+  item.slug,
+  item.bestVid,
+  Number(item.bestPrice || 0).toFixed(2),
+  item.premium == null ? '' : item.premium.toFixed(3),
+].join('|')).join('||');
+
+const _getTickerLoopPhase = (track) => {
+  if (!track || track.classList.contains('static')) return 0;
+
+  const loopWidth = Number(track.dataset.loopWidth || 0);
+  if (!(loopWidth > 0)) return 0;
+
+  const transform = window.getComputedStyle(track).transform;
+  if (!transform || transform === 'none') return 0;
+
+  const MatrixCtor = window.DOMMatrixReadOnly || window.WebKitCSSMatrix;
+  if (!MatrixCtor) return 0;
+
+  try {
+    const matrix = new MatrixCtor(transform);
+    const translateX = typeof matrix.m41 === 'number' ? matrix.m41 : 0;
+    const distance = ((-translateX % loopWidth) + loopWidth) % loopWidth;
+    return distance / loopWidth;
+  } catch (error) {
+    debugLog('[market-data] Unable to read ticker transform: ' + error.message, 'debug');
+    return 0;
+  }
+};
+
+const _finalizeTickerTrack = (container, track, primaryBlock, phase = 0, previousTrack = null) => {
+  const loopWidth = Math.ceil(primaryBlock.getBoundingClientRect().width);
+
+  track.style.removeProperty('left');
+  track.style.removeProperty('top');
+  track.style.removeProperty('position');
+  track.style.removeProperty('pointer-events');
+  track.style.removeProperty('visibility');
+
+  if (!(loopWidth > 0)) {
+    track.classList.add('static');
+    track.dataset.loopWidth = '0';
+    track.style.removeProperty('--ticker-loop-distance');
+    track.style.removeProperty('--ticker-duration');
+    track.style.removeProperty('animation-delay');
+  } else {
+    const durationSeconds = Math.max(20, loopWidth / TICKER_PIXELS_PER_SECOND);
+    track.dataset.loopWidth = String(loopWidth);
+    track.style.setProperty('--ticker-loop-distance', `${loopWidth}px`);
+    track.style.setProperty('--ticker-duration', `${durationSeconds.toFixed(3)}s`);
+    track.style.animationDelay = phase > 0
+      ? `-${(phase * durationSeconds).toFixed(3)}s`
+      : '0s';
+  }
+
+  if (previousTrack && previousTrack.parentNode === container) {
+    previousTrack.remove();
+  }
+};
+
 const renderBestPriceTicker = () => {
   const container = safeGetElement('bestPriceTickerEl');
   if (!container) return;
@@ -169,15 +231,27 @@ const renderBestPriceTicker = () => {
   items.sort((a, b) => a.name.localeCompare(b.name));
 
   if (items.length === 0) {
+    container.dataset.tickerSignature = '';
     container.setAttribute('hidden', '');
+    while (container.firstChild) container.removeChild(container.firstChild);
     return;
   }
 
+  const signature = _buildTickerSignature(items);
+  const previousTrack = container.querySelector('.ticker-track');
+  if (previousTrack && container.dataset.tickerSignature === signature) {
+    container.removeAttribute('hidden');
+    return;
+  }
+
+  const previousPhase = _getTickerLoopPhase(previousTrack);
+
   container.removeAttribute('hidden');
-  while (container.firstChild) container.removeChild(container.firstChild);
+  container.dataset.tickerSignature = signature;
 
   const track = document.createElement('div');
   track.className = 'ticker-track';
+  track.dataset.signature = signature;
 
   const buildTickerItem = (item) => {
     const el = document.createElement('div');
@@ -225,8 +299,10 @@ const renderBestPriceTicker = () => {
   // Build TWO identical content blocks for seamless loop
   const block1 = document.createElement('div');
   block1.className = 'ticker-block';
+  block1.dataset.tickerBlock = 'primary';
   const block2 = document.createElement('div');
   block2.className = 'ticker-block';
+  block2.dataset.tickerBlock = 'duplicate';
 
   for (const item of items) {
     block1.appendChild(buildTickerItem(item));
@@ -236,12 +312,25 @@ const renderBestPriceTicker = () => {
   if (items.length >= 4) {
     track.appendChild(block1);
     track.appendChild(block2);
+
+    track.style.visibility = 'hidden';
+    if (previousTrack) {
+      track.style.position = 'absolute';
+      track.style.left = '0';
+      track.style.top = '0';
+      track.style.pointerEvents = 'none';
+    }
+
+    container.appendChild(track);
+    requestAnimationFrame(() => {
+      _finalizeTickerTrack(container, track, block1, previousPhase, previousTrack);
+    });
   } else {
     track.classList.add('static');
     track.appendChild(block1);
+    if (previousTrack) previousTrack.remove();
+    container.appendChild(track);
   }
-
-  container.appendChild(track);
 };
 
 // ---------------------------------------------------------------------------

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -18,7 +18,7 @@ const SEED_DATA_YEARS = (() => {
  * Full multi-decade reference history stays in historicalDataCache/year files.
  * @constant {number}
  */
-const SEED_RUNTIME_HISTORY_DAYS = 180;
+const SEED_RUNTIME_HISTORY_DAYS = window.SPOT_HISTORY_RUNTIME_WINDOW_DAYS || 180;
 
 /**
  * Returns a storage-safe recent seed window for in-memory/persisted runtime history.

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -14,6 +14,37 @@ const SEED_DATA_YEARS = (() => {
 })();
 
 /**
+ * Local spotHistory intentionally retains a small recent window.
+ * Full multi-decade reference history stays in historicalDataCache/year files.
+ * @constant {number}
+ */
+const SEED_RUNTIME_HISTORY_DAYS = 180;
+
+/**
+ * Returns a storage-safe recent seed window for in-memory/persisted runtime history.
+ * Falls back to the latest entry per metal if the recent window is unexpectedly empty.
+ *
+ * @param {Array<{spot:number, metal:string, source:string, provider:string, timestamp:string}>} entries
+ * @returns {Array<{spot:number, metal:string, source:string, provider:string, timestamp:string}>}
+ */
+const getSeedRuntimeHistoryWindow = (entries) => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - SEED_RUNTIME_HISTORY_DAYS);
+  const cutoffStamp = cutoff.toISOString().replace("T", " ").slice(0, 19);
+
+  const recent = entries.filter(
+    (entry) => entry && typeof entry.timestamp === "string" && entry.timestamp >= cutoffStamp,
+  );
+  if (recent.length > 0) return recent;
+
+  const latestByMetal = new Map();
+  entries.forEach((entry) => {
+    if (entry && entry.metal) latestByMetal.set(entry.metal, entry);
+  });
+  return [...latestByMetal.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+};
+
+/**
  * Embedded seed data fallback for file:// protocol where fetch() cannot
  * load local JSON files. Auto-generated — do not edit by hand.
  *
@@ -1153,12 +1184,12 @@ function getEmbeddedSeedData() {
 }
 
 /**
- * Loads and merges seed spot history into spotHistory (localStorage).
+ * Loads seed/reference spot history without bulk-persisting the full bundle.
  *
- * First-time users: bulk loads all available seed data.
- * Existing users: merges seed entries for dates not already present
- * (live/API data always wins over seed for overlapping dates).
- * Runs once per app version via migration_seedHistoryMerge flag.
+ * First-time users: hydrate a recent storage-safe runtime window into spotHistory.
+ * Existing users: keep their persisted runtime history intact and use the bundle
+ * cache/year files as the source of truth for long-range reference data.
+ * Runs once per app version for existing users via migration_seedHistoryMerge flag.
  *
  * Data sources (priority order):
  *   1. historicalDataCache — pre-populated by spot-history-bundle.js
@@ -1177,7 +1208,7 @@ async function loadSeedSpotHistory() {
     return;
   }
 
-  debugLog("Seed data: " + (isMerge ? "merge mode — backfilling gaps in " + existing.length + " entries" : "loading for first-time user..."));
+  debugLog("Seed data: " + (isMerge ? "existing runtime history detected (" + existing.length + " entries)" : "loading for first-time user..."));
 
   // --- Gather seed entries from the best available source ---
   // Priority 1: historicalDataCache (populated by spot-history-bundle.js <script>)
@@ -1221,58 +1252,50 @@ async function loadSeedSpotHistory() {
     return;
   }
 
+  seedEntries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
   if (isMerge) {
-    // Build a Set of existing day+metal keys so live/API data always wins
-    const existingKeys = new Set();
-    for (const e of existing) {
-      existingKeys.add(e.timestamp.slice(0, 10) + "|" + e.metal);
-    }
-
-    // Only add seed entries for dates the user doesn't already have
-    let added = 0;
-    for (const s of seedEntries) {
-      const key = s.timestamp.slice(0, 10) + "|" + s.metal;
-      if (!existingKeys.has(key)) {
-        existing.push(s);
-        added++;
-      }
-    }
-
-    if (added === 0) {
-      debugLog("Seed data: no gaps found — history is complete");
-      localStorage.setItem("migration_seedHistoryMerge", "1");
-      return;
-    }
-
-    // Sort merged array chronologically and persist
-    existing.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
-    spotHistory = existing;
-    debugLog("Seed data: merged " + added + " historical entries into spotHistory");
+    debugLog(
+      "Seed data: bundle cache available for historical lookups — skipping persisted merge for existing spotHistory (" +
+      existing.length +
+      " entries)",
+    );
   } else {
-    // First-time user: bulk assign all seed data
-    seedEntries.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
-    spotHistory = seedEntries;
-    debugLog("Seed data: loaded " + seedEntries.length + " entries");
+    const runtimeSeedEntries = getSeedRuntimeHistoryWindow(seedEntries);
+    spotHistory = runtimeSeedEntries;
+    debugLog(
+      "Seed data: hydrated " +
+      runtimeSeedEntries.length +
+      " recent seed entries into spotHistory (" +
+      SEED_RUNTIME_HISTORY_DAYS +
+      "-day runtime window, " +
+      seedEntries.length +
+      " total reference entries remain in cache)",
+    );
+
+    if (typeof saveSpotHistory === "function") {
+      saveSpotHistory();
+    }
   }
 
   // Mark merge complete so we don't re-run on every load
   localStorage.setItem("migration_seedHistoryMerge", "1");
 
-  if (typeof saveSpotHistory === "function") {
-    saveSpotHistory();
-  }
-
   // Set latest seed price per metal in localStorage so fetchSpotPrice()
   // picks them up instead of hardcoded defaults
   const latestByMetal = {};
-  for (const entry of spotHistory) {
+  const latestSource = isMerge ? existing : spotHistory;
+  for (const entry of latestSource) {
     latestByMetal[entry.metal] = entry.spot;
+  }
+  for (const entry of seedEntries) {
+    if (!latestByMetal[entry.metal]) latestByMetal[entry.metal] = entry.spot;
   }
 
   if (typeof METALS !== "undefined") {
     Object.values(METALS).forEach((mc) => {
       const price = latestByMetal[mc.name];
-      if (price && price > 0) {
+      if (price && price > 0 && (!isMerge || !localStorage.getItem(mc.localStorageKey))) {
         localStorage.setItem(mc.localStorageKey, String(price));
       }
     });

--- a/js/spot.js
+++ b/js/spot.js
@@ -6,11 +6,103 @@
  * Writes the content of `spotHistory` to the `SPOT_HISTORY_KEY`.
  * @returns {void}
  */
+const PERSISTED_SEED_HISTORY_DAYS = 180;
+
+/**
+ * Builds the persisted spot-history snapshot.
+ * Static seed/reference entries older than the runtime window stay available
+ * through bundle/year-file sources instead of localStorage.
+ *
+ * @param {Array} entries
+ * @returns {{entries:Array, changed:boolean, trimmedSeedEntries:number, removedInvalidEntries:number, dedupedEntries:number}}
+ */
+const getPersistedSpotHistorySnapshot = (entries) => {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return {
+      entries: [],
+      changed: Array.isArray(entries) ? false : true,
+      trimmedSeedEntries: 0,
+      removedInvalidEntries: 0,
+      dedupedEntries: 0,
+    };
+  }
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - PERSISTED_SEED_HISTORY_DAYS);
+  const cutoffStamp = cutoff.toISOString().replace("T", " ").slice(0, 19);
+
+  let trimmedSeedEntries = 0;
+  let removedInvalidEntries = 0;
+  let dedupedEntries = 0;
+  const byKey = new Map();
+
+  entries.forEach((entry) => {
+    if (
+      !entry ||
+      typeof entry.spot !== "number" ||
+      entry.spot <= 0 ||
+      !entry.metal ||
+      !entry.timestamp
+    ) {
+      removedInvalidEntries++;
+      return;
+    }
+
+    if (entry.source === "seed" && entry.timestamp < cutoffStamp) {
+      trimmedSeedEntries++;
+      return;
+    }
+
+    const key = `${entry.timestamp}|${entry.metal}`;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, entry);
+      return;
+    }
+
+    dedupedEntries++;
+    if (existing.source === "seed" && entry.source !== "seed") {
+      byKey.set(key, entry);
+    }
+  });
+
+  const persisted = [...byKey.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return {
+    entries: persisted,
+    changed:
+      trimmedSeedEntries > 0 ||
+      removedInvalidEntries > 0 ||
+      dedupedEntries > 0 ||
+      persisted.length !== entries.length,
+    trimmedSeedEntries,
+    removedInvalidEntries,
+    dedupedEntries,
+  };
+};
+
 const saveSpotHistory = () => {
   try {
-    saveDataSync(SPOT_HISTORY_KEY, spotHistory);
+    const snapshot = getPersistedSpotHistorySnapshot(spotHistory);
+    if (
+      snapshot.changed &&
+      typeof debugLog === "function" &&
+      (snapshot.trimmedSeedEntries > 0 || snapshot.removedInvalidEntries > 0 || snapshot.dedupedEntries > 0)
+    ) {
+      debugLog(
+        "Spot history: persisting sanitized snapshot (" +
+        snapshot.entries.length +
+        " entries, trimmed " +
+        snapshot.trimmedSeedEntries +
+        " old seed, removed " +
+        snapshot.removedInvalidEntries +
+        " invalid, deduped " +
+        snapshot.dedupedEntries +
+        ")",
+      );
+    }
+    saveDataSync(SPOT_HISTORY_KEY, snapshot.entries, { quietQuotaToast: true });
   } catch (error) {
-    console.error('Error saving spot history:', error);
+    console.warn('Spot history save skipped:', error);
   }
 };
 
@@ -20,8 +112,25 @@ const saveSpotHistory = () => {
 const loadSpotHistory = () => {
   try {
     const data = loadDataSync(SPOT_HISTORY_KEY, []);
-    // Ensure data is an array
-    spotHistory = Array.isArray(data) ? data : [];
+    const snapshot = getPersistedSpotHistorySnapshot(Array.isArray(data) ? data : []);
+    spotHistory = snapshot.entries;
+
+    if (snapshot.changed) {
+      try {
+        saveDataSync(SPOT_HISTORY_KEY, snapshot.entries, { quietQuotaToast: true });
+        if (typeof debugLog === "function" && snapshot.trimmedSeedEntries > 0) {
+          debugLog(
+            "Spot history: migrated persisted storage to trimmed runtime snapshot (" +
+            snapshot.entries.length +
+            " entries, removed " +
+            snapshot.trimmedSeedEntries +
+            " old seed entries)",
+          );
+        }
+      } catch (saveError) {
+        console.warn("Spot history migration save failed:", saveError);
+      }
+    }
   } catch (error) {
     console.error('Error loading spot history:', error);
     spotHistory = [];

--- a/js/spot.js
+++ b/js/spot.js
@@ -6,7 +6,7 @@
  * Writes the content of `spotHistory` to the `SPOT_HISTORY_KEY`.
  * @returns {void}
  */
-const PERSISTED_SEED_HISTORY_DAYS = 180;
+const PERSISTED_SEED_HISTORY_DAYS = window.SPOT_HISTORY_RUNTIME_WINDOW_DAYS || 180;
 
 /**
  * Builds the persisted spot-history snapshot.
@@ -41,8 +41,10 @@ const getPersistedSpotHistorySnapshot = (entries) => {
       !entry ||
       typeof entry.spot !== "number" ||
       entry.spot <= 0 ||
-      !entry.metal ||
-      !entry.timestamp
+      typeof entry.metal !== "string" ||
+      entry.metal === "" ||
+      typeof entry.timestamp !== "string" ||
+      entry.timestamp === ""
     ) {
       removedInvalidEntries++;
       return;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1000,8 +1000,9 @@ const parseNumistaMetal = (composition = "") => {
  * Save data to localStorage with optional compression
  * @param {string} key - Storage key
  * @param {any} data - Data to store
+ * @param {{quietQuotaToast?: boolean}} [options] - Optional save behavior flags
  */
-const saveData = async (key, data) => {
+const saveData = async (key, data, options = {}) => {
   try {
     const raw = JSON.stringify(data);
     const out = __compressIfNeeded(raw);
@@ -1014,8 +1015,13 @@ const saveData = async (key, data) => {
     }
   } catch(e) {
     console.error('saveData failed', e);
-    // STAK-421: Surface QuotaExceededError so users know storage is full
-    if (e && e.name === 'QuotaExceededError' && typeof showToast === 'function') {
+    // STAK-421: Surface QuotaExceededError unless the caller marked the write as optional.
+    if (
+      e &&
+      e.name === 'QuotaExceededError' &&
+      !options.quietQuotaToast &&
+      typeof showToast === 'function'
+    ) {
       showToast('Storage is full — some data could not be saved. Try clearing unused spot history or image cache.', 'error');
     }
   }
@@ -1040,14 +1046,19 @@ const loadData = async (key, defaultValue = []) => {
 };
 
 // Synchronous versions for backward compatibility where async isn't supported
-const saveDataSync = (key, data) => {
+const saveDataSync = (key, data, options = {}) => {
   try {
     const raw = JSON.stringify(data);
     const out = __compressIfNeeded(raw);
     localStorage.setItem(key, out);
   } catch (e) {
     console.error('saveDataSync failed', e);
-    if (e && e.name === 'QuotaExceededError' && typeof showToast === 'function') {
+    if (
+      e &&
+      e.name === 'QuotaExceededError' &&
+      !options.quietQuotaToast &&
+      typeof showToast === 'function'
+    ) {
       showToast('Storage is full — some data could not be saved. Try clearing unused spot history or image cache.', 'error');
     }
     throw e;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.87-b1774619145';
+const CACHE_NAME = 'staktrakr-v3.33.87-b1774662477';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.87-b1774662477';
+const CACHE_NAME = 'staktrakr-v3.33.87-b1774665670';
 
 
 

--- a/tests/runbook/01-page-load.md
+++ b/tests/runbook/01-page-load.md
@@ -134,3 +134,16 @@ _Added: v3.33.25 (STAK-396)_
 **Pass criteria:** The inventory count shown in the UI (badge, header label, or filter chip) reads 8, matching the seed data that ships with the application.
 **Tags:** page-load, inventory, count
 **Section:** 01-page-load
+
+---
+
+### Test 1.12 — Fresh startup stays quota-safe and keeps market UI available
+_Added: v3.33.88 (STAK-481)_
+**Preconditions:** Fresh browser session or cleared preview-origin storage so startup runs the bundled seed-history path from scratch. The acknowledgment modal has been dismissed if it appears.
+**Steps:**
+- extract: "any visible toast, banner, or inline error mentioning 'Storage is full', 'quota', 'spot history', or 'could not be saved'" → expect: false
+- extract: "the best price ticker strip is visible on the page with at least one ticker item or price pill rendered" → expect: true
+- screenshot: "01-page-load-quota-safe-startup"
+**Pass criteria:** A cold startup completes without any visible storage-full/quota messaging, and the Market ticker strip is available on the page after load, confirming the startup storage fix did not block market UI initialization.
+**Tags:** page-load, storage, quota, market
+**Section:** 01-page-load

--- a/tests/runbook/05-market.md
+++ b/tests/runbook/05-market.md
@@ -130,3 +130,30 @@ _Added: v3.33.25 (STAK-396)_
 **Pass criteria:** At least one market item shows a source or provider badge identifying the data origin (e.g., "eBay", "APMEX", or the API source name), confirming source attribution is rendered correctly.
 **Tags:** market, source-badge, provider
 **Section:** 05-market
+
+---
+
+### Test 5.11 — Best price ticker completes one full seamless cycle
+_Added: v3.33.88 (STAK-481)_
+**Preconditions:** MANUAL/VISUAL TEST — the best price ticker strip is visible after page load or with the Market panel open. Allow roughly 45-50 seconds to observe one full cycle.
+**Steps:**
+- screenshot: "05-market-ticker-cycle-start"
+- act: "observe the ticker continuously through one full pass until the starting items reappear"
+- screenshot: "05-market-ticker-cycle-end"
+**Pass criteria:** The ticker scrolls through the entire list and returns to an identical seam without a visible flash, jump, blank gap, or early reset near the mid-list silver products (for example around the Koala/Kookaburra area).
+**Tags:** market, ticker, manual, visual
+**Section:** 05-market
+
+---
+
+### Test 5.12 — Best price ticker remains continuous after market refresh
+_Added: v3.33.88 (STAK-481)_
+**Preconditions:** Market panel is open and the best price ticker is already moving (5.11 is recommended first).
+**Steps:**
+- act: "click the market Refresh button"
+- extract: "the market updated timestamp changes or refresh feedback appears" → expect: true
+- act: "observe the ticker for 10 seconds immediately after refresh"
+- screenshot: "05-market-ticker-post-refresh"
+**Pass criteria:** After a manual market refresh, the ticker continues moving with duplicated content intact and no visible snap back to the start, flash, or partial-cycle restart.
+**Tags:** market, ticker, refresh, manual
+**Section:** 05-market

--- a/tests/runbook/08-spot-prices.md
+++ b/tests/runbook/08-spot-prices.md
@@ -15,8 +15,6 @@ _Added: v3.33.25 (STAK-396)_
 **Tags:** spot-prices, metals, display
 **Section:** 08-spot-prices
 
----
-
 ### Test 8.2 — Values within 75-minute stale threshold
 _Added: v3.33.25 (STAK-396)_
 **Preconditions:** Page fully loaded with spot data fetched. Spot poller on Fly.io is assumed healthy (data updated within the last 75 minutes).
@@ -68,4 +66,17 @@ _Added: v3.33.25 (STAK-396)_
 - screenshot: "08-spot-prices-stale-note"
 **Pass criteria:** Test documented for manual execution. To verify: when spot data age exceeds 75 minutes, a stale indicator (warning badge, color change, or explicit "stale" label) appears on one or more spot price cards. This confirms the frontend correctly detects and surfaces data freshness violations.
 **Tags:** spot-prices, stale, manual
+**Section:** 08-spot-prices
+
+---
+
+### Test 8.7 — Historical spot UI survives quota-safe startup
+_Added: v3.33.88 (STAK-481)_
+**Preconditions:** Fresh page load completed. Spot prices and inventory cards are visible. Use a cold session when possible so the bundled seed-history startup path runs before verification.
+**Steps:**
+- extract: "each visible spot price card still shows a trend period label (such as 30d or 90d) and a percentage change value next to the live price" → expect: true
+- extract: "at least one inventory card still shows a non-zero melt value after startup finishes" → expect: true
+- screenshot: "08-spot-prices-history-after-startup"
+**Pass criteria:** After the quota-safe startup path runs, the spot cards still display their normal trend/history presentation and inventory melt values remain populated, confirming the storage fix did not regress historical spot-driven UI behavior.
+**Tags:** spot-prices, history, startup, regression
 **Section:** 08-spot-prices


### PR DESCRIPTION
## Summary
- stop bulk-persisting the full bundled spot-history dataset during startup so first-load seeding no longer overruns `localStorage`
- keep long-range reference history available through in-memory/reference loaders while preserving recent runtime history for normal app behavior
- stabilize the market best-price ticker loop by measuring the primary block width, preserving loop phase across rerenders, and driving the CSS loop distance from the measured seam
- slow the ticker to roughly two-thirds of the previous pace after the seamless-loop fix
- extend the runbook coverage for startup quota safety, ticker continuity, and spot-history regression checks

## Validation
- `node --check js/seed-data.js`
- `node --check js/spot.js`
- `node --check js/utils.js`
- `node --check js/market-data.js`
- local Playwright smoke against `http://127.0.0.1:8765/index.html`
- verified cold load no longer hit the startup quota failure path
- verified the ticker continued moving after initial load and after Market refresh with the slower pacing in place

## Notes
- `sw.js` was restamped by the repo commit hook during commit creation
- follow-up issue `STAK-482` tracks the missing `npm test` smoke-test entrypoint that prevented the documented browserless command from running as written
- no screenshot attached because the visible change here is a motion/continuity fix rather than a static layout change

## Issue
- DocVault: `STAK-481`