### PR TITLE
[codex] STAK-544: make header cloud button sync or open settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.03] - 2026-04-15
+
+### Changed — STAK-544: Header cloud button sync or open settings
+
+- **Changed**: Header cloud button now triggers a manual sync for configured users (green/ready states) or opens Settings → Cloud for setup users (orange/gray states). Replaced the previous dead-end "autosync disabled" toast behavior. Added `resolveHeaderCloudAction()` helper in `cloud-sync.js` to centralize state-to-action mapping. Added Playwright regression coverage for unconfigured, auto-sync-off, and auto-sync-on header cloud button states. (STAK-544)
+
+---
+
 ## [3.34.02] - 2026-04-15
 
 ### Changed — STAK-545: Market button triggers refresh instead of opening Settings modal

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-544: Header Cloud Button Sync or Open Settings (v3.34.03)**: The header cloud button now triggers a manual sync for configured users or opens Settings → Cloud for setup users. Replaced the previous dead-end "autosync disabled" toast behavior.
 - **STAK-545: Market Button Triggers Refresh (v3.34.02)**: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon added to the Market dashboard block provides direct access to Market settings.
 - **STAK-445: Move FAQ below LOG (v3.34.01)**: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.
 - **STAK-444: Cloud Tab Settings Panel (v3.34.00)**: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.

--- a/js/about.js
+++ b/js/about.js
@@ -118,6 +118,7 @@ const setupWhatsNewPopupEvents = () => {
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.03 &ndash; STAK-544: Header Cloud Button Sync or Open Settings</strong>: The header cloud button now triggers a manual sync for configured users or opens Settings &rarr; Cloud for setup users. Replaced the previous dead-end &quot;autosync disabled&quot; toast behavior.</li>
     <li><strong>v3.34.02 &ndash; STAK-545: Market Button Triggers Refresh</strong>: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon in the Market dashboard block provides direct access to Market settings.</li>
     <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>
     <li><strong>v3.34.00 &ndash; STAK-444: Cloud Tab Settings Panel</strong>: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.</li>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -442,8 +442,8 @@ function _cloudProviderNeedsAccountId(provider) {
   return provider === 'dropbox';
 }
 
-function resolveHeaderCloudAction() {
-  var provider = _syncProvider || 'dropbox';
+function resolveHeaderCloudAction(provider) {
+  provider = provider || _syncProvider || 'dropbox';
   var connected = typeof cloudIsConnected === 'function' ? cloudIsConnected(provider) : false;
   var hasVaultPassword = !!localStorage.getItem('cloud_vault_password');
   var hasAccountId = !_cloudProviderNeedsAccountId(provider) || !!localStorage.getItem('cloud_dropbox_account_id');

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -438,12 +438,36 @@ function updateSyncStatusIndicator(state, detail) {
  * connection status, vault password, and Dropbox account ID presence.
  * Called on init, password change, and sync enable/disable.
  */
+function _cloudProviderNeedsAccountId(provider) {
+  return provider === 'dropbox';
+}
+
+function resolveHeaderCloudAction() {
+  var provider = _syncProvider || 'dropbox';
+  var connected = typeof cloudIsConnected === 'function' ? cloudIsConnected(provider) : false;
+  var hasVaultPassword = !!localStorage.getItem('cloud_vault_password');
+  var hasAccountId = !_cloudProviderNeedsAccountId(provider) || !!localStorage.getItem('cloud_dropbox_account_id');
+  var autoSyncOn = syncIsEnabled();
+  var syncCapable = connected && hasVaultPassword && hasAccountId;
+
+  return {
+    provider: provider,
+    connected: connected,
+    hasVaultPassword: hasVaultPassword,
+    hasAccountId: hasAccountId,
+    autoSyncOn: autoSyncOn,
+    syncCapable: syncCapable,
+    buttonState: syncCapable ? (autoSyncOn ? 'green' : 'ready') : (connected ? 'orange' : 'gray'),
+    action: syncCapable ? 'sync-now' : 'open-settings',
+  };
+}
+
 function updateCloudSyncHeaderBtn() {
   var btn = safeGetElement('headerCloudSyncBtn');
   var dot = safeGetElement('headerCloudDot');
   if (!btn) return;
 
-  var connected = typeof cloudIsConnected === 'function' ? cloudIsConnected(_syncProvider) : false;
+  var headerState = resolveHeaderCloudAction();
 
   // Always show the Cloud button — it is the entry point for cloud setup and status.
   // The gray dot state handles the "not connected" case visually.
@@ -451,27 +475,23 @@ function updateCloudSyncHeaderBtn() {
   if (!dot) return;
   dot.className = 'cloud-sync-dot header-cloud-dot';
 
-  var hasPw = !!localStorage.getItem('cloud_vault_password');
-  var hasAccountId = !!localStorage.getItem('cloud_dropbox_account_id');
-  var autoSyncOn = syncIsEnabled();
-
-  if (connected && hasPw && hasAccountId && autoSyncOn) {
+  if (headerState.buttonState === 'green') {
     // Green: fully operational — connected, credentials set, auto-sync enabled
     dot.classList.add('header-cloud-dot--green');
     btn.title = 'Cloud sync active';
     btn.setAttribute('aria-label', 'Cloud sync active');
     btn.dataset.syncState = 'green';
-  } else if (connected && (!hasPw || !hasAccountId)) {
+  } else if (headerState.buttonState === 'orange') {
     // Orange: connected but missing password or account ID
     dot.classList.add('header-cloud-dot--orange');
     btn.title = 'Cloud sync needs setup — tap to configure';
     btn.setAttribute('aria-label', 'Cloud sync needs setup');
     btn.dataset.syncState = 'orange';
-  } else if (connected && hasPw && hasAccountId && !autoSyncOn) {
+  } else if (headerState.buttonState === 'ready') {
     // Orange: connected and ready but auto-sync is off (distinct from 'orange' setup-needed)
     dot.classList.add('header-cloud-dot--orange');
-    btn.title = 'Cloud sync ready — enable auto-sync in Settings';
-    btn.setAttribute('aria-label', 'Cloud sync ready but not enabled');
+    btn.title = 'Cloud sync ready — tap to sync now';
+    btn.setAttribute('aria-label', 'Cloud sync ready to sync now');
     btn.dataset.syncState = 'ready';
   } else {
     dot.classList.add('header-cloud-dot--gray');
@@ -3274,6 +3294,7 @@ window.computeSettingsHash = computeSettingsHash;
 window.refreshSyncUI = refreshSyncUI;
 window.updateSyncStatusIndicator = updateSyncStatusIndicator;
 window.updateCloudSyncHeaderBtn = updateCloudSyncHeaderBtn;
+window.resolveHeaderCloudAction = resolveHeaderCloudAction;
 window.getSyncDeviceId = getSyncDeviceId;
 window.getSyncPasswordSilent = getSyncPasswordSilent;
 window.syncIsEnabled = syncIsEnabled;

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.02";
+const APP_VERSION = "3.34.03";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -764,7 +764,7 @@ const setupHeaderButtonListeners = () => {
       const state = typeof resolveHeaderCloudAction === 'function'
         ? resolveHeaderCloudAction()
         : {
-          action: headerCloudSyncBtn.dataset.syncState === 'green' ? 'sync-now' : 'open-settings',
+          action: ['green', 'ready'].includes(headerCloudSyncBtn.dataset.syncState) ? 'sync-now' : 'open-settings',
           buttonState: headerCloudSyncBtn.dataset.syncState,
         };
       if (state.action === 'sync-now') {

--- a/js/events.js
+++ b/js/events.js
@@ -761,11 +761,13 @@ const setupHeaderButtonListeners = () => {
     safeAttachListener(headerCloudSyncBtn, 'click', function (e) {
       e.preventDefault();
       e.stopPropagation();
-      const state = headerCloudSyncBtn.dataset.syncState;
-      if (state === 'orange') {
-        // Needs password setup — open inline popover
-        if (typeof _openCloudSyncPopover === 'function') _openCloudSyncPopover();
-      } else if (state === 'green') {
+      const state = typeof resolveHeaderCloudAction === 'function'
+        ? resolveHeaderCloudAction()
+        : {
+          action: headerCloudSyncBtn.dataset.syncState === 'green' ? 'sync-now' : 'open-settings',
+          buttonState: headerCloudSyncBtn.dataset.syncState,
+        };
+      if (state.action === 'sync-now') {
         // Trigger a sync on tap (STAK-398: header button should do something useful)
         if (typeof syncNow === 'function') {
           if (typeof showCloudToast === 'function') showCloudToast('Syncing…', 1500);
@@ -784,13 +786,8 @@ const setupHeaderButtonListeners = () => {
             if (typeof showCloudToast === 'function') showCloudToast('Sync failed', 2500);
           });
         }
-      } else if (state === 'ready') {
-        // Connected + credentials complete but auto-sync is off
-        if (typeof showCloudToast === 'function') {
-          showCloudToast('Cloud sync ready — enable auto-sync in Settings to start', 3000);
-        }
       } else {
-        if (typeof showSettingsModal === 'function') showSettingsModal('system');
+        if (typeof showSettingsModal === 'function') showSettingsModal('cloud');
       }
     }, 'Cloud Sync Header Button');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.02",
+  "version": "3.34.03",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.02",
+      "version": "3.34.03",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.02",
+  "version": "3.34.03",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.03-b1776266470';
+const CACHE_NAME = 'staktrakr-v3.34.03-b1776268038';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.02-b1776258548';
+const CACHE_NAME = 'staktrakr-v3.34.02-b1776262476';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.02-b1776262476';
+const CACHE_NAME = 'staktrakr-v3.34.02-b1776265805';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.02-b1776265805';
+const CACHE_NAME = 'staktrakr-v3.34.03-b1776266470';
 
 
 

--- a/tests/playwright/03-settings/settings-cloud-tab.spec.js
+++ b/tests/playwright/03-settings/settings-cloud-tab.spec.js
@@ -50,6 +50,7 @@ test.describe('STAK-444 — Cloud tab settings panel', () => {
     await injectSeedInventory(page);
     await page.goto('/index.html');
     await page.waitForFunction(() => typeof window.showSettingsModal === 'function');
+    // Wait for init.js Phase 14's delayed listener setup (200 ms) to complete
     await page.waitForTimeout(300);
     await page.evaluate(() => window.showSettingsModal('system'));
     await expect(page.locator('#settingsModal')).toBeVisible();

--- a/tests/playwright/03-settings/settings-cloud-tab.spec.js
+++ b/tests/playwright/03-settings/settings-cloud-tab.spec.js
@@ -1,11 +1,56 @@
 import { test, expect } from '@playwright/test';
 import { injectSeedInventory } from '../helpers/seed.js';
 
+async function closeSettingsModal(page) {
+  await page.evaluate(() => {
+    if (typeof window.hideSettingsModal === 'function') {
+      window.hideSettingsModal();
+      return;
+    }
+    const modal = document.getElementById('settingsModal');
+    if (modal) modal.style.display = 'none';
+    document.body.style.overflow = '';
+  });
+  await expect(page.locator('#settingsModal')).not.toBeVisible();
+}
+
+async function configureHeaderCloudState(page, {
+  connected = false,
+  hasPassword = false,
+  hasAccountId = false,
+  autoSyncEnabled = false,
+} = {}) {
+  await page.evaluate(({ connected, hasPassword, hasAccountId, autoSyncEnabled }) => {
+    localStorage.removeItem('cloud_token_dropbox');
+    localStorage.removeItem('cloud_vault_password');
+    localStorage.removeItem('cloud_dropbox_account_id');
+    localStorage.setItem('cloud_sync_enabled', autoSyncEnabled ? 'true' : 'false');
+
+    if (connected) {
+      localStorage.setItem('cloud_token_dropbox', JSON.stringify({
+        access_token: 'test-token',
+        expires_at: Date.now() + 60_000,
+      }));
+    }
+    if (hasPassword) {
+      localStorage.setItem('cloud_vault_password', 'test-password');
+    }
+    if (hasAccountId) {
+      localStorage.setItem('cloud_dropbox_account_id', 'acct:test');
+    }
+
+    if (typeof window.updateCloudSyncHeaderBtn === 'function') {
+      window.updateCloudSyncHeaderBtn();
+    }
+  }, { connected, hasPassword, hasAccountId, autoSyncEnabled });
+}
+
 test.describe('STAK-444 — Cloud tab settings panel', () => {
   test.beforeEach(async ({ page }) => {
     await injectSeedInventory(page);
     await page.goto('/index.html');
     await page.waitForFunction(() => typeof window.showSettingsModal === 'function');
+    await page.waitForTimeout(300);
     await page.evaluate(() => window.showSettingsModal('system'));
     await expect(page.locator('#settingsModal')).toBeVisible();
     await expect(page.locator('#settingsPanel_system')).toBeVisible();
@@ -43,5 +88,61 @@ test.describe('STAK-444 — Cloud tab settings panel', () => {
     await page.locator('[data-section="system"]').scrollIntoViewIfNeeded();
     await page.locator('[data-section="system"]').click();
     await expect(page.locator('#forceRefreshBtn')).toBeVisible();
+  });
+
+  test('2.6 — Header cloud button opens Cloud settings when sync is not configured', async ({ page }) => {
+    await configureHeaderCloudState(page, {
+      connected: false,
+      hasPassword: false,
+      hasAccountId: false,
+      autoSyncEnabled: false,
+    });
+    await closeSettingsModal(page);
+
+    await page.locator('#headerCloudSyncBtn').click();
+
+    await expect(page.locator('#settingsModal')).toBeVisible();
+    await expect(page.locator('#settingsPanel_cloud')).toBeVisible();
+    await expect(page.locator('#settingsPanel_system')).not.toBeVisible();
+  });
+
+  test('2.7 — Header cloud button triggers manual sync when configured and auto-sync is off', async ({ page }) => {
+    await configureHeaderCloudState(page, {
+      connected: true,
+      hasPassword: true,
+      hasAccountId: true,
+      autoSyncEnabled: false,
+    });
+    await closeSettingsModal(page);
+    await page.evaluate(() => {
+      window.__syncNowCalls = 0;
+      window.syncNow = async () => {
+        window.__syncNowCalls += 1;
+      };
+    });
+
+    await page.locator('#headerCloudSyncBtn').click();
+
+    await page.waitForFunction(() => window.__syncNowCalls === 1);
+  });
+
+  test('2.8 — Header cloud button triggers manual sync when configured and auto-sync is on', async ({ page }) => {
+    await configureHeaderCloudState(page, {
+      connected: true,
+      hasPassword: true,
+      hasAccountId: true,
+      autoSyncEnabled: true,
+    });
+    await closeSettingsModal(page);
+    await page.evaluate(() => {
+      window.__syncNowCalls = 0;
+      window.syncNow = async () => {
+        window.__syncNowCalls += 1;
+      };
+    });
+
+    await page.locator('#headerCloudSyncBtn').click();
+
+    await page.waitForFunction(() => window.__syncNowCalls === 1);
   });
 });

--- a/tests/playwright/03-settings/settings-cloud-tab.spec.js
+++ b/tests/playwright/03-settings/settings-cloud-tab.spec.js
@@ -45,7 +45,7 @@ async function configureHeaderCloudState(page, {
   }, { connected, hasPassword, hasAccountId, autoSyncEnabled });
 }
 
-test.describe('STAK-444 — Cloud tab settings panel', () => {
+test.describe('STAK-444/STAK-544 — Settings → Cloud tab and header cloud button', () => {
   test.beforeEach(async ({ page }) => {
     await injectSeedInventory(page);
     await page.goto('/index.html');

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.02",
+  "version": "3.34.03",
   "releaseDate": "2026-04-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- add a shared header cloud action resolver so setup-required states open Settings -> Cloud and configured states trigger the existing `syncNow()` flow
- update the header click handler to remove the dead-end auto-sync-disabled behavior and preserve the existing sync success/failure toast path
- add focused Playwright regression coverage for unconfigured, auto-sync-off, and auto-sync-on header cloud button states
- include the automatic `sw.js` cache stamp generated by the repo commit hook

## Why
The header cloud button previously dead-ended configured users with an "autosync disabled" toast instead of starting a manual sync, and it sent setup users to a less direct path.

## Validation
- `npx playwright test tests/playwright/03-settings/settings-cloud-tab.spec.js`
- Codacy SRM review: zero open High/Critical findings for the repo path under review
- local final review with `git diff --check`

## Notes
- Spec: `STAK-544-cloud-sync-menu-button-manual-sync-or-open-settings`
- Verification and DocVault updates were completed in DocVault alongside this repo change set