### PR TITLE
chore: re-add Clear Lock button to home poller dashboard

### DIFF
--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -546,7 +546,7 @@ function renderInfraRow(data) {
     ${item("Load", cpu ? `${cpu.load1}/${cpu.load5}` : "?")}
     ${item("Net", `${netRx} rx`)}
     ${anyLocked
-      ? `<div style="display:flex;justify-content:space-between;align-items:center;padding:3px 6px;font-size:11px;"><span style="color:var(--muted)">Lock</span><span style="display:flex;align-items:center;gap:6px;"><span style="color:var(--amber)">BUSY</span>${lockStatus.filter(l => l.locked).map(l => `<button class="btn-sm danger btn-clear-lock" data-path="${l.path}">Clear</button>`).join("")}</span></div>`
+      ? `<div style="display:flex;justify-content:space-between;align-items:center;padding:3px 6px;font-size:11px;"><span style="color:var(--muted)">Lock</span><span style="display:flex;align-items:center;gap:6px;"><span style="color:var(--amber)">BUSY</span>${lockStatus.filter(l => l.locked).map(l => `<button class="btn-sm danger btn-clear-lock" data-path="${escAttr(l.path)}">Clear</button>`).join("")}</span></div>`
       : item("Lock", "Free", "var(--green)")}
     ${item("Fly API", flyOk ? "OK" : flyOk === false ? "DOWN" : "?", flyOk ? "var(--green)" : "var(--red)")}
     ${item("Turso", tursoUp ? "OK" : "DOWN", tursoUp ? "var(--green)" : "var(--red)")}
@@ -790,6 +790,7 @@ function renderMainPage(data) {
 </style>
 </head>
 <body>
+<div id="toast" style="display:none;position:fixed;bottom:20px;right:20px;padding:10px 16px;border-radius:6px;font-size:13px;z-index:200;"></div>
 ${renderNav("home", failureCount)}
 ${renderStatusBar({ cpu, uptime, lockStatus, flyioHealth, tursoUp, failureCount, retailStats: runStats, spotCoverage })}
 
@@ -887,10 +888,21 @@ document.querySelectorAll('.btn-retry').forEach(function(btn) {
   });
 });
 
+// Minimal toast for dashboard page (showToast lives in providers page scope)
+function dashToast(text, ok) {
+  var t = document.getElementById('toast');
+  if (!t) return;
+  t.style.display = 'block';
+  t.style.background = ok ? '#14532d' : '#7f1d1d';
+  t.style.color = ok ? '#86efac' : '#fca5a5';
+  t.textContent = text;
+  setTimeout(function() { t.style.display = 'none'; }, 3000);
+}
+
 // Clear lock button handler
 document.querySelectorAll('.btn-clear-lock').forEach(function(btn) {
   btn.addEventListener('click', function() {
-    var path = this.dataset.path;
+    const path = this.dataset.path;
     if (!confirm('Clear stale lock file ' + path + '?')) return;
     this.disabled = true;
     this.textContent = '...';
@@ -899,9 +911,10 @@ document.querySelectorAll('.btn-clear-lock').forEach(function(btn) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ path: path })
     }).then(function(r) { return r.json(); }).then(function(j) {
-      showToast(j.message || (j.ok ? 'Lock cleared' : 'Failed'), j.ok);
-      if (j.ok) setTimeout(function() { location.reload(); }, 1000);
-    }).catch(function() { showToast('Request failed', false); btn.disabled = false; });
+      dashToast(j.message || (j.ok ? 'Lock cleared' : 'Failed'), j.ok);
+      if (j.ok) { setTimeout(function() { location.reload(); }, 1000); }
+      else { btn.disabled = false; btn.textContent = 'Clear'; }
+    }).catch(function() { dashToast('Request failed', false); btn.disabled = false; btn.textContent = 'Clear'; });
   });
 });
 

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -545,7 +545,9 @@ function renderInfraRow(data) {
     ${item("VM", `${uptime || "?"} | ${cpu ? cpu.memUsedPct + "%" : "?"}`, "var(--green)")}
     ${item("Load", cpu ? `${cpu.load1}/${cpu.load5}` : "?")}
     ${item("Net", `${netRx} rx`)}
-    ${item("Lock", anyLocked ? "BUSY" : "Free", anyLocked ? "var(--amber)" : "var(--green)")}
+    ${anyLocked
+      ? `<div style="display:flex;justify-content:space-between;align-items:center;padding:3px 6px;font-size:11px;"><span style="color:var(--muted)">Lock</span><span style="display:flex;align-items:center;gap:6px;"><span style="color:var(--amber)">BUSY</span>${lockStatus.filter(l => l.locked).map(l => `<button class="btn-sm danger btn-clear-lock" data-path="${l.path}">Clear</button>`).join("")}</span></div>`
+      : item("Lock", "Free", "var(--green)")}
     ${item("Fly API", flyOk ? "OK" : flyOk === false ? "DOWN" : "?", flyOk ? "var(--green)" : "var(--red)")}
     ${item("Turso", tursoUp ? "OK" : "DOWN", tursoUp ? "var(--green)" : "var(--red)")}
     ${item("Containers", `${containerCount} up`, "var(--green)")}
@@ -882,6 +884,24 @@ document.querySelectorAll('.btn-retry').forEach(function(btn) {
       btn.textContent = j.ok ? 'Queued' : 'Err';
       btn.style.background = j.ok ? '#166534' : '#7f1d1d';
     }).catch(function() { btn.textContent = 'Err'; btn.disabled = false; });
+  });
+});
+
+// Clear lock button handler
+document.querySelectorAll('.btn-clear-lock').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    var path = this.dataset.path;
+    if (!confirm('Clear stale lock file ' + path + '?')) return;
+    this.disabled = true;
+    this.textContent = '...';
+    fetch('/api/clear-lock', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ path: path })
+    }).then(function(r) { return r.json(); }).then(function(j) {
+      showToast(j.message || (j.ok ? 'Lock cleared' : 'Failed'), j.ok);
+      if (j.ok) setTimeout(function() { location.reload(); }, 1000);
+    }).catch(function() { showToast('Request failed', false); btn.disabled = false; });
   });
 });
 


### PR DESCRIPTION
## GSD Session — 2026-04-12

### Changes
- Re-add Clear Lock button to home poller dashboard infra row (STAK-537)
  - Button appears only when lock is BUSY (amber state)
  - Calls existing `POST /api/clear-lock` endpoint with path validation
  - Confirms via dialog before clearing
  - Reloads page on success

### Notes
- No version bump — rolls into next release
- Backend endpoint already existed; this was a missing UI wire-up