### PR TITLE
v3.34.07 — STAK-517: invalidate market filter cache after restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.07] - 2026-04-17
+
+### Fixed — STAK-517: Invalidate market filter cache after vault restore
+
+- **Fixed**: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull — no page reload required (STAK-517)
+- **Fixed**: `restoreVaultData()` now calls `_invalidateMarketFilterCache()` to clear stale in-memory cache after writing `staktrakr.market_filter` to localStorage (STAK-517)
+
+---
+
 ## [3.34.06] - 2026-04-17
 
 ### Fixed — STAK-551: Fix filter chip predicate logic

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-517: Invalidate market filter cache after vault restore (v3.34.07)**: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull — no page reload required.
 - **STAK-551: Fix filter chip predicate logic (v3.34.06)**: Scalar fields (metal, type, name, location) now use OR within-field — Silver+Gold shows both. Tags keep AND. Expansion chips (customGroup, dynamicName, groupedName) expand at predicate time. Chip threshold honored when filters active.
 - **STAK-546: Restore AND semantics to filter chip predicate (v3.34.05)**: Selecting multiple filter chips now intersects matches (AND) instead of unioning them (OR), matching documented behavior and expected UX.
 - **STAK-549: Fix Cloud Sync Header Button Silent Failure (v3.34.04)**: Header cloud sync button no longer shows a false "Synced" toast when vault password is not cached. Password prompt appears correctly; cancel shows an error toast instead of false success.

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -5,4 +5,3 @@
 - **STAK-546: Restore AND semantics to filter chip predicate (v3.34.05)**: Selecting multiple filter chips now intersects matches (AND) instead of unioning them (OR), matching documented behavior and expected UX.
 - **STAK-549: Fix Cloud Sync Header Button Silent Failure (v3.34.04)**: Header cloud sync button no longer shows a false "Synced" toast when vault password is not cached. Password prompt appears correctly; cancel shows an error toast instead of false success.
 - **STAK-544: Header Cloud Button Sync or Open Settings (v3.34.03)**: The header cloud button now triggers a manual sync for configured users or opens Settings → Cloud for setup users. Replaced the previous dead-end "autosync disabled" toast behavior.
-- **STAK-545: Market Button Triggers Refresh (v3.34.02)**: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon added to the Market dashboard block provides direct access to Market settings.

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.07 &ndash; STAK-517: Invalidate Market Filter Cache After Restore</strong>: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull &mdash; no page reload required.</li>
     <li><strong>v3.34.06 &ndash; STAK-551: Fix Filter Chip Predicate Logic</strong>: Scalar fields (metal, type) now use OR within-field (Silver+Gold shows both). Tags keep AND (Red+Green = items with both). Expansion chips (customGroup, dynamicName, groupedName) store single constraints and expand at predicate time. Chip threshold honored when filters active.</li>
     <li><strong>v3.34.05 &ndash; STAK-546: Restore AND Semantics to Filter Chips</strong>: Selecting multiple filter chips now narrows results (AND) instead of expanding them (OR). Within a field and across fields, every selected chip adds a constraint &mdash; matching the expected drill-down behavior.</li>
     <li><strong>v3.34.04 &ndash; STAK-549: Fix Cloud Sync Header Button Silent Failure</strong>: Header cloud sync button no longer shows a false &quot;Synced&quot; toast when vault password is not cached. Password prompt appears correctly; cancel shows error toast instead of false success.</li>

--- a/js/about.js
+++ b/js/about.js
@@ -144,8 +144,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.05 &ndash; STAK-546: Restore AND Semantics to Filter Chips</strong>: Selecting multiple filter chips now narrows results (AND) instead of expanding them (OR). Within a field and across fields, every selected chip adds a constraint &mdash; matching the expected drill-down behavior.</li>
     <li><strong>v3.34.04 &ndash; STAK-549: Fix Cloud Sync Header Button Silent Failure</strong>: Header cloud sync button no longer shows a false &quot;Synced&quot; toast when vault password is not cached. Password prompt appears correctly; cancel shows error toast instead of false success.</li>
     <li><strong>v3.34.03 &ndash; STAK-544: Header Cloud Button Sync or Open Settings</strong>: The header cloud button now triggers a manual sync for configured users or opens Settings &rarr; Cloud for setup users. Replaced the previous dead-end &quot;autosync disabled&quot; toast behavior.</li>
-    <li><strong>v3.34.02 &ndash; STAK-545: Market Button Triggers Refresh</strong>: The header Market button now triggers a market data refresh instead of opening Settings. A gear icon in the Market dashboard block provides direct access to Market settings.</li>
-    <li><strong>v3.34.01 &ndash; STAK-445: Move FAQ below LOG</strong>: Reordered the Settings modal sidebar so Log appears immediately before FAQ. FAQ content, Activity Log content, and settings panel behavior remain unchanged.</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.06";
+const APP_VERSION = "3.34.07";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/vault.js
+++ b/js/vault.js
@@ -395,6 +395,8 @@ async function restoreVaultData(payload) {
     if (typeof renderActiveFilters === "function") renderActiveFilters();
     if (typeof loadSpotHistory === "function") loadSpotHistory();
     if (typeof fetchSpotPrice === "function") fetchSpotPrice();
+    if (typeof _invalidateMarketFilterCache === "function") _invalidateMarketFilterCache();
+    if (typeof renderMarketFilterMatrix === "function") renderMarketFilterMatrix();
   } catch (e) {
     debugLog("Vault: UI refresh error", e);
   }

--- a/js/vault.js
+++ b/js/vault.js
@@ -1684,6 +1684,7 @@ window.vaultDecryptAndRestore = vaultDecryptAndRestore;
 window.vaultRestoreWithPreview = vaultRestoreWithPreview;
 window.vaultDecryptToData = vaultDecryptToData;
 window.collectVaultData = collectVaultData;
+window.restoreVaultData = restoreVaultData;
 window.collectAndHashImageVault = collectAndHashImageVault;
 window.vaultEncryptImageVault = vaultEncryptImageVault;
 window.vaultDecryptAndRestoreImages = vaultDecryptAndRestoreImages;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.06",
+  "version": "3.34.07",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.06",
+      "version": "3.34.07",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.06",
+  "version": "3.34.07",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.05-b1776369000";
+const CACHE_NAME = "staktrakr-v3.34.07-b1776397242000";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/03-settings/market-filter-cache-invalidation.spec.js
+++ b/tests/playwright/03-settings/market-filter-cache-invalidation.spec.js
@@ -1,0 +1,120 @@
+/**
+ * STAK-517 — Market filter cache invalidation after vault restore
+ *
+ * TDD test: verifies that after restoreVaultData writes a new value for
+ * `staktrakr.market_filter` to localStorage, the in-memory cache
+ * `_marketFilterCache` in retail.js is invalidated so that subsequent calls to
+ * `_loadMarketFilter()` return the new value rather than stale cached state.
+ *
+ * NOTE: `restoreVaultData` is an internal function in vault.js and is NOT
+ * exposed on `window`. The test therefore simulates its localStorage write
+ * directly (the same operation restoreVaultData performs), then asserts that
+ * `_invalidateMarketFilterCache` was called — a contract that Task 2 will
+ * satisfy by calling the invalidator inside `restoreVaultData`.
+ *
+ * This test MUST FAIL before Task 2 is implemented.
+ *
+ * Slug choice: "ase" (American Silver Eagle 1 oz) is a hardcoded manifest slug
+ * with known resolved metadata (name≠slug, metal="silver"), so it survives the
+ * STAK-521 quarantine predicate inside _loadMarketFilter.
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectSeedInventory } from "../helpers/seed.js";
+
+const MARKET_FILTER_KEY = "staktrakr.market_filter";
+
+// "ase" is a real manifest slug with resolved metadata — survives _isSlugResolved.
+const TEST_SLUG = "ase";
+const INITIAL_FILTER = { [TEST_SLUG]: { vendorA: false } };
+const UPDATED_FILTER = { [TEST_SLUG]: { vendorA: true } };
+
+test.describe("STAK-517 — Market filter cache invalidation after vault restore", () => {
+  test.afterEach(async ({ page }) => {
+    await page.evaluate(() => {
+      if (typeof window.__orig_invalidateMarketFilterCache === "function") {
+        window._invalidateMarketFilterCache = window.__orig_invalidateMarketFilterCache;
+        delete window.__orig_invalidateMarketFilterCache;
+      }
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await injectSeedInventory(page);
+
+    // Pre-set the market filter to INITIAL_FILTER so the cache is primed
+    // with a non-empty value on first _loadMarketFilter() call.
+    await page.addInitScript(
+      ({ key, value }) => {
+        localStorage.setItem(key, JSON.stringify(value));
+      },
+      { key: MARKET_FILTER_KEY, value: INITIAL_FILTER }
+    );
+
+    await page.goto("/index.html");
+    // Wait for retail.js to finish loading and expose its window functions.
+    await page.waitForFunction(
+      () =>
+        typeof window._loadMarketFilter === "function" &&
+        typeof window._invalidateMarketFilterCache === "function"
+    );
+  });
+
+  test("_invalidateMarketFilterCache is called and cache reflects new value after vault restore writes new market filter", async ({
+    page,
+  }) => {
+    // Step 1: Prime the in-memory cache by calling _loadMarketFilter().
+    // After this call, _marketFilterCache holds INITIAL_FILTER (vendorA: false).
+    const cachedBefore = await page.evaluate((slug) => {
+      const filter = window._loadMarketFilter();
+      if (filter == null) return null;
+      return Object.prototype.hasOwnProperty.call(filter, slug) ? filter[slug] : undefined;
+    }, TEST_SLUG);
+    // The "ase" entry must exist with vendorA: false
+    expect(cachedBefore).not.toBeNull();
+    expect(cachedBefore).not.toBeUndefined();
+    expect(cachedBefore).toEqual({ vendorA: false });
+
+    // Step 2: Install a spy on _invalidateMarketFilterCache BEFORE the restore.
+    // Store the original on window so afterEach can restore it and prevent
+    // test pollution.
+    await page.evaluate(() => {
+      window.__spy_invalidate_called = false;
+      window.__orig_invalidateMarketFilterCache = window._invalidateMarketFilterCache;
+      window._invalidateMarketFilterCache = function () {
+        window.__spy_invalidate_called = true;
+        if (typeof window.__orig_invalidateMarketFilterCache === "function") {
+          window.__orig_invalidateMarketFilterCache();
+        }
+      };
+    });
+
+    // Step 3: Simulate what restoreVaultData does — write the new market filter
+    // value directly to localStorage (restoreVaultData is not exposed on window).
+    // Task 2 will make restoreVaultData call _invalidateMarketFilterCache after
+    // this write; until then the spy will NOT be triggered.
+    await page.evaluate(
+      ({ key, value }) => {
+        localStorage.setItem(key, JSON.stringify(value));
+      },
+      { key: MARKET_FILTER_KEY, value: UPDATED_FILTER }
+    );
+
+    // Step 4: Assert the spy was called at least once.
+    // FAILS before Task 2 — nothing invokes _invalidateMarketFilterCache after
+    // a raw localStorage write.
+    const spyCalled = await page.evaluate(() => window.__spy_invalidate_called);
+    expect(spyCalled).toBe(true);
+
+    // Step 5: Assert that _loadMarketFilter() now returns the UPDATED value.
+    // FAILS before Task 2 — the stale cache still holds INITIAL_FILTER.
+    const cachedAfterEntry = await page.evaluate((slug) => {
+      const filter = window._loadMarketFilter();
+      if (filter == null) return null;
+      return Object.prototype.hasOwnProperty.call(filter, slug) ? filter[slug] : undefined;
+    }, TEST_SLUG);
+    expect(cachedAfterEntry).not.toBeNull();
+    expect(cachedAfterEntry).not.toBeUndefined();
+    expect(cachedAfterEntry).toEqual({ vendorA: true });
+  });
+});

--- a/tests/playwright/03-settings/market-filter-cache-invalidation.spec.js
+++ b/tests/playwright/03-settings/market-filter-cache-invalidation.spec.js
@@ -8,9 +8,9 @@
  *
  * This test verifies observable behavior (cache reflects restored value) rather
  * than implementation detail (spy on _invalidateMarketFilterCache), because
- * _invalidateMarketFilterCache is a lexical const binding in retail.js — not a
- * window property — so vault.js calls the original function directly regardless
- * of any window.* patching.
+ * vault.js references _invalidateMarketFilterCache as a lexical binding — it
+ * calls the original function directly, not via window, so patching
+ * window._invalidateMarketFilterCache in tests would not intercept the call.
  *
  * BEFORE Task 2: restoreVaultData does NOT call _invalidateMarketFilterCache,
  * so _marketFilterCache stays stale and _loadMarketFilter() returns the old
@@ -65,7 +65,7 @@ test.describe("STAK-517 — Market filter cache invalidation after vault restore
     // After this call, _marketFilterCache holds INITIAL_FILTER (vendorA: false).
     const cachedBefore = await page.evaluate((slug) => {
       const filter = window._loadMarketFilter();
-      if (filter == null) return null;
+      if (filter === null || filter === undefined) return null;
       return Object.prototype.hasOwnProperty.call(filter, slug) ? filter[slug] : undefined;
     }, TEST_SLUG);
     expect(cachedBefore).not.toBeNull();
@@ -85,7 +85,7 @@ test.describe("STAK-517 — Market filter cache invalidation after vault restore
     // PASSES after Task 2: cache cleared, fresh read from localStorage.
     const cachedAfter = await page.evaluate((slug) => {
       const filter = window._loadMarketFilter();
-      if (filter == null) return null;
+      if (filter === null || filter === undefined) return null;
       return Object.prototype.hasOwnProperty.call(filter, slug) ? filter[slug] : undefined;
     }, TEST_SLUG);
     expect(cachedAfter).not.toBeNull();

--- a/tests/playwright/03-settings/market-filter-cache-invalidation.spec.js
+++ b/tests/playwright/03-settings/market-filter-cache-invalidation.spec.js
@@ -1,18 +1,24 @@
 /**
  * STAK-517 — Market filter cache invalidation after vault restore
  *
- * TDD test: verifies that after restoreVaultData writes a new value for
+ * Verifies that after restoreVaultData writes a new value for
  * `staktrakr.market_filter` to localStorage, the in-memory cache
  * `_marketFilterCache` in retail.js is invalidated so that subsequent calls to
  * `_loadMarketFilter()` return the new value rather than stale cached state.
  *
- * NOTE: `restoreVaultData` is an internal function in vault.js and is NOT
- * exposed on `window`. The test therefore simulates its localStorage write
- * directly (the same operation restoreVaultData performs), then asserts that
- * `_invalidateMarketFilterCache` was called — a contract that Task 2 will
- * satisfy by calling the invalidator inside `restoreVaultData`.
+ * This test verifies observable behavior (cache reflects restored value) rather
+ * than implementation detail (spy on _invalidateMarketFilterCache), because
+ * _invalidateMarketFilterCache is a lexical const binding in retail.js — not a
+ * window property — so vault.js calls the original function directly regardless
+ * of any window.* patching.
  *
- * This test MUST FAIL before Task 2 is implemented.
+ * BEFORE Task 2: restoreVaultData does NOT call _invalidateMarketFilterCache,
+ * so _marketFilterCache stays stale and _loadMarketFilter() returns the old
+ * cached value → test FAILS.
+ *
+ * AFTER Task 2: restoreVaultData calls _invalidateMarketFilterCache() which
+ * sets _marketFilterCache = null, so _loadMarketFilter() reads fresh from
+ * localStorage and returns the restored value → test PASSES.
  *
  * Slug choice: "ase" (American Silver Eagle 1 oz) is a hardcoded manifest slug
  * with known resolved metadata (name≠slug, metal="silver"), so it survives the
@@ -30,15 +36,6 @@ const INITIAL_FILTER = { [TEST_SLUG]: { vendorA: false } };
 const UPDATED_FILTER = { [TEST_SLUG]: { vendorA: true } };
 
 test.describe("STAK-517 — Market filter cache invalidation after vault restore", () => {
-  test.afterEach(async ({ page }) => {
-    await page.evaluate(() => {
-      if (typeof window.__orig_invalidateMarketFilterCache === "function") {
-        window._invalidateMarketFilterCache = window.__orig_invalidateMarketFilterCache;
-        delete window.__orig_invalidateMarketFilterCache;
-      }
-    });
-  });
-
   test.beforeEach(async ({ page }) => {
     await injectSeedInventory(page);
 
@@ -52,15 +49,16 @@ test.describe("STAK-517 — Market filter cache invalidation after vault restore
     );
 
     await page.goto("/index.html");
-    // Wait for retail.js to finish loading and expose its window functions.
+    // Wait for retail.js and vault.js to expose their window functions.
     await page.waitForFunction(
       () =>
         typeof window._loadMarketFilter === "function" &&
-        typeof window._invalidateMarketFilterCache === "function"
+        typeof window._invalidateMarketFilterCache === "function" &&
+        typeof window.restoreVaultData === "function"
     );
   });
 
-  test("_invalidateMarketFilterCache is called and cache reflects new value after vault restore writes new market filter", async ({
+  test("cache reflects restored market filter value after restoreVaultData without page reload", async ({
     page,
   }) => {
     // Step 1: Prime the in-memory cache by calling _loadMarketFilter().
@@ -70,51 +68,28 @@ test.describe("STAK-517 — Market filter cache invalidation after vault restore
       if (filter == null) return null;
       return Object.prototype.hasOwnProperty.call(filter, slug) ? filter[slug] : undefined;
     }, TEST_SLUG);
-    // The "ase" entry must exist with vendorA: false
     expect(cachedBefore).not.toBeNull();
     expect(cachedBefore).not.toBeUndefined();
     expect(cachedBefore).toEqual({ vendorA: false });
 
-    // Step 2: Install a spy on _invalidateMarketFilterCache BEFORE the restore.
-    // Store the original on window so afterEach can restore it and prevent
-    // test pollution.
-    await page.evaluate(() => {
-      window.__spy_invalidate_called = false;
-      window.__orig_invalidateMarketFilterCache = window._invalidateMarketFilterCache;
-      window._invalidateMarketFilterCache = function () {
-        window.__spy_invalidate_called = true;
-        if (typeof window.__orig_invalidateMarketFilterCache === "function") {
-          window.__orig_invalidateMarketFilterCache();
-        }
-      };
-    });
-
-    // Step 3: Simulate what restoreVaultData does — write the new market filter
-    // value directly to localStorage (restoreVaultData is not exposed on window).
-    // Task 2 will make restoreVaultData call _invalidateMarketFilterCache after
-    // this write; until then the spy will NOT be triggered.
+    // Step 2: Call restoreVaultData with a minimal payload containing the
+    // updated market filter value. This writes the new value to localStorage
+    // and — after Task 2 — calls _invalidateMarketFilterCache() to clear the cache.
     await page.evaluate(
-      ({ key, value }) => {
-        localStorage.setItem(key, JSON.stringify(value));
-      },
+      ({ key, value }) => window.restoreVaultData({ data: { [key]: JSON.stringify(value) } }),
       { key: MARKET_FILTER_KEY, value: UPDATED_FILTER }
     );
 
-    // Step 4: Assert the spy was called at least once.
-    // FAILS before Task 2 — nothing invokes _invalidateMarketFilterCache after
-    // a raw localStorage write.
-    const spyCalled = await page.evaluate(() => window.__spy_invalidate_called);
-    expect(spyCalled).toBe(true);
-
-    // Step 5: Assert that _loadMarketFilter() now returns the UPDATED value.
-    // FAILS before Task 2 — the stale cache still holds INITIAL_FILTER.
-    const cachedAfterEntry = await page.evaluate((slug) => {
+    // Step 3: Assert that _loadMarketFilter() now returns the UPDATED value.
+    // FAILS before Task 2: stale cache still holds INITIAL_FILTER.
+    // PASSES after Task 2: cache cleared, fresh read from localStorage.
+    const cachedAfter = await page.evaluate((slug) => {
       const filter = window._loadMarketFilter();
       if (filter == null) return null;
       return Object.prototype.hasOwnProperty.call(filter, slug) ? filter[slug] : undefined;
     }, TEST_SLUG);
-    expect(cachedAfterEntry).not.toBeNull();
-    expect(cachedAfterEntry).not.toBeUndefined();
-    expect(cachedAfterEntry).toEqual({ vendorA: true });
+    expect(cachedAfter).not.toBeNull();
+    expect(cachedAfter).not.toBeUndefined();
+    expect(cachedAfter).toEqual({ vendorA: true });
   });
 });

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.06",
+  "version": "3.34.07",
   "releaseDate": "2026-04-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
$(cat <<'EOF'
> **Draft — QA preview.** Merge to `dev` after review.

## Changes

- **fix(vault)**: Add `_invalidateMarketFilterCache()` + `renderMarketFilterMatrix()` to `restoreVaultData()` UI refresh block — clears stale in-memory cache in `retail.js` after any vault restore or cloud sync pull so the market filter matrix reflects synced state without a page reload
- **test**: New Playwright TDD test `market-filter-cache-invalidation.spec.js` — verifies cache reflects restored value after `restoreVaultData` call
- **chore**: Expose `restoreVaultData` on `window` for Playwright testing (per project CLAUDE.md testing pattern)

## Root Cause

`MARKET_FILTER_KEY` was already in `SYNC_SCOPE_KEYS` and `ALLOWED_STORAGE_KEYS` (STAK-515). The only gap: `retail.js` uses a module-level const `_marketFilterCache` that is not cleared when `restoreVaultData()` writes a new value to localStorage. Added a defensive `typeof` guard call — same pattern used for all other optional UI refresh calls in the function.

## Issues (DocVault)

- STAK-517: Wire market filter settings into cloud sync, import/export, and backup pipelines (done)
EOF
)