### PR TITLE
chore: GSD session 2026-03-31

### DIFF
--- a/about.html
+++ b/about.html
@@ -400,7 +400,7 @@
         <a href="https://www.staktrakr.com" class="btn btn-primary">Open StakTrakr</a>
         <a href="https://github.com/lbruton/StakTrakr" class="btn btn-outline">View Source</a>
       </div>
-      <img src="/screenshots/01-hero-overview.png" alt="StakTrakr dashboard showing spot prices, market ticker, and portfolio summary" class="screenshot" style="margin-top: 2.5rem; max-width: 900px; margin-left: auto; margin-right: auto;">
+      <img src="./screenshots/01-hero-overview.png" alt="StakTrakr dashboard showing spot prices, market ticker, and portfolio summary" class="screenshot" style="margin-top: 2.5rem; max-width: 900px; margin-left: auto; margin-right: auto;">
     </div>
   </header>
 
@@ -464,9 +464,9 @@
           <p>Full-width cards with inline trend charts, brand-colored vendor chips, medal rankings, and MED/LOW/AVG stats.</p>
         </div>
       </div>
-      <img src="/screenshots/03-market-ticker.png" alt="Best Price Ticker showing cheapest vendor per coin with premium percentages" class="screenshot" style="margin-top: 1.5rem;">
+      <img src="./screenshots/03-market-ticker.png" alt="Best Price Ticker showing cheapest vendor per coin with premium percentages" class="screenshot" style="margin-top: 1.5rem;">
       <p class="screenshot-caption">Best Price Ticker &mdash; scrolling strip with cheapest vendor per coin</p>
-      <img src="/screenshots/04-vendor-prices.png" alt="Vendor Prices comparison table with per-dealer pricing across Silver, Gold, Platinum" class="screenshot">
+      <img src="./screenshots/04-vendor-prices.png" alt="Vendor Prices comparison table with per-dealer pricing across Silver, Gold, Platinum" class="screenshot">
       <p class="screenshot-caption">Vendor Price Matrix &mdash; side-by-side dealer comparison with buy links</p>
       <p style="color: var(--text-muted); font-size: 0.85rem; margin-top: 1.25rem;">
         Market price data is provided on a best-effort basis. Prices are scraped from public vendor pages hourly and may not reflect real-time changes, flash sales, or volume discounts. Always verify pricing directly with the dealer before purchasing.
@@ -507,8 +507,8 @@
         </div>
       </div>
       <div class="screenshot-grid">
-        <img src="/screenshots/03-inventory-table.png" alt="Inventory table with coin images, chip badges, and vendor prices">
-        <img src="/screenshots/06-item-view-modal.png" alt="Item view modal showing Canadian Gold Maple with price history chart">
+        <img src="./screenshots/03-inventory-table.png" alt="Inventory table with coin images, chip badges, and vendor prices">
+        <img src="./screenshots/06-item-view-modal.png" alt="Item view modal showing Canadian Gold Maple with price history chart">
       </div>
     </div>
   </section>
@@ -542,8 +542,8 @@
         </div>
       </div>
       <div class="screenshot-grid">
-        <img src="/screenshots/07-settings-about.png" alt="Settings modal About tab showing version info and What's New">
-        <img src="/screenshots/08-settings-appearance.png" alt="Settings Appearance tab with theme selector and header button configuration">
+        <img src="./screenshots/07-settings-about.png" alt="Settings modal About tab showing version info and What's New">
+        <img src="./screenshots/08-settings-appearance.png" alt="Settings Appearance tab with theme selector and header button configuration">
       </div>
     </div>
   </section>

--- a/js/retail.js
+++ b/js/retail.js
@@ -111,6 +111,14 @@ const _loadMarketFilter = () => {
     if (typeof _marketFilterCache !== 'object' || _marketFilterCache === null || Array.isArray(_marketFilterCache)) {
       _marketFilterCache = {};
     }
+    // STAK-520: Normalize per-slug entries — corrupted values (scalars, arrays)
+    // can survive cloud restore and crash checkbox interactions
+    for (const slug of Object.keys(_marketFilterCache)) {
+      const entry = _marketFilterCache[slug];
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        _marketFilterCache[slug] = {};
+      }
+    }
   } catch {
     _marketFilterCache = {};
   }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774840608';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774941630';
 
 
 


### PR DESCRIPTION
## GSD Session — Minor Fixes & Tweaks

### Changes
- **STAK-520:** Normalize per-slug market filter entries on load — corrupted nested state (scalars from cloud restore) now reset to `{}` instead of crashing checkbox interactions
- **STAK-522:** Fix about.html screenshot paths from root-relative (`/screenshots/`) to relative (`./screenshots/`) for `file://` compatibility

### Notes
- No version bump — rolls into next release
- Both fixes sourced from Codex adversarial review of v3.33.89

🤖 Generated with [Claude Code](https://claude.com/claude-code)