### PR TITLE
v3.33.92 — Remove v1 API dead code + dynamic Market log vendors (STAK-509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.92] - 2026-04-01
+
+### Changed — Remove V1 API Dead Code + Dynamic Market Log Vendors (STAK-509)
+
+- **Removed**: All v1 API code paths (USE_V2_API flag, v1 fetch blocks, v1 health checks, v1 URL constants) — v2 has been sole data source since v3.33.87
+- **Removed**: `fetchStaktrakr15minRange()` function (zero callers, confirmed dead)
+- **Fixed**: Market log tab (Settings > Activity Log > Market) now renders vendor columns dynamically from v2 manifest metadata instead of hardcoded APMEX/Monument/SDB/JM columns that went blank after v2 cutover
+- **Changed**: Net reduction of ~486 lines across 7 JS files
+
+---
+
 ## [3.33.91] - 2026-04-01
 
 ### Fixed — Cloud Sync API Key + StorageLocation Loop (STAK-519)

--- a/devops/version.lock
+++ b/devops/version.lock
@@ -1,3 +1,11 @@
 {
-  "claims": []
+  "claims": [
+    {
+      "branch": "feature/STAK-509-v1-dead-code-cleanup",
+      "issue": "STAK-509",
+      "claimedBy": "claude",
+      "claimedAt": "2026-04-01T19:08:00Z",
+      "version": "3.33.92"
+    }
+  ]
 }

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,8 +1,7 @@
 ## What's New
 
+- **V1 API Cleanup + Market Log Fix (v3.33.92)**: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)
 - **Cloud Sync Fixes (v3.33.91)**: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed — blank values persist correctly (STAK-519)
 - **StakTrakr API Settings Fix (v3.33.90)**: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)
-- **Market Filter Matrix (v3.33.89)**: Settings > Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings. Legacy market cards removed from settings
-- **Ticker & What's New Fix (v3.33.88)**: Market ticker no longer duplicates into multiple rows. Stale What's New content on cached deployments now correctly falls back to embedded data
+- **Market Filter Matrix (v3.33.89)**: Settings > Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings
 - **Market Data Module (v3.33.87)**: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts — all powered by the v2 API
-- **What's New Modal Fix (v3.33.86)**: What's New popup no longer flashes old content before showing current announcements on page load

--- a/index.html
+++ b/index.html
@@ -3803,17 +3803,7 @@
                 <div id="retailSyncLogContainer"></div>
                 <div class="retail-history-table-wrap">
                   <table id="retailHistoryTable" class="retail-history-table">
-                    <thead>
-                      <tr>
-                        <th>Date</th>
-                        <th>Avg Median</th>
-                        <th>Avg Low</th>
-                        <th>APMEX</th>
-                        <th>Monument</th>
-                        <th>SDB</th>
-                        <th>JM</th>
-                      </tr>
-                    </thead>
+                    <thead id="retailHistoryTableHead"></thead>
                     <tbody id="retailHistoryTableBody"></tbody>
                   </table>
                 </div>

--- a/js/about.js
+++ b/js/about.js
@@ -185,12 +185,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.92 &ndash; V1 API Cleanup + Market Log Fix</strong>: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)</li>
     <li><strong>v3.33.91 &ndash; Cloud Sync Fixes</strong>: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed &mdash; blank values persist correctly (STAK-519)</li>
     <li><strong>v3.33.90 &ndash; StakTrakr API Settings Fix</strong>: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)</li>
     <li><strong>v3.33.89 &ndash; Market Filter Matrix</strong>: Settings &gt; Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings (STAK-515)</li>
-    <li><strong>v3.33.88 &ndash; Ticker &amp; What&rsquo;s New Fix</strong>: Market ticker no longer duplicates into multiple rows. Stale What&rsquo;s New content on cached deployments now correctly falls back to embedded data (STAK-513)</li>
     <li><strong>v3.33.87 &ndash; Market Data Module</strong>: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts &mdash; all powered by the v2 API (STAK-504)</li>
-    <li><strong>v3.33.86 &ndash; What&rsquo;s New Modal Fix</strong>: What&rsquo;s New popup no longer flashes old content before showing current announcements on page load (STAK-500)</li>
   `;
 };
 

--- a/js/api-health.js
+++ b/js/api-health.js
@@ -45,75 +45,6 @@ const _timeAgo = (timestamp) => {
 };
 
 /**
- * Parses the raw Promise.allSettled results from a single endpoint into the
- * standard {market, spot, goldback} health shape.
- * @param {PromiseSettledResult} marketResult
- * @param {PromiseSettledResult} spotResult
- * @param {PromiseSettledResult} goldbackResult
- * @returns {{market: object, spot: object, goldback: object}}
- */
-const _parseEndpointHealth = (marketResult, spotResult, goldbackResult) => {
-  // --- Market prices (manifest.json) ---
-  let market = { ok: false, ageMin: null, ago: null, coins: [], error: null };
-  if (marketResult.status === "fulfilled") {
-    const data = marketResult.value;
-    const generatedAt = new Date(_normalizeTs(data.generated_at));
-    if (!isNaN(generatedAt.getTime())) {
-      market.ageMin = Math.max(0, Math.floor((Date.now() - generatedAt.getTime()) / 60000));
-      market.ago    = _timeAgo(data.generated_at);
-      market.ok     = market.ageMin <= API_HEALTH_MARKET_STALE_MIN;
-      market.coins  = data.coins || [];
-    } else {
-      market.error = `Invalid timestamp: ${data.generated_at}`;
-    }
-  } else {
-    market.error = marketResult.reason?.message || String(marketResult.reason);
-  }
-
-  // --- Spot prices (hourly file: data/hourly/YYYY/MM/DD/HH.json, last entry) ---
-  let spot = { ok: false, ageMin: null, ago: null, error: null };
-  if (spotResult.status === "fulfilled") {
-    const entries = spotResult.value;
-    const last    = Array.isArray(entries) && entries[entries.length - 1];
-    const ts      = last && last.timestamp;
-    if (ts) {
-      const spotDate = new Date(_normalizeTs(ts));
-      if (!isNaN(spotDate.getTime())) {
-        spot.ageMin = Math.max(0, Math.floor((Date.now() - spotDate.getTime()) / 60000));
-        spot.ago    = _timeAgo(ts);
-        spot.ok     = spot.ageMin <= API_HEALTH_SPOT_STALE_MIN;
-      } else {
-        spot.error = `Invalid timestamp: ${ts}`;
-      }
-    } else {
-      spot.error = "No entries found";
-    }
-  } else {
-    spot.error = spotResult.reason?.message || String(spotResult.reason);
-  }
-
-  // --- Goldback daily scrape (informational only — does not affect overall status) ---
-  let goldback = { ok: false, ago: null, error: null };
-  if (goldbackResult.status === "fulfilled") {
-    const data      = goldbackResult.value;
-    const scrapedAt = new Date(_normalizeTs(data.scraped_at));
-    if (data.scraped_at && !isNaN(scrapedAt.getTime())) {
-      const ageMin  = Math.max(0, Math.floor((Date.now() - scrapedAt.getTime()) / 60000));
-      goldback.ago  = _timeAgo(data.scraped_at);
-      goldback.ok   = ageMin <= API_HEALTH_GOLDBACK_STALE_MIN;
-    } else if (data.scraped_at) {
-      goldback.error = `Invalid timestamp: ${data.scraped_at}`;
-    } else {
-      goldback.error = "No scraped_at field";
-    }
-  } else {
-    goldback.error = goldbackResult.reason?.message || String(goldbackResult.reason);
-  }
-
-  return { market, spot, goldback };
-};
-
-/**
  * Parses v2 Promise.allSettled results into the standard health shape.
  * v2 endpoints return envelopes with `generated_at`, `stale_after`, and `data`.
  * Timestamps are already ISO 8601 Z-suffixed — no _normalizeTs needed.
@@ -199,53 +130,20 @@ const fetchApiHealth = async () => {
       .catch((e) => { clearTimeout(tid); throw e; });
   };
 
-  if (typeof USE_V2_API !== "undefined" && USE_V2_API) {
-    // --- v2 path: use V2_API_ENDPOINTS with envelope-based staleness ---
-    const v2Endpoints = (typeof V2_API_ENDPOINTS !== "undefined" && V2_API_ENDPOINTS.length)
-      ? V2_API_ENDPOINTS
-      : ["https://api.staktrakr.com/data/v2"];
+  const v2Endpoints = (typeof V2_API_ENDPOINTS !== "undefined" && V2_API_ENDPOINTS.length)
+    ? V2_API_ENDPOINTS
+    : ["https://api.staktrakr.com/data/v2"];
 
-    const _fetchV2FromEndpoint = async (ep) => {
-      return Promise.allSettled([
-        _fetchWithTimeout(`${ep}/manifest.json`),
-        _fetchWithTimeout(`${ep}/spot/latest.json`),
-        _fetchWithTimeout(`${ep}/goldback/latest.json`),
-      ]);
-    };
-
-    const endpointRaws = await Promise.all(v2Endpoints.map(_fetchV2FromEndpoint));
-    const parsed = endpointRaws.map(([m, s, g]) => _parseV2EndpointHealth(m, s, g));
-    return { primary: parsed[0], backup: parsed[1] ?? null };
-  }
-
-  // --- v1 path (unchanged) ---
-  const apiEndpoints = (typeof RETAIL_API_ENDPOINTS !== "undefined" && RETAIL_API_ENDPOINTS.length)
-    ? RETAIL_API_ENDPOINTS
-    : ["https://api.staktrakr.com/data/api"];
-
-  const _hourlyUrl = (dataBase, offsetHours = 0) => {
-    const d  = new Date(Date.now() - offsetHours * 3600000);
-    const y  = d.getUTCFullYear();
-    const mo = String(d.getUTCMonth() + 1).padStart(2, "0");
-    const dy = String(d.getUTCDate()).padStart(2, "0");
-    const hr = String(d.getUTCHours()).padStart(2, "0");
-    return `${dataBase}/hourly/${y}/${mo}/${dy}/${hr}.json`;
-  };
-
-  const _fetchFromEndpoint = async (ep) => {
-    const dataEp = ep.replace(/\/api$/, "");
-    const spotFetch = _fetchWithTimeout(_hourlyUrl(dataEp, 0))
-      .catch((e) => { console.debug(`[api-health] ${ep} hour-0 miss:`, e.message); return _fetchWithTimeout(_hourlyUrl(dataEp, 1)); });
+  const _fetchV2FromEndpoint = async (ep) => {
     return Promise.allSettled([
       _fetchWithTimeout(`${ep}/manifest.json`),
-      spotFetch,
-      _fetchWithTimeout(`${ep}/goldback-spot.json`),
+      _fetchWithTimeout(`${ep}/spot/latest.json`),
+      _fetchWithTimeout(`${ep}/goldback/latest.json`),
     ]);
   };
 
-  const endpointRaws = await Promise.all(apiEndpoints.map(_fetchFromEndpoint));
-  const parsed = endpointRaws.map(([m, s, g]) => _parseEndpointHealth(m, s, g));
-
+  const endpointRaws = await Promise.all(v2Endpoints.map(_fetchV2FromEndpoint));
+  const parsed = endpointRaws.map(([m, s, g]) => _parseV2EndpointHealth(m, s, g));
   return { primary: parsed[0], backup: parsed[1] ?? null };
 };
 

--- a/js/api.js
+++ b/js/api.js
@@ -46,58 +46,26 @@ const _staktrakrFetch = async (urls, path) => {
 const _V2_METAL_MAP = { xau: 'gold', xag: 'silver', xpt: 'platinum', xpd: 'palladium' };
 
 const fetchStaktrakrPrices = async (selectedMetals) => {
-  if (USE_V2_API) {
-    const data = await _staktrakrFetch(V2_API_ENDPOINTS, '/spot/latest.json');
-    const spotData = data.data || data;
-    const results = {};
-    Object.entries(spotData).forEach(([isoKey, entry]) => {
-      const metalName = _V2_METAL_MAP[isoKey];
-      if (!metalName) return;
-      const price = entry?.price ?? entry;
-      if (selectedMetals.includes(metalName) && price > 0) {
-        results[metalName] = price;
-      }
-    });
-    if (Object.keys(results).length > 0) {
-      const cfg = loadApiConfig();
-      if (cfg.usage?.STAKTRAKR) {
-        cfg.usage.STAKTRAKR.used++;
-        saveApiConfig(cfg);
-      }
-      return results;
+  const data = await _staktrakrFetch(V2_API_ENDPOINTS, '/spot/latest.json');
+  const spotData = data.data || data;
+  const results = {};
+  Object.entries(spotData).forEach(([isoKey, entry]) => {
+    const metalName = _V2_METAL_MAP[isoKey];
+    if (!metalName) return;
+    const price = entry?.price ?? entry;
+    if (selectedMetals.includes(metalName) && price > 0) {
+      results[metalName] = price;
     }
-    throw new Error('No spot data available from StakTrakr v2 API');
+  });
+  if (Object.keys(results).length > 0) {
+    const cfg = loadApiConfig();
+    if (cfg.usage?.STAKTRAKR) {
+      cfg.usage.STAKTRAKR.used++;
+      saveApiConfig(cfg);
+    }
+    return results;
   }
-
-  const baseUrls = API_PROVIDERS.STAKTRAKR.hourlyBaseUrls;
-  const now = new Date();
-
-  for (let offset = 0; offset <= 23; offset++) {
-    const target = new Date(now.getTime() - offset * 3600000);
-    const yyyy = target.getUTCFullYear();
-    const mm = String(target.getUTCMonth() + 1).padStart(2, '0');
-    const dd = String(target.getUTCDate()).padStart(2, '0');
-    const hh = String(target.getUTCHours()).padStart(2, '0');
-    const path = `/${yyyy}/${mm}/${dd}/${hh}.json`;
-
-    try {
-      const data = await _staktrakrFetch(baseUrls, path);
-      const { current } = API_PROVIDERS.STAKTRAKR.parseBatchResponse(data);
-      const results = {};
-      selectedMetals.forEach(metal => {
-        if (current[metal] > 0) results[metal] = current[metal];
-      });
-      if (Object.keys(results).length > 0) {
-        const cfg = loadApiConfig();
-        if (cfg.usage?.STAKTRAKR) {
-          cfg.usage.STAKTRAKR.used++;
-          saveApiConfig(cfg);
-        }
-        return results;
-      }
-    } catch { continue; }
-  }
-  throw new Error('No hourly data available from StakTrakr API');
+  throw new Error('No spot data available from StakTrakr v2 API');
 };
 
 /**
@@ -107,70 +75,7 @@ const fetchStaktrakrPrices = async (selectedMetals) => {
  * @returns {Promise<{newCount: number, fetchCount: number}>} Counts of new entries and successful fetches
  */
 const fetchStaktrakrHourlyRange = async (hoursBack) => {
-  if (USE_V2_API) {
-    return _fetchStaktrakrHourlyRangeV2(hoursBack);
-  }
-
-  const baseUrls = API_PROVIDERS.STAKTRAKR.hourlyBaseUrls;
-  const now = new Date();
-
-  const hours = [];
-  for (let i = 0; i < hoursBack; i++) {
-    hours.push(new Date(now.getTime() - i * 3600000));
-  }
-
-  purgeSpotHistory();
-  const existingKeys = new Set(
-    spotHistory.map(e => `${e.timestamp}|${e.metal}`)
-  );
-
-  let newCount = 0;
-  let fetchCount = 0;
-  const batchSize = 6;
-  const providerName = API_PROVIDERS.STAKTRAKR.name;
-
-  for (let i = 0; i < hours.length; i += batchSize) {
-    const batch = hours.slice(i, i + batchSize);
-    const results = await Promise.all(batch.map(async (h) => {
-      const yyyy = h.getUTCFullYear();
-      const mm = String(h.getUTCMonth() + 1).padStart(2, '0');
-      const dd = String(h.getUTCDate()).padStart(2, '0');
-      const hh = String(h.getUTCHours()).padStart(2, '0');
-      const path = `/${yyyy}/${mm}/${dd}/${hh}.json`;
-      try {
-        const data = await _staktrakrFetch(baseUrls, path);
-        const { current } = API_PROVIDERS.STAKTRAKR.parseBatchResponse(data);
-        return { current, timestamp: `${yyyy}-${mm}-${dd}T${hh}:00:00Z` };
-      } catch { return null; }
-    }));
-
-    results.forEach(result => {
-      if (!result) return;
-      fetchCount++;
-      Object.entries(result.current).forEach(([metalKey, spot]) => {
-        if (spot <= 0) return;
-        const metalConfig = Object.values(METALS).find(m => m.key === metalKey);
-        if (!metalConfig) return;
-        const entryTimestamp = result.timestamp.replace("T", " ").replace("Z", "");
-        const isDuplicate = existingKeys.has(`${entryTimestamp}|${metalConfig.name}`);
-        if (!isDuplicate) {
-          spotHistory.push({
-            spot, metal: metalConfig.name, source: "api-hourly",
-            provider: providerName, timestamp: entryTimestamp,
-          });
-          existingKeys.add(`${entryTimestamp}|${metalConfig.name}`);
-          newCount++;
-        }
-      });
-    });
-  }
-
-  if (newCount > 0) {
-    saveSpotHistory();
-    debugLog(`[StakTrakr] Added ${newCount} hourly entries (${fetchCount} files fetched)`);
-  }
-
-  return { newCount, fetchCount };
+  return _fetchStaktrakrHourlyRangeV2(hoursBack);
 };
 
 const _fetchStaktrakrHourlyRangeV2 = async (hoursBack) => {
@@ -250,80 +155,6 @@ const _fetchStaktrakrHourlyRangeV2 = async (hoursBack) => {
   if (newCount > 0) {
     saveSpotHistory();
     debugLog(`[StakTrakr v2] Added ${newCount} hourly entries (${fetchCount} daily files fetched)`);
-  }
-
-  return { newCount, fetchCount };
-};
-
-const fetchStaktrakr15minRange = async (slotsBack = 96) => {
-  const baseUrls = API_PROVIDERS.STAKTRAKR.fifteenMinBaseUrls;
-  const now = new Date();
-
-  // Build list of 15-min slots as Date objects, snapped down to nearest 15 min
-  const slots = [];
-  for (let i = 0; i < slotsBack; i++) {
-    const slotMs = now.getTime() - i * 15 * 60000;
-    const slotDate = new Date(slotMs);
-    // Snap minutes down to nearest 15
-    const snappedMin = Math.floor(slotDate.getUTCMinutes() / 15) * 15;
-    slotDate.setUTCMinutes(snappedMin, 0, 0);
-    slots.push(slotDate);
-  }
-
-  // Purge once, then build dedup set for batch append (avoids N×save)
-  purgeSpotHistory();
-  const existingKeys = new Set(
-    spotHistory.map(e => `${e.timestamp}|${e.metal}`)
-  );
-
-  // Fetch slots in batches of 6 (96 slots = 24 h of 15-min coverage)
-  let newCount = 0;
-  let fetchCount = 0;
-  const batchSize = 6;
-  const providerName = API_PROVIDERS.STAKTRAKR.name;
-
-  for (let i = 0; i < slots.length; i += batchSize) {
-    const batch = slots.slice(i, i + batchSize);
-    const results = await Promise.all(batch.map(async (s) => {
-      const yyyy = s.getUTCFullYear();
-      const mm = String(s.getUTCMonth() + 1).padStart(2, '0');
-      const dd = String(s.getUTCDate()).padStart(2, '0');
-      const hh = String(s.getUTCHours()).padStart(2, '0');
-      const min15 = String(s.getUTCMinutes()).padStart(2, '0');
-      const path = `/${yyyy}/${mm}/${dd}/${hh}${min15}.json`;
-      try {
-        // Try primary endpoint first; fall back to backup after 5-second timeout or error
-        const data = await _staktrakrFetch(baseUrls, path);
-        const { current } = API_PROVIDERS.STAKTRAKR.parseBatchResponse(data);
-        // Use ISO-format UTC timestamp so normalisation is consistent with hourly
-        return { current, timestamp: `${yyyy}-${mm}-${dd}T${hh}:${min15}:00Z` };
-      } catch { return null; }
-    }));
-
-    results.forEach(result => {
-      if (!result) return;
-      fetchCount++;
-      Object.entries(result.current).forEach(([metalKey, spot]) => {
-        if (spot <= 0) return;
-        const metalConfig = Object.values(METALS).find(m => m.key === metalKey);
-        if (!metalConfig) return;
-        const entryTimestamp = result.timestamp.replace("T", " ").replace("Z", "");
-        const isDuplicate = existingKeys.has(`${entryTimestamp}|${metalConfig.name}`);
-        if (!isDuplicate) {
-          spotHistory.push({
-            spot, metal: metalConfig.name, source: "api-15min",
-            provider: providerName, timestamp: entryTimestamp,
-          });
-          existingKeys.add(`${entryTimestamp}|${metalConfig.name}`);
-          newCount++;
-        }
-      });
-    });
-  }
-
-  if (newCount > 0) {
-    saveSpotHistory();
-    debugLog(`[StakTrakr] Added ${newCount} 15-min entries (${fetchCount} files fetched)`);
   }
 
   return { newCount, fetchCount };
@@ -1096,8 +927,6 @@ const renderApiHistoryTable = () => {
     let sourceLabel;
     if (e.source === "cached") {
       sourceLabel = '<span class="api-history-cached-badge">Cached</span>';
-    } else if (e.source === "api-15min") {
-      sourceLabel = `${escapeHtml(e.provider || "")} (15min)`;
     } else if (e.source === "api-hourly") {
       sourceLabel = `${escapeHtml(e.provider || "")} (hourly)`;
     } else {
@@ -1133,7 +962,7 @@ const showApiHistoryModal = () => {
   const modal = document.getElementById("apiHistoryModal");
   if (!modal) return;
   loadSpotHistory();
-  apiHistoryEntries = spotHistory.filter((e) => e.source === "api" || e.source === "api-hourly" || e.source === "api-15min" || e.source === "seed" || e.source === "cached");
+  apiHistoryEntries = spotHistory.filter((e) => e.source === "api" || e.source === "api-hourly" || e.source === "seed" || e.source === "cached");
   apiHistorySortColumn = "";
   apiHistorySortAsc = true;
   apiHistoryFilterText = "";
@@ -1436,7 +1265,7 @@ const getLastProviderSyncTime = (provider) => {
     // Find most recent API entry from this provider
     for (let i = spotHistory.length - 1; i >= 0; i--) {
       const entry = spotHistory[i];
-      if ((entry.source === "api" || entry.source === "api-hourly" || entry.source === "api-15min") && entry.provider === providerName) {
+      if ((entry.source === "api" || entry.source === "api-hourly") && entry.provider === providerName) {
         // Parse timestamp string "YYYY-MM-DD HH:MM:SS" to ms
         const ts = new Date(entry.timestamp).getTime();
         if (!isNaN(ts)) return ts;
@@ -3104,7 +2933,7 @@ const importSpotHistory = (file) => {
     if (typeof updateAllSparklines === "function") updateAllSparklines();
 
     // Refresh the visible history table after import
-    apiHistoryEntries = spotHistory.filter((e) => e.source === "api" || e.source === "api-hourly" || e.source === "api-15min" || e.source === "seed" || e.source === "cached");
+    apiHistoryEntries = spotHistory.filter((e) => e.source === "api" || e.source === "api-hourly" || e.source === "seed" || e.source === "cached");
     renderApiHistoryTable();
   };
   reader.readAsText(file);
@@ -3161,9 +2990,9 @@ const restoreHistoricalSpotData = async () => {
     }
 
     // --- Pass 2: API files — fills year gaps not yet covered by seed pass ---
-    // Derive data-root base URLs from RETAIL_API_ENDPOINTS (strip /api suffix)
-    const apiBaseUrls = (typeof RETAIL_API_ENDPOINTS !== "undefined" && RETAIL_API_ENDPOINTS.length)
-      ? RETAIL_API_ENDPOINTS.map(ep => ep.replace(/\/api$/, ""))
+    // Derive data-root base URLs from V2_API_ENDPOINTS (strip /v2 suffix)
+    const apiBaseUrls = (typeof V2_API_ENDPOINTS !== "undefined" && V2_API_ENDPOINTS.length)
+      ? V2_API_ENDPOINTS.map(ep => ep.replace(/\/v2$/, ""))
       : [`${API_PROVIDERS.STAKTRAKR.baseUrl}`];
 
     for (const year of years) {

--- a/js/constants.js
+++ b/js/constants.js
@@ -18,15 +18,6 @@ const API_PROVIDERS = {
     baseUrl: "https://api.staktrakr.com/data",
     requiresKey: false,
     documentation: "https://www.staktrakr.com",
-    hourlyBaseUrl: "https://api.staktrakr.com/data/hourly",
-    hourlyBaseUrls: [
-      "https://api.staktrakr.com/data/hourly",
-      "https://api2.staktrakr.com/data/hourly",
-    ],
-    fifteenMinBaseUrls: [
-      "https://api.staktrakr.com/data/15min",
-      "https://api2.staktrakr.com/data/15min",
-    ],
     endpoints: { silver: "", gold: "", platinum: "", palladium: "" },
     getEndpoint: () => "",
     parseResponse: () => null,
@@ -528,17 +519,6 @@ const RETAIL_PRICE_HISTORY_KEY = "retailPriceHistory"; // nosemgrep: codacy.java
 /** @constant {string} RETAIL_PROVIDERS_KEY - LocalStorage key for cached providers.json lookup map */
 const RETAIL_PROVIDERS_KEY = "retailProviders"; // nosemgrep: codacy.javascript.security.hard-coded-password
 
-/** @constant {string[]} RETAIL_API_ENDPOINTS - Ordered list of retail API endpoints (primary first) */
-const RETAIL_API_ENDPOINTS = [
-  "https://api.staktrakr.com/data/api",
-  "https://api2.staktrakr.com/data/api",
-];
-/** @constant {string} RETAIL_API_BASE_URL - Primary endpoint (backward compat) */
-const RETAIL_API_BASE_URL = RETAIL_API_ENDPOINTS[0];
-
-/** @constant {boolean} USE_V2_API - Feature flag for v2 API migration (internal toggle) */
-const USE_V2_API = true;
-
 /** @constant {string[]} V2_API_ENDPOINTS - Ordered list of v2 API endpoints (primary first) */
 const V2_API_ENDPOINTS = [
   "https://api.staktrakr.com/data/v2",
@@ -547,9 +527,6 @@ const V2_API_ENDPOINTS = [
 
 /** @constant {string} V2_API_BASE_URL - Primary v2 endpoint (backward compat) */
 const V2_API_BASE_URL = V2_API_ENDPOINTS[0];
-
-/** @constant {string} GOLDBACK_API_URL - Goldback daily spot price endpoint (g1_usd + denominations) */
-const GOLDBACK_API_URL = "https://api.staktrakr.com/data/api/goldback-spot.json";
 
 /** @constant {string} RETAIL_INTRADAY_KEY - LocalStorage key for 15-min intraday window data */
 const RETAIL_INTRADAY_KEY = "retailIntradayData"; // nosemgrep: codacy.javascript.security.hard-coded-password
@@ -1885,16 +1862,11 @@ if (typeof window !== "undefined") {
   window.RETAIL_PRICES_KEY = RETAIL_PRICES_KEY;
   window.RETAIL_PRICE_HISTORY_KEY = RETAIL_PRICE_HISTORY_KEY;
   window.RETAIL_PROVIDERS_KEY = RETAIL_PROVIDERS_KEY;
-  window.RETAIL_API_ENDPOINTS = RETAIL_API_ENDPOINTS;
-  window.RETAIL_API_BASE_URL = RETAIL_API_BASE_URL;
-  // STAK-503: v2 API constants
-  window.USE_V2_API = USE_V2_API;
   window.V2_API_ENDPOINTS = V2_API_ENDPOINTS;
   window.V2_API_BASE_URL = V2_API_BASE_URL;
   window.RETAIL_INTRADAY_KEY = RETAIL_INTRADAY_KEY;
   window.RETAIL_SYNC_LOG_KEY = RETAIL_SYNC_LOG_KEY;
   window.RETAIL_AVAILABILITY_KEY = RETAIL_AVAILABILITY_KEY;
-  window.GOLDBACK_API_URL = GOLDBACK_API_URL;
   window.GOLDBACK_ENABLED_KEY = GOLDBACK_ENABLED_KEY;
   window.GB_TO_OZT = GB_TO_OZT;
   window.GOLDBACK_DENOMINATIONS = GOLDBACK_DENOMINATIONS;

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.91";
+const APP_VERSION = "3.33.92";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/goldback.js
+++ b/js/goldback.js
@@ -240,92 +240,44 @@ const onGoldSpotPriceChanged = () => {
  * @returns {Promise<{ok: boolean, g1_usd?: number, error?: string}>}
  */
 const fetchGoldbackApiPrices = async () => {
-  if (typeof USE_V2_API !== 'undefined' && USE_V2_API) {
-    // --- v2 path: fetch from v2/goldback/latest.json, unwrap envelope ---
-    const v2Endpoints = (typeof V2_API_ENDPOINTS !== 'undefined' && V2_API_ENDPOINTS.length)
-      ? V2_API_ENDPOINTS
-      : ['https://api.staktrakr.com/data/v2'];
+  const v2Endpoints = (typeof V2_API_ENDPOINTS !== 'undefined' && V2_API_ENDPOINTS.length)
+    ? V2_API_ENDPOINTS
+    : ['https://api.staktrakr.com/data/v2'];
 
-    let envelope;
-    let lastErr;
-    for (const ep of v2Endpoints) {
-      const url = `${ep}/goldback/latest.json`;
-      const ctrl = new AbortController();
-      const tid = setTimeout(() => ctrl.abort(), 5000);
-      try {
-        const res = await fetch(url, { cache: 'no-store', signal: ctrl.signal });
-        clearTimeout(tid);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        envelope = await res.json();
-        break;
-      } catch (err) {
-        clearTimeout(tid);
-        lastErr = err;
-      }
-    }
-    if (!envelope || !envelope.data) return { ok: false, error: lastErr ? String(lastErr) : 'No v2 goldback data' };
-
-    const gbData = envelope.data;
-    const g1 = typeof gbData.g1_usd === 'number' && gbData.g1_usd > 0 ? gbData.g1_usd : null;
-    if (!g1) return { ok: false, error: 'Invalid or missing g1_usd in v2 response' };
-
-    if (typeof GOLDBACK_DENOMINATIONS === 'undefined') {
-      return { ok: false, error: 'GOLDBACK_DENOMINATIONS not defined' };
-    }
-
-    const now = Date.now();
-    for (const d of GOLDBACK_DENOMINATIONS) {
-      const key = String(d.weight);
-      // Use pre-computed denomination price from v2 if available, else compute from g1_usd
-      const denomKey = `g${d.weight}`;
-      const price = (gbData.denominations && typeof gbData.denominations[denomKey] === 'number')
-        ? gbData.denominations[denomKey]
-        : Math.round(g1 * d.weight * 100) / 100;
-      goldbackPrices[key] = { price, updatedAt: now, source: 'api' };
-    }
-
-    if (typeof saveGoldbackPrices === 'function') saveGoldbackPrices();
-    if (typeof recordGoldbackPrices === 'function') recordGoldbackPrices();
-    if (typeof syncGoldbackSettingsUI === 'function') syncGoldbackSettingsUI();
-
-    return { ok: true, g1_usd: g1 };
-  }
-
-  // --- v1 path (unchanged) ---
-  const goldbackUrls = (typeof RETAIL_API_ENDPOINTS !== 'undefined' && RETAIL_API_ENDPOINTS.length)
-    ? RETAIL_API_ENDPOINTS.map(ep => `${ep}/goldback-spot.json`)
-    : (typeof GOLDBACK_API_URL !== 'undefined' ? [GOLDBACK_API_URL] : null);
-  if (!goldbackUrls) return { ok: false, error: 'GOLDBACK_API_URL not defined' };
-
-  let data;
+  let envelope;
   let lastErr;
-  for (const url of goldbackUrls) {
+  for (const ep of v2Endpoints) {
+    const url = `${ep}/goldback/latest.json`;
     const ctrl = new AbortController();
     const tid = setTimeout(() => ctrl.abort(), 5000);
     try {
       const res = await fetch(url, { cache: 'no-store', signal: ctrl.signal });
       clearTimeout(tid);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      data = await res.json();
+      envelope = await res.json();
       break;
     } catch (err) {
       clearTimeout(tid);
       lastErr = err;
     }
   }
-  if (!data) return { ok: false, error: String(lastErr) };
+  if (!envelope || !envelope.data) return { ok: false, error: lastErr ? String(lastErr) : 'No v2 goldback data' };
 
-  const g1 = typeof data.g1_usd === 'number' && data.g1_usd > 0 ? data.g1_usd : null;
-  if (!g1) return { ok: false, error: 'Invalid or missing g1_usd in API response' };
+  const gbData = envelope.data;
+  const g1 = typeof gbData.g1_usd === 'number' && gbData.g1_usd > 0 ? gbData.g1_usd : null;
+  if (!g1) return { ok: false, error: 'Invalid or missing g1_usd in v2 response' };
 
-  const now = Date.now();
   if (typeof GOLDBACK_DENOMINATIONS === 'undefined') {
     return { ok: false, error: 'GOLDBACK_DENOMINATIONS not defined' };
   }
 
+  const now = Date.now();
   for (const d of GOLDBACK_DENOMINATIONS) {
     const key = String(d.weight);
-    const price = Math.round(g1 * d.weight * 100) / 100;
+    const denomKey = `g${d.weight}`;
+    const price = (gbData.denominations && typeof gbData.denominations[denomKey] === 'number')
+      ? gbData.denominations[denomKey]
+      : Math.round(g1 * d.weight * 100) / 100;
     goldbackPrices[key] = { price, updatedAt: now, source: 'api' };
   }
 

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -98,8 +98,6 @@ const _buildVendorLegend = (slug) => {
   );
   if (!hasAny) return;
 
-  const isV2 = typeof USE_V2_API !== "undefined" && USE_V2_API;
-
   knownVendors.forEach((vendorId) => {
     const vendorData = vendorMap[vendorId];
     const price = vendorData ? vendorData.price : null;
@@ -117,7 +115,7 @@ const _buildVendorLegend = (slug) => {
     // Skip vendors with no price
     if (price == null) return;
 
-    const isCarried = isV2 && vendorData && vendorData.carried === true;
+    const isCarried = vendorData && vendorData.carried === true;
     const carriedFrom = isCarried && vendorData.carried_from ? vendorData.carried_from : null;
 
     const item = document.createElement(vendorUrl ? "a" : "span");
@@ -337,7 +335,7 @@ const _buildIntradayTable = (slug, bucketed) => {
   if (!bucketed) {
     const intraday = typeof retailIntradayData !== "undefined" ? retailIntradayData[slug] : null;
     const rawWindows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
-    const windows = (typeof USE_V2_API !== "undefined" && USE_V2_API) ? _normalizeV2IntradayWindows(rawWindows) : rawWindows;
+    const windows = _normalizeV2IntradayWindows(rawWindows);
     const filled = _forwardFillVendors(_bucketWindows(_trimTo24h(windows)));
     try {
       bucketed = _flagAnomalies(filled);
@@ -456,10 +454,9 @@ const _buildIntradayChart = (slug) => {
   const canvas = safeGetElement("retailViewIntradayChart");
   const noDataEl = safeGetElement("retailViewIntradayNoData");
 
-  const isV2 = typeof USE_V2_API !== "undefined" && USE_V2_API;
   const intraday = typeof retailIntradayData !== "undefined" ? retailIntradayData[slug] : null;
   const rawWindows = intraday && Array.isArray(intraday.windows_24h) ? intraday.windows_24h : [];
-  const windows = isV2 ? _normalizeV2IntradayWindows(rawWindows) : rawWindows;
+  const windows = _normalizeV2IntradayWindows(rawWindows);
   const filled = _forwardFillVendors(_bucketWindows(_trimTo24h(windows)));
   let bucketed;
   try {

--- a/js/retail.js
+++ b/js/retail.js
@@ -451,29 +451,8 @@ const _loadV2RetailHistory = () => {
 const getRetailHistoryForSlug = (slug) => retailPriceHistory[slug] || [];
 
 /** Last API base URL that returned a valid manifest — used by retail-view-modal.js */
-let _lastSuccessfulApiBase = typeof RETAIL_API_ENDPOINTS !== "undefined" ? RETAIL_API_ENDPOINTS[0] : "https://api.staktrakr.com/data/api";
+let _lastSuccessfulApiBase = typeof V2_API_ENDPOINTS !== "undefined" ? V2_API_ENDPOINTS[0] + "/retail" : "https://api.staktrakr.com/data/v2/retail";
 
-/**
- * Fetch manifest.json from configured endpoints in order (primary first).
- * Tries each endpoint with a 5-second timeout; returns on the first success.
- * @returns {Promise<Array<{base: string, manifest: Object, ts: string}> | null>}
- */
-async function _pickFreshestEndpoint() {
-  const endpoints = typeof RETAIL_API_ENDPOINTS !== "undefined" ? RETAIL_API_ENDPOINTS : [RETAIL_API_BASE_URL];
-  for (const base of endpoints) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
-    try {
-      const resp = await fetch(`${base}/manifest.json`, { signal: controller.signal }).finally(() => clearTimeout(timeoutId));
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-      const manifest = await resp.json();
-      return [{ base, manifest, ts: manifest.generated_at || "" }];
-    } catch {
-      // try next endpoint
-    }
-  }
-  return null;
-}
 
 const _processSlugResult = (slug, latest, hist30) => {
   const result = {
@@ -804,150 +783,7 @@ const syncRetailPrices = async ({ ui = true } = {}) => {
   _retailSyncError = false;
 
   try {
-    // STAK-503: v2 API branch
-    if (USE_V2_API) {
-      await _syncRetailV2({ ui, syncBtn, syncStatus });
-      return;
-    }
-
-    // Multi-endpoint: race all configured APIs, pick freshest manifest
-    let apiBase, manifest;
-    const ranked = await _pickFreshestEndpoint();
-    if (ranked) {
-      apiBase = ranked[0].base;
-      manifest = ranked[0].manifest;
-      _lastSuccessfulApiBase = apiBase;
-      window._lastSuccessfulApiBase = apiBase;
-      // Save manifest generated_at for market health dot (STAK-314)
-      if (manifest.generated_at) {
-        try { localStorage.setItem(RETAIL_MANIFEST_TS_KEY, manifest.generated_at); } catch (e) { /* ignore */ }
-      }
-      debugLog(`[retail] Using ${apiBase} (generated: ${ranked[0].ts}, ${ranked.length} endpoint(s) reachable)`, "info");
-      // Extract manifest metadata for resolver functions
-      _manifestSlugs = Array.isArray(manifest.enabled_coins) && manifest.enabled_coins.length
-        ? manifest.enabled_coins
-        : Array.isArray(manifest.coins) && manifest.coins.length
-          ? manifest.coins
-          : Array.isArray(manifest.slugs) && manifest.slugs.length
-            ? manifest.slugs
-            : null;
-      _manifestCoinMeta = manifest.coins_meta || null;
-      // Persist slug list and coin metadata so they survive page reload
-      if (_manifestSlugs) {
-        try { localStorage.setItem(RETAIL_MANIFEST_SLUGS_KEY, JSON.stringify(_manifestSlugs)); } catch { /* ignore */ }
-      }
-      if (_manifestCoinMeta) {
-        try { localStorage.setItem(RETAIL_MANIFEST_COIN_META_KEY, JSON.stringify(_manifestCoinMeta)); } catch { /* ignore */ }
-      }
-    } else {
-      debugLog("[retail] All endpoints unreachable, using fallback slug list", "warn");
-      apiBase = RETAIL_API_ENDPOINTS[0];
-      manifest = { slugs: RETAIL_SLUGS, latest_window: null };
-      _manifestSlugs = null;
-      _manifestCoinMeta = null;
-    }
-    const slugs = _manifestSlugs || (Array.isArray(manifest.slugs) && manifest.slugs.length ? manifest.slugs : RETAIL_SLUGS);
-
-    // Fetch providers.json (product page URLs for each coin+vendor)
-    try {
-      const providersResp = await fetch(`${apiBase}/providers.json`);
-      if (providersResp.ok) {
-        retailProviders = await providersResp.json();
-        saveRetailProviders();
-        // Extract vendor display metadata if present and persist for page reload
-        if (retailProviders && retailProviders._vendor_meta) {
-          _manifestVendorMeta = retailProviders._vendor_meta;
-          try { localStorage.setItem(RETAIL_MANIFEST_VENDOR_META_KEY, JSON.stringify(_manifestVendorMeta)); } catch { /* ignore */ }
-        }
-        debugLog(`[retail] Loaded ${Object.keys(retailProviders || {}).length} coin provider mappings`, "info");
-      } else {
-        debugLog(`[retail] Providers fetch returned HTTP ${providersResp.status} — using fallback URLs`, "warn");
-      }
-    } catch (providersErr) {
-      debugLog(`[retail] Providers fetch failed (${providersErr.message}) — using homepage fallback URLs`, "warn");
-    }
-
-    const results = await Promise.allSettled(
-      slugs.map(async (slug) => {
-        const [latestResp, histResp] = await Promise.all([
-          fetch(`${apiBase}/${slug}/latest.json`),
-          fetch(`${apiBase}/${slug}/history-30d.json`),
-        ]);
-        const latest = latestResp.ok ? await latestResp.json() : null;
-        const hist30 = histResp.ok ? await histResp.json() : null;
-        return { slug, latest, hist30 };
-      })
-    );
-
-    let successCount = 0;
-    const newPrices = {};
-
-    results.forEach((r) => {
-      if (r.status !== "fulfilled") {
-        debugLog(`[retail] Slug fetch failed: ${r.reason?.message || r.reason}`, "warn");
-        return;
-      }
-      const { slug, latest, hist30 } = r.value;
-      const processed = _processSlugResult(slug, latest, hist30);
-
-      if (processed.hasLatest) {
-        newPrices[slug] = processed.price;
-        retailIntradayData[slug] = processed.intraday;
-        // Update availability data
-        if (processed.availabilityBySite) {
-          if (!retailAvailability[slug]) retailAvailability[slug] = {};
-          Object.assign(retailAvailability[slug], processed.availabilityBySite);
-        }
-        if (processed.lastKnownPriceBySite) {
-          if (!retailLastKnownPrices[slug]) retailLastKnownPrices[slug] = {};
-          Object.assign(retailLastKnownPrices[slug], processed.lastKnownPriceBySite);
-        }
-        if (processed.lastAvailableDateBySite) {
-          if (!retailLastAvailableDates[slug]) retailLastAvailableDates[slug] = {};
-          Object.assign(retailLastAvailableDates[slug], processed.lastAvailableDateBySite);
-        }
-        successCount++;
-      }
-
-      if (processed.history30) {
-        retailPriceHistory[slug] = processed.history30;
-      }
-    });
-
-    if (successCount > 0) {
-      retailPrices = {
-        lastSync: new Date().toISOString(),
-        window_start: manifest.latest_window || null,
-        prices: newPrices,
-      };
-      _retailSyncError = false;
-    }
-
-    // Check if all fetches failed
-    if (successCount === 0 && slugs.length > 0) {
-      const errorMsg = "All coin price fetches failed — check your network connection.";
-      debugLog(`[retail] ${errorMsg}`, "error");
-      if (ui && syncStatus) syncStatus.textContent = errorMsg;
-      _appendSyncLogEntry({ success: false, coins: 0, window: null, error: errorMsg });
-      _retailSyncError = true;
-      return;
-    }
-
-    if (successCount > 0) {
-      saveRetailPrices();
-      saveRetailPriceHistory();
-      saveRetailIntradayData();
-      saveRetailAvailability();
-    }
-
-    const v1Tz = (typeof TIMEZONE_KEY !== 'undefined' && localStorage.getItem(TIMEZONE_KEY)) || undefined;
-    const v1TzOpts = v1Tz && v1Tz !== 'auto' ? { timeZone: v1Tz, hour: 'numeric', minute: '2-digit' } : { hour: 'numeric', minute: '2-digit' };
-    const v1SyncTime = new Date().toLocaleTimeString(undefined, v1TzOpts);
-    const statusMsg = `Synced ${successCount} coin(s) · ${v1SyncTime}`;
-    if (ui && syncStatus) syncStatus.textContent = statusMsg;
-    debugLog(`[retail] Sync complete: ${statusMsg}`, "info");
-    _appendSyncLogEntry({ success: true, coins: successCount, window: manifest.latest_window || null, error: null });
-    if (typeof updateMarketHealthDot === 'function') updateMarketHealthDot();
+    await _syncRetailV2({ ui, syncBtn, syncStatus });
   } catch (err) {
     _retailSyncError = true;
     debugLog(`[retail] Sync error: ${err.message}`, "warn");
@@ -2077,6 +1913,41 @@ const renderRetailHistoryTable = () => {
   const prevSlug = select.value;
   select.innerHTML = "";
 
+  // Resolve vendor list from manifest metadata, or extract from history entries
+  let vendorIds = [];
+  if (typeof _manifestVendorMeta !== 'undefined' && _manifestVendorMeta && Object.keys(_manifestVendorMeta).length > 0) {
+    vendorIds = Object.keys(_manifestVendorMeta);
+  } else {
+    const vendorSet = new Set();
+    const allSlugsForVendors = getActiveRetailSlugs();
+    allSlugsForVendors.forEach(s => {
+      const h = getRetailHistoryForSlug(s);
+      h.forEach(entry => {
+        if (entry.vendors) Object.keys(entry.vendors).forEach(vid => vendorSet.add(vid));
+      });
+    });
+    vendorIds = [...vendorSet].sort();
+  }
+
+  // Build dynamic thead
+  const thead = safeGetElement("retailHistoryTableHead");
+  if (thead) {
+    while (thead.firstChild) thead.removeChild(thead.firstChild);
+    const headerRow = document.createElement("tr");
+    ["Date", "Avg Median", "Avg Low"].forEach(label => {
+      const th = document.createElement("th");
+      th.textContent = label;
+      headerRow.appendChild(th);
+    });
+    vendorIds.forEach(vid => {
+      const th = document.createElement("th");
+      const meta = (typeof _manifestVendorMeta !== 'undefined' && _manifestVendorMeta) ? _manifestVendorMeta[vid] : null;
+      th.textContent = meta && meta.name ? meta.name : vid;
+      headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+  }
+
   if (!activeSlugs.length) {
     const placeholder = document.createElement("option");
     placeholder.value = "";
@@ -2084,7 +1955,14 @@ const renderRetailHistoryTable = () => {
     placeholder.selected = true;
     placeholder.textContent = "No coins with price history yet";
     select.appendChild(placeholder);
-    tbody.innerHTML = "<tr><td colspan=\"7\" class=\"settings-subtext\" style=\"text-align:center\">No history yet \u2014 sync from the Market Prices section.</td></tr>";
+    const emptyTr = document.createElement("tr");
+    const emptyTd = document.createElement("td");
+    emptyTd.colSpan = 3 + vendorIds.length;
+    emptyTd.className = "settings-subtext";
+    emptyTd.style.textAlign = "center";
+    emptyTd.textContent = "No history yet \u2014 sync from the Market Prices section.";
+    emptyTr.appendChild(emptyTd);
+    tbody.appendChild(emptyTr);
     return;
   }
 
@@ -2107,12 +1985,12 @@ const renderRetailHistoryTable = () => {
     const cutoffStr = cutoff.toISOString().slice(0, 10);
     return allHistory.filter((entry) => entry.date >= cutoffStr);
   })();
-  tbody.innerHTML = "";
+  while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
 
   if (!history.length) {
     const tr = document.createElement("tr");
     const td = document.createElement("td");
-    td.colSpan = 7;
+    td.colSpan = 3 + vendorIds.length;
     td.className = "settings-subtext";
     td.style.textAlign = "center";
     td.textContent = "No history yet — sync from the Market Prices section.";
@@ -2123,18 +2001,14 @@ const renderRetailHistoryTable = () => {
 
   history.forEach((entry) => {
     const tr = document.createElement("tr");
-    const cells = [
-      entry.date,
-      _fmtRetailPrice(entry.avg_median),
-      _fmtRetailPrice(entry.avg_low),
-      _fmtRetailPrice(entry.vendors && entry.vendors.apmex && entry.vendors.apmex.avg),
-      _fmtRetailPrice(entry.vendors && entry.vendors.monumentmetals && entry.vendors.monumentmetals.avg),
-      _fmtRetailPrice(entry.vendors && entry.vendors.sdbullion && entry.vendors.sdbullion.avg),
-      _fmtRetailPrice(entry.vendors && entry.vendors.jmbullion && entry.vendors.jmbullion.avg),
-    ];
-    cells.forEach((text) => {
+    [entry.date, _fmtRetailPrice(entry.avg_median), _fmtRetailPrice(entry.avg_low)].forEach(text => {
       const td = document.createElement("td");
       td.textContent = text;
+      tr.appendChild(td);
+    });
+    vendorIds.forEach(vid => {
+      const td = document.createElement("td");
+      td.textContent = _fmtRetailPrice(entry.vendors && entry.vendors[vid] && entry.vendors[vid].avg);
       tr.appendChild(td);
     });
     tbody.appendChild(tr);
@@ -2182,15 +2056,9 @@ const initRetailPrices = () => {
     _manifestVendorMeta = null;
     try { localStorage.removeItem(RETAIL_MANIFEST_VENDOR_META_KEY); } catch { /* ignore */ }
   }
-  if (USE_V2_API) {
-    _loadV2RetailPrices();
-    _loadV2RetailHistory();
-    _loadV2RetailIntraday();
-  } else {
-    loadRetailPrices();
-    loadRetailPriceHistory();
-    loadRetailIntradayData();
-  }
+  _loadV2RetailPrices();
+  _loadV2RetailHistory();
+  _loadV2RetailIntraday();
   _loadRetailTrendMode();
   loadRetailProviders();
   loadRetailAvailability();

--- a/js/retail.js
+++ b/js/retail.js
@@ -1931,7 +1931,7 @@ const renderRetailHistoryTable = () => {
 
   // Build dynamic thead
   const thead = safeGetElement("retailHistoryTableHead");
-  if (thead) {
+  if (thead && typeof thead.appendChild === 'function') {
     while (thead.firstChild) thead.removeChild(thead.firstChild);
     const headerRow = document.createElement("tr");
     ["Date", "Avg Median", "Avg Low"].forEach(label => {
@@ -1962,6 +1962,7 @@ const renderRetailHistoryTable = () => {
     emptyTd.style.textAlign = "center";
     emptyTd.textContent = "No history yet \u2014 sync from the Market Prices section.";
     emptyTr.appendChild(emptyTd);
+    while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
     tbody.appendChild(emptyTr);
     return;
   }

--- a/js/retail.js
+++ b/js/retail.js
@@ -721,7 +721,9 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
         } else {
           // Merge: take the newer entry's aggregates but keep vendors if the newer lacks them
           const merged = { ...e };
-          if (!merged.vendors && existing.vendors) {
+          const mergedHasVendors = merged.vendors && Object.keys(merged.vendors).length > 0;
+          const existingHasVendors = existing.vendors && Object.keys(existing.vendors).length > 0;
+          if (!mergedHasVendors && existingHasVendors) {
             merged.vendors = existing.vendors;
           }
           byDate.set(e.date, merged);

--- a/js/retail.js
+++ b/js/retail.js
@@ -710,10 +710,22 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
     addHistory(hist7);
 
     // Deduplicate by date, preferring the latest (finest granularity) entry
+    // but preserving vendor data from coarser sources when finer source lacks it
     if (historyEntries.length) {
       const byDate = new Map();
       for (const e of historyEntries) {
-        if (e.date) byDate.set(e.date, e);
+        if (!e.date) continue;
+        const existing = byDate.get(e.date);
+        if (!existing) {
+          byDate.set(e.date, e);
+        } else {
+          // Merge: take the newer entry's aggregates but keep vendors if the newer lacks them
+          const merged = { ...e };
+          if (!merged.vendors && existing.vendors) {
+            merged.vendors = existing.vendors;
+          }
+          byDate.set(e.date, merged);
+        }
       }
       retailPriceHistory[slug] = [...byDate.values()].sort((a, b) => (a.date > b.date ? 1 : -1));
     }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775075527';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775075805';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.91-b1775059365';
+const CACHE_NAME = 'staktrakr-v3.33.91-b1775072834';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775075805';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775076663';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.91-b1775072834';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775072940';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775072940';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775075527';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.91",
+  "version": "3.33.92",
   "releaseDate": "2026-04-01",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Strip all dead v1 API code paths (USE_V2_API flag, v1 fetch blocks, v1 health checks, v1 constants) — v2 has been live since v3.33.87
- Delete `fetchStaktrakr15minRange()` (zero callers confirmed by CGC)
- Rewrite Market log table (Settings > Activity Log > Market) to render vendor columns dynamically from `_manifestVendorMeta` instead of hardcoded APMEX/Monument/SDB/JM columns
- Net: **-486 lines** (604 removed, 118 added) across 7 JS files + index.html

## Files Changed

| File | Change |
|------|--------|
| `js/constants.js` | Remove v1 URL constants, USE_V2_API flag |
| `js/api.js` | Remove v1 spot price fetch blocks, delete 15min function, clean source filters |
| `js/retail.js` | Remove v1 sync block, rewrite Market log table renderer |
| `js/goldback.js` | Remove v1 goldback fetch block |
| `js/api-health.js` | Remove v1 health check functions |
| `js/retail-view-modal.js` | Inline v2 paths, remove isV2 guards |
| `index.html` | Replace hardcoded vendor thead with dynamic |

## Test plan

- [ ] Spot prices load and display in ticker
- [ ] Retail market cards populate with vendor prices
- [ ] Goldback prices display correctly
- [ ] API health badge shows status
- [ ] Settings > Activity Log > Market tab renders dynamic vendor columns
- [ ] No console errors on load
- [ ] grep for USE_V2_API, RETAIL_API_ENDPOINTS, GOLDBACK_API_URL returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)