### PR TITLE
chore: flatten providers.json v2 shape to fix vendor product links

### DIFF
--- a/js/retail.js
+++ b/js/retail.js
@@ -602,11 +602,16 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
     const providersResp = await fetch(providersUrl, { signal: AbortSignal.timeout(5000) });
     if (providersResp.ok) {
       const raw = await providersResp.json();
-      const flattened = {};
+      // Use prototype-less objects to defend against prototype pollution via
+      // malicious __proto__ / constructor keys in parsed JSON. Bracket access at
+      // all 5 consumer call sites continues to work unchanged — this is a drop-in
+      // safer-object pattern that avoids the Map API rewrite that would otherwise
+      // cascade across market-data.js, retail-view-modal.js, and retail.js.
+      const flattened = Object.create(null);
       const coinsObj = (raw && raw.coins) || {};
       for (const [slug, coin] of Object.entries(coinsObj)) {
         if (!coin || !Array.isArray(coin.providers)) continue;
-        const vendorMap = {};
+        const vendorMap = Object.create(null);
         for (const p of coin.providers) {
           if (p && p.id && p.enabled !== false && p.url) {
             vendorMap[p.id] = p.url;
@@ -614,10 +619,20 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
         }
         if (Object.keys(vendorMap).length) flattened[slug] = vendorMap;
       }
-      retailProviders = flattened;
-      if (typeof window !== "undefined") window.retailProviders = retailProviders;
-      saveDataSync(RETAIL_PROVIDERS_KEY, retailProviders);
-      debugLog(`[retail-v2] Loaded ${Object.keys(retailProviders).length} coin provider mappings`, "info");
+      // Resilience guard: on poller hiccups the endpoint may return HTTP 200 with
+      // an empty/malformed body (no coins, empty coins object, wrong schema). If
+      // the flatten produces no slugs, keep the existing cached map instead of
+      // wiping it — overwriting with an empty map regresses previously-working
+      // product links until the next successful fetch.
+      if (Object.keys(flattened).length === 0) {
+        const existingCount = Object.keys(retailProviders || {}).length;
+        debugLog(`[retail-v2] providers.json parsed but produced empty map — keeping ${existingCount} existing cached mappings`, "warn");
+      } else {
+        retailProviders = flattened;
+        if (typeof window !== "undefined") window.retailProviders = retailProviders;
+        saveDataSync(RETAIL_PROVIDERS_KEY, retailProviders);
+        debugLog(`[retail-v2] Loaded ${Object.keys(retailProviders).length} coin provider mappings`, "info");
+      }
     } else {
       debugLog(`[retail-v2] providers.json fetch non-OK: ${providersResp.status}`, "warn");
     }

--- a/js/retail.js
+++ b/js/retail.js
@@ -592,20 +592,39 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
     try { localStorage.setItem(RETAIL_MANIFEST_VENDOR_META_KEY, JSON.stringify(_manifestVendorMeta)); } catch { /* ignore */ }
   }
 
-  // Fetch providers.json for vendor product page URLs (same as v1)
+  // Fetch providers.json for vendor product page URLs.
+  // STAK-348 migrated the shape to { coins: { slug: { name, providers: [{ id, url, enabled }] } } }.
+  // Flatten back to the legacy { slug: { vid: url } } map that all render call sites expect
+  // (js/market-data.js:229/649/879, js/retail-view-modal.js:111, js/retail.js:934).
+  // Without this transform every lookup returns undefined and clicks silently fall back to vendor homepages.
   try {
     const providersUrl = `${apiBase}/providers.json`;
     const providersResp = await fetch(providersUrl, { signal: AbortSignal.timeout(5000) });
     if (providersResp.ok) {
-      retailProviders = await providersResp.json();
-      if (retailProviders && retailProviders._vendor_meta) {
-        _manifestVendorMeta = retailProviders._vendor_meta;
+      const raw = await providersResp.json();
+      const flattened = {};
+      const coinsObj = (raw && raw.coins) || {};
+      for (const [slug, coin] of Object.entries(coinsObj)) {
+        if (!coin || !Array.isArray(coin.providers)) continue;
+        const vendorMap = {};
+        for (const p of coin.providers) {
+          if (p && p.id && p.enabled !== false && p.url) {
+            vendorMap[p.id] = p.url;
+          }
+        }
+        if (Object.keys(vendorMap).length) flattened[slug] = vendorMap;
       }
+      retailProviders = flattened;
       if (typeof window !== "undefined") window.retailProviders = retailProviders;
       saveDataSync(RETAIL_PROVIDERS_KEY, retailProviders);
-      debugLog(`[retail-v2] Loaded ${Object.keys(retailProviders || {}).length} coin provider mappings`, "info");
+      debugLog(`[retail-v2] Loaded ${Object.keys(retailProviders).length} coin provider mappings`, "info");
+    } else {
+      debugLog(`[retail-v2] providers.json fetch non-OK: ${providersResp.status}`, "warn");
     }
-  } catch { /* non-fatal — vendor links degrade to homepage */ }
+  } catch (err) {
+    // Surface fetch failures — the historical silent catch here masked the STAK-348 schema drift for months.
+    debugLog(`[retail-v2] providers.json fetch failed: ${err.message}`, "warn");
+  }
 
   const slugs = _manifestSlugs.length ? _manifestSlugs : RETAIL_SLUGS;
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.95-b1775928622';
+const CACHE_NAME = 'staktrakr-v3.33.95-b1775929761';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.95-b1775858102';
+const CACHE_NAME = 'staktrakr-v3.33.95-b1775928622';
 
 
 


### PR DESCRIPTION
## Summary

Fresh-browser users have been getting dropped on vendor homepages when clicking retail prices, instead of the product page for the coin they clicked. Root cause is a long-standing schema drift between the poller (STAK-348 moved `providers.json` to Turso with a new nested shape) and the frontend (never updated, still expects the old flat shape). The silent `catch` around the fetch is how it went unnoticed.

**User repro**: scroll to the price chart → click cheapest price on any coin → APMEX/BullionExchanges/etc. homepage opens instead of the product page. Only affects users with no prior StakTrakr localStorage — anyone with a cached v1 `retailProviders` map still works against stale data.

## Root cause

`devops/pollers/shared/export-providers-json.js` (STAK-348 — Turso migration) writes:

```json
{ "coins": { "britannia-silver": { "providers": [ {"id": "apmex", "url": "...product..."} ] } } }
```

But `js/retail.js:596-608` stores the raw response unchanged, and five render call sites all read:

```js
retailProviders[slug][vid]  // expects { "britannia-silver": { "apmex": "...product..." } }
```

Every lookup returns `undefined`. All five call sites fall through to `vendorMeta[vid].url` — the vendor homepage.

**Affected call sites** (all unchanged by this PR — they keep working because we flatten at the fetch boundary):
- `js/market-data.js:229` — best-price ticker
- `js/market-data.js:649` — vendor price table buy-link column
- `js/market-data.js:879` — vendor price table click handler
- `js/retail-view-modal.js:111` — retail view modal
- `js/retail.js:934` — retail card chips

## Fix

Transform `providers.json` at the fetch boundary in `_syncRetailV2`:

- Flatten `{coins: {slug: {providers: [{id, url, enabled}]}}}` → `{slug: {vid: url}}`
- Honor `enabled: false` so disabled vendors don't produce clickable links
- Replace the historical silent `catch` with `debugLog` warnings on both non-OK and thrown-error branches — the swallowed exception is precisely how this drift went unnoticed for months

Existing users with the old flat-shape cache self-heal on next visit when `saveDataSync(RETAIL_PROVIDERS_KEY, ...)` overwrites localStorage with the transformed response.

Also dropped the `retailProviders._vendor_meta` override code — the new schema has no `_vendor_meta` key, so the override was dead (and `_manifestVendorMeta` is correctly populated from manifest.json earlier in the same function).

## Verification

Verified the flatten logic against live data before committing:

```
$ curl -s https://api2.staktrakr.com/data/retail/providers.json | jq keys
["coins"]

$ node <flatten.js> /tmp/providers.json
Total flattened slugs: 23
britannia-silver:
  apmex: https://www.apmex.com/product/53532/great-britain-1-oz-silver-britannia-bu-random-year
  bullionexchanges: https://bullionexchanges.com/great-britain-silver-1-oz-britannia-coin-bu-random-year
  herobullion, jmbullion, monumentmetals, providentmetals, sdbullion, summitmetals: ...
```

All 8 vendors for britannia-silver resolve to real product pages. `node --check js/retail.js` passes.

## Test plan

- [ ] Hit `beta.staktrakr.com` on a fresh browser (incognito or a machine with no StakTrakr history)
- [ ] Scroll to the retail price chart
- [ ] Click the cheapest price on a britannia (silver) — should open APMEX product page, not APMEX homepage
- [ ] Click prices on a few other coins across different vendors — same expectation
- [ ] Click a ticker item (horizontal best-price strip) — same expectation
- [ ] Verify existing users (primary browser with cached `retailProviders`) keep working after next background sync overwrites their cache
- [ ] Check browser console — should now see `[retail-v2] Loaded 23 coin provider mappings` on load instead of silence (and a `warn` if the fetch ever fails)

## Notes

- No version bump — rolls into next release
- No issue — casual fix below spec threshold, tracked in this PR body
- Discovered during user session on 2026-04-11 testing StakTrakr on a fresh Edge install
- Related: splash/ackModal removal will be filed as a separate issue for a follow-up session

🤖 Generated with [Claude Code](https://claude.com/claude-code)