### PR TITLE
fix: market sync button stuck + stale renderRetailCards crash (STAK-523, STAK-525)

### DIFF
--- a/js/retail.js
+++ b/js/retail.js
@@ -765,7 +765,9 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
     saveRetailAvailability();
   }
 
-  const syncTime = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  const tz = (typeof TIMEZONE_KEY !== 'undefined' && localStorage.getItem(TIMEZONE_KEY)) || undefined;
+  const tzOpts = tz && tz !== 'auto' ? { timeZone: tz, hour: 'numeric', minute: '2-digit' } : { hour: 'numeric', minute: '2-digit' };
+  const syncTime = new Date().toLocaleTimeString(undefined, tzOpts);
   const statusMsg = `Synced ${successCount} coin(s) · ${syncTime}`;
   if (ui && syncStatus) syncStatus.textContent = statusMsg;
   debugLog(`[retail-v2] Sync complete: ${statusMsg}`, "info");
@@ -938,7 +940,9 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
       saveRetailAvailability();
     }
 
-    const v1SyncTime = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const v1Tz = (typeof TIMEZONE_KEY !== 'undefined' && localStorage.getItem(TIMEZONE_KEY)) || undefined;
+    const v1TzOpts = v1Tz && v1Tz !== 'auto' ? { timeZone: v1Tz, hour: 'numeric', minute: '2-digit' } : { hour: 'numeric', minute: '2-digit' };
+    const v1SyncTime = new Date().toLocaleTimeString(undefined, v1TzOpts);
     const statusMsg = `Synced ${successCount} coin(s) · ${v1SyncTime}`;
     if (ui && syncStatus) syncStatus.textContent = statusMsg;
     debugLog(`[retail] Sync complete: ${statusMsg}`, "info");

--- a/js/retail.js
+++ b/js/retail.js
@@ -765,7 +765,8 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
     saveRetailAvailability();
   }
 
-  const statusMsg = `Synced ${successCount} coin(s) [v2] · ${generatedAt || "unknown"}`;
+  const syncTime = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  const statusMsg = `Synced ${successCount} coin(s) · ${syncTime}`;
   if (ui && syncStatus) syncStatus.textContent = statusMsg;
   debugLog(`[retail-v2] Sync complete: ${statusMsg}`, "info");
   _appendSyncLogEntry({ success: true, coins: successCount, window: generatedAt || null, error: null });
@@ -799,7 +800,6 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
   }
   _retailSyncInProgress = true;
   _retailSyncError = false;
-  try { renderRetailCards(); } catch { /* settings panel may not have retail grid */ }
 
   try {
     // STAK-503: v2 API branch
@@ -938,7 +938,8 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
       saveRetailAvailability();
     }
 
-    const statusMsg = `Synced ${successCount} coin(s) · ${manifest.latest_window || "unknown window"}`;
+    const v1SyncTime = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const statusMsg = `Synced ${successCount} coin(s) · ${v1SyncTime}`;
     if (ui && syncStatus) syncStatus.textContent = statusMsg;
     debugLog(`[retail] Sync complete: ${statusMsg}`, "info");
     _appendSyncLogEntry({ success: true, coins: successCount, window: manifest.latest_window || null, error: null });
@@ -950,16 +951,19 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
     _appendSyncLogEntry({ success: false, coins: 0, window: null, error: err.message });
   } finally {
     _retailSyncInProgress = false;
-    renderRetailCards();
-    const mktLogActive = document.querySelector('[data-log-tab="market"].active');
-    if (mktLogActive && typeof renderRetailHistoryTable === "function") {
-      renderRetailHistoryTable();
-    }
-    // STAK-504: Refresh main-page market data (ticker + vendor table) after sync
-    if (typeof refreshMarketData === 'function') refreshMarketData();
     if (ui && syncBtn) {
       syncBtn.disabled = false;
       syncBtn.textContent = "Sync Now";
+    }
+    try {
+      const mktLogActive = document.querySelector('[data-log-tab="market"].active');
+      if (mktLogActive && typeof renderRetailHistoryTable === "function") {
+        renderRetailHistoryTable();
+      }
+    } catch (e) { debugLog(`[retail] Post-sync log render failed: ${e.message}`, "warn"); }
+    // STAK-504: Refresh main-page market data (ticker + vendor table) after sync
+    if (typeof refreshMarketData === 'function') {
+      try { refreshMarketData(); } catch (e) { debugLog(`[retail] Post-sync market refresh failed: ${e.message}`, "warn"); }
     }
   }
 };

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774998666';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774999120';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1774997212';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1774998666';
 
 
 


### PR DESCRIPTION
## Summary
- Remove stale `renderRetailCards()` calls from sync finalizer — DOM targets removed by STAK-515, causing `appendChild` throw on dummy elements that crashes the `finally` block
- Move button reset to top of `finally` so "Sync Now" always restores regardless of post-sync renderer failures
- Format sync status as "Synced N coin(s) · 10:38 PM" instead of raw ISO timestamp with `[v2]` debug marker
- Wrap post-sync renderers in individual try/catch so one failure cannot block others

## Root Cause
`renderRetailCards()` in the `finally` block called `_renderMarketListView()` which targeted `retailCardsGrid` — an element removed by the STAK-515 market filter matrix. `safeGetElement()` returned a dummy that doesn't implement `appendChild()`, throwing an error that skipped the button reset at line 961. This caused: stuck "Syncing..." state, blocked repeat clicks, and prevented `refreshMarketData()` from running.

## Test plan
- [ ] Settings > Market > Sync button completes and returns to "Sync Now"
- [ ] Status text shows formatted time (e.g., "Synced 23 coin(s) · 6:08 PM")
- [ ] Clicking Sync a second time works
- [ ] Main page market data refreshes after sync completes
- [ ] No console errors during sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)