### PR TITLE
v3.34.04 — fix: cloud sync header button silent failure (STAK-549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.04] - 2026-04-15
+
+### Fixed — STAK-549: Cloud sync header button silent failure
+
+- **Fixed**: Header cloud sync button no longer shows a false "Synced" toast when the vault password is not cached. `syncNow()` now returns `{ synced: boolean }` so the caller can distinguish success from abort. Password prompt modal appears correctly when needed; cancel shows "Cloud sync requires a vault password" instead of false success. (STAK-549)
+
+---
+
 ## [3.34.03] - 2026-04-15
 
 ### Changed — STAK-544: Header cloud button sync or open settings

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-549: Fix Cloud Sync Header Button Silent Failure (v3.34.04)**: Header cloud sync button no longer shows a false "Synced" toast when vault password is not cached. Password prompt appears correctly; cancel shows an error toast instead of false success.
 - **STAK-544: Header Cloud Button Sync or Open Settings (v3.34.03)**: The header cloud button now triggers a manual sync for configured users or opens Settings → Cloud for setup users. Replaced the previous dead-end "autosync disabled" toast behavior.
 - **STAK-545: Market Button Triggers Refresh (v3.34.02)**: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon added to the Market dashboard block provides direct access to Market settings.
 - **STAK-445: Move FAQ below LOG (v3.34.01)**: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.

--- a/js/about.js
+++ b/js/about.js
@@ -143,6 +143,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.04 &ndash; STAK-549: Fix Cloud Sync Header Button Silent Failure</strong>: Header cloud sync button no longer shows a false &quot;Synced&quot; toast when vault password is not cached. Password prompt appears correctly; cancel shows error toast instead of false success.</li>
     <li><strong>v3.34.03 &ndash; STAK-544: Header Cloud Button Sync or Open Settings</strong>: The header cloud button now triggers a manual sync for configured users or opens Settings &rarr; Cloud for setup users. Replaced the previous dead-end &quot;autosync disabled&quot; toast behavior.</li>
     <li><strong>v3.34.02 &ndash; STAK-545: Market Button Triggers Refresh</strong>: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon in the Market dashboard block provides direct access to Market settings.</li>
     <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -3246,7 +3246,7 @@ async function syncNow() {
   // Guard: skip sync if app initialization failed (STAK-485)
   if (window._initFailed) {
     console.warn('[CloudSync] Skipping syncNow — app initialization failed');
-    return;
+    return { synced: false };
   }
   // Ensure we have a password before attempting sync.  If no silent password
   // is available, prompt the user interactively.
@@ -3258,7 +3258,7 @@ async function syncNow() {
       if (typeof showCloudToast === 'function') {
         showCloudToast('Cloud sync requires a vault password.');
       }
-      return;
+      return { synced: false };
     }
   }
 
@@ -3267,6 +3267,7 @@ async function syncNow() {
   // pushSyncVault has its own pre-push remote check, so even if poll missed
   // something (race), the push will catch it and route to handleRemoteChange.
   await pushSyncVault();
+  return { synced: true };
 }
 
 // ---------------------------------------------------------------------------

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.03";
+const APP_VERSION = "3.34.04";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -771,7 +771,8 @@ const setupHeaderButtonListeners = () => {
         // Trigger a sync on tap (STAK-398: header button should do something useful)
         if (typeof syncNow === 'function') {
           if (typeof showCloudToast === 'function') showCloudToast('Syncing…', 1500);
-          syncNow().then(function () {
+          syncNow().then(function (result) {
+            if (!result || !result.synced) return;
             const lp = typeof syncGetLastPush === 'function' ? syncGetLastPush() : null;
             const msg = lp && lp.timestamp
               ? 'Synced ' + (typeof _syncRelativeTime === 'function' ? _syncRelativeTime(lp.timestamp) : '')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.03",
+  "version": "3.34.04",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.03",
+      "version": "3.34.04",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.03",
+  "version": "3.34.04",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const DEV_MODE = false; // Set to true during development — bypasses all cachi
 
 
 
-const CACHE_NAME = 'staktrakr-v3.34.03-b1776306262';
+const CACHE_NAME = 'staktrakr-v3.34.04-b1776313514';
 
 
 

--- a/tests/playwright/cloud-sync-header-button.spec.js
+++ b/tests/playwright/cloud-sync-header-button.spec.js
@@ -47,7 +47,7 @@ async function simulateStaleButtonState(page) {
 /**
  * Collect all cloud-toast text that appears within a timeout window.
  */
-async function collectToasts(page, durationMs) {
+async function collectToasts(page, durationMs = 4000) {
   return page.evaluate((ms) => {
     return new Promise((resolve) => {
       const texts = [];
@@ -74,14 +74,14 @@ test.describe('STAK-549 — Header cloud sync button silent failure', () => {
   test('shows password modal when no cached password and no false success toast', async ({ page }) => {
     await setupFullyConnected(page);
     await page.goto('/index.html');
-    // Wait for init.js Phase 14 listener setup (200ms) to complete
-    await page.waitForTimeout(400);
+    // Wait for init.js Phase 14 listener setup to complete
+    await page.waitForSelector('#headerCloudSyncBtn', { state: 'visible' });
 
     // Simulate stale button state (password cleared after init)
     await simulateStaleButtonState(page);
 
     // Start collecting toasts before clicking
-    const toastPromise = collectToasts(page, 7000);
+    const toastPromise = collectToasts(page);
 
     // Click the header cloud button — enters sync-now branch, calls syncNow()
     await page.locator('#headerCloudSyncBtn').click();
@@ -107,13 +107,14 @@ test.describe('STAK-549 — Header cloud sync button silent failure', () => {
   test('shows error toast when password modal cancelled', async ({ page }) => {
     await setupFullyConnected(page);
     await page.goto('/index.html');
-    await page.waitForTimeout(400);
+    // Wait for init.js Phase 14 listener setup to complete
+    await page.waitForSelector('#headerCloudSyncBtn', { state: 'visible' });
 
     // Simulate stale button state
     await simulateStaleButtonState(page);
 
     // Start collecting toasts before clicking
-    const toastPromise = collectToasts(page, 7000);
+    const toastPromise = collectToasts(page);
 
     // Click header cloud button -> syncNow() -> password modal
     await page.locator('#headerCloudSyncBtn').click();
@@ -146,10 +147,11 @@ test.describe('STAK-549 — Header cloud sync button silent failure', () => {
     // Full connected state with password cached — no stale state
     await setupFullyConnected(page);
     await page.goto('/index.html');
-    await page.waitForTimeout(400);
+    // Wait for init.js Phase 14 listener setup to complete
+    await page.waitForSelector('#headerCloudSyncBtn', { state: 'visible' });
 
     // Start collecting toasts
-    const toastPromise = collectToasts(page, 8000);
+    const toastPromise = collectToasts(page);
 
     // Click header cloud button — should trigger syncNow with password present
     await page.locator('#headerCloudSyncBtn').click();
@@ -159,12 +161,12 @@ test.describe('STAK-549 — Header cloud sync button silent failure', () => {
     // With password cached, the sync pathway should fire.
     // The actual Dropbox sync will fail (no real token), so we may see
     // "Sync failed" or "Synced" depending on error handling.
-    // The key regression guard: the toast pathway DOES fire (not silent).
-    // We accept "Syncing", "Synced", "Sync complete", or "Sync failed" —
-    // any of these proves the toast pathway is active.
-    const syncToasts = toasts.filter(t =>
-      /sync/i.test(t)
+    // The key regression guard: a terminal toast fires (not just "Syncing…").
+    // Match "Synced", "Sync complete", or "Sync failed" — but NOT "Syncing…"
+    // which is the in-progress toast that fires before syncNow resolves.
+    const terminalSyncToasts = toasts.filter(t =>
+      /synced|sync complete|sync failed/i.test(t)
     );
-    expect(syncToasts.length).toBeGreaterThanOrEqual(1);
+    expect(terminalSyncToasts.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/tests/playwright/cloud-sync-header-button.spec.js
+++ b/tests/playwright/cloud-sync-header-button.spec.js
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test';
+import { injectSeedInventory } from './helpers/seed.js';
+
+/**
+ * STAK-549 — Header cloud sync button silent failure bug.
+ *
+ * When no vault password is cached, syncNow() aborts silently (returns
+ * undefined via resolved promise). The caller's .then() in events.js fires
+ * unconditionally and shows a false "Synced" / "Sync complete" toast.
+ *
+ * These tests MUST FAIL before the fix is applied.
+ */
+
+/**
+ * Set up localStorage for a fully connected Dropbox state (token, account,
+ * password, sync enabled) so the header button renders in sync-capable state
+ * and resolveHeaderCloudAction() returns { action: 'sync-now' }.
+ */
+function setupFullyConnected(page) {
+  return page.addInitScript(() => {
+    localStorage.setItem('cloud_dropbox_account_id', 'dbid:AABBCCtest123');
+    localStorage.setItem('cloud_sync_enabled', 'true');
+    localStorage.setItem('cloud_token_dropbox', JSON.stringify({
+      access_token: 'sl.test-fake-token',
+      expires_at: Date.now() + 3600000,
+    }));
+    localStorage.setItem('cloud_vault_password', 'test-vault-pw-12345');
+  });
+}
+
+/**
+ * After page load, clear cached password and override resolveHeaderCloudAction
+ * to still return sync-now. This simulates the real bug scenario: password was
+ * cleared by idle timeout but the header button's stale state still routes to
+ * the sync-now branch.
+ */
+async function simulateStaleButtonState(page) {
+  await page.evaluate(() => {
+    localStorage.removeItem('cloud_vault_password');
+    // Force the sync-now path even though password is gone (stale state)
+    window.resolveHeaderCloudAction = function () {
+      return { action: 'sync-now', syncCapable: true };
+    };
+  });
+}
+
+/**
+ * Collect all cloud-toast text that appears within a timeout window.
+ */
+async function collectToasts(page, durationMs) {
+  return page.evaluate((ms) => {
+    return new Promise((resolve) => {
+      const texts = [];
+      const observer = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          for (const node of m.addedNodes) {
+            if (node.nodeType === 1 && node.classList.contains('cloud-toast')) {
+              texts.push(node.textContent.trim());
+            }
+          }
+        }
+      });
+      observer.observe(document.body, { childList: true });
+      setTimeout(() => { observer.disconnect(); resolve(texts); }, ms);
+    });
+  }, durationMs);
+}
+
+test.describe('STAK-549 — Header cloud sync button silent failure', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectSeedInventory(page);
+  });
+
+  test('shows password modal when no cached password and no false success toast', async ({ page }) => {
+    await setupFullyConnected(page);
+    await page.goto('/index.html');
+    // Wait for init.js Phase 14 listener setup (200ms) to complete
+    await page.waitForTimeout(400);
+
+    // Simulate stale button state (password cleared after init)
+    await simulateStaleButtonState(page);
+
+    // Start collecting toasts before clicking
+    const toastPromise = collectToasts(page, 7000);
+
+    // Click the header cloud button — enters sync-now branch, calls syncNow()
+    await page.locator('#headerCloudSyncBtn').click();
+
+    // syncNow() -> getSyncPasswordSilent() returns null -> getSyncPassword() opens modal
+    await expect(page.locator('#cloudSyncPasswordModal')).toBeVisible({ timeout: 5000 });
+
+    // Dismiss the modal via the cancel button
+    await page.locator('#syncPasswordCancelBtn').click();
+    await expect(page.locator('#cloudSyncPasswordModal')).not.toBeVisible({ timeout: 3000 });
+
+    const toasts = await toastPromise;
+
+    // BUG ASSERTION: No false "Synced" / "Sync complete" toast should appear
+    // after the password modal was dismissed without entering a password.
+    // Before the fix, the .then() fires unconditionally showing a success toast.
+    const falseSuccess = toasts.filter(t =>
+      /synced|sync complete/i.test(t) && !/syncing/i.test(t)
+    );
+    expect(falseSuccess).toHaveLength(0);
+  });
+
+  test('shows error toast when password modal cancelled', async ({ page }) => {
+    await setupFullyConnected(page);
+    await page.goto('/index.html');
+    await page.waitForTimeout(400);
+
+    // Simulate stale button state
+    await simulateStaleButtonState(page);
+
+    // Start collecting toasts before clicking
+    const toastPromise = collectToasts(page, 7000);
+
+    // Click header cloud button -> syncNow() -> password modal
+    await page.locator('#headerCloudSyncBtn').click();
+    await expect(page.locator('#cloudSyncPasswordModal')).toBeVisible({ timeout: 5000 });
+
+    // Cancel the password modal via the cancel button
+    await page.locator('#syncPasswordCancelBtn').click();
+    await expect(page.locator('#cloudSyncPasswordModal')).not.toBeVisible({ timeout: 3000 });
+
+    const toasts = await toastPromise;
+
+    // BUG ASSERTION 1: Should see the "requires a vault password" error toast.
+    // syncNow() does emit showCloudToast('Cloud sync requires a vault password.')
+    // when pw is null after cancel — but the caller's .then() overwrites it
+    // with a false "Synced" / "Sync complete" success toast.
+    const errorToast = toasts.filter(t =>
+      /vault password/i.test(t)
+    );
+    expect(errorToast.length).toBeGreaterThanOrEqual(1);
+
+    // BUG ASSERTION 2: Should NOT see any false success toast after cancel.
+    // Before the fix, events.js .then() fires and shows "Synced" / "Sync complete".
+    const falseSuccess = toasts.filter(t =>
+      /synced|sync complete/i.test(t) && !/syncing/i.test(t)
+    );
+    expect(falseSuccess).toHaveLength(0);
+  });
+
+  test('shows synced toast when password is cached (regression guard)', async ({ page }) => {
+    // Full connected state with password cached — no stale state
+    await setupFullyConnected(page);
+    await page.goto('/index.html');
+    await page.waitForTimeout(400);
+
+    // Start collecting toasts
+    const toastPromise = collectToasts(page, 8000);
+
+    // Click header cloud button — should trigger syncNow with password present
+    await page.locator('#headerCloudSyncBtn').click();
+
+    const toasts = await toastPromise;
+
+    // With password cached, the sync pathway should fire.
+    // The actual Dropbox sync will fail (no real token), so we may see
+    // "Sync failed" or "Synced" depending on error handling.
+    // The key regression guard: the toast pathway DOES fire (not silent).
+    // We accept "Syncing", "Synced", "Sync complete", or "Sync failed" —
+    // any of these proves the toast pathway is active.
+    const syncToasts = toasts.filter(t =>
+      /sync/i.test(t)
+    );
+    expect(syncToasts.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.03",
+  "version": "3.34.04",
   "releaseDate": "2026-04-15",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Changes

- **Fixed**: Header cloud sync button no longer shows false "Synced" toast when vault password not cached
- `syncNow()` returns `{ synced: boolean }` — abort paths return `{ synced: false }`, success returns `{ synced: true }`
- Header button `.then()` callback gates success toast on `result.synced`
- Added 3 Playwright regression tests for header cloud sync button behavior

## Files Changed

| File | Change |
|------|--------|
| `js/cloud-sync.js` | `syncNow()` return values (3 lines) |
| `js/events.js` | `.then()` guard (2 lines) |
| `tests/playwright/cloud-sync-header-button.spec.js` | New: 3 E2E tests |
| `js/constants.js`, `version.json`, `package.json`, `package-lock.json` | Version bump → 3.34.04 |
| `CHANGELOG.md`, `docs/announcements.md`, `js/about.js` | Release notes |

## Issues (DocVault)

- STAK-549: Cloud sync header button silent failure → Done

## Test Results

- Playwright: 40 pass (+4 vs baseline), 9 fail (all pre-existing), 15 skip
- Zero new regressions
- Security review: no findings
- Codex peer review: clean (1 advisory, out of scope)