### PR TITLE
v3.33.89 — STAK-515: Market Filter Matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.89] - 2026-03-29
+
+### Added — Market Filter Matrix (STAK-515)
+
+- **Added**: Settings > Market tab redesigned with checkbox filter matrix — enable/disable specific item/vendor combinations for ticker and vendor prices table
+- **Added**: Metal pill tabs (All/Silver/Gold/Platinum/Palladium/Goldback) scope the filter matrix view
+- **Added**: Row and column ALL toggles for bulk enable/disable with indeterminate state support
+- **Added**: Filter consumption in ticker (`renderBestPriceTicker`) and vendor prices table (`_renderVendorTable`) — disabled items excluded from display and price calculations
+- **Removed**: Legacy market price cards grid, search/sort/filter controls, and Sync Now button from settings (now on main page only)
+
+---
+
 ## [3.33.88] - 2026-03-29
 
 ### Fixed — Ticker Duplication & Stale What's New (STAK-513)

--- a/css/styles.css
+++ b/css/styles.css
@@ -12549,6 +12549,118 @@ th {
   background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
   box-shadow: 0 2px 6px rgba(217, 119, 6, 0.4);
 }
+/* Market Filter Matrix (STAK-515) */
+.market-settings-header {
+  margin-bottom: 0.5rem;
+}
+.market-filter-matrix-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-top: 0.75rem;
+  border: 1px solid var(--border, var(--bs-border-color));
+  border-radius: 6px;
+}
+.market-filter-matrix {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 12px;
+}
+.market-filter-matrix th,
+.market-filter-matrix td {
+  padding: 6px 8px;
+  text-align: center;
+  border-bottom: 1px solid var(--border, var(--bs-border-color));
+  white-space: nowrap;
+}
+.market-filter-matrix th:first-child,
+.market-filter-matrix td:first-child {
+  text-align: left;
+  position: sticky;
+  left: 0;
+  background: var(--bg-primary, var(--bs-body-bg, #1a1d23));
+  z-index: 1;
+  padding-left: 12px;
+  font-weight: 500;
+  min-width: 160px;
+}
+.market-filter-matrix thead th {
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--text-muted, #6c757d);
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--border, var(--bs-border-color));
+}
+.market-filter-matrix thead th:first-child {
+  z-index: 2;
+}
+.market-filter-matrix tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+.market-filter-matrix tbody tr:hover td:first-child {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.03));
+}
+.market-filter-matrix tbody tr:last-child td {
+  border-bottom: none;
+}
+.market-filter-matrix .vendor-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+.market-filter-matrix input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: var(--bs-primary, #3b82f6);
+  width: 15px;
+  height: 15px;
+  vertical-align: middle;
+}
+.market-filter-matrix input[type="checkbox"]:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+.market-filter-matrix .mfm-all-row td {
+  border-bottom: 2px solid var(--border, var(--bs-border-color));
+  font-weight: 600;
+}
+.market-filter-matrix .mfm-all-row td:first-child {
+  background: var(--bg-primary, var(--bs-body-bg, #1a1d23));
+}
+.market-filter-matrix th:nth-child(2),
+.market-filter-matrix td:nth-child(2) {
+  border-right: 1px solid var(--border, var(--bs-border-color));
+}
+.market-filter-matrix .mfm-product-name {
+  font-size: 12px;
+  color: var(--text-primary, var(--bs-body-color));
+}
+.market-filter-matrix .mfm-status-line {
+  font-size: 12px;
+  color: var(--text-muted, #6c757d);
+  padding: 6px 0 2px;
+}
+.market-filter-matrix .mfm-status-line strong {
+  color: var(--text-primary, var(--bs-body-color));
+  font-weight: 600;
+}
+@media (max-width: 640px) {
+  .market-filter-matrix {
+    font-size: 11px;
+  }
+  .market-filter-matrix th,
+  .market-filter-matrix td {
+    padding: 4px 6px;
+  }
+  .market-filter-matrix th:first-child,
+  .market-filter-matrix td:first-child {
+    min-width: 130px;
+  }
+}
 
 /* ── Cards Container ── */
 .market-cards-list { display: flex; flex-direction: column; gap: 20px; }

--- a/css/styles.css
+++ b/css/styles.css
@@ -13198,6 +13198,9 @@ th {
   z-index: 1;
 }
 
+.vendor-prices-table .vp-muted {
+  color: var(--text-muted, #6c757d);
+}
 .vendor-prices-table tr:hover td {
   background: var(--bg-secondary);
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -12563,11 +12563,11 @@ th {
 .market-filter-matrix {
   border-collapse: collapse;
   width: 100%;
-  font-size: 12px;
+  font-size: 11px;
 }
 .market-filter-matrix th,
 .market-filter-matrix td {
-  padding: 6px 8px;
+  padding: 4px 5px;
   text-align: center;
   border-bottom: 1px solid var(--border, var(--bs-border-color));
   white-space: nowrap;
@@ -12579,9 +12579,11 @@ th {
   left: 0;
   background: var(--bg-primary, var(--bs-body-bg, #1a1d23));
   z-index: 1;
-  padding-left: 12px;
+  padding-left: 10px;
   font-weight: 500;
-  min-width: 160px;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .market-filter-matrix thead th {
   font-weight: 600;

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,0 +1,7 @@
+## What's New
+
+- **Market Filter Matrix (v3.33.89)**: Settings > Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings. Legacy market cards removed from settings
+- **Ticker & What's New Fix (v3.33.88)**: Market ticker no longer duplicates into multiple rows. Stale What's New content on cached deployments now correctly falls back to embedded data
+- **Market Data Module (v3.33.87)**: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts — all powered by the v2 API
+- **What's New Modal Fix (v3.33.86)**: What's New popup no longer flashes old content before showing current announcements on page load
+- **Market Price Fixes (v3.33.84)**: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view

--- a/index.html
+++ b/index.html
@@ -3628,77 +3628,32 @@
 
             <!-- ===== MARKET PRICES ===== -->
             <div id="settingsPanel_market" class="settings-section-panel" style="display: none">
-
-              <!-- Market List View header -->
-              <div id="marketListHeader" style="display:none">
-                <div class="market-header">
-                  <div class="market-header-row">
-                    <h3>Market Prices</h3>
-                    <div class="market-header-sync-group">
-                      <button id="retailSyncBtnList" class="retail-sync-btn market-sync-btn" type="button">Sync Now</button>
-                      <span id="retailLastSyncList" class="settings-subtext">Last sync: —</span>
-                    </div>
-                  </div>
-                  <div class="market-header-divider"></div>
-                  <div class="market-header-controls-row">
-                    <input type="search" id="marketSearchInput" class="market-search"
-                           placeholder="Search items, metals, vendors..." autocomplete="off"
-                           aria-label="Search market items">
-                    <div class="market-sort-wrap">
-                      <span class="market-header-btn market-sort-label">Sort: Name <span class="btn-chevron">&#9662;</span></span>
-                      <select id="marketSortSelect" aria-label="Sort market items">
-                        <option value="name" selected>Name</option>
-                        <option value="metal">Metal</option>
-                        <option value="price-low">Price: Low</option>
-                        <option value="price-high">Price: High</option>
-                        <option value="trend">Trend</option>
-                      </select>
-                    </div>
-                  </div>
-                  <div class="market-header-controls-row market-header-view-row">
-                    <div class="market-filter-pills" id="marketFilterPills">
-                      <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>
-                      <button class="market-filter-pill" data-metal="silver" type="button" aria-pressed="false">Silver</button>
-                      <button class="market-filter-pill" data-metal="gold" type="button" aria-pressed="false">Gold</button>
-                      <button class="market-filter-pill" data-metal="goldback" type="button" aria-pressed="false">Goldback</button>
-                      <button class="market-filter-pill" data-metal="platinum" type="button" aria-pressed="false">Platinum</button>
-                      <button class="market-filter-pill" data-metal="palladium" type="button" aria-pressed="false">Palladium</button>
-                    </div>
-                    <div class="market-header-controls-right">
-                      <button class="market-header-btn market-expand-btn" id="marketExpandAllBtn" type="button" title="Expand All" aria-label="Expand All">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
-                      </button>
-                    </div>
+              <!-- Market Filter Matrix (STAK-515) -->
+              <div class="market-settings-header">
+                <div class="market-header-row">
+                  <h3>Market Settings</h3>
+                  <div class="market-header-sync-group">
+                    <button id="marketFilterSyncBtn" class="retail-sync-btn market-sync-btn" type="button">Sync Now</button>
+                    <span id="marketFilterLastSync" class="settings-subtext">Last sync: —</span>
                   </div>
                 </div>
               </div>
-
-              <!-- Legacy grid header (hidden when list view active) -->
-              <div id="marketGridHeader">
-                <h3 style="margin-bottom:0.75rem;">Market Prices</h3>
-                <div style="display:flex; align-items:center; justify-content:space-between; gap:0.75rem; margin-bottom:0.5rem;">
-                  <div style="display:flex;flex-direction:column;gap:0.15rem;">
-                    <span id="retailLastSync" class="settings-subtext"></span>
-                    <span id="retailSyncStatus" class="settings-subtext"></span>
-                  </div>
-                  <button id="retailSyncBtn" class="retail-card-action" type="button">Sync Now</button>
-                </div>
+              <p class="settings-subtext" style="margin:0.5rem 0 0.75rem;">Filter which items appear in the ticker and market price table on the main page.</p>
+              <div class="market-filter-pills" id="marketFilterMetalPills">
+                <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>
+                <button class="market-filter-pill" data-metal="silver" type="button" aria-pressed="false">Silver</button>
+                <button class="market-filter-pill" data-metal="gold" type="button" aria-pressed="false">Gold</button>
+                <button class="market-filter-pill" data-metal="platinum" type="button" aria-pressed="false">Platinum</button>
+                <button class="market-filter-pill" data-metal="palladium" type="button" aria-pressed="false">Palladium</button>
+                <button class="market-filter-pill" data-metal="goldback" type="button" aria-pressed="false">Goldback</button>
               </div>
-
-              <div id="retailDisclaimer" class="retail-disclaimer-inline" style="display:none; margin-bottom:0.75rem;" role="status">
-                Best-effort pricing · Sourced from public data, may not reflect real-time or credit card pricing · Confidence: 80=aligned · 35=outlier · 15=significant outlier
+              <div id="marketFilterMatrixWrap" class="market-filter-matrix-wrap">
+                <table id="marketFilterMatrix" class="market-filter-matrix" aria-label="Market item filter matrix">
+                  <thead id="marketFilterMatrixHead"></thead>
+                  <tbody id="marketFilterMatrixBody"></tbody>
+                </table>
               </div>
-
-              <div id="retailCardsGrid" class="retail-cards-grid" aria-live="polite" aria-label="Retail coin price cards">
-                <!-- Cards rendered by renderRetailCards() -->
-              </div>
-
-              <div id="retailEmptyState" class="retail-empty-state" style="display: none">
-                <div class="retail-empty-icon">📊</div>
-                <p class="retail-empty-title">No market prices yet</p>
-                <p class="retail-empty-desc">Sync to load current bullion retail prices from APMEX, Monument, SDB, and JM Bullion.</p>
-                <button class="retail-sync-cta" type="button" onclick="syncRetailPrices()">Sync Now</button>
-              </div>
+              <div id="marketFilterStatus" class="settings-subtext" style="margin-top:0.5rem;"></div>
             </div>
 
             <!-- ===== ACTIVITY LOG ===== -->

--- a/index.html
+++ b/index.html
@@ -3629,7 +3629,13 @@
             <!-- ===== MARKET PRICES ===== -->
             <div id="settingsPanel_market" class="settings-section-panel" style="display: none">
               <!-- Market Filter Matrix (STAK-515) -->
-              <h3 style="margin-bottom:0.25rem;">Market Settings</h3>
+              <div class="market-header-row" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.25rem;">
+                <h3 style="margin:0;">Market Settings</h3>
+                <div class="market-header-sync-group" style="display:flex;align-items:center;gap:8px;">
+                  <button id="retailSyncBtn" class="retail-sync-btn market-sync-btn" type="button">Sync Now</button>
+                  <span id="retailSyncStatus" class="settings-subtext"></span>
+                </div>
+              </div>
               <p class="settings-subtext" style="margin:0.5rem 0 0.75rem;">Filter which items appear in the ticker and market price table on the main page.</p>
               <div class="market-filter-pills" id="marketFilterMetalPills">
                 <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>

--- a/index.html
+++ b/index.html
@@ -3629,15 +3629,7 @@
             <!-- ===== MARKET PRICES ===== -->
             <div id="settingsPanel_market" class="settings-section-panel" style="display: none">
               <!-- Market Filter Matrix (STAK-515) -->
-              <div class="market-settings-header">
-                <div class="market-header-row">
-                  <h3>Market Settings</h3>
-                  <div class="market-header-sync-group">
-                    <button id="marketFilterSyncBtn" class="retail-sync-btn market-sync-btn" type="button">Sync Now</button>
-                    <span id="marketFilterLastSync" class="settings-subtext">Last sync: —</span>
-                  </div>
-                </div>
-              </div>
+              <h3 style="margin-bottom:0.25rem;">Market Settings</h3>
               <p class="settings-subtext" style="margin:0.5rem 0 0.75rem;">Filter which items appear in the ticker and market price table on the main page.</p>
               <div class="market-filter-pills" id="marketFilterMetalPills">
                 <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>

--- a/js/about.js
+++ b/js/about.js
@@ -185,11 +185,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.89 &ndash; Market Filter Matrix</strong>: Settings &gt; Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings (STAK-515)</li>
     <li><strong>v3.33.88 &ndash; Ticker &amp; What&rsquo;s New Fix</strong>: Market ticker no longer duplicates into multiple rows. Stale What&rsquo;s New content on cached deployments now correctly falls back to embedded data (STAK-513)</li>
     <li><strong>v3.33.87 &ndash; Market Data Module</strong>: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts &mdash; all powered by the v2 API (STAK-504)</li>
     <li><strong>v3.33.86 &ndash; What&rsquo;s New Modal Fix</strong>: What&rsquo;s New popup no longer flashes old content before showing current announcements on page load (STAK-500)</li>
     <li><strong>v3.33.84 &ndash; Market Price Fixes</strong>: JM Bullion now uses column-aware eCheck/Wire parser first, preventing inflated Card/PayPal prices. Goldback-g1 baseline no longer appears as a ghost card in market view (STAK-498)</li>
-    <li><strong>v3.33.83 &ndash; Intraday Chart Fix</strong>: Charts now show exactly 24 hourly data points instead of multi-day spans with excessive dotted lines. Dotted lines only for 2+ hour gaps. OOS vendors excluded from chart datasets (STAK-498)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -290,7 +290,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.88";
+const APP_VERSION = "3.33.89";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -745,6 +745,8 @@ const RETAIL_MANIFEST_VENDOR_META_KEY = "retailManifestVendorMeta"; // nosemgrep
 /** @constant {string} RETAIL_TREND_MODE_KEY - LocalStorage key for retail trend display mode; stored values: "7d" or "intraday" */
 const RETAIL_TREND_MODE_KEY = "retailTrendMode"; // nosemgrep: codacy.javascript.security.hard-coded-password
 
+const MARKET_FILTER_KEY = 'staktrakr.market_filter'; // nosemgrep: codacy.javascript.security.hard-coded-password
+
 // =============================================================================
 // IMAGE PROCESSOR DEFAULTS (STACK-95)
 // =============================================================================
@@ -959,6 +961,7 @@ const ALLOWED_STORAGE_KEYS = [
   RETAIL_MANIFEST_COIN_META_KEY,   // JSON object: cached manifest coin metadata (canonical names)
   RETAIL_MANIFEST_VENDOR_META_KEY, // JSON object: cached manifest vendor display metadata
   RETAIL_TREND_MODE_KEY,           // string: retail trend display mode (7d | intraday)
+  MARKET_FILTER_KEY,               // string: market price filter preferences (STAK-515)
   "layoutVisibility",         // JSON object: { spotPrices, totals, search, table } (STACK-54) — legacy, migrated to layoutSectionConfig
   "layoutSectionConfig",      // JSON array: ordered section config [{ id, label, enabled }] (STACK-54)
   LAST_VERSION_CHECK_KEY,     // timestamp: last remote version check (STACK-67)
@@ -1934,6 +1937,7 @@ if (typeof window !== "undefined") {
   window.RETAIL_MANIFEST_COIN_META_KEY = RETAIL_MANIFEST_COIN_META_KEY;
   window.RETAIL_MANIFEST_VENDOR_META_KEY = RETAIL_MANIFEST_VENDOR_META_KEY;
   window.RETAIL_TREND_MODE_KEY = RETAIL_TREND_MODE_KEY;
+  window.MARKET_FILTER_KEY = MARKET_FILTER_KEY;
   window.RETAIL_ANOMALY_THRESHOLD = RETAIL_ANOMALY_THRESHOLD;
   window.RETAIL_SPIKE_NEIGHBOR_TOLERANCE = RETAIL_SPIKE_NEIGHBOR_TOLERANCE;
   // Disposition types for realized gains (STAK-72)

--- a/js/constants.js
+++ b/js/constants.js
@@ -745,7 +745,7 @@ const RETAIL_MANIFEST_VENDOR_META_KEY = "retailManifestVendorMeta"; // nosemgrep
 /** @constant {string} RETAIL_TREND_MODE_KEY - LocalStorage key for retail trend display mode; stored values: "7d" or "intraday" */
 const RETAIL_TREND_MODE_KEY = "retailTrendMode"; // nosemgrep: codacy.javascript.security.hard-coded-password
 
-const MARKET_FILTER_KEY = 'staktrakr.market_filter'; // nosemgrep: codacy.javascript.security.hard-coded-password
+const MARKET_FILTER_KEY = "staktrakr.market_filter"; // nosemgrep: codacy.javascript.security.hard-coded-password
 
 // =============================================================================
 // IMAGE PROCESSOR DEFAULTS (STACK-95)

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -846,7 +846,7 @@ const _renderVendorTable = async (metalCode) => {
       if (typeof _isMarketItemEnabled === 'function' && !_isMarketItemEnabled(slug, vid)) {
         const skipTd = document.createElement('td');
         skipTd.textContent = '\u2014';
-        skipTd.style.color = 'var(--text-muted)';
+        skipTd.className = 'vp-muted';
         tr.appendChild(skipTd);
         continue;
       }

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -200,6 +200,7 @@ const renderBestPriceTicker = () => {
     let bestPrice = Infinity;
     for (const vid in coin.vendors) {
       const v = coin.vendors[vid];
+      if (typeof _isMarketItemEnabled === 'function' && !_isMarketItemEnabled(slug, vid)) continue;
       if (!v || v.price <= 0) continue;
       // Cross-reference with fresh v2 detail for accurate stock status
       const fresh = _cachedSlugDetail[slug] && _cachedSlugDetail[slug].vendors && _cachedSlugDetail[slug].vendors[vid];

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -713,6 +713,14 @@ const _renderVendorTable = async (metalCode) => {
     const metalLower = (meta.metal || '').toLowerCase();
     const isoCode = _METAL_TO_ISO[metalLower] || metalLower;
     if (isoCode === metalCode) {
+      // STAK-515: Skip slugs where ALL vendors are disabled by market filter
+      if (typeof _isMarketItemEnabled === 'function') {
+        const coin = coins[slug];
+        if (coin && coin.vendors) {
+          const vids = Object.keys(coin.vendors);
+          if (vids.length > 0 && !vids.some(vid => _isMarketItemEnabled(slug, vid))) continue;
+        }
+      }
       metalSlugs.push({ slug, meta });
     }
   }
@@ -810,6 +818,8 @@ const _renderVendorTable = async (metalCode) => {
 
     const inStockPrices = [];
     for (const vid in vData) {
+      // STAK-515: Skip disabled vendors in price calculations
+      if (typeof _isMarketItemEnabled === 'function' && !_isMarketItemEnabled(slug, vid)) continue;
       const _vs = vData[vid];
       if (_vs && _vs.price > 0 && (_vs.in_stock === true || _vs.inStock === true)) {
         inStockPrices.push(vData[vid].price);
@@ -832,6 +842,14 @@ const _renderVendorTable = async (metalCode) => {
     tr.appendChild(tdName);
 
     for (const vid of vendorIds) {
+      // STAK-515: Skip disabled vendor cells
+      if (typeof _isMarketItemEnabled === 'function' && !_isMarketItemEnabled(slug, vid)) {
+        const skipTd = document.createElement('td');
+        skipTd.textContent = '\u2014';
+        skipTd.style.color = 'var(--text-muted)';
+        tr.appendChild(skipTd);
+        continue;
+      }
       const td = document.createElement('td');
       const vInfo = vData[vid];
 
@@ -985,6 +1003,14 @@ const renderVendorPrices = () => {
     else meta = { metal: 'unknown' };
     const metalLower = (meta.metal || '').toLowerCase();
     const isoCode = _METAL_TO_ISO[metalLower] || metalLower;
+    // STAK-515: Only count metal if at least one vendor is enabled for this slug
+    if (typeof _isMarketItemEnabled === 'function') {
+      const coin = coins[slug];
+      if (coin && coin.vendors) {
+        const vids = Object.keys(coin.vendors);
+        if (vids.length > 0 && !vids.some(vid => _isMarketItemEnabled(slug, vid))) continue;
+      }
+    }
     metalHasCoins[isoCode] = true;
   }
 

--- a/js/retail.js
+++ b/js/retail.js
@@ -1256,6 +1256,7 @@ const _buildMarketListCard = (slug, meta, priceData, historyData) => {
 
     const top3Keys = displayVendors.slice(0, 3).map(({ key }) => key);
     displayVendors.forEach(({ key, price }) => {
+      if (!_isMarketItemEnabled(slug, key)) return;
       const chip = document.createElement("span");
       chip.className = "vendor-chip";
 
@@ -1743,6 +1744,14 @@ const _getFilteredSortedSlugs = (query, sortKey) => {
       return meta.metal === _marketMetalFilter;
     });
   }
+  // STAK-515: Exclude slugs where ALL vendors are disabled by market filter
+  slugs = slugs.filter((slug) => {
+    const priceData = retailPrices && retailPrices.prices ? retailPrices.prices[slug] : null;
+    if (!priceData || !priceData.vendors) return true;
+    const vendorIds = Object.keys(priceData.vendors);
+    if (vendorIds.length === 0) return true;
+    return vendorIds.some((vid) => _isMarketItemEnabled(slug, vid));
+  });
   if (query && query.trim()) {
     const q = query.trim().toLowerCase();
     slugs = slugs.filter((slug) => {

--- a/js/retail.js
+++ b/js/retail.js
@@ -791,7 +791,7 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
   }
   _retailSyncInProgress = true;
   _retailSyncError = false;
-  renderRetailCards();
+  try { renderRetailCards(); } catch { /* settings panel may not have retail grid */ }
 
   try {
     // STAK-503: v2 API branch

--- a/js/retail.js
+++ b/js/retail.js
@@ -99,6 +99,39 @@ let _manifestSlugs = null;
 let _manifestCoinMeta = null;
 let _manifestVendorMeta = null;
 
+// ---------------------------------------------------------------------------
+// Market Filter — user-configurable slug/vendor visibility (STAK-515)
+// ---------------------------------------------------------------------------
+let _marketFilterCache = null;
+
+const _loadMarketFilter = () => {
+  if (_marketFilterCache !== null) return _marketFilterCache;
+  try {
+    _marketFilterCache = loadDataSync(MARKET_FILTER_KEY, {});
+    if (typeof _marketFilterCache !== 'object' || _marketFilterCache === null || Array.isArray(_marketFilterCache)) {
+      _marketFilterCache = {};
+    }
+  } catch {
+    _marketFilterCache = {};
+  }
+  return _marketFilterCache;
+};
+
+const _saveMarketFilter = (filter) => {
+  _marketFilterCache = filter;
+  saveDataSync(MARKET_FILTER_KEY, filter);
+};
+
+const _isMarketItemEnabled = (slug, vendorId) => {
+  const f = _loadMarketFilter();
+  if (!f[slug]) return true;
+  return f[slug][vendorId] !== false;
+};
+
+const _invalidateMarketFilterCache = () => {
+  _marketFilterCache = null;
+};
+
 /** Slugs excluded from market card display — baseline references, not user-facing products. */
 const _HIDDEN_SLUGS = new Set(["goldback-g1"]);
 
@@ -2244,6 +2277,10 @@ if (typeof window !== "undefined") {
   window.getVendorDisplay = getVendorDisplay;
   window._parseGoldbackSlug = _parseGoldbackSlug;
   window.GOLDBACK_WEIGHTS = GOLDBACK_WEIGHTS;
+  window._isMarketItemEnabled = _isMarketItemEnabled;
+  window._invalidateMarketFilterCache = _invalidateMarketFilterCache;
+  window._loadMarketFilter = _loadMarketFilter;
+  window._saveMarketFilter = _saveMarketFilter;
 }
 
 // =============================================================================

--- a/js/retail.js
+++ b/js/retail.js
@@ -786,9 +786,8 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
   const syncStatus = safeGetElement("retailSyncStatus");
 
   if (ui) {
-    syncBtn.disabled = true;
-    syncBtn.textContent = "Syncing…";
-    syncStatus.textContent = "";
+    if (syncBtn) { syncBtn.disabled = true; syncBtn.textContent = "Syncing\u2026"; }
+    if (syncStatus) { syncStatus.textContent = ""; }
   }
   _retailSyncInProgress = true;
   _retailSyncError = false;
@@ -918,7 +917,7 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
     if (successCount === 0 && slugs.length > 0) {
       const errorMsg = "All coin price fetches failed — check your network connection.";
       debugLog(`[retail] ${errorMsg}`, "error");
-      if (ui) syncStatus.textContent = errorMsg;
+      if (ui && syncStatus) syncStatus.textContent = errorMsg;
       _appendSyncLogEntry({ success: false, coins: 0, window: null, error: errorMsg });
       _retailSyncError = true;
       return;
@@ -932,14 +931,14 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
     }
 
     const statusMsg = `Synced ${successCount} coin(s) · ${manifest.latest_window || "unknown window"}`;
-    if (ui) syncStatus.textContent = statusMsg;
+    if (ui && syncStatus) syncStatus.textContent = statusMsg;
     debugLog(`[retail] Sync complete: ${statusMsg}`, "info");
     _appendSyncLogEntry({ success: true, coins: successCount, window: manifest.latest_window || null, error: null });
     if (typeof updateMarketHealthDot === 'function') updateMarketHealthDot();
   } catch (err) {
     _retailSyncError = true;
     debugLog(`[retail] Sync error: ${err.message}`, "warn");
-    if (ui) syncStatus.textContent = `Sync failed: ${err.message}`;
+    if (ui && syncStatus) syncStatus.textContent = `Sync failed: ${err.message}`;
     _appendSyncLogEntry({ success: false, coins: 0, window: null, error: err.message });
   } finally {
     _retailSyncInProgress = false;
@@ -950,7 +949,7 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
     }
     // STAK-504: Refresh main-page market data (ticker + vendor table) after sync
     if (typeof refreshMarketData === 'function') refreshMarketData();
-    if (ui) {
+    if (ui && syncBtn) {
       syncBtn.disabled = false;
       syncBtn.textContent = "Sync Now";
     }

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1081,6 +1081,142 @@ const bindApiCacheListeners = () => {
 };
 
 /**
+ * Wires up Market Filter Matrix listeners (STAK-515).
+ * Delegated change handler on the matrix table + metal pill filtering.
+ */
+const bindMarketFilterListeners = () => {
+  const table = safeGetElement('marketFilterMatrix');
+  if (table) {
+    table.addEventListener('change', (e) => {
+      const cb = e.target;
+      if (cb.type !== 'checkbox' || cb.disabled) return;
+
+      const slug = cb.getAttribute('data-slug');
+      const vendor = cb.getAttribute('data-vendor');
+      const rowToggle = cb.getAttribute('data-row-toggle');
+      const colToggle = cb.getAttribute('data-col-toggle');
+
+      const filter = typeof _loadMarketFilter === 'function' ? _loadMarketFilter() : {};
+      const slugs = typeof getActiveRetailSlugs === 'function' ? getActiveRetailSlugs() : [];
+      const vendorSource = (typeof _manifestVendorMeta !== 'undefined' && _manifestVendorMeta)
+        ? _manifestVendorMeta
+        : (typeof RETAIL_VENDOR_NAMES !== 'undefined' ? RETAIL_VENDOR_NAMES : {});
+      const vendorIds = Object.keys(vendorSource);
+
+      if (slug && vendor) {
+        // Individual cell toggle
+        if (!filter[slug]) filter[slug] = {};
+        filter[slug][vendor] = cb.checked ? undefined : false;
+        // Clean up: remove key if truthy (default enabled)
+        if (filter[slug][vendor] === undefined) delete filter[slug][vendor];
+        if (Object.keys(filter[slug]).length === 0) delete filter[slug];
+
+      } else if (rowToggle) {
+        // Row toggle — set all vendors for this slug
+        const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(rowToggle) : [];
+        if (!cb.checked) {
+          if (!filter[rowToggle]) filter[rowToggle] = {};
+          available.forEach((vid) => { filter[rowToggle][vid] = false; });
+        } else {
+          delete filter[rowToggle];
+        }
+
+      } else if (colToggle) {
+        // Column toggle — set this vendor for all slugs
+        slugs.forEach((s) => {
+          const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(s) : [];
+          if (available.indexOf(colToggle) === -1) return;
+          if (!cb.checked) {
+            if (!filter[s]) filter[s] = {};
+            filter[s][colToggle] = false;
+          } else {
+            if (filter[s]) {
+              delete filter[s][colToggle];
+              if (Object.keys(filter[s]).length === 0) delete filter[s];
+            }
+          }
+        });
+
+      } else if (cb.classList.contains('mfm-master-toggle')) {
+        // Master toggle — toggle everything
+        slugs.forEach((s) => {
+          const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(s) : [];
+          if (!cb.checked) {
+            if (!filter[s]) filter[s] = {};
+            available.forEach((vid) => { filter[s][vid] = false; });
+          } else {
+            delete filter[s];
+          }
+        });
+      }
+
+      if (typeof _saveMarketFilter === 'function') _saveMarketFilter(filter);
+      if (typeof _invalidateMarketFilterCache === 'function') _invalidateMarketFilterCache();
+      if (typeof renderMarketFilterMatrix === 'function') renderMarketFilterMatrix();
+      if (typeof renderBestPriceTicker === 'function') renderBestPriceTicker();
+      if (typeof _renderMarketListView === 'function') _renderMarketListView();
+    });
+  }
+
+  // Metal pill filtering
+  const pillContainer = safeGetElement('marketFilterMetalPills');
+  if (pillContainer) {
+    pillContainer.addEventListener('click', (e) => {
+      const pill = e.target.closest('[data-metal]');
+      if (!pill) return;
+
+      const metal = pill.getAttribute('data-metal');
+
+      // Update active pill
+      pillContainer.querySelectorAll('[data-metal]').forEach((p) => {
+        const isActive = p === pill;
+        p.classList.toggle('active', isActive);
+        p.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+
+      // Filter matrix rows
+      const tbody = safeGetElement('marketFilterMatrixBody');
+      if (!tbody) return;
+
+      const rows = tbody.querySelectorAll('tr');
+      let visibleCount = 0;
+      rows.forEach((row) => {
+        if (row.classList.contains('mfm-all-row')) {
+          row.style.display = '';
+          return;
+        }
+        const rowMetal = row.getAttribute('data-metal');
+        if (metal === 'all' || rowMetal === metal) {
+          row.style.display = '';
+          visibleCount++;
+        } else {
+          row.style.display = 'none';
+        }
+      });
+
+      // Update status line with filtered count
+      const statusEl = safeGetElement('marketFilterStatus');
+      if (statusEl && metal !== 'all') {
+        const current = statusEl.textContent;
+        const match = current.match(/·(.+)$/);
+        const vendorPart = match ? ' \u00b7' + match[1] : '';
+        statusEl.textContent = 'Showing ' + visibleCount + ' products' + vendorPart;
+      } else if (statusEl && typeof renderMarketFilterMatrix === 'function') {
+        // Re-render to get accurate global count
+        renderMarketFilterMatrix();
+        // Re-apply pill active state after re-render
+        if (pillContainer) {
+          pillContainer.querySelectorAll('[data-metal]').forEach((p) => {
+            p.classList.toggle('active', p.getAttribute('data-metal') === metal);
+            p.setAttribute('aria-pressed', p.getAttribute('data-metal') === metal ? 'true' : 'false');
+          });
+        }
+      }
+    });
+  }
+};
+
+/**
  * Wires up all Settings modal event listeners.
  * Called once during initialization.
  */
@@ -1097,6 +1233,7 @@ const setupSettingsEventListeners = () => {
   bindStorageListeners();
   bindRetailMarketListeners();
   bindApiCacheListeners();
+  bindMarketFilterListeners();
 };
 
 if (typeof window !== 'undefined') {

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1097,26 +1097,42 @@ const bindMarketFilterListeners = () => {
       const colToggle = cb.getAttribute('data-col-toggle');
 
       const filter = typeof _loadMarketFilter === 'function' ? _loadMarketFilter() : {};
-      const slugs = typeof getActiveRetailSlugs === 'function' ? getActiveRetailSlugs() : [];
+      const allSlugs = typeof getActiveRetailSlugs === 'function' ? getActiveRetailSlugs() : [];
       const vendorSource = (typeof _manifestVendorMeta !== 'undefined' && _manifestVendorMeta)
         ? _manifestVendorMeta
         : (typeof RETAIL_VENDOR_NAMES !== 'undefined' ? RETAIL_VENDOR_NAMES : {});
       const vendorIds = Object.keys(vendorSource);
 
+      // Determine active metal pill — scope column/master toggles to visible rows only
+      const activePill = document.querySelector('#marketFilterMetalPills .market-filter-pill.active');
+      const activeMetal = activePill ? activePill.getAttribute('data-metal') : 'all';
+      const slugs = activeMetal === 'all' ? allSlugs : allSlugs.filter((s) => {
+        const m = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(s) : { metal: 'unknown' };
+        return (m.metal || '').toLowerCase() === activeMetal;
+      });
+
+      // Helper: get effective vendor list for a slug (all vendors if no price data yet)
+      const _effectiveVendors = (s) => {
+        const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(s) : [];
+        return available.length > 0 ? available : vendorIds;
+      };
+
       if (slug && vendor) {
         // Individual cell toggle
         if (!filter[slug]) filter[slug] = {};
-        filter[slug][vendor] = cb.checked ? undefined : false;
-        // Clean up: remove key if truthy (default enabled)
-        if (filter[slug][vendor] === undefined) delete filter[slug][vendor];
-        if (Object.keys(filter[slug]).length === 0) delete filter[slug];
+        if (cb.checked) {
+          delete filter[slug][vendor];
+          if (Object.keys(filter[slug]).length === 0) delete filter[slug];
+        } else {
+          filter[slug][vendor] = false;
+        }
 
       } else if (rowToggle) {
         // Row toggle — set all vendors for this slug
-        const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(rowToggle) : [];
+        const effective = _effectiveVendors(rowToggle);
         if (!cb.checked) {
           if (!filter[rowToggle]) filter[rowToggle] = {};
-          available.forEach((vid) => { filter[rowToggle][vid] = false; });
+          effective.forEach((vid) => { filter[rowToggle][vid] = false; });
         } else {
           delete filter[rowToggle];
         }
@@ -1124,8 +1140,8 @@ const bindMarketFilterListeners = () => {
       } else if (colToggle) {
         // Column toggle — set this vendor for all slugs
         slugs.forEach((s) => {
-          const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(s) : [];
-          if (available.indexOf(colToggle) === -1) return;
+          const effective = _effectiveVendors(s);
+          if (effective.indexOf(colToggle) === -1) return;
           if (!cb.checked) {
             if (!filter[s]) filter[s] = {};
             filter[s][colToggle] = false;
@@ -1140,10 +1156,10 @@ const bindMarketFilterListeners = () => {
       } else if (cb.classList.contains('mfm-master-toggle')) {
         // Master toggle — toggle everything
         slugs.forEach((s) => {
-          const available = typeof _getAvailableVendorsForSlug === 'function' ? _getAvailableVendorsForSlug(s) : [];
+          const effective = _effectiveVendors(s);
           if (!cb.checked) {
             if (!filter[s]) filter[s] = {};
-            available.forEach((vid) => { filter[s][vid] = false; });
+            effective.forEach((vid) => { filter[s][vid] = false; });
           } else {
             delete filter[s];
           }
@@ -1154,7 +1170,7 @@ const bindMarketFilterListeners = () => {
       if (typeof _invalidateMarketFilterCache === 'function') _invalidateMarketFilterCache();
       if (typeof renderMarketFilterMatrix === 'function') renderMarketFilterMatrix();
       if (typeof renderBestPriceTicker === 'function') renderBestPriceTicker();
-      if (typeof _renderMarketListView === 'function') _renderMarketListView();
+      if (typeof renderVendorPrices === 'function') renderVendorPrices();
     });
   }
 
@@ -1174,7 +1190,13 @@ const bindMarketFilterListeners = () => {
         p.setAttribute('aria-pressed', isActive ? 'true' : 'false');
       });
 
-      // Filter matrix rows
+      // Re-render matrix with pill-scoped toggle states
+      if (typeof renderMarketFilterMatrix === 'function') {
+        renderMarketFilterMatrix();
+        return;
+      }
+
+      // Fallback: manual row filtering if render not available
       const tbody = safeGetElement('marketFilterMatrixBody');
       if (!tbody) return;
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -77,9 +77,9 @@ const switchSettingsSection = (name) => {
     switchLogTab(activeKey);
   }
 
-  // Render coin price cards when switching to the market section
-  if (targetName === 'market' && typeof renderRetailCards === 'function') {
-    renderRetailCards();
+  // Render market filter matrix when switching to the market section
+  if (targetName === 'market' && typeof renderMarketFilterMatrix === 'function') {
+    renderMarketFilterMatrix();
   }
 
   // Populate Storage section when switching to it
@@ -2329,6 +2329,214 @@ const renderNumistaTagSettings = () => {
   renderBlacklist();
 };
 
+// ---------------------------------------------------------------------------
+// Market Filter Matrix (STAK-515)
+// ---------------------------------------------------------------------------
+
+const _getAvailableVendorsForSlug = (slug) => {
+  if (!retailPrices || !retailPrices.prices || !retailPrices.prices[slug] || !retailPrices.prices[slug].vendors) return [];
+  return Object.keys(retailPrices.prices[slug].vendors);
+};
+
+const renderMarketFilterMatrix = () => {
+  const thead = safeGetElement('marketFilterMatrixHead');
+  const tbody = safeGetElement('marketFilterMatrixBody');
+  const statusEl = safeGetElement('marketFilterStatus');
+  if (!thead || !tbody) return;
+
+  const slugs = typeof getActiveRetailSlugs === 'function' ? getActiveRetailSlugs() : [];
+  const filter = typeof _loadMarketFilter === 'function' ? _loadMarketFilter() : {};
+
+  // Build vendor list from manifest or fallback constants
+  const vendorSource = (typeof _manifestVendorMeta !== 'undefined' && _manifestVendorMeta)
+    ? _manifestVendorMeta
+    : (typeof RETAIL_VENDOR_NAMES !== 'undefined' ? RETAIL_VENDOR_NAMES : {});
+  const vendors = Object.keys(vendorSource).map((id) => {
+    if (typeof getVendorDisplay === 'function') {
+      const info = getVendorDisplay(id);
+      return { id, name: info.name || id, color: info.color || '#6c757d' };
+    }
+    const colors = typeof RETAIL_VENDOR_COLORS !== 'undefined' ? RETAIL_VENDOR_COLORS : {};
+    return { id, name: vendorSource[id]?.name || vendorSource[id] || id, color: colors[id] || '#6c757d' };
+  });
+
+  // --- thead ---
+  while (thead.firstChild) thead.removeChild(thead.firstChild);
+  const headerRow = document.createElement('tr');
+
+  const thProduct = document.createElement('th');
+  thProduct.textContent = 'PRODUCT';
+  headerRow.appendChild(thProduct);
+
+  const thAll = document.createElement('th');
+  thAll.textContent = 'ALL';
+  headerRow.appendChild(thAll);
+
+  vendors.forEach((v) => {
+    const th = document.createElement('th');
+    const dot = document.createElement('span');
+    dot.className = 'vendor-dot';
+    dot.style.background = v.color;
+    th.appendChild(dot);
+    th.appendChild(document.createTextNode(v.name));
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+
+  // --- ALL row (column toggles) ---
+  while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
+  const allRow = document.createElement('tr');
+  allRow.className = 'mfm-all-row';
+
+  const allLabelTd = document.createElement('td');
+  allLabelTd.textContent = 'ALL';
+  allRow.appendChild(allLabelTd);
+
+  const masterTd = document.createElement('td');
+  const masterCb = document.createElement('input');
+  masterCb.type = 'checkbox';
+  masterCb.title = 'Toggle everything';
+  masterCb.className = 'mfm-master-toggle';
+  masterTd.appendChild(masterCb);
+  allRow.appendChild(masterTd);
+
+  vendors.forEach((v) => {
+    const td = document.createElement('td');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.setAttribute('data-col-toggle', v.id);
+    cb.title = 'Toggle all ' + v.name;
+    td.appendChild(cb);
+    allRow.appendChild(td);
+  });
+  tbody.appendChild(allRow);
+
+  // --- Product rows ---
+  slugs.forEach((slug) => {
+    const meta = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(slug) : { name: slug, metal: 'unknown' };
+    const metal = (meta.metal || 'unknown').toLowerCase();
+    const available = _getAvailableVendorsForSlug(slug);
+
+    const tr = document.createElement('tr');
+    tr.setAttribute('data-metal', metal);
+
+    const nameTd = document.createElement('td');
+    nameTd.className = 'mfm-product-name';
+    nameTd.textContent = meta.name;
+    tr.appendChild(nameTd);
+
+    const rowAllTd = document.createElement('td');
+    const rowCb = document.createElement('input');
+    rowCb.type = 'checkbox';
+    rowCb.setAttribute('data-row-toggle', slug);
+    rowCb.title = 'Toggle all for ' + meta.name;
+    rowAllTd.appendChild(rowCb);
+    tr.appendChild(rowAllTd);
+
+    let rowTotal = 0;
+    let rowChecked = 0;
+
+    vendors.forEach((v) => {
+      const td = document.createElement('td');
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      const hasData = available.indexOf(v.id) !== -1;
+      if (!hasData) {
+        cb.disabled = true;
+        cb.checked = false;
+      } else {
+        cb.setAttribute('data-slug', slug);
+        cb.setAttribute('data-vendor', v.id);
+        const isEnabled = typeof _isMarketItemEnabled === 'function' ? _isMarketItemEnabled(slug, v.id) : true;
+        cb.checked = isEnabled;
+        rowTotal++;
+        if (isEnabled) rowChecked++;
+      }
+      td.appendChild(cb);
+      tr.appendChild(td);
+    });
+
+    // Set row toggle state
+    rowCb.checked = rowTotal > 0 && rowChecked === rowTotal;
+    rowCb.indeterminate = rowChecked > 0 && rowChecked < rowTotal;
+    if (rowTotal === 0) rowCb.disabled = true;
+
+    tbody.appendChild(tr);
+  });
+
+  // --- Sync column toggle states ---
+  vendors.forEach((v) => {
+    const colCb = tbody.querySelector(`input[data-col-toggle="${v.id}"]`);
+    if (!colCb) return;
+    let colTotal = 0;
+    let colChecked = 0;
+    slugs.forEach((slug) => {
+      const available = _getAvailableVendorsForSlug(slug);
+      if (available.indexOf(v.id) !== -1) {
+        colTotal++;
+        if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, v.id)) colChecked++;
+      }
+    });
+    colCb.checked = colTotal > 0 && colChecked === colTotal;
+    colCb.indeterminate = colChecked > 0 && colChecked < colTotal;
+    if (colTotal === 0) { colCb.disabled = true; colCb.checked = false; }
+  });
+
+  // --- Sync master toggle ---
+  let grandTotal = 0;
+  let grandChecked = 0;
+  slugs.forEach((slug) => {
+    const available = _getAvailableVendorsForSlug(slug);
+    available.forEach((vid) => {
+      grandTotal++;
+      if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, vid)) grandChecked++;
+    });
+  });
+  masterCb.checked = grandTotal > 0 && grandChecked === grandTotal;
+  masterCb.indeterminate = grandChecked > 0 && grandChecked < grandTotal;
+
+  // --- Status line ---
+  if (statusEl) {
+    const activeVendors = {};
+    slugs.forEach((slug) => {
+      const available = _getAvailableVendorsForSlug(slug);
+      available.forEach((vid) => {
+        if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, vid)) {
+          activeVendors[vid] = true;
+        }
+      });
+    });
+    const enabledCount = grandChecked;
+    const activeVendorCount = Object.keys(activeVendors).length;
+    const totalVendors = vendors.filter((v) => {
+      return slugs.some((slug) => _getAvailableVendorsForSlug(slug).indexOf(v.id) !== -1);
+    }).length;
+    statusEl.textContent = 'Showing ' + enabledCount + ' items \u00b7 ' + activeVendorCount + ' of ' + totalVendors + ' vendors active';
+  }
+
+  // --- Sync button & last sync ---
+  const syncBtn = safeGetElement('marketFilterSyncBtn');
+  if (syncBtn && !syncBtn._mfmBound) {
+    syncBtn._mfmBound = true;
+    syncBtn.addEventListener('click', () => {
+      if (typeof syncRetailPrices === 'function') syncRetailPrices();
+    });
+  }
+
+  const lastSyncEl = safeGetElement('marketFilterLastSync');
+  if (lastSyncEl && typeof retailPrices !== 'undefined' && retailPrices && retailPrices.lastSync) {
+    const d = new Date(retailPrices.lastSync);
+    const elapsed = Date.now() - d.getTime();
+    if (elapsed < 60000) {
+      lastSyncEl.textContent = 'Last sync: just now';
+    } else if (elapsed < 3600000) {
+      lastSyncEl.textContent = 'Last sync: ' + Math.round(elapsed / 60000) + 'm ago';
+    } else {
+      lastSyncEl.textContent = 'Last sync: ' + d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+    }
+  }
+};
+
 // Expose globally
 if (typeof window !== 'undefined') {
   window.showSettingsModal = showSettingsModal;
@@ -2347,4 +2555,5 @@ if (typeof window !== 'undefined') {
   window.populateImagesSection = populateImagesSection;
   window.renderStorageSection = renderStorageSection;
   window.renderNumistaTagSettings = renderNumistaTagSettings;
+  window.renderMarketFilterMatrix = renderMarketFilterMatrix;
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -2378,7 +2378,10 @@ const renderMarketFilterMatrix = () => {
     dot.className = 'vendor-dot';
     dot.style.background = v.color;
     th.appendChild(dot);
-    th.appendChild(document.createTextNode(v.name));
+    // Ultra-short vendor names for compact matrix headers
+    const _vendorAbbrev = { 'APMEX': 'APX', 'Monument': 'MON', 'Gainesville': 'GVL', 'Provident': 'PRV', 'BullionX': 'BLX', 'Summit': 'SMT', 'Hero': 'HRO', 'Goldback': 'GB' };
+    th.appendChild(document.createTextNode(_vendorAbbrev[v.name] || v.name));
+    th.title = v.name; // Full name on hover
     headerRow.appendChild(th);
   });
   thead.appendChild(headerRow);
@@ -2412,7 +2415,12 @@ const renderMarketFilterMatrix = () => {
   tbody.appendChild(allRow);
 
   // --- Product rows ---
-  slugs.forEach((slug) => {
+  // Filter out slugs with no resolved display name (e.g. goldback-g10 denomination stubs)
+  const displaySlugs = slugs.filter((slug) => {
+    const m = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(slug) : { name: slug };
+    return m.name !== slug;
+  });
+  displaySlugs.forEach((slug) => {
     const meta = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(slug) : { name: slug, metal: 'unknown' };
     const metal = (meta.metal || 'unknown').toLowerCase();
     const available = _getAvailableVendorsForSlug(slug);
@@ -2422,7 +2430,14 @@ const renderMarketFilterMatrix = () => {
 
     const nameTd = document.createElement('td');
     nameTd.className = 'mfm-product-name';
-    nameTd.textContent = meta.name;
+    // Abbreviate product names: strip weight/purity suffixes for compact display
+    const shortName = (meta.name || slug)
+      .replace(/\s*\(1\/1000 oz gold\)/i, '')  // Goldback weight suffix
+      .replace(/\s*\(\.\d+\)/i, '')             // (.999) purity
+      .replace(/\s+1\s*oz$/i, '')               // trailing "1 oz"
+      .replace(/\s+10\s*oz$/i, ' 10oz');         // "10 oz" → compact
+    nameTd.textContent = shortName;
+    nameTd.title = meta.name; // Full name on hover
     tr.appendChild(nameTd);
 
     const rowAllTd = document.createElement('td');
@@ -2436,11 +2451,15 @@ const renderMarketFilterMatrix = () => {
     let rowTotal = 0;
     let rowChecked = 0;
 
+    // When no price data is available (e.g. file:// or before first sync),
+    // treat all vendor combos as available so checkboxes are enabled.
+    const hasAnyData = available.length > 0;
+
     vendors.forEach((v) => {
       const td = document.createElement('td');
       const cb = document.createElement('input');
       cb.type = 'checkbox';
-      const hasData = available.indexOf(v.id) !== -1;
+      const hasData = !hasAnyData || available.indexOf(v.id) !== -1;
       if (!hasData) {
         cb.disabled = true;
         cb.checked = false;
@@ -2464,15 +2483,25 @@ const renderMarketFilterMatrix = () => {
     tbody.appendChild(tr);
   });
 
-  // --- Sync column toggle states ---
+  // --- Determine visible slugs for ALL row toggle scoping ---
+  const activePillEl = document.querySelector('#marketFilterMetalPills .market-filter-pill.active');
+  const activeMetalFilter = activePillEl ? activePillEl.getAttribute('data-metal') : 'all';
+  const visibleSlugs = activeMetalFilter === 'all' ? displaySlugs : displaySlugs.filter((s) => {
+    const m = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(s) : { metal: 'unknown' };
+    return (m.metal || '').toLowerCase() === activeMetalFilter;
+  });
+
+  // --- Sync column toggle states (scoped to visible slugs) ---
+  const anySlugHasData = visibleSlugs.some((s) => _getAvailableVendorsForSlug(s).length > 0);
   vendors.forEach((v) => {
     const colCb = tbody.querySelector(`input[data-col-toggle="${v.id}"]`);
     if (!colCb) return;
     let colTotal = 0;
     let colChecked = 0;
-    slugs.forEach((slug) => {
+    visibleSlugs.forEach((slug) => {
       const available = _getAvailableVendorsForSlug(slug);
-      if (available.indexOf(v.id) !== -1) {
+      const isAvailable = !anySlugHasData || available.indexOf(v.id) !== -1;
+      if (isAvailable) {
         colTotal++;
         if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, v.id)) colChecked++;
       }
@@ -2482,57 +2511,61 @@ const renderMarketFilterMatrix = () => {
     if (colTotal === 0) { colCb.disabled = true; colCb.checked = false; }
   });
 
-  // --- Sync master toggle ---
+  // --- Sync master toggle (scoped to visible slugs) ---
   let grandTotal = 0;
   let grandChecked = 0;
-  slugs.forEach((slug) => {
+  visibleSlugs.forEach((slug) => {
     const available = _getAvailableVendorsForSlug(slug);
-    available.forEach((vid) => {
-      grandTotal++;
-      if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, vid)) grandChecked++;
-    });
+    const hasAny = available.length > 0;
+    if (hasAny) {
+      available.forEach((vid) => {
+        grandTotal++;
+        if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, vid)) grandChecked++;
+      });
+    } else {
+      // No price data — count all vendors as available
+      vendors.forEach((v) => {
+        grandTotal++;
+        if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, v.id)) grandChecked++;
+      });
+    }
   });
   masterCb.checked = grandTotal > 0 && grandChecked === grandTotal;
   masterCb.indeterminate = grandChecked > 0 && grandChecked < grandTotal;
 
   // --- Status line ---
-  if (statusEl) {
-    const activeVendors = {};
-    slugs.forEach((slug) => {
-      const available = _getAvailableVendorsForSlug(slug);
-      available.forEach((vid) => {
-        if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, vid)) {
-          activeVendors[vid] = true;
-        }
-      });
+  const activeVendors = {};
+  displaySlugs.forEach((slug) => {
+    const available = _getAvailableVendorsForSlug(slug);
+    const effective = available.length > 0 ? available : vendors.map((v) => v.id);
+    effective.forEach((vid) => {
+      if (typeof _isMarketItemEnabled === 'function' && _isMarketItemEnabled(slug, vid)) {
+        activeVendors[vid] = true;
+      }
     });
-    const enabledCount = grandChecked;
-    const activeVendorCount = Object.keys(activeVendors).length;
-    const totalVendors = vendors.filter((v) => {
-      return slugs.some((slug) => _getAvailableVendorsForSlug(slug).indexOf(v.id) !== -1);
-    }).length;
+  });
+  const enabledCount = grandChecked;
+  const activeVendorCount = Object.keys(activeVendors).length;
+  const totalVendors = vendors.length;
+  if (statusEl) {
     statusEl.textContent = 'Showing ' + enabledCount + ' items \u00b7 ' + activeVendorCount + ' of ' + totalVendors + ' vendors active';
   }
 
-  // --- Sync button & last sync ---
-  const syncBtn = safeGetElement('marketFilterSyncBtn');
-  if (syncBtn && !syncBtn._mfmBound) {
-    syncBtn._mfmBound = true;
-    syncBtn.addEventListener('click', () => {
-      if (typeof syncRetailPrices === 'function') syncRetailPrices();
+  // Re-apply active metal pill filter after re-render
+  if (activeMetalFilter !== 'all') {
+    const rows = tbody.querySelectorAll('tr');
+    let visibleProductCount = 0;
+    rows.forEach((row) => {
+      if (row.classList.contains('mfm-all-row')) return;
+      const rowMetal = row.getAttribute('data-metal');
+      if (rowMetal && rowMetal !== activeMetalFilter) {
+        row.style.display = 'none';
+      } else {
+        visibleProductCount++;
+      }
     });
-  }
-
-  const lastSyncEl = safeGetElement('marketFilterLastSync');
-  if (lastSyncEl && typeof retailPrices !== 'undefined' && retailPrices && retailPrices.lastSync) {
-    const d = new Date(retailPrices.lastSync);
-    const elapsed = Date.now() - d.getTime();
-    if (elapsed < 60000) {
-      lastSyncEl.textContent = 'Last sync: just now';
-    } else if (elapsed < 3600000) {
-      lastSyncEl.textContent = 'Last sync: ' + Math.round(elapsed / 60000) + 'm ago';
-    } else {
-      lastSyncEl.textContent = 'Last sync: ' + d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+    if (statusEl) {
+      statusEl.textContent = 'Showing ' + visibleProductCount + ' products \u00b7 ' + activeVendorCount + ' of ' + totalVendors + ' vendors active';
     }
   }
 };

--- a/js/settings.js
+++ b/js/settings.js
@@ -2342,10 +2342,9 @@ const renderMarketFilterMatrix = () => {
   const thead = safeGetElement('marketFilterMatrixHead');
   const tbody = safeGetElement('marketFilterMatrixBody');
   const statusEl = safeGetElement('marketFilterStatus');
-  if (!thead || !tbody) return;
+  if (!thead || !thead.id || !tbody || !tbody.id) return;
 
   const slugs = typeof getActiveRetailSlugs === 'function' ? getActiveRetailSlugs() : [];
-  const filter = typeof _loadMarketFilter === 'function' ? _loadMarketFilter() : {};
 
   // Build vendor list from manifest or fallback constants
   const vendorSource = (typeof _manifestVendorMeta !== 'undefined' && _manifestVendorMeta)

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774839161';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774839249';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774835678';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774835757';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774838829';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774839161';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774835982';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774836253';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774839249';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774840608';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774821033';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774835678';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774836253';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774838745';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774835826';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774835862';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774835862';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774835979';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774835979';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774835982';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774838745';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774838829';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.88-b1774835757';
+const CACHE_NAME = 'staktrakr-v3.33.88-b1774835826';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.88",
+  "version": "3.33.89",
   "releaseDate": "2026-03-29",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Summary

- **Settings > Market redesigned**: Replaced legacy retail price cards grid with interactive checkbox filter matrix (product rows × vendor columns)
- **Metal pill tab scoping**: Gold/Silver/Platinum/Palladium/Goldback pills filter the matrix view, ALL row toggles scoped to visible metal
- **Filter consumption**: Ticker (`renderBestPriceTicker`) and vendor prices table (`_renderVendorTable`) respect filter — disabled items/vendors excluded from display and price calculations
- **Vendor tab visibility**: Metal tabs in vendor prices section hidden when all slugs for that metal are disabled
- **Compact UI**: Abbreviated product/vendor names, 11px font, tight padding — fits without horizontal scroll
- **Sync fix**: Guarded `syncRetailPrices()` against removed DOM elements (retailSyncBtn/retailSyncStatus)

## Vault Issues

- STAK-515: Replace Market Settings tab with Ticker & Market Filter controls
- STAK-516: Follow-up — Vendor prices refresh button and timestamp stuck on file://

## Files Changed

- `js/constants.js` — MARKET_FILTER_KEY constant + ALLOWED_STORAGE_KEYS
- `js/retail.js` — Filter helpers, consumption guards in _getFilteredSortedSlugs + card builder, sync DOM guards
- `js/market-data.js` — Filter guards in renderBestPriceTicker + _renderVendorTable + metal tab visibility
- `js/settings.js` — renderMarketFilterMatrix() with metal-scoped toggle states
- `js/settings-listeners.js` — Delegated checkbox/pill handlers with metal-scoped toggles
- `index.html` — Gutted settingsPanel_market, replaced with filter matrix HTML
- `css/styles.css` — Market filter matrix styles
- Version bump: 3.33.88 → 3.33.89

🤖 Generated with [Claude Code](https://claude.com/claude-code)