### PR TITLE
fix: publish providers.json to v2 endpoint surface (the actual fix)

### DIFF
--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -857,6 +857,23 @@ async function exportGoldback(client) {
 }
 
 // ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+async function writeProviders(client) {
+  log("Writing v2 providers...");
+  await initProviderSchema(client);
+  const providersData = await getProviders(client);
+  // 86400s (24h) stale_after — vendor product URLs are stable reference data,
+  // not price data. They change only when a dealer restructures their site.
+  // This fills the gap where v1 had data/api/providers.json but v2 never
+  // published an equivalent under data/v2/, causing the frontend to 404 on
+  // every providers.json lookup and fall back to vendor homepage URLs.
+  writeV2File("providers.json", providersData, 86400);
+  log("Providers written");
+}
+
+// ---------------------------------------------------------------------------
 // Manifest
 // ---------------------------------------------------------------------------
 
@@ -914,6 +931,7 @@ async function writeManifest(client) {
       goldback_latest:     "goldback/latest.json",
       goldback_monthly:    "goldback/{YYYY}/{MM}.json",
       goldback_history:    "goldback/history-30d.json",
+      providers:           "providers.json",
       manifest:            "manifest.json",
     },
   }, 1800);
@@ -961,6 +979,16 @@ async function main() {
     } catch (err) {
       hadError = true;
       warn(`Goldback export failed: ${err.message}`);
+    }
+
+    // Providers export (vendor product URLs — stable reference data, 24h stale)
+    const providersStart = Date.now();
+    try {
+      await writeProviders(client);
+      log(`Providers phase: ${Date.now() - providersStart}ms`);
+    } catch (err) {
+      hadError = true;
+      warn(`Providers export failed: ${err.message}`);
     }
 
     // Manifest (always written last, even if some exports failed)

--- a/js/retail.js
+++ b/js/retail.js
@@ -608,7 +608,10 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
       // safer-object pattern that avoids the Map API rewrite that would otherwise
       // cascade across market-data.js, retail-view-modal.js, and retail.js.
       const flattened = Object.create(null);
-      const coinsObj = (raw && raw.coins) || {};
+      // v2 endpoints use a self-describing envelope { v, generated_at, stale_after, data }.
+      // Defensive fallback to bare { coins } shape handles the brief deploy window where
+      // the poller hasn't redeployed yet and the old non-envelope shape is still served.
+      const coinsObj = (raw && raw.data && raw.data.coins) || (raw && raw.coins) || {};
       for (const [slug, coin] of Object.entries(coinsObj)) {
         if (!coin || !Array.isArray(coin.providers)) continue;
         const vendorMap = Object.create(null);

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.95-b1775929761';
+const CACHE_NAME = 'staktrakr-v3.33.95-b1775934251';
 
 
 


### PR DESCRIPTION
## Summary

This is the **actual fix** for the vendor-URL-opens-homepage bug that PR #950 was aimed at but did not resolve. Chrome DevTools clean-state testing today revealed that PR #950's frontend schema-drift analysis was correct about the file shape but **at the wrong layer** — the frontend was never receiving the file at all because the fetch URL returns 404.

## Root cause

Confirmed live via Chrome DevTools Network tab:

```
reqid=492  GET https://api.staktrakr.com/data/v2/providers.json  [404]
```

The frontend fetches `${apiBase}/providers.json` where `apiBase` resolves to `https://api.staktrakr.com/data/v2`. That gives `data/v2/providers.json`, which **doesn't exist at that path**.

Curl probe of all plausible URLs:

| URL | Status |
|---|---|
| `api.staktrakr.com/data/v2/providers.json` (what frontend fetches) | **404** |
| `api.staktrakr.com/data/retail/providers.json` | 200 (37249 bytes) |
| `api2.staktrakr.com/data/retail/providers.json` | 200 (37249 bytes) |

The file is produced by `export-providers-json.js` and written to `data/retail/providers.json`, and separately by v1's `api-export.js` at `data/api/providers.json`. The STAK-503 v2 API redesign migrated spot, retail, and goldback endpoints to `data/v2/` but **never published a v2 equivalent of providers.json**. The frontend was updated to fetch from v2 but the publisher side of that migration never happened. Every frontend click on a vendor price has been silently falling back to `vendorMeta[vid].url` (the vendor homepage) for fresh-browser users ever since.

The previously-working case (primary browser with stale localStorage) is explained by `loadRetailProviders()` reading a pre-regression `retailProviders` blob from localStorage on every page load, which kept product URLs resolving correctly until the browser was cleared.

PR #950 was technically-correct-but-useless: it processed JSON the frontend never received. The `Object.create(null)` hardening and resilience guard from that PR remain valid defensive code once this PR lands the data pipeline.

## Fix — publisher side (`devops/pollers/shared/api-export-v2.js`)

Three surgical additions to the existing v2 publisher:

1. **New `writeProviders(client)` function** — calls `initProviderSchema` and `getProviders` from `provider-db.js` (the same functions `writeManifest` already uses), then writes the result to `data/v2/providers.json` via the shared `writeV2File` helper with `stale_after=86400` (24h). The 24-hour threshold reflects that vendor product URLs are stable reference data, not price data — they change only when a dealer restructures their site. Consistent with the goldback threshold (25h).

2. **Call in `main()`** between `exportGoldback` and `writeManifest`, wrapped in the same hadError-accumulating try/catch pattern as all other phases. Non-fatal if the write fails — the manifest still publishes.

3. **`providers: "providers.json"`** added to the v2 manifest endpoints registry so the v2 manifest advertises the new endpoint per the v2 self-describing design.

## Fix — frontend side (`js/retail.js`)

One-line change to unwrap the v2 envelope:

```diff
  const flattened = Object.create(null);
- const coinsObj = (raw && raw.coins) || {};
+ // v2 endpoints use a self-describing envelope { v, generated_at, stale_after, data }.
+ // Defensive fallback to bare { coins } shape handles the brief deploy window where
+ // the poller hasn't redeployed yet and the old non-envelope shape is still served.
+ const coinsObj = (raw && raw.data && raw.data.coins) || (raw && raw.coins) || {};
```

The defensive fallback handles the deploy crossover window.

## DocVault updates (mandatory per api-infrastructure skill)

The `api-infrastructure` skill's "When Making Changes — Update ALL of These" table requires documentation updates alongside any API surface change. Committed locally in DocVault (will sync via nightly cadence):

**`Projects/StakTrakr/API Reference.md`:**
- Added `data/v2/providers.json` row to the v2 endpoint table
- Added Providers (86400s / 24h) row to the stale_after thresholds table
- Added `providers` key to the v2 manifest schema JSON example
- Added `devops/pollers/shared/api-export-v2.js` and `js/retail.js` to sourceFiles frontmatter so future changes to these files are auto-detected by `/vault-update`

**`Projects/StakTrakr/Remote Poller.md`:**
- Added `devops/pollers/shared/api-export-v2.js` to sourceFiles frontmatter (pre-existing drift — it was missing despite being called from `run-publish.sh` since STAK-503)
- Updated publish pipeline step 2 to include providers in the v2 endpoint output list with a historical note on the 2026-04-11 regression
- Bumped `updated` from 2026-03-25 to 2026-04-11

## Verification

**Syntax:** `node --check` passes on both `api-export-v2.js` and `retail.js`.

**Envelope unwrap simulation** — 5 payload shapes tested against the new logic:
- Old non-envelope `{coins: {...}}` → ✓ flattens via fallback
- New v2 envelope `{v: 2, data: {coins: {...}}}` → ✓ flattens via `raw.data.coins`
- Empty body `{}` → ✓ empty flatten → resilience guard keeps existing cache
- `null` → ✓ empty flatten → resilience guard
- Wrong shape `{foo: "bar"}` → ✓ empty flatten → resilience guard

**Anchor placement verified** in the v2 publisher:
- `writeProviders` function definition at line 863
- `providers: "providers.json"` in manifest endpoints at line 934
- `await writeProviders(client)` in main() at line 987

## Deployment — TWO-phase, requires manual Fly.io deploy

Per DocVault `Remote Poller.md` and the `api-infrastructure` skill, the Fly.io poller is **manual-deploy only** — there is no GHA workflow that redeploys on merge. The old `spot-poller.yml` is retired, and `Merge Poller Branches` on StakTrakrApi just merges `api → main` for Pages serving.

- [ ] Step 1: Merge this PR to `dev` → frontend auto-deploys to `beta.staktrakr.com` via GitHub Pages
      *(No user-visible effect yet — the poller hasn't redeployed, so `data/v2/providers.json` still returns 404.)*
- [ ] Step 2: Manually run `fly deploy --config remote-poller/fly.toml --dockerfile remote-poller/Dockerfile` from `devops/pollers/` to push the updated `api-export-v2.js` to the Fly.io poller image
- [ ] Step 3: Wait for the next publish tick (cron `8,23,38,53` — worst case ~15 minutes)
- [ ] Step 4: Verify `curl https://api.staktrakr.com/data/v2/providers.json` returns a v2 envelope with `data.coins` populated (~23 slugs)
- [ ] Step 5: Clean-state browser test on `beta.staktrakr.com` — clicking the cheapest price on britannia-silver should open the APMEX product page, not the APMEX homepage

## Followup (out of scope for this PR)

- GHA workflow for auto-deploying Fly.io poller on merge when `devops/pollers/**` changes — would eliminate the manual step 2 as a future footgun. Worth a separate issue.
- Architectural consideration: a redirect endpoint pattern (`/go/{slug}/{vendor}` → 302 to vendor product URL) would eliminate frontend URL caching entirely, be popup-blocker safe, and enable click analytics. Raised during today's session. Worth a separate `/discover` or `/spec` session.

## Notes

- Discovered 2026-04-11 via Chrome DevTools clean-state reload on `beta.staktrakr.com` after PR #950 merged. Network tab showed `GET https://api.staktrakr.com/data/v2/providers.json [404]` — the 30-second-smoking-gun I should have checked before writing PR #950. Saved as a retro-learning lesson.
- This is a `/gsd`-class touch count but the mandatory DocVault updates override `/gsd`'s "no vault update" default because the higher-priority project CLAUDE.md rule ("DocVault updates are mandatory before PR push") wins.
- No version bump — rolls into next release with PR #950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)