### PR TITLE
v3.34.02 — STAK-545: market button triggers refresh instead of opening settings modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.02] - 2026-04-15
+
+### Changed — STAK-545: Market button triggers refresh instead of opening Settings modal
+
+- **Changed**: Header Market button now calls `syncRetailPrices()` (market data refresh) instead of opening the Market Settings panel. A new gear icon (`#marketSettingsBtn`) in the Market block vendor prices section provides direct access to Market settings, matching the existing refresh button visual pattern. (STAK-545)
+
+---
+
 ## [3.34.01] - 2026-04-15
 
 ### Changed — STAK-445: Move FAQ below LOG in Settings

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-545: Market Button Triggers Refresh (v3.34.02)**: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon added to the Market dashboard block provides direct access to Market settings.
 - **STAK-445: Move FAQ below LOG (v3.34.01)**: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.
 - **STAK-444: Cloud Tab Settings Panel (v3.34.00)**: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.
 - **STAK-538: Remove First-Run Modal (v3.33.99)**: First-run acknowledgment modal removed -- users now see the app immediately. The Info tab and What's New popup already cover disclaimers and version announcements.

--- a/js/about.js
+++ b/js/about.js
@@ -118,6 +118,7 @@ const setupWhatsNewPopupEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.02 &ndash; STAK-545: Market Button Triggers Refresh</strong>: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon in the Market dashboard block provides direct access to Market settings.</li>
     <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>
     <li><strong>v3.34.00 &ndash; STAK-444: Cloud Tab Settings Panel</strong>: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.</li>
     <li><strong>v3.33.99 &ndash; STAK-538: Remove First-Run Modal</strong>: First-run acknowledgment modal removed &mdash; users now see the app immediately. The Info tab and What&rsquo;s New popup already cover disclaimers and version announcements.</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.01";
+const APP_VERSION = "3.34.02";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -988,6 +988,17 @@ const renderVendorPrices = () => {
   });
   rightGroup.appendChild(refreshBtn);
 
+  const settingsBtn = document.createElement('button');
+  settingsBtn.id = 'marketSettingsBtn';
+  settingsBtn.title = 'Market settings';
+  settingsBtn.setAttribute('aria-label', 'Market settings');
+  settingsBtn.style.cssText = 'background:var(--bg-secondary);border:1px solid var(--border);color:var(--text-secondary);padding:3px 10px;border-radius:6px;font-size:11px;cursor:pointer;font-weight:600;';
+  settingsBtn.textContent = '\u2699';
+  settingsBtn.addEventListener('click', () => {
+    if (typeof showSettingsModal === 'function') showSettingsModal('market');
+  });
+  rightGroup.appendChild(settingsBtn);
+
   headerRow.appendChild(rightGroup);
   container.appendChild(headerRow);
 

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -142,13 +142,11 @@ const bindAppearanceAndHeaderListeners = () => {
     });
   }
 
-  // Market button - open Settings → Market tab.
+  // Market button - trigger market refresh (STAK-545).
   const headerMarketBtn = safeGetElement('headerMarketBtn');
   if (headerMarketBtn) {
     headerMarketBtn.addEventListener('click', () => {
-      if (typeof showSettingsModal === 'function') {
-        showSettingsModal('market');
-      }
+      if (typeof window.syncRetailPrices === 'function') window.syncRetailPrices();
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.33.97",
+  "version": "3.34.02",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.33.97",
+      "version": "3.34.02",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.01",
+  "version": "3.34.02",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.01-b1776227356';
+const CACHE_NAME = 'staktrakr-v3.34.01-b1776230322';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.02-b1776231726';
+const CACHE_NAME = 'staktrakr-v3.34.02-b1776258548';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.01-b1776230322';
+const CACHE_NAME = 'staktrakr-v3.34.01-b1776230826';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.01-b1776230826';
+const CACHE_NAME = 'staktrakr-v3.34.02-b1776231726';
 
 
 

--- a/tests/playwright/03-settings/04-market-controls.spec.js
+++ b/tests/playwright/03-settings/04-market-controls.spec.js
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+import { injectSeedInventory } from '../helpers/seed.js';
+
+/**
+ * Playwright regression spec for STAK-545 — Market button behavior split.
+ *
+ * TDD Phase: RED — tests express intended behavior BEFORE production code changes.
+ *
+ * Expected failures (current implementation does NOT satisfy these):
+ *   4.1 — header Market button opens Settings modal (should NOT after STAK-545)
+ *   4.2 — header Market button does NOT call syncRetailPrices (should AFTER STAK-545)
+ *   4.3 — market block gear control does not exist yet (added in Task 3)
+ *
+ * Expected passes (existing behavior is already correct):
+ *   4.4 — LOG / Vault header button opens Settings on the System tab (regression guard)
+ */
+
+test.describe('03-settings/04-market-controls — STAK-545 header Market button & gear control', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSeedInventory(page);
+    await page.goto('/index.html');
+    // Wait for showSettingsModal to exist AND for the 200ms delayed event-listener
+    // setup in init.js (Phase 14) to have completed before interacting with buttons.
+    await page.waitForFunction(() => typeof window.showSettingsModal === 'function');
+    await page.waitForTimeout(300);
+  });
+
+  // ─── NEW BEHAVIOR (expected FAIL against current implementation) ─────────
+
+  test('4.1 — clicking header Market button does NOT open the Settings modal', async ({ page }) => {
+    const settingsModal = page.locator('#settingsModal');
+
+    // Confirm modal is not already open
+    await expect(settingsModal).not.toBeVisible();
+
+    // Click the header Market button
+    const headerMarketBtn = page.locator('#headerMarketBtn');
+    await expect(headerMarketBtn).toBeVisible();
+    await headerMarketBtn.click();
+
+    // After STAK-545: modal must remain hidden
+    await expect(settingsModal).not.toBeVisible();
+  });
+
+  test('4.2 — clicking header Market button calls syncRetailPrices', async ({ page }) => {
+    // Install a spy on window.syncRetailPrices before clicking
+    await page.evaluate(() => {
+      window._stak545SyncCalled = false;
+      if (typeof window.syncRetailPrices === 'function') {
+        const orig = window.syncRetailPrices;
+        window.syncRetailPrices = (...args) => {
+          window._stak545SyncCalled = true;
+          // Do not invoke the real fetch — test environment has no API
+        };
+        window._stak545OrigSyncRetailPrices = orig;
+      }
+    });
+
+    const headerMarketBtn = page.locator('#headerMarketBtn');
+    await expect(headerMarketBtn).toBeVisible();
+    await headerMarketBtn.click();
+
+    const called = await page.evaluate(() => window._stak545SyncCalled);
+    expect(called).toBe(true);
+  });
+
+  test('4.3 — clicking Market block gear control opens Settings on the Market tab', async ({ page }) => {
+    // This element is added in Task 3 — does not exist yet.
+    // The test fails because #marketSettingsBtn is absent.
+    const gearBtn = page.locator('#marketSettingsBtn');
+    await expect(gearBtn).toBeVisible();
+    await gearBtn.click();
+
+    const settingsModal = page.locator('#settingsModal');
+    await expect(settingsModal).toBeVisible();
+
+    const marketPanel = page.locator('#settingsPanel_market');
+    await expect(marketPanel).toBeVisible();
+  });
+
+  // ─── EXISTING BEHAVIOR (expected PASS — regression guard) ────────────────
+
+  test('4.4 — Vault/System header button still opens Settings on the System tab', async ({ page }) => {
+    // Make the vault button visible (it is hidden by default; force click via JS)
+    await page.evaluate(() => {
+      if (typeof window.showSettingsModal === 'function') {
+        window.showSettingsModal('system');
+      }
+    });
+
+    const settingsModal = page.locator('#settingsModal');
+    await expect(settingsModal).toBeVisible();
+
+    const systemPanel = page.locator('#settingsPanel_system');
+    await expect(systemPanel).toBeVisible();
+  });
+
+  test('4.5 — other settings entry points still open their expected tabs', async ({ page }) => {
+    // LOG / changelog tab
+    await page.evaluate(() => {
+      if (typeof window.showSettingsModal === 'function') {
+        window.showSettingsModal('changelog');
+      }
+    });
+
+    const settingsModal = page.locator('#settingsModal');
+    await expect(settingsModal).toBeVisible();
+
+    const changelogPanel = page.locator('#settingsPanel_changelog');
+    await expect(changelogPanel).toBeVisible();
+
+    // Close and reopen on Market tab via the programmatic path (not the header button)
+    await page.evaluate(() => {
+      if (typeof window.hideSettingsModal === 'function') window.hideSettingsModal();
+    });
+
+    await page.evaluate(() => {
+      if (typeof window.showSettingsModal === 'function') {
+        window.showSettingsModal('market');
+      }
+    });
+
+    await expect(settingsModal).toBeVisible();
+
+    const marketPanel = page.locator('#settingsPanel_market');
+    await expect(marketPanel).toBeVisible();
+  });
+});

--- a/tests/playwright/03-settings/04-market-controls.spec.js
+++ b/tests/playwright/03-settings/04-market-controls.spec.js
@@ -48,7 +48,7 @@ test.describe('03-settings/04-market-controls — STAK-545 header Market button 
       window._stak545SyncCalled = false;
       if (typeof window.syncRetailPrices === 'function') {
         const orig = window.syncRetailPrices;
-        window.syncRetailPrices = (...args) => {
+        window.syncRetailPrices = () => {
           window._stak545SyncCalled = true;
           // Do not invoke the real fetch — test environment has no API
         };

--- a/tests/playwright/03-settings/04-market-controls.spec.js
+++ b/tests/playwright/03-settings/04-market-controls.spec.js
@@ -12,7 +12,8 @@ import { injectSeedInventory } from '../helpers/seed.js';
  *   4.3 — market block gear control does not exist yet (added in Task 3)
  *
  * Expected passes (existing behavior is already correct):
- *   4.4 — LOG / Vault header button opens Settings on the System tab (regression guard)
+ *   4.4 — Vault header button click opens Settings on the System tab (regression guard)
+ *   4.5 — other settings entry points still open their expected tabs (programmatic path)
  */
 
 test.describe('03-settings/04-market-controls — STAK-545 header Market button & gear control', () => {
@@ -48,7 +49,7 @@ test.describe('03-settings/04-market-controls — STAK-545 header Market button 
       window._stak545SyncCalled = false;
       if (typeof window.syncRetailPrices === 'function') {
         const orig = window.syncRetailPrices;
-        window.syncRetailPrices = () => {
+        window.syncRetailPrices = async () => {
           window._stak545SyncCalled = true;
           // Do not invoke the real fetch — test environment has no API
         };
@@ -80,13 +81,11 @@ test.describe('03-settings/04-market-controls — STAK-545 header Market button 
 
   // ─── EXISTING BEHAVIOR (expected PASS — regression guard) ────────────────
 
-  test('4.4 — Vault/System header button still opens Settings on the System tab', async ({ page }) => {
-    // Make the vault button visible (it is hidden by default; force click via JS)
-    await page.evaluate(() => {
-      if (typeof window.showSettingsModal === 'function') {
-        window.showSettingsModal('system');
-      }
-    });
+  test('4.4 — Vault header button click opens Settings on the System tab', async ({ page }) => {
+    // #headerVaultBtn is visible by default (null=show in constants.js)
+    const vaultBtn = page.locator('#headerVaultBtn');
+    await expect(vaultBtn).toBeVisible();
+    await vaultBtn.click();
 
     const settingsModal = page.locator('#settingsModal');
     await expect(settingsModal).toBeVisible();

--- a/tests/playwright/03-settings/04-market-controls.spec.js
+++ b/tests/playwright/03-settings/04-market-controls.spec.js
@@ -4,16 +4,14 @@ import { injectSeedInventory } from '../helpers/seed.js';
 /**
  * Playwright regression spec for STAK-545 — Market button behavior split.
  *
- * TDD Phase: RED — tests express intended behavior BEFORE production code changes.
+ * All tests GREEN — production changes ship in the same PR as this spec.
  *
- * Expected failures (current implementation does NOT satisfy these):
- *   4.1 — header Market button opens Settings modal (should NOT after STAK-545)
- *   4.2 — header Market button does NOT call syncRetailPrices (should AFTER STAK-545)
- *   4.3 — market block gear control does not exist yet (added in Task 3)
- *
- * Expected passes (existing behavior is already correct):
+ * Covers:
+ *   4.1 — header Market button does NOT open the Settings modal
+ *   4.2 — header Market button calls syncRetailPrices (market data refresh)
+ *   4.3 — Market block gear control opens Settings on the Market tab
  *   4.4 — Vault header button click opens Settings on the System tab (regression guard)
- *   4.5 — other settings entry points still open their expected tabs (programmatic path)
+ *   4.5 — other settings entry points still open their expected tabs (regression guard)
  */
 
 test.describe('03-settings/04-market-controls — STAK-545 header Market button & gear control', () => {

--- a/tests/runbook/05-market.md
+++ b/tests/runbook/05-market.md
@@ -6,15 +6,17 @@ Each test in this section is independently runnable given that the application h
 
 ---
 
-### Test 5.1 — Open market menu
+### Test 5.1 — Market panel is visible on page load
 _Added: v3.33.25 (STAK-396)_
+_Updated: v3.34.02 (STAK-545) — header Market button now triggers a data refresh, not panel navigation; market data is always visible on the main page_
 **Preconditions:** Application is loaded at the PR preview URL. The What's New modal has been dismissed (see 00-setup.md).
 **Steps:**
-- act: "click the Market button or icon in the header navigation"
-- extract: "is a market panel, market page, or market overlay visible on screen" → expect: true
+- extract: "is the market prices section or vendor prices panel visible on the main page" → expect: true
+- act: "click the Market button in the header navigation"
+- extract: "does a refresh or sync animation appear on the market prices section" → expect: true
 - screenshot: "05-market-open"
-**Pass criteria:** The market panel or page opens and is visible without a page reload error.
-**Tags:** market, navigation
+**Pass criteria:** The market prices section is visible on the main page after load. Clicking the header Market button triggers a data refresh (not navigation) — a loading state or updated timestamp confirms the sync ran.
+**Tags:** market, navigation, refresh
 **Section:** 05-market
 
 ---

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.01",
+  "version": "3.34.02",
   "releaseDate": "2026-04-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Header Market button** now triggers `syncRetailPrices()` (market data refresh) instead of opening the Settings modal
- **`#marketSettingsBtn` gear control** added to the Market dashboard block — opens Settings on the Market tab via `showSettingsModal('market')`
- Matches existing market action button visual pattern exactly (same inline styles, same `rightGroup` container)

## Changes

| File | Change |
|---|---|
| `js/settings-listeners.js` | Rewired `headerMarketBtn` listener to call `window.syncRetailPrices()` |
| `js/market-data.js` | Added `#marketSettingsBtn` gear button in `renderVendorPrices()` |
| `tests/playwright/03-settings/04-market-controls.spec.js` | New Playwright regression spec — 5 tests, all green |
| `tests/runbook/05-market.md` | Updated Test 5.1 to reflect new header button behavior |
| `js/constants.js` / `package.json` / `CHANGELOG.md` | Version bump to 3.34.02 |

## Test plan

- [ ] Header Market button refreshes market data (no Settings modal opens)
- [ ] Market block gear icon opens Settings on the Market tab
- [ ] All other header buttons and settings entry points unaffected
- [ ] Market block layout intact on desktop and mobile-width viewports
- [ ] Playwright: `npx playwright test tests/playwright/03-settings/04-market-controls.spec.js` → 5/5 pass

## Spec

STAK-545 — [Implementation Logs](../tree/patch/3.34.02) | DocVault: `specflow/StakTrakr/specs/STAK-545-market-button-triggers-refresh-instead-of-opening-settings-modal/`