### PR TITLE
docs: trim announcements for v3.33.93 ship

### DIFF
--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -4,5 +4,4 @@
 - **V1 API Cleanup + Market Log Fix (v3.33.92)**: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)
 - **Cloud Sync Fixes (v3.33.91)**: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed — blank values persist correctly (STAK-519)
 - **StakTrakr API Settings Fix (v3.33.90)**: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)
-- **Market Filter Matrix (v3.33.89)**: Settings > Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings
-- **Market Data Module (v3.33.87)**: Best Price Ticker, Vendor Prices comparison table with clickable buy links, and Market Detail Modal with TradingView charts — all powered by the v2 API
+- **Market Filter Matrix (v3.33.89)**: Settings > Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings (STAK-515)


### PR DESCRIPTION
## Summary

- Trim What's New to 5 entries (remove stale v3.33.87 entry)
- Add missing STAK-515 reference to market filter matrix entry

Pre-ship cleanup per Step 3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)