### PR TITLE
v3.34.05 — STAK-546: restore AND semantics to filter chip predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.05] - 2026-04-16
+
+### Fixed — STAK-546: Restore AND semantics to filter chip predicate
+
+- **Fixed**: Restore AND semantics to filter chip predicate — selecting multiple chips intersects instead of unions (STAK-546)
+
+---
+
 ## [3.34.04] - 2026-04-15
 
 ### Fixed — STAK-549: Cloud sync header button silent failure

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,10 +1,7 @@
 ## What's New
 
+- **STAK-546: Restore AND semantics to filter chip predicate (v3.34.05)**: Selecting multiple filter chips now intersects matches (AND) instead of unioning them (OR), matching documented behavior and expected UX.
 - **STAK-549: Fix Cloud Sync Header Button Silent Failure (v3.34.04)**: Header cloud sync button no longer shows a false "Synced" toast when vault password is not cached. Password prompt appears correctly; cancel shows an error toast instead of false success.
 - **STAK-544: Header Cloud Button Sync or Open Settings (v3.34.03)**: The header cloud button now triggers a manual sync for configured users or opens Settings → Cloud for setup users. Replaced the previous dead-end "autosync disabled" toast behavior.
 - **STAK-545: Market Button Triggers Refresh (v3.34.02)**: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon added to the Market dashboard block provides direct access to Market settings.
 - **STAK-445: Move FAQ below LOG (v3.34.01)**: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.
-- **STAK-444: Cloud Tab Settings Panel (v3.34.00)**: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.
-- **STAK-538: Remove First-Run Modal (v3.33.99)**: First-run acknowledgment modal removed -- users now see the app immediately. The Info tab and What's New popup already cover disclaimers and version announcements.
-- **STAK-529: Sort Direction Toggle (v3.33.98)**: Asc/Desc toggle added to Settings > Appearance next to Default Sort Column dropdown. Uses existing chip-sort-toggle pattern. Persists to localStorage via DEFAULT_SORT_DIR_KEY.
-- **STAK-532: Playwright-first testing (v3.33.97)**: Playwright (`@playwright/test`) is now the primary local TDD layer. 18 active tests across runbook sections 01-page-load and 02-crud (plus 15 stubs for future coverage). Run offline with `npm run test:offline`. Browserbase/Stagehand retained for live-site and cloud-only flows.

--- a/js/about.js
+++ b/js/about.js
@@ -139,12 +139,11 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.05 &ndash; STAK-546: Restore AND Semantics to Filter Chips</strong>: Selecting multiple filter chips now narrows results (AND) instead of expanding them (OR). Within a field and across fields, every selected chip adds a constraint &mdash; matching the expected drill-down behavior.</li>
     <li><strong>v3.34.04 &ndash; STAK-549: Fix Cloud Sync Header Button Silent Failure</strong>: Header cloud sync button no longer shows a false &quot;Synced&quot; toast when vault password is not cached. Password prompt appears correctly; cancel shows error toast instead of false success.</li>
     <li><strong>v3.34.03 &ndash; STAK-544: Header Cloud Button Sync or Open Settings</strong>: The header cloud button now triggers a manual sync for configured users or opens Settings &rarr; Cloud for setup users. Replaced the previous dead-end &quot;autosync disabled&quot; toast behavior.</li>
     <li><strong>v3.34.02 &ndash; STAK-545: Market Button Triggers Refresh</strong>: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon in the Market dashboard block provides direct access to Market settings.</li>
     <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>
-    <li><strong>v3.34.00 &ndash; STAK-444: Cloud Tab Settings Panel</strong>: Dropbox and Cloud Sync Beta cards moved from System tab to a dedicated Cloud tab. The Cloud nav button now opens cloud sync configuration instead of falling back to About.</li>
-    <li><strong>v3.33.99 &ndash; STAK-538: Remove First-Run Modal</strong>: First-run acknowledgment modal removed &mdash; users now see the app immediately. The Info tab and What&rsquo;s New popup already cover disclaimers and version announcements.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.04";
+const APP_VERSION = "3.34.05";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/filters.js
+++ b/js/filters.js
@@ -916,12 +916,16 @@ const filterInventoryAdvanced = () => {
     if (criteria && typeof criteria === "object" && Array.isArray(criteria.values)) {
       const { values, exclude } = criteria;
       switch (field) {
+        // STAK-546: Include mode uses `every` (AND — item must match all selected values);
+        // exclude mode uses `!some` (hide if item matches ANY selected value, preserving the
+        // pre-STAK-546 exclude semantics). Computing both allows one return site per case.
         case "name": {
           const simplifiedValues = values.map((v) => simplifyChipValue(v, field));
           result = result.filter((item) => {
             const itemName = simplifyChipValue(item.name || "", field);
-            const match = simplifiedValues.every((v) => v === itemName);
-            return exclude ? !match : match;
+            const matchAll = simplifiedValues.every((v) => v === itemName);
+            const matchAny = simplifiedValues.some((v) => v === itemName);
+            return exclude ? !matchAny : matchAll;
           });
           break;
         }
@@ -931,43 +935,49 @@ const filterInventoryAdvanced = () => {
             const itemMetal = getCompositionFirstWords(
               item.composition || item.metal || ""
             ).toLowerCase();
-            const match = lowerVals.every((v) => v === itemMetal);
-            return exclude ? !match : match;
+            const matchAll = lowerVals.every((v) => v === itemMetal);
+            const matchAny = lowerVals.some((v) => v === itemMetal);
+            return exclude ? !matchAny : matchAll;
           });
           break;
         }
         case "type":
           result = result.filter((item) => {
-            const match = values.every((v) => v === item.type);
-            return exclude ? !match : match;
+            const matchAll = values.every((v) => v === item.type);
+            const matchAny = values.some((v) => v === item.type);
+            return exclude ? !matchAny : matchAll;
           });
           break;
         case "purchaseLocation":
           result = result.filter((item) => {
             const loc = item.purchaseLocation;
             const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const match = values.every((v) => v === normalized);
-            return exclude ? !match : match;
+            const matchAll = values.every((v) => v === normalized);
+            const matchAny = values.some((v) => v === normalized);
+            return exclude ? !matchAny : matchAll;
           });
           break;
         case "storageLocation":
           result = result.filter((item) => {
             const loc = item.storageLocation;
             const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const match = values.every((v) => v === normalized);
-            return exclude ? !match : match;
+            const matchAll = values.every((v) => v === normalized);
+            const matchAny = values.some((v) => v === normalized);
+            return exclude ? !matchAny : matchAll;
           });
           break;
         case "tags": {
           // STAK-126: Filter by item tags
-          // STAK-546: AND semantics — item must carry EVERY selected tag value.
+          // STAK-546: include AND across selected tags; exclude removes items carrying ANY
+          // selected tag (pre-STAK-546 exclude semantics preserved).
           if (typeof getItemTags === "function") {
             const lowerVals = values.map((v) => v.toLowerCase());
             result = result.filter((item) => {
               const rawTags = getItemTags(item.uuid);
               const itemTags = Array.isArray(rawTags) ? rawTags.map((t) => t.toLowerCase()) : [];
-              const match = lowerVals.every((v) => itemTags.includes(v));
-              return exclude ? !match : match;
+              const matchAll = lowerVals.every((v) => itemTags.includes(v));
+              const matchAny = lowerVals.some((v) => itemTags.includes(v));
+              return exclude ? !matchAny : matchAll;
             });
           }
           break;
@@ -976,8 +986,9 @@ const filterInventoryAdvanced = () => {
           const lowerVals = values.map((v) => String(v).toLowerCase());
           result = result.filter((item) => {
             const fieldVal = String(item[field] ?? "").toLowerCase();
-            const match = lowerVals.every((v) => v === fieldVal);
-            return exclude ? !match : match;
+            const matchAll = lowerVals.every((v) => v === fieldVal);
+            const matchAny = lowerVals.some((v) => v === fieldVal);
+            return exclude ? !matchAny : matchAll;
           });
           break;
         }

--- a/js/filters.js
+++ b/js/filters.js
@@ -920,7 +920,7 @@ const filterInventoryAdvanced = () => {
           const simplifiedValues = values.map((v) => simplifyChipValue(v, field));
           result = result.filter((item) => {
             const itemName = simplifyChipValue(item.name || "", field);
-            const match = simplifiedValues.includes(itemName);
+            const match = simplifiedValues.every((v) => v === itemName);
             return exclude ? !match : match;
           });
           break;
@@ -931,14 +931,14 @@ const filterInventoryAdvanced = () => {
             const itemMetal = getCompositionFirstWords(
               item.composition || item.metal || ""
             ).toLowerCase();
-            const match = lowerVals.includes(itemMetal);
+            const match = lowerVals.every((v) => v === itemMetal);
             return exclude ? !match : match;
           });
           break;
         }
         case "type":
           result = result.filter((item) => {
-            const match = values.includes(item.type);
+            const match = values.every((v) => v === item.type);
             return exclude ? !match : match;
           });
           break;
@@ -946,7 +946,7 @@ const filterInventoryAdvanced = () => {
           result = result.filter((item) => {
             const loc = item.purchaseLocation;
             const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const match = values.includes(normalized);
+            const match = values.every((v) => v === normalized);
             return exclude ? !match : match;
           });
           break;
@@ -954,17 +954,19 @@ const filterInventoryAdvanced = () => {
           result = result.filter((item) => {
             const loc = item.storageLocation;
             const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const match = values.includes(normalized);
+            const match = values.every((v) => v === normalized);
             return exclude ? !match : match;
           });
           break;
         case "tags": {
           // STAK-126: Filter by item tags
+          // STAK-546: AND semantics — item must carry EVERY selected tag value.
           if (typeof getItemTags === "function") {
             const lowerVals = values.map((v) => v.toLowerCase());
             result = result.filter((item) => {
-              const tags = getItemTags(item.uuid);
-              const match = tags.some((t) => lowerVals.includes(t.toLowerCase()));
+              const rawTags = getItemTags(item.uuid);
+              const itemTags = Array.isArray(rawTags) ? rawTags.map((t) => t.toLowerCase()) : [];
+              const match = lowerVals.every((v) => itemTags.includes(v));
               return exclude ? !match : match;
             });
           }
@@ -974,7 +976,7 @@ const filterInventoryAdvanced = () => {
           const lowerVals = values.map((v) => String(v).toLowerCase());
           result = result.filter((item) => {
             const fieldVal = String(item[field] ?? "").toLowerCase();
-            const match = lowerVals.includes(fieldVal);
+            const match = lowerVals.every((v) => v === fieldVal);
             return exclude ? !match : match;
           });
           break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.04",
+  "version": "3.34.05",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.04",
+      "version": "3.34.05",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.04",
+  "version": "3.34.05",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.04-b1776313514";
+const CACHE_NAME = "staktrakr-v3.34.05-b1776369000";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/filter-chip-and-logic.spec.js
+++ b/tests/playwright/filter-chip-and-logic.spec.js
@@ -350,4 +350,27 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
 
     expect(await dataRowCount(page)).toBe(4);
   });
+
+  // Case 7 — Multi-value exclude must hide items matching ANY selected value (not ALL).
+  // tags:Damaged + tags:Rare in exclude mode → hide items carrying EITHER tag.
+  // Fixture: only item E has a Damaged tag; no item has Rare. Expected survivors: {A,B,C,D}.
+  // Previously under `every`-based exclude, an item would only be hidden if it carried BOTH
+  // selected tags — dropping the exclude filter to a no-op for multi-chip exclude selections.
+  test("Case 7 — exclude-mode multi-tag removes items matching ANY excluded value", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      // applyQuickFilter(field, value, isGrouped, exclude)
+      window.applyQuickFilter("tags", "Damaged", false, true);
+      window.applyQuickFilter("tags", "Rare", false, true);
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(
+      new Set([FIXTURE_UUIDS.A, FIXTURE_UUIDS.B, FIXTURE_UUIDS.C, FIXTURE_UUIDS.D])
+    );
+    expect(uuids).toHaveLength(4);
+
+    expect(await dataRowCount(page)).toBe(4);
+  });
 });

--- a/tests/playwright/filter-chip-and-logic.spec.js
+++ b/tests/playwright/filter-chip-and-logic.spec.js
@@ -1,0 +1,353 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Playwright regression spec for STAK-546 — filter chip AND/OR predicate.
+ *
+ * Locks the AND-within-field contract for `filterInventoryAdvanced()` so the
+ * bug (OR within a field) cannot silently regress.
+ *
+ *   Case 1 — Single `tags:Allegory` chip           → 4 Allegory items (A,B,D,E)
+ *   Case 2 — `tags:Allegory` + `tags:Cat`          → 1 item with BOTH (A)          MUST FAIL today (OR)
+ *   Case 3 — `metal:Silver` + `tags:Cat`           → 2 silver cats (A,C)           already correct (cross-field)
+ *   Case 4 — `metal:Gold` + `metal:Silver`         → 0 rows                        MUST FAIL today (OR)
+ *   Case 5 — Remove `tags:Cat` from case 2         → 4 Allegory items (A,B,D,E)    single-chip identity; passes today
+ *   Case 6 — Exclude-mode `tags:Damaged`           → 4 non-damaged items (A,B,C,D) existing behavior preserved
+ *
+ * Seeds inventory + item-tag map + ackVersion via `page.addInitScript` under the
+ * existing keys (`metalInventory`, `itemTags`, `ackVersion`). UUIDs are
+ * pre-assigned so tag lookup (`itemTags` is keyed by uuid) resolves correctly.
+ *
+ * Uses the app's own `window.applyQuickFilter(field, value)` entry point to
+ * install chips — same code path a user clicks. Assertions cover both the
+ * filtered array (length + UUID set) and the rendered DOM row count.
+ */
+
+const FIXTURE_UUIDS = {
+  A: "stak546-item-a-silver-allegory-cat",
+  B: "stak546-item-b-silver-allegory",
+  C: "stak546-item-c-silver-cat",
+  D: "stak546-item-d-gold-allegory",
+  E: "stak546-item-e-silver-allegory-damaged",
+};
+
+const FIXTURE_INVENTORY = [
+  {
+    uuid: FIXTURE_UUIDS.A,
+    metal: "Silver",
+    composition: "Silver",
+    name: "STAK546 Silver Allegory Cat",
+    qty: 1,
+    type: "Coin",
+    weight: 1,
+    price: 40,
+    marketValue: 0,
+    date: "2025-01-01",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "",
+    serialNumber: "",
+    notes: "",
+    year: "2025",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 37,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 0.999,
+    numistaId: "",
+    serial: 101,
+  },
+  {
+    uuid: FIXTURE_UUIDS.B,
+    metal: "Silver",
+    composition: "Silver",
+    name: "STAK546 Silver Allegory",
+    qty: 1,
+    type: "Coin",
+    weight: 1,
+    price: 41,
+    marketValue: 0,
+    date: "2025-01-02",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "",
+    serialNumber: "",
+    notes: "",
+    year: "2025",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 37,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 0.999,
+    numistaId: "",
+    serial: 102,
+  },
+  {
+    uuid: FIXTURE_UUIDS.C,
+    metal: "Silver",
+    composition: "Silver",
+    name: "STAK546 Silver Cat",
+    qty: 1,
+    type: "Coin",
+    weight: 1,
+    price: 39,
+    marketValue: 0,
+    date: "2025-01-03",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "",
+    serialNumber: "",
+    notes: "",
+    year: "2025",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 37,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 0.999,
+    numistaId: "",
+    serial: 103,
+  },
+  {
+    uuid: FIXTURE_UUIDS.D,
+    metal: "Gold",
+    composition: "Gold",
+    name: "STAK546 Gold Allegory",
+    qty: 1,
+    type: "Coin",
+    weight: 1,
+    price: 3400,
+    marketValue: 0,
+    date: "2025-01-04",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "",
+    serialNumber: "",
+    notes: "",
+    year: "2025",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 3333,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 0.9999,
+    numistaId: "",
+    serial: 104,
+  },
+  {
+    uuid: FIXTURE_UUIDS.E,
+    metal: "Silver",
+    composition: "Silver",
+    name: "STAK546 Silver Allegory Damaged",
+    qty: 1,
+    type: "Coin",
+    weight: 1,
+    price: 38,
+    marketValue: 0,
+    date: "2025-01-05",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "",
+    serialNumber: "",
+    notes: "",
+    year: "2025",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 37,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 0.999,
+    numistaId: "",
+    serial: 105,
+  },
+];
+
+const FIXTURE_ITEM_TAGS = {
+  [FIXTURE_UUIDS.A]: ["Allegory", "Cat"],
+  [FIXTURE_UUIDS.B]: ["Allegory"],
+  [FIXTURE_UUIDS.C]: ["Cat"],
+  [FIXTURE_UUIDS.D]: ["Allegory"],
+  [FIXTURE_UUIDS.E]: ["Allegory", "Damaged"],
+};
+
+/** Return the UUIDs present in `filterInventoryAdvanced()` output. */
+async function filteredUuids(page) {
+  return page.evaluate(() => {
+    const items = window.filterInventoryAdvanced();
+    return items.map((item) => item.uuid);
+  });
+}
+
+/** Count rendered data rows (exclude empty-state placeholder).
+ *  Uses `:not()` self-selector — Playwright's `filter({hasNot})` checks DESCENDANTS,
+ *  so an empty-state row with no children would slip through and inflate the count. */
+async function dataRowCount(page) {
+  return page.locator("#inventoryTable tbody tr:not(.empty-state-row)").count();
+}
+
+/** Reset chips between tests via the app's own clear entry point. */
+async function clearChips(page) {
+  await page.evaluate(() => {
+    if (typeof window.clearAllFilters === "function") window.clearAllFilters();
+  });
+}
+
+test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ({ inv, tags }) => {
+        localStorage.setItem("metalInventory", JSON.stringify(inv));
+        localStorage.setItem("itemTags", JSON.stringify(tags));
+      },
+      { inv: FIXTURE_INVENTORY, tags: FIXTURE_ITEM_TAGS }
+    );
+
+    // Suppress What's New modal — ack the current APP_VERSION at DOMContentLoaded
+    // (same pattern as tests/playwright/helpers/seed.js).
+    await page.addInitScript(() => {
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          if (typeof APP_VERSION !== "undefined") {
+            localStorage.setItem("ackVersion", APP_VERSION);
+          }
+        },
+        { once: true }
+      );
+    });
+
+    await page.goto("/index.html");
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    // Wait for the initial inventory load so filterInventoryAdvanced() has data.
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 5;
+      } catch (e) {
+        return false;
+      }
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearChips(page);
+  });
+
+  // Case 1 — Single tag chip narrows to the Allegory-tagged items.
+  // Passes under both OR and AND (single-chip identity) — sanity check for harness.
+  test("Case 1 — single tags:Allegory chip renders exactly the Allegory items", async ({
+    page,
+  }) => {
+    await page.evaluate(() => window.applyQuickFilter("tags", "Allegory"));
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(
+      new Set([FIXTURE_UUIDS.A, FIXTURE_UUIDS.B, FIXTURE_UUIDS.D, FIXTURE_UUIDS.E])
+    );
+    expect(uuids).toHaveLength(4);
+
+    expect(await dataRowCount(page)).toBe(4);
+  });
+
+  // Case 2 — Adding a second tag chip must AND-intersect (regression exposed).
+  // Under current OR code: returns A∪B∪C∪D∪E = 5 items. Expected after fix: {A} = 1 item.
+  test("Case 2 — tags:Allegory + tags:Cat intersects to items carrying BOTH (AND)", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      window.applyQuickFilter("tags", "Allegory");
+      window.applyQuickFilter("tags", "Cat");
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(new Set([FIXTURE_UUIDS.A]));
+    expect(uuids).toHaveLength(1);
+
+    expect(await dataRowCount(page)).toBe(1);
+  });
+
+  // Case 3 — Cross-field AND (already correct today, must remain correct).
+  // metal:Silver + tags:Cat → A and C (silver cats only).
+  test("Case 3 — metal:Silver + tags:Cat intersects cross-field", async ({ page }) => {
+    await page.evaluate(() => {
+      window.applyQuickFilter("metal", "Silver");
+      window.applyQuickFilter("tags", "Cat");
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(new Set([FIXTURE_UUIDS.A, FIXTURE_UUIDS.C]));
+    expect(uuids).toHaveLength(2);
+
+    expect(await dataRowCount(page)).toBe(2);
+  });
+
+  // Case 4 — Two incompatible scalar chips must return zero (regression exposed).
+  // Under current OR code: returns Gold ∪ Silver = 4 items. Expected after fix: 0.
+  test("Case 4 — metal:Gold + metal:Silver returns zero items (AND of disjoint scalars)", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      window.applyQuickFilter("metal", "Gold");
+      window.applyQuickFilter("metal", "Silver");
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(uuids).toEqual([]);
+
+    // Empty result renders the empty-state row; no data rows.
+    expect(await dataRowCount(page)).toBe(0);
+  });
+
+  // Case 5 — Removing a chip broadens back.
+  // Note: with a single remaining chip (tags:Allegory), OR and AND both return the same
+  // set (single-chip reduces to identity), so this PASSES under both predicates today.
+  // The test documents chip-removal correctness; it is NOT a regression-exposer.
+  test("Case 5 — removing tags:Cat from case 2 returns the Allegory-only set", async ({ page }) => {
+    await page.evaluate(() => {
+      window.applyQuickFilter("tags", "Allegory");
+      window.applyQuickFilter("tags", "Cat");
+      // applyQuickFilter toggles: the second call with the same value removes it.
+      window.applyQuickFilter("tags", "Cat");
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(
+      new Set([FIXTURE_UUIDS.A, FIXTURE_UUIDS.B, FIXTURE_UUIDS.D, FIXTURE_UUIDS.E])
+    );
+    expect(uuids).toHaveLength(4);
+
+    expect(await dataRowCount(page)).toBe(4);
+  });
+
+  // Case 6 — Exclude-mode must keep working unchanged.
+  // tags:Damaged in exclude mode → everything except E.
+  test("Case 6 — exclude-mode tags:Damaged keeps items without that tag", async ({ page }) => {
+    await page.evaluate(() => {
+      // applyQuickFilter(field, value, isGrouped, exclude)
+      window.applyQuickFilter("tags", "Damaged", false, true);
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(
+      new Set([FIXTURE_UUIDS.A, FIXTURE_UUIDS.B, FIXTURE_UUIDS.C, FIXTURE_UUIDS.D])
+    );
+    expect(uuids).toHaveLength(4);
+
+    expect(await dataRowCount(page)).toBe(4);
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.04",
-  "releaseDate": "2026-04-15",
+  "version": "3.34.05",
+  "releaseDate": "2026-04-16",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

Restore uniform AND semantics to the inventory filter-chip predicate. Every selected chip is now an additional required constraint — within a field and across fields.

## Root Cause

`filterInventoryAdvanced()` in `js/filters.js` used `values.includes()` / `tags.some()` per-field matchers, giving OR within a field. Cross-field AND was already correct via the outer `result.filter` chain.

## Fix

Flipped every per-field matcher to `values.every()` form.

- **Scalar fields** (name, metal, type, year, grade, numistaId, purity, purchaseLocation, storageLocation, default): `values.every(v => v === normalizedItemVal)`. Arity 1 preserves equality; arity ≥2 with distinct values returns empty (intended — e.g. `metal:Gold + metal:Silver` → zero items).
- **Tags field** (multi-value): `lowerVals.every(v => itemTags.includes(v))`. Item must carry every selected tag. Added `Array.isArray(rawTags)` guard per design §Error Handling item 3.
- **Exclude branch** preserved verbatim in every case.

No schema change, no settings UI, no cloud-sync impact.

## Test Plan

- [x] New Playwright regression at `tests/playwright/filter-chip-and-logic.spec.js` — 6 cases: single-tag narrow, two-tag intersect (Allegory+Cat repro), metal+tag cross-field, two-scalar empty, chip-removal broaden, exclude preserved. **All 6 PASS.**
- [x] Full Playwright suite run — 10 pre-existing flaky failures (01-page-load, 03-settings, retail/slug-resolution) baseline-reproduced, unrelated to filter code.
- [ ] Manual browser smoke — click Allegory + Cat chips, confirm intersection.

## Issues (DocVault)

- **STAK-546**: Filter chip regression — additive (OR) instead of subtractive (AND) across categories → **Done** ([[STAK-546]])

## Spec

- `DocVault/specflow/StakTrakr/specs/STAK-546-filter-chip-and-or-regression/` — requirements, design, tasks, readiness-report, verification all approved/complete.

## Files

9 files changed, 379 insertions(+), 20 deletions(-):
- `js/filters.js` — predicate flip
- `tests/playwright/filter-chip-and-logic.spec.js` — new
- Version bump: `version.json`, `package.json`, `package-lock.json`, `js/constants.js`, `js/about.js`, `docs/announcements.md`, `CHANGELOG.md`