### PR TITLE
chore: remove r/Silverbugs shoutout, add beta pill (STAK-524)

### DIFF
--- a/about.html
+++ b/about.html
@@ -673,22 +673,20 @@
   </section>
 
   <!-- ================================================================== -->
-  <!-- SHOUTOUT                                                           -->
+  <!-- THANK YOU                                                          -->
   <!-- ================================================================== -->
   <section>
     <div class="container">
       <h2>Thank You</h2>
       <div class="shoutout">
         <p>
-          Big thanks to the <a href="https://www.reddit.com/r/Silverbugs/">r/Silverbugs</a> community
-          for the early enthusiasm that got this project off the ground, and to everyone on
-          <a href="https://www.reddit.com/r/staktrakr/">r/staktrakr</a> who's been testing, filing bugs,
-          and requesting features since the beginning.
-        </p>
-        <p>
           To the beta testers who stuck with the project through the cloud sync saga, the market page
           rewrites, and the occasional "why is my inventory empty" moment &mdash; your patience
           and detailed bug reports are the reason v3.33 is as solid as it is. This one's for you.
+        </p>
+        <p>
+          Join us on <a href="https://www.reddit.com/r/staktrakr/">r/staktrakr</a> for updates,
+          feature requests, and bug reports.
         </p>
       </div>
     </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -534,19 +534,13 @@ section {
 
 .version-badge--beta {
   background: var(--info);
-  color: #fff;
+  color: #000;
   cursor: pointer;
 }
 
 .version-badge--beta:hover {
   background: var(--info-hover);
   text-decoration: none;
-}
-
-.footer-beta {
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  margin-top: 0.25rem;
 }
 
 .api-health-badge {

--- a/css/styles.css
+++ b/css/styles.css
@@ -532,6 +532,23 @@ section {
   cursor: pointer;
 }
 
+.version-badge--beta {
+  background: var(--info);
+  color: #fff;
+  cursor: pointer;
+}
+
+.version-badge--beta:hover {
+  background: var(--info-hover);
+  text-decoration: none;
+}
+
+.footer-beta {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
 .api-health-badge {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -1868,8 +1868,8 @@
       <div class="footer-meta">
         <span>Thank you for using <span id="footerBrand">StakTrakr</span> <a id="versionBadge" class="version-badge" style="display: none"></a>. &copy; 2025-2026 <a id="footerDomain" href="https://staktrakr.com" target="_blank" rel="noopener">staktrakr.com</a>. &middot; <a href="#" onclick="if(window.showFaqModal){event.preventDefault();window.showFaqModal();}">FAQ</a> &middot; <button type="button" class="api-health-badge" id="apiHealthBadge" onclick="if(window.showApiHealthModal)window.showApiHealthModal()">Checking API…</button></span>
       </div>
-      <div class="footer-thanks">
-        Special thanks to the <a href="https://www.reddit.com/r/Silverbugs/" target="_blank" rel="noopener">r/Silverbugs</a> community for the feedback, bug reports, and encouragement that shaped this app.
+      <div class="footer-beta">
+        Try the latest build on <a href="https://beta.staktrakr.com" target="_blank" rel="noopener" class="version-badge version-badge--beta">beta</a>
       </div>
     </footer>
     <!-- =============================================================================

--- a/index.html
+++ b/index.html
@@ -1866,10 +1866,7 @@
       </div>
       <div class="storage-line">Storage: <span id="storageUsage"></span> <div class="storage-bar" id="storageBar"><div class="storage-bar-ls" id="storageBarLs" title="localStorage"></div><div class="storage-bar-idb" id="storageBarIdb" title="IndexedDB Images"></div></div></div>
       <div class="footer-meta">
-        <span>Thank you for using <span id="footerBrand">StakTrakr</span> <a id="versionBadge" class="version-badge" style="display: none"></a>. &copy; 2025-2026 <a id="footerDomain" href="https://staktrakr.com" target="_blank" rel="noopener">staktrakr.com</a>. &middot; <a href="#" onclick="if(window.showFaqModal){event.preventDefault();window.showFaqModal();}">FAQ</a> &middot; <button type="button" class="api-health-badge" id="apiHealthBadge" onclick="if(window.showApiHealthModal)window.showApiHealthModal()">Checking API…</button></span>
-      </div>
-      <div class="footer-beta">
-        Try the latest build on <a href="https://beta.staktrakr.com" target="_blank" rel="noopener" class="version-badge version-badge--beta">beta</a>
+        <span>Thank you for using <span id="footerBrand">StakTrakr</span> <a id="versionBadge" class="version-badge" style="display: none"></a> <a href="https://beta.staktrakr.com" target="_blank" rel="noopener" class="version-badge version-badge--beta">beta</a>. &copy; 2025-2026 <a id="footerDomain" href="https://staktrakr.com" target="_blank" rel="noopener">staktrakr.com</a>. &middot; <a href="#" onclick="if(window.showFaqModal){event.preventDefault();window.showFaqModal();}">FAQ</a> &middot; <button type="button" class="api-health-badge" id="apiHealthBadge" onclick="if(window.showApiHealthModal)window.showApiHealthModal()">Checking API…</button></span>
       </div>
     </footer>
     <!-- =============================================================================

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774840608';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774996829';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774996829';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774997120';
 
 
 


### PR DESCRIPTION
## Summary
- Remove "Special thanks to r/Silverbugs" row from main page footer
- Rewrite about.html shoutout section to focus on r/staktrakr community and beta testers
- Add a `beta` pill link in the footer pointing to beta.staktrakr.com, styled with `--info` color

## Test plan
- [ ] Verify footer no longer shows r/Silverbugs text on main page
- [ ] Verify about.html Thank You section updated (no Silverbugs reference)
- [ ] Verify beta pill renders with info-blue color and links to beta.staktrakr.com
- [ ] Verify pill hover state works
- [ ] Check all three themes (dark, light, sepia) for contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)