### PR TITLE
v3.34.06 — STAK-551: fix filter chip predicate logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed — STAK-551: Fix filter chip predicate logic
 
-- **Fixed**: Scalar fields (metal, type) use OR within-field — Silver+Gold shows both metals (STAK-551)
+- **Fixed**: Scalar fields (metal, type, name, purchaseLocation, storageLocation) use OR within-field — Silver+Gold shows both metals (STAK-551)
 - **Fixed**: Expansion chips (customGroup, dynamicName, groupedName) store single constraints and expand at predicate time — Florida chip no longer returns zero results (STAK-551)
 - **Fixed**: Chip threshold honored when filters active — no more minCount=1 override flooding chip bar (STAK-551)
 - **Changed**: `isMultiSelect` renamed to `isAccumulate` for clarity (STAK-551)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.06] - 2026-04-17
+
+### Fixed — STAK-551: Fix filter chip predicate logic
+
+- **Fixed**: Scalar fields (metal, type) use OR within-field — Silver+Gold shows both metals (STAK-551)
+- **Fixed**: Expansion chips (customGroup, dynamicName, groupedName) store single constraints and expand at predicate time — Florida chip no longer returns zero results (STAK-551)
+- **Fixed**: Chip threshold honored when filters active — no more minCount=1 override flooding chip bar (STAK-551)
+- **Changed**: `isMultiSelect` renamed to `isAccumulate` for clarity (STAK-551)
+
+---
+
 ## [3.34.05] - 2026-04-16
 
 ### Fixed — STAK-546: Restore AND semantics to filter chip predicate

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-551: Fix filter chip predicate logic (v3.34.06)**: Scalar fields (metal, type, name, location) now use OR within-field — Silver+Gold shows both. Tags keep AND. Expansion chips (customGroup, dynamicName, groupedName) expand at predicate time. Chip threshold honored when filters active.
 - **STAK-546: Restore AND semantics to filter chip predicate (v3.34.05)**: Selecting multiple filter chips now intersects matches (AND) instead of unioning them (OR), matching documented behavior and expected UX.
 - **STAK-549: Fix Cloud Sync Header Button Silent Failure (v3.34.04)**: Header cloud sync button no longer shows a false "Synced" toast when vault password is not cached. Password prompt appears correctly; cancel shows an error toast instead of false success.
 - **STAK-544: Header Cloud Button Sync or Open Settings (v3.34.03)**: The header cloud button now triggers a manual sync for configured users or opens Settings → Cloud for setup users. Replaced the previous dead-end "autosync disabled" toast behavior.

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -5,4 +5,3 @@
 - **STAK-549: Fix Cloud Sync Header Button Silent Failure (v3.34.04)**: Header cloud sync button no longer shows a false "Synced" toast when vault password is not cached. Password prompt appears correctly; cancel shows an error toast instead of false success.
 - **STAK-544: Header Cloud Button Sync or Open Settings (v3.34.03)**: The header cloud button now triggers a manual sync for configured users or opens Settings → Cloud for setup users. Replaced the previous dead-end "autosync disabled" toast behavior.
 - **STAK-545: Market Button Triggers Refresh (v3.34.02)**: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon added to the Market dashboard block provides direct access to Market settings.
-- **STAK-445: Move FAQ below LOG (v3.34.01)**: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.06 &ndash; STAK-551: Fix Filter Chip Predicate Logic</strong>: Scalar fields (metal, type) now use OR within-field (Silver+Gold shows both). Tags keep AND (Red+Green = items with both). Expansion chips (customGroup, dynamicName, groupedName) store single constraints and expand at predicate time. Chip threshold honored when filters active.</li>
     <li><strong>v3.34.05 &ndash; STAK-546: Restore AND Semantics to Filter Chips</strong>: Selecting multiple filter chips now narrows results (AND) instead of expanding them (OR). Within a field and across fields, every selected chip adds a constraint &mdash; matching the expected drill-down behavior.</li>
     <li><strong>v3.34.04 &ndash; STAK-549: Fix Cloud Sync Header Button Silent Failure</strong>: Header cloud sync button no longer shows a false &quot;Synced&quot; toast when vault password is not cached. Password prompt appears correctly; cancel shows error toast instead of false success.</li>
     <li><strong>v3.34.03 &ndash; STAK-544: Header Cloud Button Sync or Open Settings</strong>: The header cloud button now triggers a manual sync for configured users or opens Settings &rarr; Cloud for setup users. Replaced the previous dead-end &quot;autosync disabled&quot; toast behavior.</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.05";
+const APP_VERSION = "3.34.06";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/filters.js
+++ b/js/filters.js
@@ -978,17 +978,23 @@ const filterInventoryAdvanced = () => {
             .map((id) => groups.find((g) => g.id === id))
             .filter(Boolean);
           if (resolvedGroups.length === 0) break;
+          // Precompile regex matchers once per filter pass (not per item)
+          const groupMatchers = resolvedGroups.map((group) => {
+            const patterns = Array.isArray(group.patterns) ? group.patterns : [];
+            return patterns.map((p) => {
+              try {
+                // nosemgrep: javascript.dos.rule-non-literal-regexp
+                const escaped = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                return new RegExp("\\b" + escaped + "\\b", "i");
+              } catch (e) {
+                return String(p).toLowerCase();
+              }
+            });
+          });
           result = result.filter((item) => {
             const itemName = (item.name || "").toLowerCase();
-            const matchAny = resolvedGroups.some((group) =>
-              group.patterns.some((p) => {
-                try {
-                  const escaped = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                  return new RegExp("\\b" + escaped + "\\b", "i").test(itemName);
-                } catch (e) {
-                  return itemName.includes(String(p).toLowerCase());
-                }
-              })
+            const matchAny = groupMatchers.some((matchers) =>
+              matchers.some((m) => (m instanceof RegExp ? m.test(itemName) : itemName.includes(m)))
             );
             return exclude ? !matchAny : matchAny;
           });
@@ -1299,7 +1305,9 @@ const filterInventoryAdvanced = () => {
  * @param {boolean} [exclude=false] - Whether to apply the filter in exclusion mode
  */
 const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
-  // Fields that support OR-logic accumulation (filter engine already handles these natively)
+  // Fields that accumulate values on repeated clicks (multi-select).
+  // metal/type: OR in predicate (scalar — item has one value, show any match).
+  // tags: AND in predicate (array — item has many, must match all selected).
   const isAccumulate = field === "tags" || field === "metal" || field === "type";
 
   // Handle custom group chip click — store the group ID; predicate expands at filter time

--- a/js/filters.js
+++ b/js/filters.js
@@ -131,17 +131,7 @@ const generateCategorySummary = (inventory) => {
     minCount = parseInt(localStorage.getItem("chipMinCount") || "3", 10);
   }
 
-  // When the user has active filters or a search query, drop minCount to 1
-  // for descriptive categories (metal, type, year, grade, location, groups)
-  // so the filtered subset's attributes are always visible.
-  // Name chips keep the user's threshold (min 2) to avoid flooding the chip
-  // bar with every unique item name in the filtered set.
-  const hasActiveFilters = Object.keys(activeFilters).length > 0;
-  const hasSearchQuery = typeof searchQuery === "string" && searchQuery.trim().length > 0;
   const nameMinCount = Math.max(2, minCount);
-  if (hasActiveFilters || hasSearchQuery) {
-    minCount = 1;
-  }
 
   const metals = {};
   const types = {};
@@ -242,8 +232,7 @@ const generateCategorySummary = (inventory) => {
   }
 
   // Apply minCount threshold to all categories
-  // Metals always show (max 5 values, primary categorization) — threshold 1
-  const filteredMetals = applyMinCountThreshold(metals, 1);
+  const filteredMetals = applyMinCountThreshold(metals, minCount);
   const filteredTypes = applyMinCountThreshold(types, minCount);
   const filteredPurchaseLocations = applyMinCountThreshold(purchaseLocations, minCount);
   const filteredStorageLocations = applyMinCountThreshold(storageLocations, minCount);
@@ -555,17 +544,20 @@ const renderActiveFilters = () => {
     let isActiveFilter = false;
     if (f.count !== undefined && f.total !== undefined) {
       // Summary chip — active only if its value is in activeFilters
-      const criteria = activeFilters[f.field];
-      if (criteria && Array.isArray(criteria.values) && !criteria.exclude) {
-        if (f.field === "customGroup") {
-          // customGroup expands to name values — active if any non-excluded name filter exists
-          const nc = activeFilters["name"];
-          isActiveFilter = !!(nc && !nc.exclude && nc.values && nc.values.length > 0);
-        } else if (f.field === "dynamicName") {
-          // dynamicName expands to name values — same check
-          const nc = activeFilters["name"];
-          isActiveFilter = !!(nc && !nc.exclude && nc.values && nc.values.length > 0);
-        } else {
+      // STAK-551: expansion chips store their own activeFilters entries,
+      // so check those directly before falling through to the generic check.
+      if (f.field === "customGroup") {
+        const cg = activeFilters["customGroup"];
+        isActiveFilter = !!(cg && !cg.exclude && cg.values && cg.values.includes(f.value));
+      } else if (f.field === "dynamicName") {
+        const dn = activeFilters["dynamicName"];
+        isActiveFilter = !!(dn && !dn.exclude && dn.values && dn.values.includes(f.value));
+      } else if (f.field === "name" && f.isGrouped) {
+        const gn = activeFilters["groupedName"];
+        isActiveFilter = !!(gn && !gn.exclude && gn.values && gn.values.includes(f.value));
+      } else {
+        const criteria = activeFilters[f.field];
+        if (criteria && Array.isArray(criteria.values) && !criteria.exclude) {
           isActiveFilter = criteria.values.includes(f.value);
         }
       }
@@ -916,16 +908,16 @@ const filterInventoryAdvanced = () => {
     if (criteria && typeof criteria === "object" && Array.isArray(criteria.values)) {
       const { values, exclude } = criteria;
       switch (field) {
-        // STAK-546: Include mode uses `every` (AND — item must match all selected values);
-        // exclude mode uses `!some` (hide if item matches ANY selected value, preserving the
-        // pre-STAK-546 exclude semantics). Computing both allows one return site per case.
+        // STAK-551: Scalar fields use OR (item matches if it equals ANY selected value).
+        // Tags use AND (item must carry ALL selected tags). Expansion chips
+        // (customGroup, dynamicName, groupedName) resolve at predicate time with OR.
+        // Exclude mode always uses !some (hide if item matches ANY value).
         case "name": {
           const simplifiedValues = values.map((v) => simplifyChipValue(v, field));
           result = result.filter((item) => {
             const itemName = simplifyChipValue(item.name || "", field);
-            const matchAll = simplifiedValues.every((v) => v === itemName);
-            const matchAny = simplifiedValues.some((v) => v === itemName);
-            return exclude ? !matchAny : matchAll;
+            const match = simplifiedValues.includes(itemName);
+            return exclude ? !match : match;
           });
           break;
         }
@@ -935,35 +927,31 @@ const filterInventoryAdvanced = () => {
             const itemMetal = getCompositionFirstWords(
               item.composition || item.metal || ""
             ).toLowerCase();
-            const matchAll = lowerVals.every((v) => v === itemMetal);
-            const matchAny = lowerVals.some((v) => v === itemMetal);
-            return exclude ? !matchAny : matchAll;
+            const match = lowerVals.includes(itemMetal);
+            return exclude ? !match : match;
           });
           break;
         }
         case "type":
           result = result.filter((item) => {
-            const matchAll = values.every((v) => v === item.type);
-            const matchAny = values.some((v) => v === item.type);
-            return exclude ? !matchAny : matchAll;
+            const match = values.includes(item.type);
+            return exclude ? !match : match;
           });
           break;
         case "purchaseLocation":
           result = result.filter((item) => {
             const loc = item.purchaseLocation;
             const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const matchAll = values.every((v) => v === normalized);
-            const matchAny = values.some((v) => v === normalized);
-            return exclude ? !matchAny : matchAll;
+            const match = values.includes(normalized);
+            return exclude ? !match : match;
           });
           break;
         case "storageLocation":
           result = result.filter((item) => {
             const loc = item.storageLocation;
             const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const matchAll = values.every((v) => v === normalized);
-            const matchAny = values.some((v) => v === normalized);
-            return exclude ? !matchAny : matchAll;
+            const match = values.includes(normalized);
+            return exclude ? !match : match;
           });
           break;
         case "tags": {
@@ -982,13 +970,61 @@ const filterInventoryAdvanced = () => {
           }
           break;
         }
+        case "customGroup": {
+          const groups =
+            typeof window.loadCustomGroups === "function" ? window.loadCustomGroups() : [];
+          // Skip filter if none of the selected groupIds resolve to valid groups
+          const resolvedGroups = values
+            .map((id) => groups.find((g) => g.id === id))
+            .filter(Boolean);
+          if (resolvedGroups.length === 0) break;
+          result = result.filter((item) => {
+            const itemName = (item.name || "").toLowerCase();
+            const matchAny = resolvedGroups.some((group) =>
+              group.patterns.some((p) => {
+                try {
+                  const escaped = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                  return new RegExp("\\b" + escaped + "\\b", "i").test(itemName);
+                } catch (e) {
+                  return itemName.includes(String(p).toLowerCase());
+                }
+              })
+            );
+            return exclude ? !matchAny : matchAny;
+          });
+          break;
+        }
+        case "dynamicName": {
+          result = result.filter((item) => {
+            const name = item.name || "";
+            const matchAny = values.some(
+              (key) => name.includes("(" + key + ")") || name.includes('"' + key + '"')
+            );
+            return exclude ? !matchAny : matchAny;
+          });
+          break;
+        }
+        case "groupedName": {
+          result = result.filter((item) => {
+            const matchAny = values.some((base) => {
+              if (
+                window.autocomplete &&
+                typeof window.autocomplete.normalizeItemName === "function"
+              ) {
+                return window.autocomplete.normalizeItemName(item.name || "") === base;
+              }
+              return (item.name || "") === base;
+            });
+            return exclude ? !matchAny : matchAny;
+          });
+          break;
+        }
         default: {
           const lowerVals = values.map((v) => String(v).toLowerCase());
           result = result.filter((item) => {
             const fieldVal = String(item[field] ?? "").toLowerCase();
-            const matchAll = lowerVals.every((v) => v === fieldVal);
-            const matchAny = lowerVals.some((v) => v === fieldVal);
-            return exclude ? !matchAny : matchAll;
+            const match = lowerVals.includes(fieldVal);
+            return exclude ? !match : match;
           });
           break;
         }
@@ -1263,78 +1299,45 @@ const filterInventoryAdvanced = () => {
  * @param {boolean} [exclude=false] - Whether to apply the filter in exclusion mode
  */
 const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
-  // Fields that support OR-logic multi-select (filter engine already handles these natively)
-  const isMultiSelect = field === "tags" || field === "metal" || field === "type";
+  // Fields that support OR-logic accumulation (filter engine already handles these natively)
+  const isAccumulate = field === "tags" || field === "metal" || field === "type";
 
-  // Handle custom group chip click
+  // Handle custom group chip click — store the group ID; predicate expands at filter time
   if (field === "customGroup") {
-    const groups = typeof window.loadCustomGroups === "function" ? window.loadCustomGroups() : [];
-    const group = groups.find((g) => g.id === value);
-    if (group) {
-      const matchingNames = [];
-      inventory.forEach((item) => {
-        const itemName = (item.name || "").toLowerCase();
-        if (
-          group.patterns.some((p) => {
-            try {
-              // nosemgrep: javascript.dos.rule-non-literal-regexp
-              return new RegExp("\\b" + p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\b", "i").test(
-                itemName
-              );
-            } catch (e) {
-              return itemName.includes(p.toLowerCase());
-            }
-          })
-        ) {
-          matchingNames.push(item.name);
-        }
-      });
-      const uniqueNames = [...new Set(matchingNames)];
+    // Toggle behavior: if same custom group filter is active, remove it
+    const cg = activeFilters["customGroup"];
+    const isCurrentlyActive = !!(
+      cg &&
+      cg.values &&
+      cg.values.includes(value) &&
+      cg.exclude === exclude
+    );
 
-      // Toggle behavior: if same custom group filter is active, remove it
-      const currentValues = activeFilters["name"]?.values || [];
-      const currentExclude = !!activeFilters["name"]?.exclude;
-      const isCurrentlyActive =
-        uniqueNames.length > 0 &&
-        uniqueNames.every((n) => currentValues.includes(n)) &&
-        currentValues.length === uniqueNames.length &&
-        currentExclude === exclude;
-
-      if (isCurrentlyActive) {
-        delete activeFilters["name"];
-      } else if (uniqueNames.length > 0) {
-        activeFilters["name"] = { values: uniqueNames, exclude };
-      }
+    if (isCurrentlyActive) {
+      delete activeFilters["customGroup"];
+    } else {
+      activeFilters["customGroup"] = { values: [value], exclude };
     }
     renderTable();
     renderActiveFilters();
     return;
   }
 
-  // Handle dynamic name chip click
+  // Handle dynamic name chip click — store the key; predicate expands at filter time
   if (field === "dynamicName") {
-    const matchingNames = [];
-    inventory.forEach((item) => {
-      const name = item.name || "";
-      if (name.includes("(" + value + ")") || name.includes('"' + value + '"')) {
-        matchingNames.push(name);
-      }
-    });
-    const uniqueNames = [...new Set(matchingNames)];
-
     // Toggle behavior
-    const currentValues = activeFilters["name"]?.values || [];
-    const currentExclude = !!activeFilters["name"]?.exclude;
-    const isCurrentlyActive =
-      uniqueNames.length > 0 &&
-      uniqueNames.every((n) => currentValues.includes(n)) &&
-      currentValues.length === uniqueNames.length &&
-      currentExclude === exclude;
+    const dn = activeFilters["dynamicName"];
+    const isCurrentlyActive = !!(
+      dn &&
+      dn.values &&
+      dn.values.includes(value) &&
+      dn.exclude === exclude
+    );
 
     if (isCurrentlyActive) {
-      delete activeFilters["name"];
-    } else if (uniqueNames.length > 0) {
-      activeFilters["name"] = { values: uniqueNames, exclude };
+      delete activeFilters["dynamicName"];
+    } else {
+      activeFilters["dynamicName"] = { values: [value], exclude };
     }
     renderTable();
     renderActiveFilters();
@@ -1343,7 +1346,7 @@ const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
 
   // If this exact filter is already active, remove it (toggle behavior — single-select fields only)
   if (
-    !isMultiSelect &&
+    !isAccumulate &&
     activeFilters[field]?.values?.[0] === value &&
     activeFilters[field]?.exclude === exclude &&
     !isGrouped
@@ -1355,44 +1358,21 @@ const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
     window.featureFlags &&
     window.featureFlags.isEnabled("GROUPED_NAME_CHIPS")
   ) {
-    // Handle grouped name filtering
-    if (window.autocomplete && window.autocomplete.normalizeItemName) {
-      // Find all item names that normalize to this base name
-      const matchingNames = [];
-      inventory.forEach((item) => {
-        if (item.name) {
-          const baseName = window.autocomplete.normalizeItemName(item.name);
-          if (baseName === value) {
-            matchingNames.push(item.name);
-          }
-        }
-      });
+    // Handle grouped name filtering — store the base name; predicate expands at filter time
+    const gn = activeFilters["groupedName"];
+    const isCurrentlyActive = !!(
+      gn &&
+      gn.values &&
+      gn.values.includes(value) &&
+      gn.exclude === exclude
+    );
 
-      // Remove duplicates
-      const uniqueNames = [...new Set(matchingNames)];
-
-      if (uniqueNames.length > 0) {
-        // Check if this grouped filter is already active
-        const currentValues = activeFilters[field]?.values || [];
-        const currentExclude = !!activeFilters[field]?.exclude;
-        const isCurrentlyActive =
-          uniqueNames.every((name) => currentValues.includes(name)) &&
-          currentValues.length === uniqueNames.length &&
-          currentExclude === exclude;
-
-        if (isCurrentlyActive) {
-          // Toggle off - remove the filter
-          delete activeFilters[field];
-        } else {
-          // Apply the grouped filter
-          activeFilters[field] = { values: uniqueNames, exclude };
-        }
-      }
+    if (isCurrentlyActive) {
+      delete activeFilters["groupedName"];
     } else {
-      // Fallback to regular filtering if normalization is not available
-      activeFilters[field] = { values: [value], exclude };
+      activeFilters["groupedName"] = { values: [value], exclude };
     }
-  } else if (isMultiSelect && activeFilters[field] && activeFilters[field].exclude === exclude) {
+  } else if (isAccumulate && activeFilters[field] && activeFilters[field].exclude === exclude) {
     // Accumulate: toggle individual values in/out of the active set
     const existing = activeFilters[field].values;
     const idx = existing.indexOf(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.05",
+  "version": "3.34.06",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.05",
+      "version": "3.34.06",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.05",
+  "version": "3.34.06",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/tests/playwright/filter-chip-and-logic.spec.js
+++ b/tests/playwright/filter-chip-and-logic.spec.js
@@ -693,11 +693,10 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
     expect(uuids).toHaveLength(1);
   });
 
-  // Case 13 — Chip threshold honored: chipMinCount=5 means no chip should show count < 5.
-  // Currently broken — minCount drops to 1 when active filters are present.
+  // Case 13 — Chip threshold honored: chipMinCount=2 means no chip should show count < 2.
+  // Verifies the fix: minCount no longer drops to 1 when active filters are present.
   test("Case 13 — chipMinCount threshold is honored in rendered chip badges", async ({ page }) => {
-    // Set chipMinCount to 5 before page load via addInitScript won't work after beforeEach,
-    // so we set it and reload.
+    // Set chipMinCount to 2 (fits the small seed fixture) and reload.
     await page.evaluate(() => {
       localStorage.setItem("chipMinCount", "2");
     });

--- a/tests/playwright/filter-chip-and-logic.spec.js
+++ b/tests/playwright/filter-chip-and-logic.spec.js
@@ -9,7 +9,7 @@ import { test, expect } from "@playwright/test";
  *   Case 1 — Single `tags:Allegory` chip           → 4 Allegory items (A,B,D,E)
  *   Case 2 — `tags:Allegory` + `tags:Cat`          → 1 item with BOTH (A)          MUST FAIL today (OR)
  *   Case 3 — `metal:Silver` + `tags:Cat`           → 2 silver cats (A,C)           already correct (cross-field)
- *   Case 4 — `metal:Gold` + `metal:Silver`         → 0 rows                        MUST FAIL today (OR)
+ *   Case 4 — `metal:Gold` + `metal:Silver`         → 4 rows (OR)                   STAK-551: scalar multi-select is OR
  *   Case 5 — Remove `tags:Cat` from case 2         → 4 Allegory items (A,B,D,E)    single-chip identity; passes today
  *   Case 6 — Exclude-mode `tags:Damaged`           → 4 non-damaged items (A,B,C,D) existing behavior preserved
  *
@@ -296,9 +296,9 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
     expect(await dataRowCount(page)).toBe(2);
   });
 
-  // Case 4 — Two incompatible scalar chips must return zero (regression exposed).
-  // Under current OR code: returns Gold ∪ Silver = 4 items. Expected after fix: 0.
-  test("Case 4 — metal:Gold + metal:Silver returns zero items (AND of disjoint scalars)", async ({
+  // Case 4 — STAK-551: Scalar multi-select fields use OR, not AND.
+  // Metal is scalar — an item has one metal. Silver + Gold = show items of either metal.
+  test("Case 4 — metal:Gold + metal:Silver returns all items (OR of scalar multi-select)", async ({
     page,
   }) => {
     await page.evaluate(() => {
@@ -306,11 +306,8 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
       window.applyQuickFilter("metal", "Silver");
     });
 
-    const uuids = await filteredUuids(page);
-    expect(uuids).toEqual([]);
-
-    // Empty result renders the empty-state row; no data rows.
-    expect(await dataRowCount(page)).toBe(0);
+    // All 5 items are either Gold or Silver — OR returns all of them.
+    expect(await dataRowCount(page)).toBeGreaterThan(0);
   });
 
   // Case 5 — Removing a chip broadens back.
@@ -372,5 +369,461 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
     expect(uuids).toHaveLength(4);
 
     expect(await dataRowCount(page)).toBe(4);
+  });
+
+  // =========================================================================
+  // STAK-551 — filter chip predicate refactor (TDD red phase)
+  // Cases 8-14 target the new OR-within-field / customGroup / groupedName /
+  // chipMinCount behaviors. Expected to FAIL until Task 7 lands the impl.
+  // =========================================================================
+
+  // Case 8 — Metal multi-select OR: Silver + Gold should return items of BOTH metals.
+  // Under current AND logic this returns 0 (no item is both Silver AND Gold).
+  // After refactor, metal becomes OR-within-field → Silver ∪ Gold = all 5 items.
+  test("Case 8 — metal:Silver + metal:Gold returns items of both metals (OR within field)", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      window.applyQuickFilter("metal", "Silver");
+      window.applyQuickFilter("metal", "Gold");
+    });
+
+    const uuids = await filteredUuids(page);
+    // Should include Silver items (A,B,C,E) and Gold item (D)
+    expect(uuids.length).toBeGreaterThan(0);
+    const metals = await page.evaluate(() => {
+      return window.filterInventoryAdvanced().map((item) => item.metal);
+    });
+    expect(metals).toContain("Silver");
+    expect(metals).toContain("Gold");
+  });
+
+  // Case 9 — Tags AND preserved: items must carry ALL selected tags.
+  // Item F has ["Red","Green"], Item G has ["Red"] only.
+  // tags:Red + tags:Green → only F survives (AND within tags is preserved).
+  test("Case 9 — tags AND is preserved: two tag chips intersect correctly", async ({ page }) => {
+    const extraItems = [
+      {
+        uuid: "stak551-item-f-red-green",
+        metal: "Silver",
+        composition: "Silver",
+        name: "STAK551 Red Green Item",
+        qty: 1,
+        type: "Coin",
+        weight: 1,
+        price: 30,
+        marketValue: 0,
+        date: "2025-02-01",
+        purchaseLocation: "staktrakr.com",
+        storageLocation: "",
+        serialNumber: "",
+        notes: "",
+        year: "2025",
+        grade: "",
+        gradingAuthority: "",
+        certNumber: "",
+        pcgsNumber: "",
+        pcgsVerified: false,
+        spotPriceAtPurchase: 28,
+        premiumPerOz: 0,
+        totalPremium: 0,
+        purity: 0.999,
+        numistaId: "",
+        serial: 201,
+      },
+      {
+        uuid: "stak551-item-g-red-only",
+        metal: "Silver",
+        composition: "Silver",
+        name: "STAK551 Red Only Item",
+        qty: 1,
+        type: "Coin",
+        weight: 1,
+        price: 30,
+        marketValue: 0,
+        date: "2025-02-02",
+        purchaseLocation: "staktrakr.com",
+        storageLocation: "",
+        serialNumber: "",
+        notes: "",
+        year: "2025",
+        grade: "",
+        gradingAuthority: "",
+        certNumber: "",
+        pcgsNumber: "",
+        pcgsVerified: false,
+        spotPriceAtPurchase: 28,
+        premiumPerOz: 0,
+        totalPremium: 0,
+        purity: 0.999,
+        numistaId: "",
+        serial: 202,
+      },
+    ];
+    const extraTags = {
+      "stak551-item-f-red-green": ["Red", "Green"],
+      "stak551-item-g-red-only": ["Red"],
+    };
+
+    // addInitScript runs in registration order — this appends after the beforeEach seed
+    await page.addInitScript(
+      ({ extras, eTags }) => {
+        const inv = JSON.parse(localStorage.getItem("metalInventory") || "[]");
+        inv.push(...extras);
+        localStorage.setItem("metalInventory", JSON.stringify(inv));
+        const tags = JSON.parse(localStorage.getItem("itemTags") || "{}");
+        Object.assign(tags, eTags);
+        localStorage.setItem("itemTags", JSON.stringify(tags));
+      },
+      { extras: extraItems, eTags: extraTags }
+    );
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 7;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    await page.evaluate(() => {
+      window.applyQuickFilter("tags", "Red");
+      window.applyQuickFilter("tags", "Green");
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(new Set(uuids)).toEqual(new Set(["stak551-item-f-red-green"]));
+    expect(uuids).toHaveLength(1);
+  });
+
+  // Case 10 — customGroup + metal intersection.
+  // Set up a custom group "Allegories" matching pattern "Allegory".
+  // Apply metal:Gold + customGroup:Allegories → Item D (Gold Allegory) should survive.
+  // Currently broken: customGroup expands into activeFilters["name"] with multiple values,
+  // and AND on names means an item must match ALL names — always 0.
+  test("Case 10 — customGroup + metal intersection returns matching items", async ({ page }) => {
+    // Inject a custom group into localStorage
+    await page.evaluate(() => {
+      const groups = [
+        {
+          id: "cg_test_allegory",
+          label: "Allegories",
+          patterns: ["Allegory"],
+          enabled: true,
+        },
+      ];
+      localStorage.setItem("chipCustomGroups", JSON.stringify(groups));
+    });
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 5;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    await page.evaluate(() => {
+      window.applyQuickFilter("metal", "Gold");
+      window.applyQuickFilter("customGroup", "cg_test_allegory");
+    });
+
+    const uuids = await filteredUuids(page);
+    // Gold + Allegory pattern → only item D (Gold Allegory)
+    expect(uuids.length).toBeGreaterThan(0);
+    expect(uuids).toContain(FIXTURE_UUIDS.D);
+  });
+
+  // Case 11 — groupedName + metal.
+  // Seed items: two "American Silver Eagle" variants (different years).
+  // Apply metal:Silver + grouped name chip "American Silver Eagle".
+  // Currently broken: grouped name expands into activeFilters["name"] with multiple
+  // specific names, and AND within the name field returns 0.
+  test("Case 11 — groupedName + metal returns items matching grouped base name", async ({
+    page,
+  }) => {
+    // Inject ASE items with different years via addInitScript (runs after beforeEach seed)
+    const aseItems = [
+      {
+        uuid: "stak551-ase-1999",
+        metal: "Silver",
+        composition: "Silver",
+        name: "1999 American Silver Eagle",
+        qty: 1,
+        type: "Coin",
+        weight: 1,
+        price: 25,
+        marketValue: 0,
+        date: "2025-03-01",
+        purchaseLocation: "tulsacoins.com",
+        storageLocation: "",
+        serialNumber: "",
+        notes: "",
+        year: "1999",
+        grade: "",
+        gradingAuthority: "",
+        certNumber: "",
+        pcgsNumber: "",
+        pcgsVerified: false,
+        spotPriceAtPurchase: 20,
+        premiumPerOz: 0,
+        totalPremium: 0,
+        purity: 0.999,
+        numistaId: "",
+        serial: 301,
+      },
+      {
+        uuid: "stak551-ase-2024",
+        metal: "Silver",
+        composition: "Silver",
+        name: "2024 American Silver Eagle",
+        qty: 1,
+        type: "Coin",
+        weight: 1,
+        price: 35,
+        marketValue: 0,
+        date: "2025-03-02",
+        purchaseLocation: "apmex.com",
+        storageLocation: "",
+        serialNumber: "",
+        notes: "",
+        year: "2024",
+        grade: "",
+        gradingAuthority: "",
+        certNumber: "",
+        pcgsNumber: "",
+        pcgsVerified: false,
+        spotPriceAtPurchase: 28,
+        premiumPerOz: 0,
+        totalPremium: 0,
+        purity: 0.999,
+        numistaId: "",
+        serial: 302,
+      },
+    ];
+    await page.addInitScript(
+      ({ extras }) => {
+        const inv = JSON.parse(localStorage.getItem("metalInventory") || "[]");
+        inv.push(...extras);
+        localStorage.setItem("metalInventory", JSON.stringify(inv));
+      },
+      { extras: aseItems }
+    );
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 7;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    await page.evaluate(() => {
+      window.applyQuickFilter("metal", "Silver");
+      // isGrouped=true triggers the GROUPED_NAME_CHIPS code path
+      window.applyQuickFilter("name", "American Silver Eagle", true);
+    });
+
+    const uuids = await filteredUuids(page);
+    // Should include both ASE variants (and only them, intersected with Silver)
+    expect(uuids.length).toBeGreaterThan(0);
+    expect(uuids).toContain("stak551-ase-1999");
+    expect(uuids).toContain("stak551-ase-2024");
+  });
+
+  // Case 12 — Exclude customGroup: items matching the group pattern should be hidden.
+  test("Case 12 — exclude customGroup hides items matching group patterns", async ({ page }) => {
+    // Inject a custom group matching "Allegory"
+    await page.evaluate(() => {
+      const groups = [
+        {
+          id: "cg_test_allegory",
+          label: "Allegories",
+          patterns: ["Allegory"],
+          enabled: true,
+        },
+      ];
+      localStorage.setItem("chipCustomGroups", JSON.stringify(groups));
+    });
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 5;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    await page.evaluate(() => {
+      // Exclude the custom group — 4th arg = true for exclude
+      window.applyQuickFilter("customGroup", "cg_test_allegory", false, true);
+    });
+
+    const uuids = await filteredUuids(page);
+    // Allegory items: A, B, D, E → excluded. Only C (Silver Cat) remains.
+    expect(uuids).not.toContain(FIXTURE_UUIDS.A);
+    expect(uuids).not.toContain(FIXTURE_UUIDS.B);
+    expect(uuids).not.toContain(FIXTURE_UUIDS.D);
+    expect(uuids).not.toContain(FIXTURE_UUIDS.E);
+    expect(uuids).toContain(FIXTURE_UUIDS.C);
+    expect(uuids).toHaveLength(1);
+  });
+
+  // Case 13 — Chip threshold honored: chipMinCount=5 means no chip should show count < 5.
+  // Currently broken — minCount drops to 1 when active filters are present.
+  test("Case 13 — chipMinCount threshold is honored in rendered chip badges", async ({ page }) => {
+    // Set chipMinCount to 5 before page load via addInitScript won't work after beforeEach,
+    // so we set it and reload.
+    await page.evaluate(() => {
+      localStorage.setItem("chipMinCount", "5");
+    });
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 5;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    // Apply Silver chip to trigger filter + chip re-render
+    await page.evaluate(() => window.applyQuickFilter("metal", "Silver"));
+
+    // Enable CHIP_QTY_BADGE so counts render in chip text
+    await page.evaluate(() => {
+      const flags = JSON.parse(localStorage.getItem("featureFlags") || "{}");
+      flags.CHIP_QTY_BADGE = true;
+      localStorage.setItem("featureFlags", JSON.stringify(flags));
+      if (window.featureFlags && typeof window.featureFlags.enable === "function") {
+        window.featureFlags.enable("CHIP_QTY_BADGE");
+      }
+    });
+    // Re-render chips
+    await page.evaluate(() => {
+      if (typeof window.renderActiveFilters === "function") window.renderActiveFilters();
+      if (typeof window.renderTable === "function") window.renderTable();
+    });
+
+    // Get all chip elements from the filter bar (category summary chips with counts)
+    const chipCounts = await page.evaluate(() => {
+      const chips = document.querySelectorAll(".filter-chip, .chip");
+      const counts = [];
+      chips.forEach((chip) => {
+        const text = chip.textContent || "";
+        const match = text.match(/\((\d+)\)/);
+        if (match) {
+          counts.push(parseInt(match[1], 10));
+        }
+      });
+      return counts;
+    });
+
+    // All visible chips with count badges should respect the minCount=5 threshold
+    // (no chip should show a count below 5 in its badge)
+    for (const count of chipCounts) {
+      expect(count).toBeGreaterThanOrEqual(5);
+    }
+  });
+
+  // Case 14 — Reference Fixture A: precise multi-field intersection.
+  // Silver + Coin + vendor "tulsacoins.com" + year "1999" + name "1 Dollar American Silver Eagle (Bullion Coin)"
+  // → exactly 1 item.
+  test("Case 14 — Reference Fixture A: precise multi-field filter narrows to exactly 1 item", async ({
+    page,
+  }) => {
+    // Inject a specific item via addInitScript (runs after beforeEach seed)
+    const fixtureAItem = {
+      uuid: "stak551-fixture-a",
+      metal: "Silver",
+      composition: "Silver",
+      name: "1 Dollar American Silver Eagle (Bullion Coin)",
+      qty: 1,
+      type: "Coin",
+      weight: 1,
+      price: 22,
+      marketValue: 0,
+      date: "1999-06-15",
+      purchaseLocation: "tulsacoins.com",
+      storageLocation: "",
+      serialNumber: "",
+      notes: "",
+      year: "1999",
+      grade: "",
+      gradingAuthority: "",
+      certNumber: "",
+      pcgsNumber: "",
+      pcgsVerified: false,
+      spotPriceAtPurchase: 5.2,
+      premiumPerOz: 0,
+      totalPremium: 0,
+      purity: 0.999,
+      numistaId: "",
+      serial: 401,
+    };
+    await page.addInitScript(
+      ({ extra }) => {
+        const inv = JSON.parse(localStorage.getItem("metalInventory") || "[]");
+        inv.push(extra);
+        localStorage.setItem("metalInventory", JSON.stringify(inv));
+      },
+      { extra: fixtureAItem }
+    );
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventoryAdvanced === "function" &&
+        typeof window.applyQuickFilter === "function" &&
+        typeof window.clearAllFilters === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length >= 6;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    await page.evaluate(() => {
+      window.applyQuickFilter("metal", "Silver");
+      window.applyQuickFilter("type", "Coin");
+      window.applyQuickFilter("purchaseLocation", "tulsacoins.com");
+      window.applyQuickFilter("year", "1999");
+      window.applyQuickFilter("name", "1 Dollar American Silver Eagle (Bullion Coin)");
+    });
+
+    const uuids = await filteredUuids(page);
+    expect(uuids).toEqual(["stak551-fixture-a"]);
+    expect(uuids).toHaveLength(1);
+    expect(await dataRowCount(page)).toBe(1);
   });
 });

--- a/tests/playwright/filter-chip-and-logic.spec.js
+++ b/tests/playwright/filter-chip-and-logic.spec.js
@@ -1,10 +1,10 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Playwright regression spec for STAK-546 — filter chip AND/OR predicate.
+ * Playwright regression spec for filter chip predicate logic (STAK-546, STAK-551).
  *
- * Locks the AND-within-field contract for `filterInventoryAdvanced()` so the
- * bug (OR within a field) cannot silently regress.
+ * Locks the field-aware filter contract: scalar fields (metal, type) use OR
+ * within-field, tags use AND, expansion chips expand at predicate time.
  *
  *   Case 1 — Single `tags:Allegory` chip           → 4 Allegory items (A,B,D,E)
  *   Case 2 — `tags:Allegory` + `tags:Cat`          → 1 item with BOTH (A)          MUST FAIL today (OR)
@@ -306,8 +306,8 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
       window.applyQuickFilter("metal", "Silver");
     });
 
-    // All 5 items are either Gold or Silver — OR returns all of them.
-    expect(await dataRowCount(page)).toBeGreaterThan(0);
+    // All 5 seed items are either Gold or Silver — OR returns all of them.
+    expect(await dataRowCount(page)).toBe(5);
   });
 
   // Case 5 — Removing a chip broadens back.
@@ -372,9 +372,9 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
   });
 
   // =========================================================================
-  // STAK-551 — filter chip predicate refactor (TDD red phase)
-  // Cases 8-14 target the new OR-within-field / customGroup / groupedName /
-  // chipMinCount behaviors. Expected to FAIL until Task 7 lands the impl.
+  // STAK-551 — filter chip predicate refactor
+  // Cases 8-14 target OR-within-field for scalars, customGroup / groupedName
+  // predicate-time expansion, and chipMinCount threshold enforcement.
   // =========================================================================
 
   // Case 8 — Metal multi-select OR: Silver + Gold should return items of BOTH metals.
@@ -699,7 +699,7 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
     // Set chipMinCount to 5 before page load via addInitScript won't work after beforeEach,
     // so we set it and reload.
     await page.evaluate(() => {
-      localStorage.setItem("chipMinCount", "5");
+      localStorage.setItem("chipMinCount", "2");
     });
     await page.reload();
     await page.waitForFunction(
@@ -748,10 +748,13 @@ test.describe("filter-chip-and-logic — STAK-546 AND semantics", () => {
       return counts;
     });
 
-    // All visible chips with count badges should respect the minCount=5 threshold
-    // (no chip should show a count below 5 in its badge)
+    // Guard: at least one chip with a count badge must be visible for this test to be meaningful
+    expect(chipCounts.length).toBeGreaterThan(0);
+
+    // All visible chips with count badges should respect the minCount=2 threshold
+    // (no chip with count < 2 should appear — the old bug showed count=1 chips)
     for (const count of chipCounts) {
-      expect(count).toBeGreaterThanOrEqual(5);
+      expect(count).toBeGreaterThanOrEqual(2);
     }
   });
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.05",
-  "releaseDate": "2026-04-16",
+  "version": "3.34.06",
+  "releaseDate": "2026-04-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Fixed**: Scalar fields (metal, type) use OR within-field — Silver+Gold shows both metals instead of zero results
- **Fixed**: Expansion chips (customGroup, dynamicName, groupedName) store single constraints and expand at predicate time — Florida/ASE chips no longer return zero results
- **Fixed**: Chip threshold honored when filters active — chip bar no longer floods with 1-count chips
- **Changed**: `isMultiSelect` renamed to `isAccumulate` for clarity

## Issues (DocVault)

- STAK-551: customGroup/dynamicName chip = single constraint (todo → done)
- Follow-up to STAK-546 (v3.34.05)

## Test plan

- [x] 14 Playwright filter chip tests pass (7 new + 7 existing, Case 4 updated)
- [x] 51/51 full Playwright suite pass, zero regressions
- [x] Codex peer review: 0 Critical, 2 Important fixed
- [x] Security review: zero findings
- [x] verification.md: 18/18 acceptance criteria verified
- [ ] Manual QA on beta.staktrakr.com: Silver chip, Florida chip, ASE chip, chip threshold