### PR TITLE
feat: replace What's New modal with toast card; cap changelog to 5 (STAK-547)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3682,22 +3682,16 @@ input[type="submit"] {
 /* F) Sidebar separator */
 .stk-nav-separator { border: 0; border-top: 1px solid var(--border); margin: 4px 8px; }
 
-/* G) Thin What's New popup */
-.whats-new-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 1100; }
-.whats-new-popup { background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 12px; width: 380px; max-width: 90vw; box-shadow: 0 25px 50px rgba(0,0,0,0.5); overflow: hidden; }
-.whats-new-popup-header { padding: 16px 20px 12px; display: flex; align-items: center; gap: 12px; }
-.whats-new-popup-header svg { width: 40px; height: 40px; border-radius: 8px; flex-shrink: 0; }
-.popup-title-group { display: flex; flex-direction: column; gap: 2px; }
-.popup-title { font-size: 15px; font-weight: 600; letter-spacing: 2px; }
-.popup-title .stak { color: var(--text-secondary, #e2e8f0); }
-.popup-title .trakr { color: #d4a017; }
-.popup-version { font-size: 11px; color: var(--text-muted); font-family: monospace; }
-.whats-new-popup-body { padding: 0 20px 16px; }
-.whats-new-popup-body h4 { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px; }
-.whats-new-popup-body ul { list-style: none; display: flex; flex-direction: column; gap: 5px; padding-left: 0; }
-.whats-new-popup-body li { font-size: 12px; color: var(--text-secondary); line-height: 1.5; padding: 6px 10px; background: var(--bg-primary); border-radius: 6px; }
-.whats-new-popup-body li strong { color: var(--text-primary); }
-.whats-new-popup-footer { padding: 12px 20px; border-top: 1px solid var(--border); display: flex; justify-content: flex-end; gap: 8px; }
+/* G) What's New toast card (STAK-547 — replaces modal) */
+.whats-new-toast-card { position: fixed; bottom: 1.5rem; right: 1.5rem; width: 340px; max-width: calc(100vw - 2rem); background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 10px; box-shadow: 0 8px 32px rgba(0,0,0,0.45); z-index: 10000; cursor: pointer; animation: cloudToastIn 0.3s ease; overflow: hidden; }
+.whats-new-toast-card.fade-out { animation: cloudToastOut 0.3s ease forwards; }
+.wntc-header { display: flex; align-items: center; gap: 6px; padding: 8px 10px 6px; border-bottom: 1px solid var(--border); }
+.wntc-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #d4a017; flex: 1; }
+.wntc-version { font-size: 10px; color: var(--text-muted); font-family: monospace; }
+.wntc-close { background: none; border: none; color: var(--text-muted); font-size: 14px; line-height: 1; cursor: pointer; padding: 0 2px; margin-left: 4px; }
+.wntc-close:hover { color: var(--text-primary); }
+.wntc-body { padding: 8px 10px 10px; font-size: 12px; color: var(--text-secondary); line-height: 1.5; }
+.wntc-body strong { color: var(--text-primary); }
 
 /* H) About tab responsive */
 @media (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -1941,7 +1941,7 @@
         </div>
       </div>
     </div>
-    <!-- aboutModal and versionModal removed — content moved to settingsPanel_about + whatsNewPopup -->
+    <!-- aboutModal and versionModal removed — content moved to settingsPanel_about; whatsNewPopup replaced by toast card (STAK-547) -->
     <!-- =============================================================================
        ============================================================================= -->
 
@@ -4033,39 +4033,6 @@
         <div class="settings-footer" id="settingsFooter"></div>
       </div><!-- .settings-modal-content -->
     </div><!-- #settingsModal -->
-
-    <!-- ===== WHAT'S NEW POPUP (thin version splash) ===== -->
-    <div class="whats-new-overlay" id="whatsNewPopup" style="display: none">
-      <div class="whats-new-popup">
-        <div class="whats-new-popup-header">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="32" height="32">
-            <defs>
-              <linearGradient id="bgPopup" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f1729"/><stop offset="100%" stop-color="#1a2744"/></linearGradient>
-              <linearGradient id="silverPopup" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#64748b"/><stop offset="50%" stop-color="#cbd5e1"/><stop offset="100%" stop-color="#94a3b8"/></linearGradient>
-              <linearGradient id="goldPopup" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#92700c"/><stop offset="50%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#d4a017"/></linearGradient>
-            </defs>
-            <rect width="512" height="512" rx="96" fill="url(#bgPopup)"/>
-            <rect x="170" y="68" width="215" height="38" rx="19" fill="url(#silverPopup)" opacity="0.45"/>
-            <rect x="115" y="124" width="175" height="38" rx="19" fill="url(#silverPopup)" opacity="0.68"/>
-            <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldPopup)"/>
-            <rect x="222" y="250" width="175" height="38" rx="19" fill="url(#silverPopup)" opacity="0.68"/>
-            <rect x="127" y="306" width="230" height="38" rx="19" fill="url(#silverPopup)" opacity="0.45"/>
-          </svg>
-          <div class="popup-title-group">
-            <div class="popup-title"><span class="stak">STAK</span><span class="trakr">TRAKR</span></div>
-            <div class="popup-version" id="whatsNewVersion"></div>
-          </div>
-        </div>
-        <div class="whats-new-popup-body">
-          <h4>What's New</h4>
-          <ul id="versionChanges"></ul>
-        </div>
-        <div class="whats-new-popup-footer">
-          <button class="btn secondary" id="whatsNewChangelogBtn">Full Changelog</button>
-          <button class="btn premium" id="whatsNewDismissBtn">Got it!</button>
-        </div>
-      </div>
-    </div><!-- #whatsNewPopup -->
 
     <div class="modal" id="cloudSyncModal" style="display: none">
       <div class="modal-content">

--- a/js/about.js
+++ b/js/about.js
@@ -36,11 +36,9 @@ const populateAboutTab = () => {
 const loadAnnouncements = async () => {
   const whatsNewTargets = [
     document.getElementById("aboutChangelogLatest"),
-    document.getElementById("versionChanges"),
   ].filter(Boolean);
   const roadmapTargets = [
     document.getElementById("aboutRoadmapList"),
-    document.getElementById("versionRoadmapList"),
   ].filter(Boolean);
 
   if (!whatsNewTargets.length && !roadmapTargets.length) return;
@@ -63,58 +61,75 @@ const showFullChangelog = () => {
   );
 };
 
-const showWhatsNewPopup = async () => {
-  const overlay = safeGetElement('whatsNewPopup');
-  if (!overlay) return;
-  // Populate version
-  const versionEl = safeGetElement('whatsNewVersion');
-  if (versionEl && typeof APP_VERSION !== 'undefined') {
-    versionEl.textContent = `v${APP_VERSION} — Updated!`;
-  }
-  // STAK-500: Load announcements BEFORE showing popup to prevent content flash
-  if (typeof loadAnnouncements === 'function') await loadAnnouncements();
-  overlay.style.display = 'flex';
-  document.body.style.overflow = 'hidden';
-};
-
-const hideWhatsNewPopup = () => {
-  const overlay = safeGetElement('whatsNewPopup');
-  if (overlay) overlay.style.display = 'none';
-  document.body.style.overflow = '';
-  // Acknowledge version so popup doesn't show again
+// STAK-547: Acknowledge version so toast doesn't show again
+const acknowledgeVersion = () => {
   if (typeof APP_VERSION !== 'undefined') {
     localStorage.setItem(VERSION_ACK_KEY, APP_VERSION);
   }
 };
 
-const setupWhatsNewPopupEvents = () => {
-  const dismissBtn = safeGetElement('whatsNewDismissBtn');
-  if (dismissBtn) dismissBtn.addEventListener('click', hideWhatsNewPopup);
-
-  const changelogBtn = safeGetElement('whatsNewChangelogBtn');
-  if (changelogBtn) {
-    changelogBtn.addEventListener('click', () => {
-      hideWhatsNewPopup();
-      showFullChangelog();
-    });
+// STAK-547: Show latest changelog entry as a bottom-right toast card (replaces modal)
+const showWhatsNewPopup = () => {
+  // Parse first entry from embedded list (developer-controlled HTML)
+  const doc = new DOMParser().parseFromString(
+    `<ul>${getEmbeddedWhatsNew()}</ul>`, 'text/html',
+  );
+  const firstLi = doc.querySelector('li');
+  if (!firstLi) {
+    acknowledgeVersion();
+    return;
   }
 
-  // Click overlay background to dismiss
-  const overlay = safeGetElement('whatsNewPopup');
-  if (overlay) {
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) hideWhatsNewPopup();
-    });
-  }
+  // Build card with DOM methods — no innerHTML on appended elements
+  const label = document.createElement('span');
+  label.className = 'wntc-label';
+  label.textContent = 'What\u2019s New';
 
-  // Escape key to dismiss
-  document.addEventListener('keydown', (e) => {
-    const popup = safeGetElement('whatsNewPopup');
-    if (e.key === 'Escape' && popup && popup.style.display === 'flex') {
-      hideWhatsNewPopup();
-    }
-  });
+  const versionSpan = document.createElement('span');
+  versionSpan.className = 'wntc-version';
+  versionSpan.textContent = typeof APP_VERSION !== 'undefined' ? `v${APP_VERSION}` : '';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'wntc-close';
+  closeBtn.setAttribute('aria-label', 'Dismiss');
+  closeBtn.textContent = '\u00D7';
+
+  const header = document.createElement('div');
+  header.className = 'wntc-header';
+  header.appendChild(label);
+  header.appendChild(versionSpan);
+  header.appendChild(closeBtn);
+
+  const body = document.createElement('div');
+  body.className = 'wntc-body';
+  // Clone parsed li child nodes (developer-controlled, not user input)
+  Array.from(firstLi.childNodes).forEach((node) => body.appendChild(node.cloneNode(true)));
+
+  const card = document.createElement('div');
+  card.className = 'whats-new-toast-card';
+  card.appendChild(header);
+  card.appendChild(body);
+  document.body.appendChild(card);
+
+  let dismissed = false;
+  const dismiss = () => {
+    if (dismissed) return;
+    dismissed = true;
+    clearTimeout(timer);
+    card.classList.add('fade-out');
+    card.addEventListener('animationend', () => card.remove(), { once: true });
+    acknowledgeVersion();
+  };
+
+  card.addEventListener('click', dismiss);
+  const timer = setTimeout(dismiss, 4000);
 };
+
+// Kept for backward compat — no modal to hide
+const hideWhatsNewPopup = acknowledgeVersion;
+
+// setupWhatsNewPopupEvents kept as no-op — modal removed (STAK-547)
+const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
@@ -123,8 +138,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>
     <li><strong>v3.34.00 &ndash; STAK-444: Cloud Tab Settings Panel</strong>: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.</li>
     <li><strong>v3.33.99 &ndash; STAK-538: Remove First-Run Modal</strong>: First-run acknowledgment modal removed &mdash; users now see the app immediately. The Info tab and What&rsquo;s New popup already cover disclaimers and version announcements.</li>
-    <li><strong>v3.33.98 &ndash; STAK-529: Sort Direction Toggle</strong>: Asc/Desc toggle added to Settings &gt; Appearance next to Default Sort Column dropdown. Uses existing chip-sort-toggle pattern. Persists to localStorage via DEFAULT_SORT_DIR_KEY.</li>
-    <li><strong>v3.33.97 &ndash; STAK-532: Playwright-first testing</strong>: Playwright (@playwright/test) is now the primary local TDD layer. 33 tests across runbook sections 01-page-load and 02-crud. Run offline with <code>npm test</code>. Browserbase/Stagehand retained for live-site and cloud-only flows.</li>
   `;
 };
 
@@ -145,5 +158,6 @@ if (typeof window !== "undefined") {
   window.showFullChangelog = showFullChangelog;
   window.showWhatsNewPopup = showWhatsNewPopup;
   window.hideWhatsNewPopup = hideWhatsNewPopup;
+  window.acknowledgeVersion = acknowledgeVersion;
   window.setupWhatsNewPopupEvents = setupWhatsNewPopupEvents;
 }

--- a/js/about.js
+++ b/js/about.js
@@ -70,6 +70,9 @@ const acknowledgeVersion = () => {
 
 // STAK-547: Show latest changelog entry as a bottom-right toast card (replaces modal)
 const showWhatsNewPopup = () => {
+  // Prevent duplicate cards if called more than once
+  if (document.querySelector('.whats-new-toast-card')) return;
+
   // Parse first entry from embedded list (developer-controlled HTML)
   const doc = new DOMParser().parseFromString(
     `<ul>${getEmbeddedWhatsNew()}</ul>`, 'text/html',
@@ -91,6 +94,7 @@ const showWhatsNewPopup = () => {
 
   const closeBtn = document.createElement('button');
   closeBtn.className = 'wntc-close';
+  closeBtn.setAttribute('type', 'button');
   closeBtn.setAttribute('aria-label', 'Dismiss');
   closeBtn.textContent = '\u00D7';
 
@@ -107,6 +111,8 @@ const showWhatsNewPopup = () => {
 
   const card = document.createElement('div');
   card.className = 'whats-new-toast-card';
+  card.setAttribute('role', 'status');
+  card.setAttribute('aria-live', 'polite');
   card.appendChild(header);
   card.appendChild(body);
   document.body.appendChild(card);
@@ -125,8 +131,12 @@ const showWhatsNewPopup = () => {
   const timer = setTimeout(dismiss, 4000);
 };
 
-// Kept for backward compat — no modal to hide
-const hideWhatsNewPopup = acknowledgeVersion;
+// Kept for backward compat — removes toast card if present and acknowledges version
+const hideWhatsNewPopup = () => {
+  const card = document.querySelector('.whats-new-toast-card');
+  if (card) card.remove();
+  acknowledgeVersion();
+};
 
 // setupWhatsNewPopupEvents kept as no-op — modal removed (STAK-547)
 const setupWhatsNewPopupEvents = () => {};

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.03-b1776278442';
+const CACHE_NAME = 'staktrakr-v3.34.03-b1776279276';
 
 
 

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.03-b1776275151';
+const CACHE_NAME = 'staktrakr-v3.34.03-b1776278442';
 
 
 


### PR DESCRIPTION
## Summary

- Removes the blocking `#whatsNewPopup` modal overlay from `index.html`
- `showWhatsNewPopup()` now creates a bottom-right toast card with the single latest changelog entry (4s auto-dismiss, click to dismiss early)
- Version acknowledgment (`VERSION_ACK_KEY`) still written to localStorage — toast won't reappear after dismiss
- `getEmbeddedWhatsNew()` trimmed from 7 → 5 entries (About tab changelog cap)
- Old modal CSS (`.whats-new-overlay`, `.whats-new-popup*`, `.popup-*`) removed; replaced with `.whats-new-toast-card` / `.wntc-*`
- `setupWhatsNewPopupEvents` kept as a no-op for backward compat with `init.js` caller

## Test plan

- [ ] Clear `VERSION_ACK_KEY` from localStorage, reload — toast appears bottom-right after page load
- [ ] Toast auto-dismisses after ~4 seconds
- [ ] Clicking toast dismisses it immediately
- [ ] After dismiss, reload — no toast (version acknowledged)
- [ ] About tab → "What's New" section shows exactly 5 entries
- [ ] No modal overlay, no body scroll lock while toast is visible
- [ ] Settings > Cloud, About, and all other panels unaffected