### PR TITLE
v3.33.96 — STAK-521: Quarantine unresolved slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.33.96] - 2026-04-11
+
+### Added — STAK-521: Quarantine unresolved slugs
+
+- **Fixed**: Three-plane asymmetry in market filter — unresolved slugs (metadata not yet landed from manifest) were hidden from the filter matrix UI but defaulted to enabled in the control plane, leaking into cards/ticker/table with raw-string labels users could not toggle off. Closed at the upstream chokepoint via new `_isSlugResolved` predicate in `getActiveRetailSlugs()`. Also removes redundant `displaySlugs` filter in `settings.js` and deletes the obsolete `_HIDDEN_SLUGS` hardcoded exclusion set. Latent fail-safe — historical trigger already retired by v2 API publisher refactor. (STAK-521)
+
+---
+
 ## [3.33.95] - 2026-04-10
 
 ### Fixed — Cloud Sync Atomic Rollback on Settings Write Failure (STAK-526)

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,7 +1,7 @@
 ## What's New
 
+- **STAK-521: Quarantine unresolved slugs (v3.33.96)**: Closed a latent three-plane asymmetry in the market filter — unresolved slugs are now quarantined symmetrically from matrix, cards, and ticker at the upstream chokepoint.
 - **Cloud Sync Atomic Rollback (v3.33.95)**: `_applyAndFinalize()` now rolls back atomically on settings write failure — inventory restored, `lastPull` not advanced, success toast suppressed (STAK-526)
 - **Catalog API Key Sync Fix (v3.33.94)**: Numista API key and PCGS bearer token now sync across devices. Catalog key conflicts appear in merge diff modal (STAK-533)
 - **Shape-Aware Dimensions (v3.33.93)**: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing "LxW" diameter strings auto-migrate on edit (STAK-528)
 - **V1 API Cleanup + Market Log Fix (v3.33.92)**: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)
-- **Cloud Sync Fixes (v3.33.91)**: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed — blank values persist correctly (STAK-519)

--- a/js/about.js
+++ b/js/about.js
@@ -185,11 +185,11 @@ const setupAckModalEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.33.96 &ndash; STAK-521: Quarantine unresolved slugs</strong>: Closed a latent three-plane asymmetry in the market filter &mdash; unresolved slugs are now quarantined symmetrically from matrix, cards, and ticker at the upstream chokepoint.</li>
     <li><strong>v3.33.95 &ndash; Cloud Sync Atomic Rollback</strong>: _applyAndFinalize() now rolls back atomically on settings write failure &mdash; inventory restored, lastPull not advanced, success toast suppressed (STAK-526)</li>
     <li><strong>v3.33.94 &ndash; Catalog API Key Sync Fix</strong>: Numista API key and PCGS bearer token now sync across devices. Catalog key conflicts appear in merge diff modal (STAK-533)</li>
     <li><strong>v3.33.93 &ndash; Shape-Aware Dimensions</strong>: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing &ldquo;LxW&rdquo; diameter strings auto-migrate on edit (STAK-528)</li>
     <li><strong>v3.33.92 &ndash; V1 API Cleanup + Market Log Fix</strong>: Removed all dead v1 API code (~486 lines). Market log tab now shows dynamic vendor columns from the v2 manifest instead of blank hardcoded columns (STAK-509)</li>
-    <li><strong>v3.33.91 &ndash; Cloud Sync Fixes</strong>: API keys no longer destroyed as [object Object] when synced. StorageLocation sync loop fixed &mdash; blank values persist correctly (STAK-519)</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.33.95";
+const APP_VERSION = "3.33.96";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -140,16 +140,38 @@ const _invalidateMarketFilterCache = () => {
   _marketFilterCache = null;
 };
 
-/** Slugs excluded from market card display — baseline references, not user-facing products. */
-const _HIDDEN_SLUGS = new Set(["goldback-g1"]);
+/** _isSlugResolved — STAK-521 upstream quarantine predicate.
+ *
+ * Returns true only when a slug's coin metadata has fully resolved through
+ * the getRetailCoinMeta resolver chain (manifest -> hardcoded -> goldback
+ * parser -> default). The default fallback returns {name: slug, weight: 0,
+ * metal: "unknown"}, so a slug fails this predicate when name === slug
+ * AND/OR metal === "unknown".
+ *
+ * This is the upstream chokepoint fix for the three-plane asymmetry where
+ * the market filter matrix hid unresolved slugs but the control plane
+ * defaulted them to enabled, so they leaked into cards/ticker/tables with
+ * raw-string labels users could not toggle off.
+ *
+ * Historical note: this automatically quarantines bare `goldback-gN`
+ * denomination stubs that lack a state segment, because _parseGoldbackSlug
+ * returns null for them and the resolver falls through to the default.
+ * The old _HIDDEN_SLUGS hardcoded exclusion for "goldback-g1" has been
+ * removed because this predicate catches it for free. See STAK-498 /
+ * STAK-521 history for context.
+ */
+const _isSlugResolved = (slug) => {
+  const meta = getRetailCoinMeta(slug);
+  return meta.name !== slug && meta.metal !== "unknown";
+};
 
 /** Returns active slugs: manifest-driven (filtered to those with data) or hardcoded fallback.
- *  Excludes _HIDDEN_SLUGS on ALL return paths (STAK-498 Task 7). */
+ *  Excludes slugs that fail `_isSlugResolved` on ALL return paths (STAK-521 upstream quarantine). */
 const getActiveRetailSlugs = () => {
-  if (!_manifestSlugs) return RETAIL_SLUGS.filter((s) => !_HIDDEN_SLUGS.has(s));
-  if (!retailPrices?.prices) return _manifestSlugs.filter((s) => !_HIDDEN_SLUGS.has(s));
+  if (!_manifestSlugs) return RETAIL_SLUGS.filter(_isSlugResolved);
+  if (!retailPrices?.prices) return _manifestSlugs.filter(_isSlugResolved);
   return _manifestSlugs.filter((slug) => {
-    if (_HIDDEN_SLUGS.has(slug)) return false;
+    if (!_isSlugResolved(slug)) return false;
     const entry = retailPrices.prices[slug];
     if (!entry) return false;
     if (entry.median_price != null || entry.lowest_price != null) return true;

--- a/js/settings.js
+++ b/js/settings.js
@@ -2428,11 +2428,11 @@ const renderMarketFilterMatrix = () => {
   tbody.appendChild(allRow);
 
   // --- Product rows ---
-  // Filter out slugs with no resolved display name (e.g. goldback-g10 denomination stubs)
-  const displaySlugs = slugs.filter((slug) => {
-    const m = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(slug) : { name: slug };
-    return m.name !== slug;
-  });
+  // STAK-521: `slugs` is already filtered by _isSlugResolved upstream in getActiveRetailSlugs.
+  // Retain `displaySlugs` as a read-only alias so the downstream forEach, metal-pill
+  // visibleSlugs filter, and master-toggle scoping below do not need to change. The alias
+  // is intentionally preserved to keep the STAK-521 diff minimally invasive — do not inline.
+  const displaySlugs = slugs;
   displaySlugs.forEach((slug) => {
     const meta = typeof getRetailCoinMeta === 'function' ? getRetailCoinMeta(slug) : { name: slug, metal: 'unknown' };
     const metal = (meta.metal || 'unknown').toLowerCase();

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.95-b1775934251';
+const CACHE_NAME = 'staktrakr-v3.33.96-b1775947345';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.33.95",
-  "releaseDate": "2026-04-10",
+  "version": "3.33.96",
+  "releaseDate": "2026-04-11",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

Closes a latent three-plane asymmetry in the StakTrakr market filter where unresolved slugs (manifest entries whose coin metadata hasn't landed) were hidden from the filter matrix UI but defaulted to enabled in the control plane, leaking into cards/ticker/table with raw-string labels users could not toggle off. Fix is a single upstream predicate at `getActiveRetailSlugs()` — the existing chokepoint that feeds all three planes.

**Framing:** latent invariant hardening, not an active user-visible bug fix. The historical trigger (goldback denomination stubs like \`goldback-g10\` emitted to feed hourly-slot baseline rendering) was already retired by the v2 API publisher refactor in the STAK-503 era (PRs #950–#953). The structural asymmetry nevertheless remains in frontend code and this PR closes it as a fail-safe.

## Changes

- **New predicate** \`_isSlugResolved(slug)\` in \`js/retail.js\` — pure function, returns true only when \`getRetailCoinMeta(slug).name !== slug\` AND \`.metal !== \"unknown\"\` (broad Option B per spec Resolved Open Question)
- **Modified** \`getActiveRetailSlugs()\` — all three return paths now filter via \`_isSlugResolved\` instead of the deleted \`_HIDDEN_SLUGS\` hardcoded set
- **Deleted** \`_HIDDEN_SLUGS = new Set([\"goldback-g1\"])\` — now dead code because \`_parseGoldbackSlug\` returns null for bare denomination stubs, so the resolver falls through to the default and the new predicate auto-quarantines it
- **Removed** redundant \`displaySlugs\` filter in \`js/settings.js:2430-2434\` — replaced with \`const displaySlugs = slugs;\` alias to minimize blast radius (downstream references at the forEach, metal-pill filter, and master-toggle scoping are unchanged)

Also includes the standard release bundle: \`APP_VERSION\` 3.33.95 → 3.33.96, CHANGELOG entry, announcements.md + about.js sync, version.json, sw.js CACHE_NAME auto-stamped.

## Spec

Full spec at \`DocVault/specflow/StakTrakr/specs/STAK-521-quarantine-unresolved-slugs/\` — requirements.md, design.md, tasks.md (with Readiness Concerns), readiness-report.md. All phases approved via dashboard.

## Test plan

**Testing strategy per Readiness Concerns:** Playwright TDD is deferred to STAK-532 (Playwright infra migration, backlog). This spec uses code review + manual Chrome DevTools spot check on preview + Browserbase regression smoke instead.

- [x] Stage 1 spec-compliance review — PASS
- [x] Stage 2 code-quality review — APPROVED-WITH-MINOR (minor comment accuracy fix applied)
- [x] \`npm run lint\` — passes (0 new errors, 2 pre-existing unrelated warnings)
- [ ] C1/C4 lint baseline + final (Tasks 2 and 5 of the spec closing chain)
- [ ] C5 consolidated implementation log
- [ ] C5.5 Codacy SRM scan on modified files
- [ ] C6 verification.md + manual Chrome DevTools spot check on Cloudflare Pages preview URL
- [ ] C6.5 Codex peer review
- [ ] C7 loop-or-complete gate
- [ ] C8 Browserbase \`/bb-test sections=05\` regression smoke
- [ ] C9 \`/vault-update\` on affected DocVault pages
- [ ] C10 file follow-up DocVault issues (retroactive Playwright test blocked on STAK-532, orphan localStorage cleanup, steering drift, CLAUDE.md stale test-model line)

## Follow-ups

Tracked via Task 13 of the spec after merge:

1. Retroactive Playwright regression test for \`_isSlugResolved\` (blocked on STAK-532)
2. Orphaned \`staktrakr.market_filter\` localStorage cleanup in the STAK-520 normalize pass
3. Steering doc drift — \`tech.md:68\` and \`package.json\` \`\"dash\"\` script inconsistencies
4. Project \`CLAUDE.md\` stale \"Single test model\" line (from backup restore today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)