### PR TITLE
chore: gitignore .claude/* with project.json exception; add CLAUDE.md pre-commit guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 
 # AI tooling & personal config — all backed up via /backup-claude nightly to Nextcloud
 # Matches the established TRMCompare/PAPiTA pattern: repo holds source + docs, not tooling state.
-.claude/
+.claude/*
+!.claude/project.json
 .opencode/
 .specflow/
 .spec-workflow/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
         language: system
         pass_filenames: false
         files: ^(js/constants\.js|js/about\.js|version\.json|package\.json|CHANGELOG\.md)$
+      - id: check-claude-md
+        name: Verify CLAUDE.md exists (gitignored, must be restored manually if missing)
+        entry: bash devops/hooks/check-claude-md.sh
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/devops/hooks/check-claude-md.sh
+++ b/devops/hooks/check-claude-md.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Verify CLAUDE.md exists. It is gitignored but must be present locally.
+# Restore with: git show 494271bd:CLAUDE.md > CLAUDE.md
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -f "${REPO_ROOT}/CLAUDE.md" ]; then
+  echo "ERROR: CLAUDE.md is missing." >&2
+  echo "  Restore: git show 494271bd:CLAUDE.md > CLAUDE.md" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `.gitignore`: scope `.claude/` → `.claude/*` with `!.claude/project.json` exception so `project.json` stays tracked while personal tooling state (skills, memory, settings) remains gitignored
- `.pre-commit-config.yaml`: add `check-claude-md` hook — errors if `CLAUDE.md` is missing (gitignored but required locally for AI tooling)
- `devops/hooks/check-claude-md.sh`: hook implementation; restore with `git show 494271bd:CLAUDE.md > CLAUDE.md`

## Test plan
- [ ] Pre-commit hooks pass on commit with CLAUDE.md present
- [ ] Hook fails cleanly if CLAUDE.md is removed
- [ ] `.claude/project.json` remains tracked; rest of `.claude/` gitignored