### PR TITLE
v3.33.93 — Shape-aware dimension fields (STAK-528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.93] - 2026-04-03
+
+### Added — Shape-Aware Dimension Fields (STAK-528)
+
+- **Added**: Shape-aware dimension fields — rectangular items (bars, ingots) show Length/Width instead of Diameter. Shape selector drives conditional field display. Numista API size field mapped by shape. Existing "LxW" diameter strings auto-migrated on edit
+- **Changed**: View modal displays "105 x 74 mm" for rectangular items, "40.6 mm" for round items. Composite dimensions include thickness when available
+
+---
+
 ## [3.33.92] - 2026-04-01
 
 ### Changed — Remove V1 API Dead Code + Dynamic Market Log Vendors (STAK-509)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **Shape-Aware Dimensions (v3.33.93)**: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing "LxW" diameter strings auto-migrate on edit (STAK-528)
 - **V1 API Cleanup + Market Log Fix (v3.33.92)**: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)
 - **Cloud Sync Fixes (v3.33.91)**: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed — blank values persist correctly (STAK-519)
 - **StakTrakr API Settings Fix (v3.33.90)**: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)

--- a/index.html
+++ b/index.html
@@ -1555,13 +1555,27 @@
                   </div>
                   <div>
                     <label for="numistaShape">Shape</label>
-                    <input id="numistaShape" type="text" placeholder="e.g. Round" />
+                    <select id="numistaShape">
+                      <option value="Round" selected>Round</option>
+                      <option value="Rectangular">Rectangular</option>
+                      <option value="Square">Square</option>
+                      <option value="Oval">Oval</option>
+                      <option value="Other">Other</option>
+                    </select>
                   </div>
                 </div>
                 <div class="grid grid-3-equal">
-                  <div>
+                  <div id="numistaDiameterWrap">
                     <label for="numistaDiameter">Diameter <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
                     <input id="numistaDiameter" type="text" placeholder="e.g. 40.6" />
+                  </div>
+                  <div id="numistaLengthWrap" style="display:none">
+                    <label for="numistaLength">Length <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
+                    <input id="numistaLength" type="text" placeholder="e.g. 105.0" />
+                  </div>
+                  <div id="numistaWidthWrap" style="display:none">
+                    <label for="numistaWidth">Width <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
+                    <input id="numistaWidth" type="text" placeholder="e.g. 74.0" />
                   </div>
                   <div>
                     <label for="numistaThickness">Thickness <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>

--- a/index.html
+++ b/index.html
@@ -4062,6 +4062,14 @@
                     <p>Actual transaction prices will differ due to dealer premiums, bid/ask spreads, and market conditions. The "Melt Value" shown is a reference floor, not a guaranteed sale price.</p>
                   </div>
                 </details>
+
+                <details class="faq-item">
+                  <summary class="faq-question">Numista only fills one dimension for bars and ingots</summary>
+                  <div class="faq-answer">
+                    <p>When you look up a rectangular item (bar, ingot) via Numista, the <strong>length</strong> auto-fills but the <strong>width</strong> is left blank. This is a limitation of the Numista API &mdash; their website shows both dimensions, but the API only returns one.</p>
+                    <p>Simply enter the width manually after the lookup. Your manual entry is preserved &mdash; future Numista syncs will not overwrite fields you have edited.</p>
+                  </div>
+                </details>
               </div>
 
               <!-- Section 7: More Information -->

--- a/js/about.js
+++ b/js/about.js
@@ -185,11 +185,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.93 &ndash; Shape-Aware Dimensions</strong>: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing &ldquo;LxW&rdquo; diameter strings auto-migrate on edit (STAK-528)</li>
     <li><strong>v3.33.92 &ndash; V1 API Cleanup + Market Log Fix</strong>: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)</li>
     <li><strong>v3.33.91 &ndash; Cloud Sync Fixes</strong>: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed &mdash; blank values persist correctly (STAK-519)</li>
     <li><strong>v3.33.90 &ndash; StakTrakr API Settings Fix</strong>: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)</li>
     <li><strong>v3.33.89 &ndash; Market Filter Matrix</strong>: Settings &gt; Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings (STAK-515)</li>
-    <li><strong>v3.33.87 &ndash; Market Data Module</strong>: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts &mdash; all powered by the v2 API (STAK-504)</li>
   `;
 };
 

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -443,6 +443,50 @@ class CatalogProvider {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Shape classification & dimension parsing (STAK-528)
+// ---------------------------------------------------------------------------
+
+function classifyShape(shapeStr) {
+  if (!shapeStr) return 'round';
+  const s = shapeStr.toLowerCase();
+  if (s.startsWith('round') || s.startsWith('circular')) return 'round';
+  if (s.startsWith('rectangular') || s.startsWith('rectangle')) return 'rectangular';
+  if (s.startsWith('square')) return 'square';
+  if (s.startsWith('oval') || s.startsWith('elliptical')) return 'oval';
+  return 'other';
+}
+
+function parseDimensions(sizeValue, shapeStr) {
+  let diameter = 0;
+  let length = 0;
+  let width = 0;
+
+  // Check for "LxW" pattern in sizeValue
+  const sizeStr = sizeValue != null ? String(sizeValue) : '';
+  const splitMatch = sizeStr.match(/^([\d.]+)\s*[xX×]\s*([\d.]+)/);
+  if (splitMatch) {
+    length = parseFloat(splitMatch[1]) || 0;
+    width = parseFloat(splitMatch[2]) || 0;
+    return { diameter: 0, length, width };
+  }
+
+  // Check for embedded width in shape string, e.g. "Rectangular (41.8mm wide)"
+  const shapeString = shapeStr || '';
+  const embeddedMatch = shapeString.match(/\((\d+\.?\d*)\s*mm\s*wide\)/i);
+  const embeddedWidth = embeddedMatch ? parseFloat(embeddedMatch[1]) || 0 : 0;
+
+  const category = classifyShape(shapeString);
+  if (category === 'rectangular' || category === 'square') {
+    length = parseFloat(sizeValue) || 0;
+    width = embeddedWidth;
+  } else {
+    diameter = parseFloat(sizeValue) || 0;
+  }
+
+  return { diameter, length, width };
+}
+
 /**
  * Numista API Provider
  * Implements Numista-specific API calls
@@ -617,7 +661,7 @@ class NumistaProvider extends CatalogProvider {
       country: numistaData.issuer?.name || '',
       metal: this.normalizeMetal(composition),
       weight: numistaData.weight || 0,
-      diameter: numistaData.size || 0,
+      ...parseDimensions(numistaData.size, numistaData.shape || ''),
       thickness: numistaData.thickness || 0,
       type: this.normalizeType(numistaData.category || ''),
       mintage: 0, // Mintage is per-issue, not per-type in Numista API
@@ -1895,6 +1939,9 @@ if (typeof window !== 'undefined') {
   window.renderPcgsUsageBar = renderPcgsUsageBar;
   window.renderCatalogHistoryForSettings = renderCatalogHistoryForSettings;
   window.clearCatalogHistory = clearCatalogHistory;
+  // STAK-528: Shape-aware dimension helpers
+  window.classifyShape = classifyShape;
+  window.parseDimensions = parseDimensions;
   // STAK-222: Numista response cache
   window.loadNumistaCache = loadNumistaCache;
   window.saveNumistaCache = saveNumistaCache;

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -463,9 +463,9 @@ function parseDimensions(sizeValue, shapeStr) {
   let width = 0;
 
   // Check for "LxW" pattern in sizeValue
-  const sizeStr = sizeValue != null ? String(sizeValue) : '';
-  const splitMatch = sizeStr.match(/^([\d.]+)\s*[xX×]\s*([\d.]+)/);
-  if (splitMatch) {
+  const sizeStr = sizeValue != null ? String(sizeValue).trim() : '';
+  const splitMatch = sizeStr.match(/^([\d.]+)\s*[xX\u00D7]\s*([\d.]+)/);
+  if (splitMatch && splitMatch.length >= 3) {
     length = parseFloat(splitMatch[1]) || 0;
     width = parseFloat(splitMatch[2]) || 0;
     return { diameter: 0, length, width };
@@ -479,7 +479,8 @@ function parseDimensions(sizeValue, shapeStr) {
   const category = classifyShape(shapeString);
   if (category === 'rectangular' || category === 'square') {
     length = parseFloat(sizeValue) || 0;
-    width = embeddedWidth;
+    // Square items: default width to length when no embedded width available
+    width = embeddedWidth || (category === 'square' ? length : 0);
   } else {
     diameter = parseFloat(sizeValue) || 0;
   }

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.92";
+const APP_VERSION = "3.33.93";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -1281,6 +1281,8 @@ const NUMISTA_VIEW_FIELD_DEFAULTS = {
   denomination: true,
   shape: true,
   diameter: true,
+  length: true,
+  width: true,
   thickness: true,
   orientation: true,
   composition: true,

--- a/js/events.js
+++ b/js/events.js
@@ -1990,16 +1990,30 @@ const setupItemFormListeners = () => {
       if (diamWrap) diamWrap.style.display = 'none';
       if (lenWrap) lenWrap.style.display = '';
       if (widWrap) widWrap.style.display = '';
-      // Copy diameter to length on transition if length is empty
+      // Copy diameter to length on transition — parse LxW strings first
       const diamEl = safeGetElement('numistaDiameter');
       const lenEl = safeGetElement('numistaLength');
-      if (lenEl && !lenEl.value && diamEl && diamEl.value) {
-        lenEl.value = diamEl.value;
+      const widEl = safeGetElement('numistaWidth');
+      if (diamEl && diamEl.value && lenEl && !lenEl.value) {
+        if (window.parseDimensions && /[xX\u00D7]/.test(diamEl.value)) {
+          const parsed = window.parseDimensions(diamEl.value, shapeValue);
+          if (parsed.length > 0) lenEl.value = parsed.length;
+          if (parsed.width > 0 && widEl) widEl.value = parsed.width;
+        } else {
+          lenEl.value = diamEl.value;
+        }
       }
+      // Clear stale diameter since we're in rectangular mode
+      if (diamEl) diamEl.value = '';
     } else {
       if (diamWrap) diamWrap.style.display = '';
       if (lenWrap) lenWrap.style.display = 'none';
       if (widWrap) widWrap.style.display = 'none';
+      // Clear stale length/width since we're in round mode
+      const lenEl = safeGetElement('numistaLength');
+      const widEl = safeGetElement('numistaWidth');
+      if (lenEl) lenEl.value = '';
+      if (widEl) widEl.value = '';
     }
   };
 
@@ -2012,6 +2026,9 @@ const setupItemFormListeners = () => {
       "Shape dropdown dimension toggle",
     );
   }
+
+  // Expose for programmatic use (Numista fill, migration)
+  window.toggleDimensionFields = toggleDimensionFields;
 
   // COMMEMORATIVE CHECKBOX — toggle description field (STAK-173)
   const numistaCommemorative = document.getElementById('numistaCommemorative');

--- a/js/events.js
+++ b/js/events.js
@@ -1068,6 +1068,8 @@ const parseNumistaDataFields = (isEditing, existingItem, catalog = '') => {
     shape: getOrPrev('numistaShape', prev.shape),
     diameter: getOrPrev('numistaDiameter', prev.diameter),
     thickness: getOrPrev('numistaThickness', prev.thickness),
+    length: getOrPrev('numistaLength', prev.length),
+    width: getOrPrev('numistaWidth', prev.width),
     orientation: getOrPrev('numistaOrientation', prev.orientation),
     technique: getOrPrev('numistaTechnique', prev.technique),
     mintage: getOrPrev('numistaMintage', prev.mintage),
@@ -1165,7 +1167,7 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
         'storageLocation', 'serialNumber', 'notes', 'year', 'grade',
         'gradingAuthority', 'certNumber', 'pcgsNumber', 'purity',
         'country', 'denomination', 'shape', 'diameter', 'thickness',
-        'orientation', 'description', 'technique'];
+        'length', 'width', 'orientation', 'description', 'technique'];
       for (const field of trackedFields) {
         if (oldItem[field] !== cur[field]) {
           window.markUserModified(cur, field);
@@ -1975,6 +1977,39 @@ const setupItemFormListeners = () => {
         }
       },
       "View item from edit button",
+    );
+  }
+
+  // SHAPE DROPDOWN — toggle dimension fields (STAK-528)
+  const toggleDimensionFields = (shapeValue) => {
+    const category = window.classifyShape ? window.classifyShape(shapeValue) : 'round';
+    const diamWrap = safeGetElement('numistaDiameterWrap');
+    const lenWrap = safeGetElement('numistaLengthWrap');
+    const widWrap = safeGetElement('numistaWidthWrap');
+    if (category === 'rectangular' || category === 'square') {
+      if (diamWrap) diamWrap.style.display = 'none';
+      if (lenWrap) lenWrap.style.display = '';
+      if (widWrap) widWrap.style.display = '';
+      // Copy diameter to length on transition if length is empty
+      const diamEl = safeGetElement('numistaDiameter');
+      const lenEl = safeGetElement('numistaLength');
+      if (lenEl && !lenEl.value && diamEl && diamEl.value) {
+        lenEl.value = diamEl.value;
+      }
+    } else {
+      if (diamWrap) diamWrap.style.display = '';
+      if (lenWrap) lenWrap.style.display = 'none';
+      if (widWrap) widWrap.style.display = 'none';
+    }
+  };
+
+  const shapeSelect = safeGetElement('numistaShape');
+  if (shapeSelect) {
+    safeAttachListener(
+      shapeSelect,
+      "change",
+      () => { toggleDimensionFields(shapeSelect.value); },
+      "Shape dropdown dimension toggle",
     );
   }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -613,6 +613,8 @@ const populateNumistaDataFields = (catalogId, itemData) => {
     { id: 'numistaShape',          itemKey: 'shape',         cacheKey: 'shape' },
     { id: 'numistaDiameter',       itemKey: 'diameter',      cacheKey: 'diameter' },
     { id: 'numistaThickness',      itemKey: 'thickness',     cacheKey: 'thickness' },
+    { id: 'numistaLength',         itemKey: 'length',        cacheKey: 'length' },
+    { id: 'numistaWidth',          itemKey: 'width',         cacheKey: 'width' },
     { id: 'numistaOrientation',    itemKey: 'orientation',   cacheKey: 'orientation' },
     { id: 'numistaTechnique',      itemKey: 'technique',     cacheKey: 'technique' },
     { id: 'numistaMintage',        itemKey: 'mintage',       cacheKey: null },
@@ -888,6 +890,35 @@ const editItem = (idx, logIdx = null) => {
 
   // Populate Numista Data fields: item data first, API cache as fallback (STAK-173)
   populateNumistaDataFields(item.numistaId || item.catalog || '', item.numistaData);
+
+  // STAK-528: Migrate legacy "LxW" diameter values into length/width fields
+  const diamEl = safeGetElement('numistaDiameter');
+  const shapeEl = safeGetElement('numistaShape');
+  const lenEl = safeGetElement('numistaLength');
+  const widEl = safeGetElement('numistaWidth');
+  if (diamEl && shapeEl) {
+    const diamVal = diamEl.value || '';
+    if (/[xX\u00d7]/.test(diamVal) && window.parseDimensions) {
+      const parsed = window.parseDimensions(diamVal, shapeEl.value);
+      if (parsed.length > 0 && lenEl) lenEl.value = parsed.length;
+      if (parsed.width > 0 && widEl) widEl.value = parsed.width;
+      diamEl.value = '';
+    }
+    // Set correct field visibility based on shape
+    const category = window.classifyShape ? window.classifyShape(shapeEl.value) : 'round';
+    const diamWrap = safeGetElement('numistaDiameterWrap');
+    const lenWrap = safeGetElement('numistaLengthWrap');
+    const widWrap = safeGetElement('numistaWidthWrap');
+    if (category === 'rectangular' || category === 'square') {
+      if (diamWrap) diamWrap.style.display = 'none';
+      if (lenWrap) lenWrap.style.display = '';
+      if (widWrap) widWrap.style.display = '';
+    } else {
+      if (diamWrap) diamWrap.style.display = '';
+      if (lenWrap) lenWrap.style.display = 'none';
+      if (widWrap) widWrap.style.display = 'none';
+    }
+  }
 
   // STAK-343: Populate tags in edit modal
   if (item.uuid && typeof getItemTags === 'function') {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -891,9 +891,21 @@ const editItem = (idx, logIdx = null) => {
   // Populate Numista Data fields: item data first, API cache as fallback (STAK-173)
   populateNumistaDataFields(item.numistaId || item.catalog || '', item.numistaData);
 
+  // STAK-528: Normalize shape select value from raw API strings
+  const shapeEl = safeGetElement('numistaShape');
+  if (shapeEl && window.classifyShape) {
+    const rawShape = shapeEl.value || '';
+    // If raw API string doesn't match a select option, normalize it
+    const validOptions = ['Round', 'Rectangular', 'Square', 'Oval', 'Other'];
+    if (rawShape && !validOptions.includes(rawShape)) {
+      const category = window.classifyShape(rawShape);
+      const normalized = category.charAt(0).toUpperCase() + category.slice(1);
+      shapeEl.value = validOptions.includes(normalized) ? normalized : 'Other';
+    }
+  }
+
   // STAK-528: Migrate legacy "LxW" diameter values into length/width fields
   const diamEl = safeGetElement('numistaDiameter');
-  const shapeEl = safeGetElement('numistaShape');
   const lenEl = safeGetElement('numistaLength');
   const widEl = safeGetElement('numistaWidth');
   if (diamEl && shapeEl) {
@@ -902,22 +914,14 @@ const editItem = (idx, logIdx = null) => {
       const parsed = window.parseDimensions(diamVal, shapeEl.value);
       if (parsed.length > 0 && lenEl) lenEl.value = parsed.length;
       if (parsed.width > 0 && widEl) widEl.value = parsed.width;
-      diamEl.value = '';
+      // Only clear diameter after confirmed valid parse
+      if (parsed.length > 0 || parsed.width > 0) diamEl.value = '';
     }
-    // Set correct field visibility based on shape
-    const category = window.classifyShape ? window.classifyShape(shapeEl.value) : 'round';
-    const diamWrap = safeGetElement('numistaDiameterWrap');
-    const lenWrap = safeGetElement('numistaLengthWrap');
-    const widWrap = safeGetElement('numistaWidthWrap');
-    if (category === 'rectangular' || category === 'square') {
-      if (diamWrap) diamWrap.style.display = 'none';
-      if (lenWrap) lenWrap.style.display = '';
-      if (widWrap) widWrap.style.display = '';
-    } else {
-      if (diamWrap) diamWrap.style.display = '';
-      if (lenWrap) lenWrap.style.display = 'none';
-      if (widWrap) widWrap.style.display = 'none';
-    }
+  }
+
+  // Set correct field visibility — use shared toggle if available
+  if (shapeEl && window.toggleDimensionFields) {
+    window.toggleDimensionFields(shapeEl.value);
   }
 
   // STAK-343: Populate tags in edit modal

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -879,8 +879,22 @@ async function loadViewNumistaData(item, container, apiResult) {
 
   if (cfg.denomination !== false && meta.denomination) _addDetail(grid, 'Denomination', meta.denomination);
   if (cfg.shape !== false && meta.shape) _addDetail(grid, 'Shape', meta.shape);
-  if (cfg.diameter !== false && meta.diameter) _addDetail(grid, 'Diameter', `${meta.diameter}mm`);
-  if (cfg.thickness !== false && meta.thickness) _addDetail(grid, 'Thickness', `${meta.thickness}mm`);
+  if (cfg.diameter !== false) {
+    if (meta.length && meta.width) {
+      const dims = meta.thickness
+        ? `${meta.length} \u00D7 ${meta.width} \u00D7 ${meta.thickness} mm`
+        : `${meta.length} \u00D7 ${meta.width} mm`;
+      _addDetail(grid, 'Dimensions', dims);
+    } else if (meta.diameter) {
+      _addDetail(grid, 'Diameter', `${meta.diameter} mm`);
+      if (cfg.thickness !== false && meta.thickness) {
+        _addDetail(grid, 'Thickness', `${meta.thickness} mm`);
+      }
+    }
+  }
+  if (cfg.thickness !== false && meta.thickness && !meta.diameter && !meta.length) {
+    _addDetail(grid, 'Thickness', `${meta.thickness} mm`);
+  }
   if (cfg.orientation !== false && meta.orientation) _addDetail(grid, 'Orientation', meta.orientation);
   if (cfg.composition !== false && meta.composition) _addDetail(grid, 'Composition', meta.composition);
   if (cfg.country !== false && meta.country) _addDetail(grid, 'Country', meta.country);
@@ -1049,6 +1063,8 @@ function _extractMetadata(result) {
     denomination: result.denomination || '',
     diameter: result.diameter || result.size || 0,
     thickness: result.thickness || 0,
+    length: result.length || 0,
+    width: result.width || 0,
     weight: result.weight || 0,
     shape: result.shape || '',
     composition: result.composition || result.metal || '',

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -881,10 +881,17 @@ async function loadViewNumistaData(item, container, apiResult) {
   if (cfg.shape !== false && meta.shape) _addDetail(grid, 'Shape', meta.shape);
   if (cfg.diameter !== false) {
     if (meta.length && meta.width) {
-      const dims = meta.thickness
+      // Both dimensions available — composite "L × W" or "L × W × T"
+      const dims = (cfg.thickness !== false && meta.thickness)
         ? `${meta.length} \u00D7 ${meta.width} \u00D7 ${meta.thickness} mm`
         : `${meta.length} \u00D7 ${meta.width} mm`;
       _addDetail(grid, 'Dimensions', dims);
+    } else if (meta.length) {
+      // Only length (width=0) — show what we have
+      _addDetail(grid, 'Dimensions', `${meta.length} mm`);
+      if (cfg.thickness !== false && meta.thickness) {
+        _addDetail(grid, 'Thickness', `${meta.thickness} mm`);
+      }
     } else if (meta.diameter) {
       _addDetail(grid, 'Diameter', `${meta.diameter} mm`);
       if (cfg.thickness !== false && meta.thickness) {
@@ -892,6 +899,7 @@ async function loadViewNumistaData(item, container, apiResult) {
       }
     }
   }
+  // Standalone thickness for items with only thickness (no other dimensions)
   if (cfg.thickness !== false && meta.thickness && !meta.diameter && !meta.length) {
     _addDetail(grid, 'Thickness', `${meta.thickness} mm`);
   }

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.93-b1775235863';
+const CACHE_NAME = 'staktrakr-v3.33.93-b1775243384';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775232984';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775232987';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775233042';
+const CACHE_NAME = 'staktrakr-v3.33.93-b1775233204';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775232853';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775232984';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775232825';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775232853';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.93-b1775233204';
+const CACHE_NAME = 'staktrakr-v3.33.93-b1775235863';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775232987';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775233042';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.92-b1775076663';
+const CACHE_NAME = 'staktrakr-v3.33.92-b1775232825';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.92",
-  "releaseDate": "2026-04-01",
+  "version": "3.33.93",
+  "releaseDate": "2026-04-03",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Summary

- **Shape-aware dimension fields** — rectangular items (bars, ingots) now show Length/Width instead of Diameter in the edit modal
- Shape `<select>` dropdown (Round/Rectangular/Square/Oval/Other) drives conditional field visibility
- Numista API `size` field mapped by shape: rectangular → length, round → diameter
- Embedded width parsed from Numista shape strings (e.g., "Rectangular (41.8mm wide)")
- View modal displays "105 × 74 mm" for rectangular, "40.6 mm" for round items
- Legacy "LxW" diameter strings auto-migrated on edit modal open
- New `length`/`width` fields in numistaData — cloud sync unaffected (field-agnostic)

## Files Changed

- `js/catalog-api.js` — `classifyShape()`, `parseDimensions()`, updated `normalizeItemData()`
- `index.html` — Shape select dropdown, Length/Width input fields with wrapper divs
- `js/events.js` — Shape toggle listener, form field integration, migration parser
- `js/inventory.js` — Extended fieldMap with length/width entries
- `js/viewModal.js` — Shape-aware dimension display in Numista section
- `js/constants.js` — APP_VERSION bump + NUMISTA_VIEW_FIELD_DEFAULTS extended
- Version files: CHANGELOG.md, announcements.md, about.js, version.json, sw.js

## Issue

- STAK-528: Shape-aware dimension fields — bars show Length/Width instead of Diameter

## Test Plan

- [ ] Add a rectangular bar item — verify Length/Width fields appear when Shape = Rectangular
- [ ] Edit a round coin — verify Diameter field appears when Shape = Round
- [ ] Toggle Shape dropdown — verify instant field swap with no page reload
- [ ] Numista lookup for N#288223 (rectangular APMEX bar) — verify shape auto-populates
- [ ] Enter "105 x 74" in Diameter, change shape to Rectangular — verify migration
- [ ] View modal: rectangular item shows "L × W mm" format
- [ ] View modal: round item shows "D mm" format
- [ ] Settings > Numista Field Visibility: disable Diameter — verify all dimension fields hidden
- [ ] Cloud sync round-trip preserves length/width fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)