### PR TITLE
fix: height-driven logo sizing at 56px (STAK-514)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -369,9 +369,8 @@ label {
 
 /* StakTrakr Logo Styles */
 .stackr-logo {
-  max-width: 800px;
-  width: 100%;
-  height: auto;
+  height: 56px;
+  width: auto;
 }
 
 /* Default state - show light mode */

--- a/css/styles.css
+++ b/css/styles.css
@@ -325,7 +325,7 @@ label {
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
-  min-height: 120px; /* match dark mode banner height */
+  /* min-height removed — let content determine header height (STAK-514) */
 }
 
 /* Header action buttons — 2-col grid at narrow widths, flex row at wider */

--- a/css/styles.css
+++ b/css/styles.css
@@ -577,8 +577,8 @@ section {
 /* Environment badge (BETA / PREVIEW / LOCAL) — STAK-376 */
 .env-badge {
   position: absolute;
-  bottom: 4px;
-  left: 0;
+  bottom: -2px;
+  left: 2px;
   display: inline-flex;
   align-items: center;
   font-size: 0.55rem;

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1775002189';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1775002505';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1775002901';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1775002995';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.89-b1775002505';
+const CACHE_NAME = 'staktrakr-v3.33.89-b1775002901';
 
 
 


### PR DESCRIPTION
## Summary
- Switch `.stackr-logo` from `width: 100%; height: auto` to `height: 56px; width: auto`
- Width-driven sizing made the logo too small because it competed with the button grid for horizontal space
- Height-driven sizing decouples the logo from the button layout — the 5:1 SVG ratio produces ~280px wide at 56px tall

## Test plan
- [ ] Logo renders larger than before in dark, light, and sepia modes
- [ ] Logo doesn't overflow or overlap buttons on mobile
- [ ] PREVIEW/BETA badge still visible at bottom-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)