### PR TITLE
v3.34.01 — STAK-445: move FAQ below LOG in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.01] - 2026-04-15
+
+### Changed — STAK-445: Move FAQ below LOG in Settings
+
+- **Changed**: Reordered the Settings modal sidebar so Log now appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged. (STAK-445)
+
+---
+
 ## [3.34.00] - 2026-04-15
 
 ### Changed — STAK-444: Cloud tab settings panel

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,8 +1,7 @@
 ## What's New
 
+- **STAK-445: Move FAQ below LOG (v3.34.01)**: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.
 - **STAK-444: Cloud Tab Settings Panel (v3.34.00)**: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.
+- **STAK-538: Remove First-Run Modal (v3.33.99)**: First-run acknowledgment modal removed -- users now see the app immediately. The Info tab and What's New popup already cover disclaimers and version announcements.
+- **STAK-529: Sort Direction Toggle (v3.33.98)**: Asc/Desc toggle added to Settings > Appearance next to Default Sort Column dropdown. Uses existing chip-sort-toggle pattern. Persists to localStorage via DEFAULT_SORT_DIR_KEY.
 - **STAK-532: Playwright-first testing (v3.33.97)**: Playwright (`@playwright/test`) is now the primary local TDD layer. 18 active tests across runbook sections 01-page-load and 02-crud (plus 15 stubs for future coverage). Run offline with `npm run test:offline`. Browserbase/Stagehand retained for live-site and cloud-only flows.
-- **STAK-521: Quarantine unresolved slugs (v3.33.96)**: Closed a latent three-plane asymmetry in the market filter — unresolved slugs are now quarantined symmetrically from matrix, cards, and ticker at the upstream chokepoint.
-- **Cloud Sync Atomic Rollback (v3.33.95)**: `_applyAndFinalize()` now rolls back atomically on settings write failure — inventory restored, `lastPull` not advanced, success toast suppressed (STAK-526)
-- **Catalog API Key Sync Fix (v3.33.94)**: Numista API key and PCGS bearer token now sync across devices. Catalog key conflicts appear in merge diff modal (STAK-533)
-- **Shape-Aware Dimensions (v3.33.93)**: Bars and ingots now show Length/Width instead of Diameter. Shape dropdown drives conditional fields. Numista API maps size by shape. Existing "LxW" diameter strings auto-migrate on edit (STAK-528)

--- a/index.html
+++ b/index.html
@@ -2011,13 +2011,13 @@
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
               Cloud
             </button>
-            <button class="settings-nav-item" data-section="faq">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-              FAQ
-            </button>
             <button class="settings-nav-item" data-section="changelog">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v4l3 3"/><circle cx="12" cy="12" r="10"/></svg>
               Log
+            </button>
+            <button class="settings-nav-item" data-section="faq">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              FAQ
             </button>
           </nav>
 

--- a/js/about.js
+++ b/js/about.js
@@ -118,11 +118,11 @@ const setupWhatsNewPopupEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>
     <li><strong>v3.34.00 &ndash; STAK-444: Cloud Tab Settings Panel</strong>: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.</li>
     <li><strong>v3.33.99 &ndash; STAK-538: Remove First-Run Modal</strong>: First-run acknowledgment modal removed &mdash; users now see the app immediately. The Info tab and What&rsquo;s New popup already cover disclaimers and version announcements.</li>
     <li><strong>v3.33.98 &ndash; STAK-529: Sort Direction Toggle</strong>: Asc/Desc toggle added to Settings &gt; Appearance next to Default Sort Column dropdown. Uses existing chip-sort-toggle pattern. Persists to localStorage via DEFAULT_SORT_DIR_KEY.</li>
     <li><strong>v3.33.97 &ndash; STAK-532: Playwright-first testing</strong>: Playwright (@playwright/test) is now the primary local TDD layer. 33 tests across runbook sections 01-page-load and 02-crud. Run offline with <code>npm test</code>. Browserbase/Stagehand retained for live-site and cloud-only flows.</li>
-    <li><strong>v3.33.96 &ndash; STAK-521: Quarantine unresolved slugs</strong>: Closed a latent three-plane asymmetry in the market filter &mdash; unresolved slugs are now quarantined symmetrically from matrix, cards, and ticker at the upstream chokepoint.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.00";
+const APP_VERSION = "3.34.01";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.33.60",
+  "version": "3.34.01",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.00-b1776215205';
+const CACHE_NAME = 'staktrakr-v3.34.00-b1776226414';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.00-b1776226414';
+const CACHE_NAME = 'staktrakr-v3.34.01-b1776227356';
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.00",
+  "version": "3.34.01",
   "releaseDate": "2026-04-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Changes

- Reordered the Settings modal sidebar so Log appears immediately before FAQ
- Kept FAQ content, Activity Log content, and section-switching behavior unchanged
- Bumped version metadata to `3.34.01`

## Validation

- Manual verification of sidebar order and existing section lookup
- Settings Playwright baseline: 10 passed, 6 failed
- Post-change rerun: 11 passed, 5 failed
- No regression attributable to the FAQ/LOG reorder; existing instability remains in `tests/playwright/03-settings/03-appearance.spec.js`
- Local Codacy CLI scan on `index.html` reported no applicable security findings

## Issues (DocVault)

- STAK-445: Settings Redesign: Move FAQ below LOG, keep as-is (done)