### PR TITLE
fix: resolve PR #978 review findings (T10, T11, T12, T13)

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -623,7 +623,7 @@ const updateProviderSettings = (provider) => {
 
   // STAKTRAKR has no cache dropdown — persist toggle + auto-refresh only
   if (provider === 'STAKTRAKR') {
-    const enabledEl = document.getElementById('enabled_STAKTRAKR');
+    const enabledEl = safeGetElement('enabled_STAKTRAKR');
     if (enabledEl) {
       if (!config.syncMode) config.syncMode = {};
       const enabled = enabledEl.checked ? 1 : 0;

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2056,7 +2056,7 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
     var _failedCount = 0;
     var _failedKeys = [];
     var _appliedKeys = [];
-    var _priorValues = {};
+    var _priorValues = Object.create(null);
     for (var i = 0; i < settingsChanges.length; i++) {
       var sc = settingsChanges[i];
       if (!sc || !sc.key) { continue; }

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -79,7 +79,7 @@ const GITHUB_RELEASES_URL = "https://github.com/lbruton/StakTrakr/releases/lates
  * Used as the default state; upgraded by checkRemoteVersion() when possible.
  */
 const showStaticVersionBadge = () => {
-  const badge = document.getElementById("versionBadge");
+  const badge = safeGetElement("versionBadge");
   if (!badge) return;
   const val = safeGetElement("versionBadgeValue");
   if (val) {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.03-b1776306262';
+const CACHE_NAME = 'staktrakr-v3.34.03-b1776308909';
 
 
 

--- a/tests/playwright/03-settings/04-market-controls.spec.js
+++ b/tests/playwright/03-settings/04-market-controls.spec.js
@@ -64,8 +64,7 @@ test.describe('03-settings/04-market-controls — STAK-545 header Market button 
   });
 
   test('4.3 — clicking Market block gear control opens Settings on the Market tab', async ({ page }) => {
-    // This element is added in Task 3 — does not exist yet.
-    // The test fails because #marketSettingsBtn is absent.
+    // #marketSettingsBtn ships in this PR (Task 3).
     const gearBtn = page.locator('#marketSettingsBtn');
     await expect(gearBtn).toBeVisible();
     await gearBtn.click();


### PR DESCRIPTION
Fixes from PR #978 (Release v3.34.03) review triage.

- **T10** `js/api.js:626` — `safeGetElement('enabled_STAKTRAKR')` replaces `getElementById`
- **T11** `js/versionCheck.js:82` — `safeGetElement('versionBadge')` replaces `getElementById`
- **T12** `tests/playwright/.../04-market-controls.spec.js:67` — remove stale "expected FAIL" comment; `#marketSettingsBtn` ships in this PR
- **T13** `js/cloud-sync.js:2059` — `Object.create(null)` replaces `{}` for `_priorValues` (prevents prototype pollution on arbitrary `sc.key` values)