### PR TITLE
v3.33.88 — Ticker Duplication & Stale What's New Fix (STAK-513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.88] - 2026-03-29
+
+### Fixed — Ticker Duplication & Stale What's New (STAK-513)
+
+- **Fixed**: Market ticker marquee duplicating into 4-5 stacked rows due to race condition in renderBestPriceTicker() — orphaned .ticker-track elements now swept on every finalize (STAK-513)
+- **Fixed**: Removed redundant renderBestPriceTicker() call inside async _renderVendorTable completion that was the primary trigger for the race (STAK-513)
+- **Fixed**: Stale What's New content on Cloudflare-proxied deployments — SPA fallback returning HTML instead of 404 for deleted announcements.md now detected and bypassed (STAK-513)
+- **Added**: CSS max-height safety clamp on .market-ticker to prevent visual overflow if ticker tracks accumulate (STAK-513)
+
+---
+
 ## [3.33.87] - 2026-03-26
 
 ### Added — Market Data Module (STAK-504)

--- a/css/styles.css
+++ b/css/styles.css
@@ -12882,7 +12882,7 @@ th {
   padding: 12px 0;
   position: relative;
   /* STAK-513: Clamp to single row height as visual safety net */
-  max-height: 52px;
+  max-height: 72px;
 }
 .market-ticker::before,
 .market-ticker::after {

--- a/css/styles.css
+++ b/css/styles.css
@@ -12881,6 +12881,8 @@ th {
   border-radius: 12px;
   padding: 12px 0;
   position: relative;
+  /* STAK-513: Clamp to single row height as visual safety net */
+  max-height: 52px;
 }
 .market-ticker::before,
 .market-ticker::after {

--- a/js/about.js
+++ b/js/about.js
@@ -88,6 +88,11 @@ const loadAnnouncements = async () => {
     const res = await fetch("docs/announcements.md");
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
     const text = await res.text();
+    // STAK-513: Cloudflare Pages SPA fallback returns index.html (200 OK)
+    // for missing files. Detect HTML and fall through to embedded content.
+    if (text.trimStart().startsWith('<!') || text.trimStart().startsWith('<html')) {
+      throw new Error('Response is HTML, not markdown — SPA fallback detected');
+    }
 
     const section = (name) => {
       const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/js/about.js
+++ b/js/about.js
@@ -252,11 +252,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.88 &ndash; Ticker &amp; What&rsquo;s New Fix</strong>: Market ticker no longer duplicates into multiple rows. Stale What&rsquo;s New content on cached deployments now correctly falls back to embedded data (STAK-513)</li>
     <li><strong>v3.33.87 &ndash; Market Data Module</strong>: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts &mdash; all powered by the v2 API (STAK-504)</li>
     <li><strong>v3.33.86 &ndash; What&rsquo;s New Modal Fix</strong>: What&rsquo;s New popup no longer flashes old content before showing current announcements on page load (STAK-500)</li>
     <li><strong>v3.33.84 &ndash; Market Price Fixes</strong>: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view (STAK-498)</li>
     <li><strong>v3.33.83 &ndash; Intraday Chart Fix</strong>: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets (STAK-498)</li>
-    <li><strong>v3.33.82 &ndash; Grid View Cleanup</strong>: Removed ~260 lines of dead grid/card view code from retail.js, eliminated the MARKET_LIST_VIEW feature flag, and cleaned up orphaned CSS. List view is now unconditional (STAK-473)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.87";
+const APP_VERSION = "3.33.88";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -159,9 +159,12 @@ const _finalizeTickerTrack = (container, track, primaryBlock, phase = 0, previou
       : '0s';
   }
 
-  // STAK-513: Sweep ALL orphaned tracks, not just the one captured at call-time.
-  // Rapid re-renders with changing signatures can accumulate multiple tracks
-  // before any rAF fires — querySelector only finds the first, leaving the rest.
+  // STAK-513: Guard against stale rAF callbacks — only the latest track sweeps.
+  if (!container.contains(track) || track.dataset.signature !== container.dataset.tickerSignature) {
+    if (track.parentNode === container) track.remove();
+    return;
+  }
+  // Sweep ALL orphaned tracks so rapid re-renders can't accumulate rows.
   container.querySelectorAll('.ticker-track').forEach(t => {
     if (t !== track) t.remove();
   });

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -159,9 +159,12 @@ const _finalizeTickerTrack = (container, track, primaryBlock, phase = 0, previou
       : '0s';
   }
 
-  if (previousTrack && previousTrack.parentNode === container) {
-    previousTrack.remove();
-  }
+  // STAK-513: Sweep ALL orphaned tracks, not just the one captured at call-time.
+  // Rapid re-renders with changing signatures can accumulate multiple tracks
+  // before any rAF fires — querySelector only finds the first, leaving the rest.
+  container.querySelectorAll('.ticker-track').forEach(t => {
+    if (t !== track) t.remove();
+  });
 };
 
 const renderBestPriceTicker = () => {
@@ -905,8 +908,10 @@ const _renderVendorTable = async (metalCode) => {
   scrollWrap.appendChild(table);
   tableWrap.appendChild(scrollWrap);
 
-  // Re-render ticker now that _cachedSlugDetail has fresh v2 stock data
-  renderBestPriceTicker();
+  // STAK-513: Removed redundant renderBestPriceTicker() call here.
+  // Both initMarketData and refreshMarketData already call it — re-calling
+  // inside the async _renderVendorTable completion was the primary trigger
+  // for the stale-reference race that duplicated ticker rows.
 };
 
 const renderVendorPrices = () => {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.87-b1774817648';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774817939';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.87-b1774808759';
+const CACHE_NAME = 'staktrakr-v3.33.87-b1774816616';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.87-b1774816616';
+const CACHE_NAME = 'staktrakr-v3.33.87-b1774817648';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774817939';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774817975';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.87",
-  "releaseDate": "2026-03-26",
+  "version": "3.33.88",
+  "releaseDate": "2026-03-29",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: Market ticker marquee duplicating into 4-5 stacked rows — race condition in `renderBestPriceTicker()` where rapid calls with changing signatures accumulated orphaned `.ticker-track` DOM elements
- **Fixed**: Stale "What's New" content on production — `fetch("docs/announcements.md")` now detects HTML SPA fallback responses and falls through to correct embedded content
- **Added**: CSS max-height safety clamp and stale rAF callback guard for defense-in-depth

## Version Tags Included

- v3.33.88 — Ticker Duplication & Stale What's New Fix (STAK-513)

## Linear Issues

- STAK-513: Market ticker marquee duplicates into 4-5 stacked lines

## QA Notes

- Reported by beta user PumpkinCrouton on r/Silverbugs
- Verify single ticker row after deploy
- Verify correct What's New entries (v3.33.88 at top) on staktrakr.com after cache refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)