### PR TITLE
v3.33.94 — fix: catalog API key cloud sync (STAK-533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.94] - 2026-04-05
+
+### Fixed — Catalog API Key Cloud Sync (STAK-533)
+
+- **Fixed**: Numista API key and PCGS bearer token now sync across devices via cloud sync. `catalog_api_config` was missing from `SYNC_SCOPE_KEYS` — the root cause of recurring sync failures across STAK-519 and STAK-526
+- **Fixed**: Misleading comment on `metalApiConfig` that incorrectly claimed it stored Numista/PCGS keys — it only stores spot provider keys
+- **Added**: Catalog API key conflicts now appear in the merge diff modal under "API & Numista" group
+
+---
+
 ## [3.33.93] - 2026-04-03
 
 ### Added — Shape-Aware Dimension Fields (STAK-528)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,7 +1,7 @@
 ## What's New
 
+- **Catalog API Key Sync Fix (v3.33.94)**: Numista API key and PCGS bearer token now sync across devices. Catalog key conflicts appear in merge diff modal (STAK-533)
 - **Shape-Aware Dimensions (v3.33.93)**: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing "LxW" diameter strings auto-migrate on edit (STAK-528)
 - **V1 API Cleanup + Market Log Fix (v3.33.92)**: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)
 - **Cloud Sync Fixes (v3.33.91)**: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed — blank values persist correctly (STAK-519)
 - **StakTrakr API Settings Fix (v3.33.90)**: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)
-- **Market Filter Matrix (v3.33.89)**: Settings > Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings (STAK-515)

--- a/js/about.js
+++ b/js/about.js
@@ -185,11 +185,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.94 &ndash; Catalog API Key Sync Fix</strong>: Numista API key and PCGS bearer token now sync across devices. Catalog key conflicts appear in merge diff modal (STAK-533)</li>
     <li><strong>v3.33.93 &ndash; Shape-Aware Dimensions</strong>: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing &ldquo;LxW&rdquo; diameter strings auto-migrate on edit (STAK-528)</li>
     <li><strong>v3.33.92 &ndash; V1 API Cleanup + Market Log Fix</strong>: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)</li>
     <li><strong>v3.33.91 &ndash; Cloud Sync Fixes</strong>: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed &mdash; blank values persist correctly (STAK-519)</li>
     <li><strong>v3.33.90 &ndash; StakTrakr API Settings Fix</strong>: Cache settings no longer revert to 24h. StakTrakr panel simplified to enabled toggle + auto-refresh. Tab moved to first position as primary free provider (STAK-518)</li>
-    <li><strong>v3.33.89 &ndash; Market Filter Matrix</strong>: Settings &gt; Market redesigned with checkbox filter matrix. Enable/disable items and vendors per metal category. Ticker and vendor prices table respect filter settings (STAK-515)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.93";
+const APP_VERSION = "3.33.94";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -862,7 +862,8 @@ const SYNC_SCOPE_KEYS = [
   'providerPriority',          // provider priority config
 
   // ── API credentials ──
-  'metalApiConfig',            // API_KEY_STORAGE_KEY — Numista/PCGS/spot provider keys
+  'metalApiConfig',            // API_KEY_STORAGE_KEY — spot provider keys (MetalPriceAPI, Metals-API, Custom)
+  'catalog_api_config',          // Numista API key, PCGS bearer token (CatalogConfig)
 ];
 
 const SPOT_HISTORY_RUNTIME_WINDOW_DAYS = 180;

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -501,7 +501,7 @@
   }
 
   function _formatSettingValue(key, value) {
-    if (key === 'metalApiConfig') return value ? '\u2022\u2022\u2022 configured' : 'not set';
+    if (key === 'metalApiConfig' || key === 'catalog_api_config') return value ? '\u2022\u2022\u2022 configured' : 'not set';
     value = _parseSetting(value);
     if (value === null || value === undefined) return '\u2014';
     if (typeof value === 'boolean') return value ? 'On' : 'Off';

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -51,7 +51,7 @@
     },
     'API & Numista': {
       icon: '\uD83D\uDCDA',
-      keys: ['metalApiConfig','numista_tags_auto','numistaLookupRules','numistaViewFields']
+      keys: ['metalApiConfig','catalog_api_config','numista_tags_auto','numistaLookupRules','numistaViewFields']
     }
   };
 
@@ -98,7 +98,8 @@
     'numista_tags_auto': 'Auto-Tag on Lookup',
     'numistaLookupRules': 'Lookup Rules',
     'numistaViewFields': 'View Fields',
-    'metalApiConfig': 'API Keys'
+    'metalApiConfig': 'API Keys',
+    'catalog_api_config': 'Catalog API Keys'
   };
 
   var SETTINGS_VALUE_TYPE = {

--- a/js/settings.js
+++ b/js/settings.js
@@ -2578,7 +2578,7 @@ const renderMarketFilterMatrix = () => {
       }
     });
     if (statusEl) {
-      statusEl.textContent = 'Showing ' + visibleProductCount + ' products \u00b7 ' + activeVendorCount + ' of ' + totalVendors + ' vendors active';
+      statusEl.textContent = 'Showing ' + visibleProductCount + (visibleProductCount === 1 ? ' product' : ' products') + ' \u00b7 ' + activeVendorCount + ' of ' + totalVendors + (totalVendors === 1 ? ' vendor' : ' vendors') + ' active';
     }
   }
 };

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.93-b1775351990';
+const CACHE_NAME = 'staktrakr-v3.33.94-b1775398034';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.93-b1775243384';
+const CACHE_NAME = 'staktrakr-v3.33.93-b1775351990';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.94-b1775398034';
+const CACHE_NAME = 'staktrakr-v3.33.94-b1775399084';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.93",
-  "releaseDate": "2026-04-03",
+  "version": "3.33.94",
+  "releaseDate": "2026-04-05",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after QA passes. Do NOT target main.

## Changes

- **Fixed**: `catalog_api_config` added to `SYNC_SCOPE_KEYS` — Numista API key and PCGS bearer token now sync across devices via cloud sync
- **Fixed**: Misleading comment on `metalApiConfig` corrected (stores spot provider keys only, not Numista/PCGS)
- **Added**: `catalog_api_config` added to DiffModal `SETTINGS_GROUPS` and `SETTINGS_LABELS` so catalog key conflicts appear in merge diff UI

## Issues (DocVault)

- STAK-533: Numista API key stripped during cloud sync — recurring regression (in-progress)

## Files Changed

- `js/constants.js` — SYNC_SCOPE_KEYS + comment fix
- `js/diff-modal.js` — SETTINGS_GROUPS + SETTINGS_LABELS
- `js/about.js`, `docs/announcements.md`, `CHANGELOG.md`, `version.json` — version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)