### PR TITLE
chore: pre-ship cleanup — CODEOWNERS, skill updates, GEMINI.md

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -150,7 +150,7 @@ Before gathering release context, run the `/seed-sync` workflow to check for uns
 
 1. `git log --oneline main..dev` — list all commits on dev that aren't on main yet
 2. `git diff --stat main..dev` — summary of files changed
-3. (Optional — requires Linear MCP) Check Linear for any **In Progress** or recently **Done** issues on the StakTrakr team (ID: `f876864d-ff80-4231-ae6c-a8e5cb69aca4`) that relate to commits on dev
+3. Check DocVault issues (`/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Issues/`) for any **in-progress** or recently **done** issues that relate to commits on dev
 
 ### Step 2: Read current state
 
@@ -172,7 +172,7 @@ New version:     3.XX.YY (based on [release/patch] bump)
 Commits since main:
 - [commit list]
 
-Proposed title: [inferred from commits/Linear issues]
+Proposed title: [inferred from commits/DocVault issues]
 
 Proposed changelog bullets:
 - **Label**: Description (STAK-XX)
@@ -256,7 +256,7 @@ Format rules:
 - **What's New**: Keep only the **3–5 most recent** entries (lines between `## What's New` and `## Development Roadmap`). Delete older entries beyond 5.
 - **Development Roadmap**: Keep only the **3–4 most relevant** items. Remove completed items (anything shipped in this release or earlier). If the roadmap has grown beyond 4 items, trim the lowest-priority entries and note which were removed in the release plan output.
 
-Read `ROADMAP.md` (and Linear backlog if MCP is available) to determine which roadmap items are still relevant vs. completed.
+Read `ROADMAP.md` and DocVault issues to determine which roadmap items are still relevant vs. completed.
 
 #### about.js — `getEmbeddedWhatsNew()`
 
@@ -405,16 +405,16 @@ If uncommitted wiki changes exist, commit them before pushing. **Do NOT create a
 
    - [bullet points for this commit/batch]
 
-   ## Linear Issues
+   ## Issues (DocVault)
 
-   - [STAK-XX: title — link] (if applicable)
+   - [STAK-XX: title (status)] (if applicable)
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    EOF
    )"
    ```
 
-3. (Optional — requires Linear MCP) If Linear issues are referenced, update status to **In Progress** (not Done — that happens at merge time).
+3. If DocVault issues are referenced, update frontmatter status to **in-progress** (not done — that happens at merge time).
 
 ### Step 2: PR Resolution & Scan Monitoring (MANDATORY)
 
@@ -450,9 +450,12 @@ git tag --merged origin/dev --sort=-version:refname | grep '^v3\.' | head -20
 
 The tag list gives you every patch breadcrumb on `dev` that hasn't shipped to main yet. These are your changelog source — more reliable than commit messages alone.
 
-### Step 2: Fetch Linear issue titles
+### Step 2: Fetch DocVault issue titles
 
-For each STAK-### found across commits and tag names, call `get_issue` (Linear MCP) to get the current title and status. This ensures the PR description is accurate, not just copy-pasted from commit messages.
+For each STAK-### found across commits and tag names, read the issue file from
+DocVault (`/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Issues/STAK-###.md`)
+to get the current title and status. This ensures the PR description is accurate,
+not just copy-pasted from commit messages.
 
 ### Step 3: Create the `dev → main` PR
 
@@ -477,10 +480,10 @@ gh pr create --base main --head dev --label "codacy-review" \
 - vX.X.X — [title]
 - ...
 
-## Linear Issues
+## Issues (DocVault)
 
-- STAK-XX: [title] — [url]
-- STAK-XX: [title] — [url]
+- STAK-XX: [title] ([status])
+- STAK-XX: [title] ([status])
 
 ## QA Notes
 
@@ -514,9 +517,11 @@ gh pr ready [number]
 
 Then run `/pr-resolve` to clear all open Codacy and Copilot review threads before the PR goes to final review.
 
-### Step 5: Update Linear issues
+### Step 5: Update DocVault issues
 
-Mark all referenced STAK-### issues as **Done** (they ship with this merge).
+Mark all referenced STAK-### issues as **done** in DocVault (they ship with this merge).
+Update each issue file's YAML frontmatter: `status: done`, `completed: "YYYY-MM-DD"`.
+Commit DocVault changes separately (direct to main).
 
 ### Step 6: After the PR merges to main — run Phase 5 immediately
 
@@ -544,7 +549,7 @@ EOF
 
 - Use the changelog section heading as the `## TITLE`
 - Copy changelog bullets verbatim (they're already formatted correctly)
-- Do NOT include file update lists or Linear references — those belong in the PR body, not the release
+- Do NOT include file update lists or issue references — those belong in the PR body, not the release
 
 ### Verify
 
@@ -562,7 +567,7 @@ Version:  vNEW_VERSION
 Commit:   [hash] [message]
 PR:       #XX merged — [url]
 Release:  https://github.com/lbruton/StakTrakr/releases/tag/vNEW_VERSION
-Linear:   STAK-XX → Done
+Issues:   STAK-XX → Done (DocVault)
 ```
 
 ## Dry Run Mode

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -42,28 +42,31 @@ For each tag found, get its commit message title:
 git log --format="%s" "$tag"^.."$tag" | head -1
 ```
 
-## Step 3: Fetch Linear issue titles
+## Step 2.5: Seed Data Sync (MANDATORY)
+
+Before creating the ship PR, ensure seed data is fresh:
+
+```bash
+bash .claude/skills/seed-sync/fetch-live.sh
+```
+
+This pulls the latest spot-history entries from `api.staktrakr.com` and merges
+them into local `data/spot-history-*.json` files. If new entries are found,
+stage and commit them to dev before proceeding.
+
+## Step 3: Fetch DocVault issue titles
 
 For each `STAK-###` reference found across tag names and commit messages,
-fetch the current title and URL via the Linear GraphQL API. This ensures
-the PR description is accurate, not just copy-pasted from commits.
+read the issue file from DocVault to get the current title and status:
 
 ```bash
-# Fetch API key from Infisical first (see linear skill)
-curl -s -X POST https://api.linear.app/graphql \
-  -H "Authorization: $LINEAR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ issue(id: \"STAK-###\") { identifier title url state { name } } }"}'
+ISSUE_DIR="/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Issues"
+# For each STAK-### found:
+cat "$ISSUE_DIR/STAK-###.md"
+# Extract: id, title, status from YAML frontmatter
 ```
 
-For multiple issues, batch them in a single aliased query:
-
-```bash
-curl -s -X POST https://api.linear.app/graphql \
-  -H "Authorization: $LINEAR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ a: issue(id: \"STAK-462\") { identifier title url } b: issue(id: \"STAK-463\") { identifier title url } }"}'
-```
+This ensures the PR description uses accurate titles, not just commit messages.
 
 ## Step 3.5: Audit announcements & about.js (MANDATORY)
 
@@ -120,9 +123,9 @@ gh pr create --base main --head dev --label "codacy-review" \
 - vX.X.X — [title]
 [list all tags from Step 2]
 
-## Linear Issues
+## Issues (DocVault)
 
-- STAK-XX: [title] — [url]
+- STAK-XX: [title] ([status])
 [list all STAK references from Step 3]
 
 ## QA Notes
@@ -144,25 +147,22 @@ gh pr ready "$PR_NUMBER"
 Then run `/pr-resolve` to clear all open Codacy and Copilot review threads
 before the PR goes to final review.
 
-## Step 6: Update Linear issues
+## Step 6: Update DocVault issues
 
-Mark all referenced STAK-### issues as **Done** — they ship with this merge.
+Mark all referenced STAK-### issues as **done** — they ship with this merge.
 
-Use the Linear GraphQL API to update each issue's state to Done:
+For each issue file in DocVault:
 
 ```bash
-# First get the "Done" state ID for the team
-curl -s -X POST https://api.linear.app/graphql \
-  -H "Authorization: $LINEAR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ team(id: \"f876864d-ff80-4231-ae6c-a8e5cb69aca4\") { states(filter: { type: { eq: \"completed\" } }) { nodes { id name } } } }"}'
-
-# Then batch-update all issues
-curl -s -X POST https://api.linear.app/graphql \
-  -H "Authorization: $LINEAR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "mutation { a: issueUpdate(id: \"<UUID_1>\", input: { stateId: \"<DONE_STATE_ID>\" }) { issue { identifier } } b: issueUpdate(id: \"<UUID_2>\", input: { stateId: \"<DONE_STATE_ID>\" }) { issue { identifier } } }"}'
+ISSUE_DIR="/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Issues"
+# Update YAML frontmatter: status: done, completed: "YYYY-MM-DD"
 ```
+
+Update each issue's frontmatter:
+- `status: done`
+- `completed: "YYYY-MM-DD"` (today's date)
+
+Commit the DocVault changes separately (DocVault commits go direct to main).
 
 ## Step 7: After the PR merges to main — GitHub Release (MANDATORY)
 
@@ -197,5 +197,5 @@ Ship complete!
 Version:  vLATEST
 PR:       #XX merged
 Release:  https://github.com/lbruton/StakTrakr/releases/tag/vLATEST
-Linear:   STAK-XX → Done
+Issues:   STAK-XX → Done (DocVault)
 ```

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Require owner review for workflow changes — prevents unauthorized CI/CD modifications
+# See: STAK-531 (malicious workflow incident)
+/.github/workflows/ @lbruton
+/.github/CODEOWNERS @lbruton

--- a/.spec-workflow/steering/tech.md
+++ b/.spec-workflow/steering/tech.md
@@ -60,8 +60,13 @@ Event-driven single-page application with imperative DOM manipulation:
 ### Code Quality Tools
 - **Static Analysis**: ESLint 9.21.0 with custom rules; Codacy automated PR quality gates
 - **Formatting**: ESLint-enforced style (no Prettier)
-- **Testing Framework**: Playwright 1.50.0 for E2E browser tests (16 spec files)
 - **Documentation**: JSDoc comments; in-repo wiki under `wiki/`
+
+### Testing Strategy
+- **Methodology**: TDD — write failing tests BEFORE implementation code. All new behavior gets a regression test first.
+- **Unit/Integration**: No unit test framework (vanilla JS SPA) — Playwright E2E is the primary test layer.
+- **Browser/E2E**: Playwright 1.50.0 (16 spec files). Local execution for TDD loops and pre-merge QA. Transitioning from Browserbase-only E2E to Playwright-first for development workflows.
+- **Cloud verification**: Browserbase reserved for testing live deployed sites only (bug reproduction on production/staging URLs, runbook execution against PR preview URLs).
 
 ### Version Control & Collaboration
 - **VCS**: Git (GitHub)

--- a/.spec-workflow/steering/tech.md
+++ b/.spec-workflow/steering/tech.md
@@ -64,9 +64,9 @@ Event-driven single-page application with imperative DOM manipulation:
 
 ### Testing Strategy
 - **Methodology**: TDD — write failing tests BEFORE implementation code. All new behavior gets a regression test first.
-- **Unit/Integration**: No unit test framework (vanilla JS SPA) — Playwright E2E is the primary test layer.
-- **Browser/E2E**: Playwright 1.50.0 (16 spec files). Local execution for TDD loops and pre-merge QA. Transitioning from Browserbase-only E2E to Playwright-first for development workflows.
-- **Cloud verification**: Browserbase reserved for testing live deployed sites only (bug reproduction on production/staging URLs, runbook execution against PR preview URLs).
+- **Unit/Integration**: No unit test framework (vanilla JS SPA) — natural language E2E runbook tests are the primary test layer.
+- **Browser/E2E**: `tests/runbook/*.md` — 84 NL E2E tests across 8 sections, executed via `/bb-test` through Browserbase/Stagehand against PR preview URLs. TDD enforced: write test blocks BEFORE code.
+- **Cloud verification**: Browserbase executes all E2E tests against Cloudflare preview deployments. Cloud sync/OAuth tested manually at `beta.staktrakr.com`.
 
 ### Version Control & Collaboration
 - **VCS**: Git (GitHub)

--- a/.spec-workflow/templates/tasks-template.md
+++ b/.spec-workflow/templates/tasks-template.md
@@ -153,30 +153,33 @@
   - _Requirements: 5.2, 5.3_
   - _Prompt: Role: React Developer with expertise in state management and API integration | Task: Implement feature-specific components following requirements 5.2 and 5.3, using API hooks from src/hooks/useApi.ts and extending BaseComponent patterns | Restrictions: Must use existing state management patterns, handle loading and error states properly, maintain component performance | Success: Components are fully functional with proper state management, API integration works smoothly, user experience is responsive and intuitive_
 
-- [ ] 6. Integration and testing
-  - Plan integration approach and identify affected runbook sections for TDD test authoring
-  - _Leverage: tests/runbook/*.md, /browserbase-test-maintenance skill_
-  - _Requirements: 6.0_
-  - _Prompt: Role: Integration Engineer with expertise in system integration and testing strategies | Task: Plan comprehensive integration approach following requirement 6.0. Identify which tests/runbook/ section files are affected by this spec and write new runbook test blocks BEFORE implementation tasks begin (TDD). Use the /browserbase-test-maintenance skill for format guidance and section mapping. | Restrictions: Must consider all system components, ensure proper test coverage, write tests in the standard 7-field runbook format | Success: Integration plan is comprehensive, runbook test blocks are written for all new user-facing behavior, tests are appended to the correct section files_
+## Standard Closing Tasks
 
-- [ ] 6.1 Write end-to-end runbook tests (TDD — write BEFORE implementation)
-  - Write runbook test blocks in tests/runbook/*.md for new user-facing behavior
-  - Use the /browserbase-test-maintenance skill for the standard 7-field format
-  - Map implementation changes to the correct runbook section file
-  - _Leverage: /browserbase-test-maintenance skill, tests/runbook/*.md section files_
+- [ ] 6. Run project test suite and verify baseline
+  - Run the project's test command to establish a passing baseline before changes
+  - If no test suite exists, flag this and discuss with the user
+  - _Leverage: Project test configuration (package.json scripts, vitest.config, jest.config, etc.)_
   - _Requirements: All_
-  - _Prompt: Role: QA Automation Engineer with expertise in Browserbase/Stagehand natural-language browser automation | Task: Write runbook test blocks in tests/runbook/*.md for all new user-facing behavior using the /browserbase-test-maintenance skill. Each test block must use the 7-field format (Test name, Added, Preconditions, Steps, Pass criteria, Tags, Section). Map changes to the correct section file. After implementation, verify by running /bb-test sections=NN against the PR preview URL. | Restrictions: Use the standard runbook format, append to section files (never modify existing tests), act steps must be atomic. No Playwright, no browserless. | Success: All new user-facing behavior has corresponding runbook test blocks, tests pass when run via /bb-test against the PR preview URL_
+  - _Prompt: Role: QA Engineer | Task: Run the project's established test suite to verify a passing baseline before implementation. Identify the test command from package.json, CLAUDE.md, or project conventions. If no test suite exists, flag this to the user. | Restrictions: Use the project's existing test framework, do not introduce a new one. | Success: Test suite runs and baseline results are recorded._
 
-- [ ] 6.2 Verify tests against PR preview
-  - Run /bb-test sections=NN against PR preview URL to verify all new tests pass
-  - _Leverage: /bb-test skill, PR preview URL from gh pr checks_
+- [ ] 6.1 Write tests for new behavior (TDD — write BEFORE implementation)
+  - Write failing tests using the project's test framework for all new behavior
+  - Tests should cover the acceptance criteria from requirements.md
+  - _Leverage: Project test framework, requirements.md acceptance criteria_
   - _Requirements: All_
-  - _Prompt: Role: QA Automation Engineer | Task: Run /bb-test sections=NN against the PR preview URL to verify all new runbook tests pass. Get the preview URL with: gh pr checks <PR_NUMBER> --json name,state,targetUrl. For 1-3 tests, consider manual verification via Chrome DevTools instead of a full Browserbase session. | Restrictions: Do NOT use Playwright or browserless. | Success: All new tests pass against the PR preview URL_
+  - _Prompt: Role: QA Engineer | Task: Write failing tests for all new behavior described in requirements.md using the project's test framework. Follow TDD - tests must fail before implementation, pass after. | Restrictions: Use the project's existing test framework. Tests must be runnable with the project's test command. | Success: Failing tests exist for all new acceptance criteria._
+
+- [ ] 6.2 Verify all tests pass after implementation
+  - Run the full test suite after all implementation tasks are complete
+  - All new tests must pass; no existing tests may regress
+  - _Leverage: Project test command_
+  - _Requirements: All_
+  - _Prompt: Role: QA Engineer | Task: Run the project's full test suite. Verify all new tests pass and no existing tests regressed. | Restrictions: Do not skip or disable failing tests. | Success: Full test suite passes with zero regressions._
 
 - [ ] 6.3 Final integration and cleanup
   - Integrate all components
-  - Fix any integration issues
-  - Clean up code and documentation
-  - _Leverage: src/utils/cleanup.ts, docs/templates/_
+  - Verify no lint or type errors
+  - Clean up temporary code and documentation
+  - _Leverage: Project lint/build commands_
   - _Requirements: All_
-  - _Prompt: Role: Senior Developer with expertise in code quality and system integration | Task: Complete final integration of all components and perform comprehensive cleanup covering all requirements, using cleanup utilities and documentation templates | Restrictions: Must not break existing functionality, ensure code quality standards are met, maintain documentation consistency | Success: All components are fully integrated and working together, code is clean and well-documented, system meets all requirements and quality standards_
+  - _Prompt: Role: Senior Developer | Task: Complete final integration of all components and perform comprehensive cleanup. Run lint and type checks. Remove any temporary code or debug statements. | Restrictions: Must not break existing functionality. Ensure code quality standards are met. | Success: All components integrated, no lint or type errors, code is clean._

--- a/.spec-workflow/user-templates/design-template.md
+++ b/.spec-workflow/user-templates/design-template.md
@@ -2,7 +2,7 @@
 
 ## References
 
-- **Issue:** PROJ-XXX
+- **Issue:** STAK-XXX
 - **GitHub PR:** [#NNN](https://github.com/owner/repo/pull/NNN)
 - **Spec Path:** `.spec-workflow/specs/{spec-name}/`
 

--- a/.spec-workflow/user-templates/design-template.md
+++ b/.spec-workflow/user-templates/design-template.md
@@ -131,13 +131,11 @@ _If **No**, skip this section entirely. If **Yes**, complete all fields below �
 
 ## Testing Strategy
 
-### Automated Tests
-- **Test Framework:** [Identify the project's test framework — check for vitest.config, jest.config, pytest.ini, or package.json test script]
-- **Test Command:** [The command to run the project's test suite — e.g., `npm test`, `npx vitest`, `pytest`]
-- **Test Directory:** [Where tests live in this project — e.g., `src/__tests__/`, `tests/`, `test/`]
-- **New tests to write (TDD — before implementation):** [describe tests using the project's framework]
-- **Run via:** [project's test command] after implementation
+### Runbook E2E Tests (Primary)
+- Identify affected `tests/runbook/` section(s): [01-page-load, 02-crud, 03-backup-restore, 04-import-export, 05-market, 06-ui-ux, 07-activity-log, 08-spot-prices]
+- New test blocks to write (TDD — before implementation): [describe tests]
+- Run via `/bb-test sections=NN` against PR preview URL
 
 ### Manual Verification
-- [Any flows that require manual testing beyond the automated test suite]
-- [Flows requiring API keys, external services, or user interaction]
+- [Any flows that require manual testing, e.g., OAuth/Dropbox cloud sync at beta.staktrakr.com]
+- [Flows requiring API keys from Infisical]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,19 +17,20 @@ Specializes in: documentation, research, security, and full-lifecycle spec imple
 
 ## Project Context
 
-**StakTrakr** is a vanilla JS inventory system. Zero build step, zero dependencies. 
+**StakTrakr** is a vanilla JS inventory system. Zero build step, zero dependencies.
 **Key mandate:** All DOM access must use `safeGetElement(id)` from `js/utils.js`.
 
 ## Specflow Lifecycle
 
 Specs live in `.spec-workflow/specs/`. Use the following tools:
+
 - `spec-workflow.spec-status` — Check task progress
 - `spec-workflow.log-implementation` — Mandatory after every task
 - `code-graph-context` — Map script load order and function calls
 
 ## Security & Audit
 
-- **Storage**: Inventory data lives in `localStorage`. Validate encryption/decryption logic in `js/storage.js`.
+- **Storage**: Inventory data lives in `localStorage`. Validate encryption/decryption logic in `js/vault.js`.
 - **API**: Fly.io pollers populate the market/spot feeds. Verify stale thresholds during audits.
 - **Secrets**: Use Infisical for test keys and API credentials.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,38 @@
+# GEMINI.md
+
+**For Gemini CLI (Interactive Agent)** — Full peer agent in the specflow stack.
+Specializes in: documentation, research, security, and full-lifecycle spec implementation.
+
+> See `~/.gemini/GEMINI.md` for global workflow rules, mandatory gates, and shared peer stack protocols.
+
+---
+
+## Peer Stack Context
+
+| Agent | Focus in StakTrakr |
+|-------|--------------------|
+| Claude Code | Architecture, feature implementation, Browserbase testing |
+| Codex | Adversarial review, localStorage data modeling, security |
+| Gemini | Specflow orchestration, DocVault truth, API infrastructure, audits |
+
+## Project Context
+
+**StakTrakr** is a vanilla JS inventory system. Zero build step, zero dependencies. 
+**Key mandate:** All DOM access must use `safeGetElement(id)` from `js/utils.js`.
+
+## Specflow Lifecycle
+
+Specs live in `.spec-workflow/specs/`. Use the following tools:
+- `spec-workflow.spec-status` — Check task progress
+- `spec-workflow.log-implementation` — Mandatory after every task
+- `code-graph-context` — Map script load order and function calls
+
+## Security & Audit
+
+- **Storage**: Inventory data lives in `localStorage`. Validate encryption/decryption logic in `js/storage.js`.
+- **API**: Fly.io pollers populate the market/spot feeds. Verify stale thresholds during audits.
+- **Secrets**: Use Infisical for test keys and API credentials.
+
+## Issue Tracking
+
+DocVault Prefix: `STAK-`. All code changes require a DocVault issue.


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` requiring owner review for workflow changes (STAK-531 Phase 4 hardening)
- Migrate `/ship` and `/release` skills from Linear API references to DocVault issue reads
- Add seed-sync step to ship skill (was missing)
- Add `GEMINI.md` instruction file
- Update spec-workflow steering doc and templates

## Context

Pre-ship housekeeping before the v3.33.93 dev→main weekly release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)