### PR TITLE
chore: drop orphaned market_filter entries for unresolved slugs on load (STAK-540)

### DIFF
--- a/js/retail.js
+++ b/js/retail.js
@@ -118,6 +118,10 @@ const _loadMarketFilter = () => {
       if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
         _marketFilterCache[slug] = {};
       }
+      // STAK-540: Drop orphaned entries for slugs that now fail the STAK-521 predicate
+      if (typeof _isSlugResolved === 'function' && !_isSlugResolved(slug)) {
+        delete _marketFilterCache[slug];
+      }
     }
   } catch {
     _marketFilterCache = {};

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.33.96-b1775947345';
+const CACHE_NAME = 'staktrakr-v3.33.96-b1775972942';
 
 
 


### PR DESCRIPTION
## Summary

- Extends the STAK-520 normalize-on-load pass in `_loadMarketFilter` to delete entries for slugs that fail the STAK-521 `_isSlugResolved` predicate
- Deletion runs after normalization to preserve STAK-520 behavior ordering
- `typeof === 'function'` guard prevents hard failure if `_isSlugResolved` is ever moved or renamed

## Changes

- `js/retail.js` — 3 lines added inside existing `_loadMarketFilter` normalization loop

## Test plan

- [ ] Inject `{"fake-unresolved-slug": {"apmex": false}}` into `staktrakr.market_filter` localStorage, reload, verify key is gone on next persist
- [ ] Verify existing valid filter state is preserved through normalization (STAK-520 regression check)
- [ ] Verify no matrix rendering regressions for users with large persisted filter state

## Related

- Closes STAK-540
- Extends STAK-520 (market filter normalize-on-load)
- Uses STAK-521 `_isSlugResolved` predicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)