### PR TITLE
chore(a11y): STAK-552 — accessibility hardening

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1367,6 +1367,10 @@ input[type="submit"] {
   padding: 0.1rem 0.25rem;
   outline: none;
 }
+.spot-inline-input:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
 
 /* Hide number spinners on inline input */
 .spot-inline-input::-webkit-outer-spin-button,
@@ -5053,6 +5057,10 @@ td.editing .inline-input:focus {
   outline: none;
   background: var(--bg-primary);
   border-radius: var(--radius);
+}
+td.editing .inline-input:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
 }
 
 td.editing .save-inline,
@@ -13992,9 +14000,13 @@ th {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ticker-track {
-    animation: none;
-    transform: none;
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -14005,8 +14005,17 @@ th {
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    animation-delay: 0s !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
     scroll-behavior: auto !important;
+  }
+
+  /* Preserve repeating animations for active-operation indicators */
+  .spot-sync-icon.syncing svg,
+  .cloud-sync-dot--syncing,
+  .pcgs-verify-btn.pcgs-verifying {
+    animation-iteration-count: infinite !important;
   }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -14011,10 +14011,11 @@ th {
     scroll-behavior: auto !important;
   }
 
-  /* Preserve repeating animations for active-operation indicators */
+  /* Preserve repeating animations for active-operation indicators at reduced speed */
   .spot-sync-icon.syncing svg,
   .cloud-sync-dot--syncing,
   .pcgs-verify-btn.pcgs-verifying {
+    animation-duration: 1.5s !important;
     animation-iteration-count: infinite !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -43,9 +43,15 @@
     <link rel="apple-touch-icon" href="./images/icon-192.png" />
 
     <title>StakTrakr — Precious Metals Inventory Tracker</title>
-    <meta name="description" content="Track your silver, gold, platinum, and palladium portfolio. Live spot prices, melt values, gain/loss tracking. Free, open source, no data collected." />
+    <meta
+      name="description"
+      content="Track your silver, gold, platinum, and palladium portfolio. Live spot prices, melt values, gain/loss tracking. Free, open source, no data collected."
+    />
     <meta property="og:title" content="StakTrakr — Precious Metals Inventory Tracker" />
-    <meta property="og:description" content="Track your silver, gold, platinum, and palladium portfolio. Live spot prices, melt values, gain/loss tracking. Free, open source, no data collected." />
+    <meta
+      property="og:description"
+      content="Track your silver, gold, platinum, and palladium portfolio. Live spot prices, melt values, gain/loss tracking. Free, open source, no data collected."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.staktrakr.com" />
     <!-- FILE PROTOCOL COMPATIBILITY - MUST LOAD FIRST -->
@@ -63,28 +69,65 @@
     <!-- CDN fallbacks — only execute if the local vendor copy failed to load -->
     <script>
       window.__vendorFallbacks = [
-        { global: 'Papa',                   src: 'https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js', integrity: 'sha512-dfX5uYVXzyU8+KHqj8bjo7UkOdg18PaOtpa48djpNbZHwExddghZ+ZmzWT06R5v6NSk3ZUfsH6FNEDepLx9hPQ==' },
-        { global: 'jspdf',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js', integrity: 'sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==' },
-        { check: function() { return !!(window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.prototype.autoTable); }, src: 'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js', integrity: 'sha512-SgWewGM3r8xXm8LNXt4ZHqKVKu/7eKrJ1aBCbMaX44xXXaCcIvCAvD2kj9qnC1lhyjAu04mcPiTzcc/CaACnUQ==' },
-        { global: 'Chart',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js', integrity: 'sha512-ElRFoEQdI5Ht6kZvyzXhYG9NqjtkmlkfYk0wr6wHxU9JEHakS7UJZNeml5ALk+8IKlU6jDgMabC3vkumRokgJA==' },
-        { global: 'ChartDataLabels',        src: 'https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js', integrity: 'sha512-JPcRR8yFa8mmCsfrw4TNte1ZvF1e3+1SdGMslZvmrzDYxS69J7J49vkFL8u6u8PlPJK+H3voElBtUCzaXj+6ig==' },
-        { global: 'JSZip',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js', integrity: 'sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==' },
-        { global: 'forge',                  src: 'https://cdnjs.cloudflare.com/ajax/libs/forge/0.10.0/forge.min.js', integrity: 'sha512-S/UB/AdGt16YP1OyopwfVG1BO93nkwVNY7No5zfALnztixutqOuP3DGvo7G4YqB77uL791jWNjQnT/63CjOZNw==' },
+        {
+          global: "Papa",
+          src: "https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js",
+          integrity:
+            "sha512-dfX5uYVXzyU8+KHqj8bjo7UkOdg18PaOtpa48djpNbZHwExddghZ+ZmzWT06R5v6NSk3ZUfsH6FNEDepLx9hPQ==",
+        },
+        {
+          global: "jspdf",
+          src: "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js",
+          integrity:
+            "sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==",
+        },
+        {
+          check: function () {
+            return !!(window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.prototype.autoTable);
+          },
+          src: "https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js",
+          integrity:
+            "sha512-SgWewGM3r8xXm8LNXt4ZHqKVKu/7eKrJ1aBCbMaX44xXXaCcIvCAvD2kj9qnC1lhyjAu04mcPiTzcc/CaACnUQ==",
+        },
+        {
+          global: "Chart",
+          src: "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js",
+          integrity:
+            "sha512-ElRFoEQdI5Ht6kZvyzXhYG9NqjtkmlkfYk0wr6wHxU9JEHakS7UJZNeml5ALk+8IKlU6jDgMabC3vkumRokgJA==",
+        },
+        {
+          global: "ChartDataLabels",
+          src: "https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.2.0/chartjs-plugin-datalabels.min.js",
+          integrity:
+            "sha512-JPcRR8yFa8mmCsfrw4TNte1ZvF1e3+1SdGMslZvmrzDYxS69J7J49vkFL8u6u8PlPJK+H3voElBtUCzaXj+6ig==",
+        },
+        {
+          global: "JSZip",
+          src: "https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js",
+          integrity:
+            "sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==",
+        },
+        {
+          global: "forge",
+          src: "https://cdnjs.cloudflare.com/ajax/libs/forge/0.10.0/forge.min.js",
+          integrity:
+            "sha512-S/UB/AdGt16YP1OyopwfVG1BO93nkwVNY7No5zfALnztixutqOuP3DGvo7G4YqB77uL791jWNjQnT/63CjOZNw==",
+        },
       ];
-      document.addEventListener('DOMContentLoaded', function () {
+      document.addEventListener("DOMContentLoaded", function () {
         window.__vendorFallbacks.forEach(function (lib) {
           var missing = lib.check ? !lib.check() : !window[lib.global];
           if (missing) {
-            var label = lib.global || lib.src.split('/').pop();
-            console.warn('[vendor] ' + label + ' not loaded from local — falling back to CDN');
-            var s = document.createElement('script');
+            var label = lib.global || lib.src.split("/").pop();
+            console.warn("[vendor] " + label + " not loaded from local — falling back to CDN");
+            var s = document.createElement("script");
             s.src = lib.src;
             if (lib.integrity) {
               s.integrity = lib.integrity;
-              s.crossOrigin = 'anonymous';
+              s.crossOrigin = "anonymous";
             }
-            s.addEventListener('error', function () {
-              console.error('[vendor] SRI/network failure: ' + label + ' — ' + lib.src);
+            s.addEventListener("error", function () {
+              console.error("[vendor] SRI/network failure: " + label + " — " + lib.src);
             });
             document.head.appendChild(s);
           }
@@ -98,11 +141,11 @@
          avoid any dependency on constants.js (which loads deferred). -->
     <script>
       try {
-        var __t = localStorage.getItem('appTheme');
-        if (__t === 'dark' || __t === 'light' || __t === 'sepia' || __t === 'hello-kitty') {
-          document.documentElement.setAttribute('data-theme', __t);
+        var __t = localStorage.getItem("appTheme");
+        if (__t === "dark" || __t === "light" || __t === "sepia" || __t === "hello-kitty") {
+          document.documentElement.setAttribute("data-theme", __t);
         } else {
-          document.documentElement.setAttribute('data-theme', 'dark');
+          document.documentElement.setAttribute("data-theme", "dark");
         }
       } catch (e) {}
     </script>
@@ -159,8 +202,12 @@
         color: var(--text-primary);
         font-weight: 600;
       }
-      .card-sort-summary .summary-positive .summary-val { color: var(--gain, #22c55e); }
-      .card-sort-summary .summary-negative .summary-val { color: var(--loss, #ef4444); }
+      .card-sort-summary .summary-positive .summary-val {
+        color: var(--gain, #22c55e);
+      }
+      .card-sort-summary .summary-negative .summary-val {
+        color: var(--loss, #ef4444);
+      }
       .card-sort-summary .summary-sep {
         color: var(--border);
         padding: 0 0.1rem;
@@ -177,11 +224,13 @@
         height: 10px;
         margin: 4px 6px 6px;
         border-radius: 5px;
-        background: var(--bg-tertiary, rgba(128,128,128,0.15));
+        background: var(--bg-tertiary, rgba(128, 128, 128, 0.15));
         cursor: pointer;
         /* Hide when .hidden attribute is set */
       }
-      .h-scroll-track[hidden] { display: none; }
+      .h-scroll-track[hidden] {
+        display: none;
+      }
       .h-scroll-thumb {
         position: absolute;
         top: 0;
@@ -195,10 +244,16 @@
         /* Smooth reposition during scroll */
         transition: transform 0.05s linear;
       }
-      .h-scroll-thumb:active { cursor: grabbing; }
+      .h-scroll-thumb:active {
+        cursor: grabbing;
+      }
       /* Hide native horizontal scrollbar when using custom one */
-      body.view-mode-d .portal-scroll::-webkit-scrollbar { height: 0; }
-      body.view-mode-d .portal-scroll { scrollbar-width: none; }
+      body.view-mode-d .portal-scroll::-webkit-scrollbar {
+        height: 0;
+      }
+      body.view-mode-d .portal-scroll {
+        scrollbar-width: none;
+      }
 
       /* ── Table (D mode): constrain container + force overflow ──────────────
          table-section must be overflow:hidden so it can't inflate to match
@@ -255,205 +310,555 @@
           min-width: 5.5rem;
         }
       }
-
-
     </style>
-    <script defer src="https://cdn.jsdelivr.net/npm/lightweight-charts@4/dist/lightweight-charts.standalone.production.js"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/lightweight-charts@4/dist/lightweight-charts.standalone.production.js"
+    ></script>
   </head>
   <body>
     <!-- Application Header -->
-    <div class="app-header">
+    <header class="app-header">
       <div class="app-logo-group">
         <h1 class="app-logo" id="appLogo" aria-label="StakTrakr">
-          <svg class="stackr-logo" viewBox="0 0 400 80" xmlns="http://www.w3.org/2000/svg" width="100%">
+          <svg
+            class="stackr-logo"
+            viewBox="0 0 400 80"
+            xmlns="http://www.w3.org/2000/svg"
+            width="100%"
+          >
             <defs>
               <!-- S-stack bar gradients (shared across themes) -->
               <linearGradient id="silverBar" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stop-color="#64748b"/><stop offset="50%" stop-color="#cbd5e1"/><stop offset="100%" stop-color="#94a3b8"/>
+                <stop offset="0%" stop-color="#64748b" />
+                <stop offset="50%" stop-color="#cbd5e1" />
+                <stop offset="100%" stop-color="#94a3b8" />
               </linearGradient>
               <linearGradient id="goldBar" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stop-color="#92700c"/><stop offset="50%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#d4a017"/>
+                <stop offset="0%" stop-color="#92700c" />
+                <stop offset="50%" stop-color="#fbbf24" />
+                <stop offset="100%" stop-color="#d4a017" />
               </linearGradient>
               <!-- Light mode bar gradient (darker for contrast on light bg) -->
               <linearGradient id="silverBarLight" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stop-color="#334155"/><stop offset="50%" stop-color="#64748b"/><stop offset="100%" stop-color="#475569"/>
+                <stop offset="0%" stop-color="#334155" />
+                <stop offset="50%" stop-color="#64748b" />
+                <stop offset="100%" stop-color="#475569" />
               </linearGradient>
               <!-- Sepia mode bar gradient -->
               <linearGradient id="silverBarSepia" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stop-color="#8d8d8d"/><stop offset="50%" stop-color="#d1c2a5"/><stop offset="100%" stop-color="#a8a29e"/>
+                <stop offset="0%" stop-color="#8d8d8d" />
+                <stop offset="50%" stop-color="#d1c2a5" />
+                <stop offset="100%" stop-color="#a8a29e" />
               </linearGradient>
               <linearGradient id="goldBarSepia" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stop-color="#6b5416"/><stop offset="50%" stop-color="#b58900"/><stop offset="100%" stop-color="#8b6914"/>
+                <stop offset="0%" stop-color="#6b5416" />
+                <stop offset="50%" stop-color="#b58900" />
+                <stop offset="100%" stop-color="#8b6914" />
               </linearGradient>
             </defs>
 
             <!-- Light Mode Group -->
             <g class="light-mode">
               <g transform="translate(8, 8) scale(0.125)">
-                <rect x="170" y="68" width="215" height="38" rx="19" fill="url(#silverBarLight)" opacity="0.8"/>
-                <rect x="115" y="124" width="175" height="38" rx="19" fill="url(#silverBarLight)" opacity="0.9"/>
-                <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldBar)"/>
-                <rect x="222" y="250" width="175" height="38" rx="19" fill="url(#silverBarLight)" opacity="0.9"/>
-                <rect x="127" y="306" width="230" height="38" rx="19" fill="url(#silverBarLight)" opacity="0.8"/>
+                <rect
+                  x="170"
+                  y="68"
+                  width="215"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarLight)"
+                  opacity="0.8"
+                />
+                <rect
+                  x="115"
+                  y="124"
+                  width="175"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarLight)"
+                  opacity="0.9"
+                />
+                <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldBar)" />
+                <rect
+                  x="222"
+                  y="250"
+                  width="175"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarLight)"
+                  opacity="0.9"
+                />
+                <rect
+                  x="127"
+                  y="306"
+                  width="230"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarLight)"
+                  opacity="0.8"
+                />
               </g>
-              <text x="86" y="50" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="32" font-weight="700" letter-spacing="2">
-                <tspan class="logo-silver" fill="#1e3a5f">STAK</tspan><tspan class="logo-gold" fill="#b8860b">TRAKR</tspan>
+              <text
+                x="86"
+                y="50"
+                font-family="-apple-system, 'Segoe UI', sans-serif"
+                font-size="32"
+                font-weight="700"
+                letter-spacing="2"
+              >
+                <tspan class="logo-silver" fill="#1e3a5f">STAK</tspan>
+                <tspan class="logo-gold" fill="#b8860b">TRAKR</tspan>
               </text>
             </g>
 
             <!-- Dark Mode Group -->
             <g class="dark-mode">
               <g transform="translate(8, 8) scale(0.125)">
-                <rect x="170" y="68" width="215" height="38" rx="19" fill="url(#silverBar)" opacity="0.45"/>
-                <rect x="115" y="124" width="175" height="38" rx="19" fill="url(#silverBar)" opacity="0.68"/>
-                <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldBar)"/>
-                <rect x="222" y="250" width="175" height="38" rx="19" fill="url(#silverBar)" opacity="0.68"/>
-                <rect x="127" y="306" width="230" height="38" rx="19" fill="url(#silverBar)" opacity="0.45"/>
+                <rect
+                  x="170"
+                  y="68"
+                  width="215"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBar)"
+                  opacity="0.45"
+                />
+                <rect
+                  x="115"
+                  y="124"
+                  width="175"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBar)"
+                  opacity="0.68"
+                />
+                <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldBar)" />
+                <rect
+                  x="222"
+                  y="250"
+                  width="175"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBar)"
+                  opacity="0.68"
+                />
+                <rect
+                  x="127"
+                  y="306"
+                  width="230"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBar)"
+                  opacity="0.45"
+                />
               </g>
-              <text x="86" y="50" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="32" font-weight="700" letter-spacing="2">
-                <tspan class="logo-silver" fill="#e2e8f0">STAK</tspan><tspan class="logo-gold" fill="#d4a017">TRAKR</tspan>
+              <text
+                x="86"
+                y="50"
+                font-family="-apple-system, 'Segoe UI', sans-serif"
+                font-size="32"
+                font-weight="700"
+                letter-spacing="2"
+              >
+                <tspan class="logo-silver" fill="#e2e8f0">STAK</tspan>
+                <tspan class="logo-gold" fill="#d4a017">TRAKR</tspan>
               </text>
             </g>
 
             <!-- Sepia Mode Group -->
             <g class="sepia-mode">
               <g transform="translate(8, 8) scale(0.125)">
-                <rect x="170" y="68" width="215" height="38" rx="19" fill="url(#silverBarSepia)" opacity="0.5"/>
-                <rect x="115" y="124" width="175" height="38" rx="19" fill="url(#silverBarSepia)" opacity="0.7"/>
-                <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldBarSepia)"/>
-                <rect x="222" y="250" width="175" height="38" rx="19" fill="url(#silverBarSepia)" opacity="0.7"/>
-                <rect x="127" y="306" width="230" height="38" rx="19" fill="url(#silverBarSepia)" opacity="0.5"/>
+                <rect
+                  x="170"
+                  y="68"
+                  width="215"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarSepia)"
+                  opacity="0.5"
+                />
+                <rect
+                  x="115"
+                  y="124"
+                  width="175"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarSepia)"
+                  opacity="0.7"
+                />
+                <rect x="140" y="186" width="240" height="44" rx="22" fill="url(#goldBarSepia)" />
+                <rect
+                  x="222"
+                  y="250"
+                  width="175"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarSepia)"
+                  opacity="0.7"
+                />
+                <rect
+                  x="127"
+                  y="306"
+                  width="230"
+                  height="38"
+                  rx="19"
+                  fill="url(#silverBarSepia)"
+                  opacity="0.5"
+                />
               </g>
-              <text x="86" y="50" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="32" font-weight="700" letter-spacing="2">
-                <tspan class="logo-silver" fill="#5c4f3a">STAK</tspan><tspan class="logo-gold" fill="#8b6914">TRAKR</tspan>
+              <text
+                x="86"
+                y="50"
+                font-family="-apple-system, 'Segoe UI', sans-serif"
+                font-size="32"
+                font-weight="700"
+                letter-spacing="2"
+              >
+                <tspan class="logo-silver" fill="#5c4f3a">STAK</tspan>
+                <tspan class="logo-gold" fill="#8b6914">TRAKR</tspan>
               </text>
             </g>
           </svg>
         </h1>
-        <span class="env-badge" id="envBadge" style="display:none"></span>
+        <span class="env-badge" id="envBadge" style="display: none"></span>
       </div>
       <div class="app-header-actions" id="headerBtnContainer">
         <!-- Spot sync button (STAK-314) — order: 1 -->
-        <button class="btn theme-btn header-toggle-btn" id="headerSyncBtn"
-                title="Sync spot prices" aria-label="Sync spot prices" style="display:none;position:relative">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/>
-            <path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/>
-            <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerSyncBtn"
+          title="Sync spot prices"
+          aria-label="Sync spot prices"
+          style="display: none; position: relative"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21.5 2v6h-6" />
+            <path d="M2.5 22v-6h6" />
+            <path d="M2.5 11.5a10 10 0 0 1 18.4-4.5" />
+            <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5" />
           </svg>
           <span class="cloud-sync-dot header-cloud-dot" id="headerSyncDot"></span>
           <span class="header-btn-text">Spot</span>
         </button>
         <!-- Trend cycle button — order: 2 -->
-        <button class="btn theme-btn header-toggle-btn" id="headerTrendBtn"
-                title="Trend period" aria-label="Trend period" style="display:none">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerTrendBtn"
+          title="Trend period"
+          aria-label="Trend period"
+          style="display: none"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
           </svg>
           <span class="header-btn-text">Trend</span>
         </button>
         <!-- Market button — order: 3 -->
-        <button class="btn theme-btn header-toggle-btn" id="headerMarketBtn"
-                title="Market prices" aria-label="Market prices">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"/>
-            <line x1="3" y1="6" x2="21" y2="6"/>
-            <path d="M16 10a4 4 0 0 1-8 0"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerMarketBtn"
+          title="Market prices"
+          aria-label="Market prices"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <path d="M16 10a4 4 0 0 1-8 0" />
           </svg>
           <span class="cloud-sync-dot header-cloud-dot" id="headerMarketDot"></span>
           <span class="header-btn-text">Market</span>
         </button>
         <!-- Currency toggle button — order: 4 -->
-        <button class="btn theme-btn header-toggle-btn" id="headerCurrencyBtn"
-                title="Toggle currency" aria-label="Toggle currency">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="12" y1="1" x2="12" y2="23"/>
-            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerCurrencyBtn"
+          title="Toggle currency"
+          aria-label="Toggle currency"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line x1="12" y1="1" x2="12" y2="23" />
+            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
           </svg>
           <span class="header-btn-text">Currency</span>
         </button>
         <!-- Cloud sync status button + inline popover wrapper — order: 5 (STAK-264) -->
-        <div style="position:relative;display:inline-flex" id="headerCloudSyncWrapper">
-          <button class="btn theme-btn header-toggle-btn" id="headerCloudSyncBtn"
-                  title="Cloud sync status" aria-label="Cloud sync status" style="display:none;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                 stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
+        <div style="position: relative; display: inline-flex" id="headerCloudSyncWrapper">
+          <button
+            class="btn theme-btn header-toggle-btn"
+            id="headerCloudSyncBtn"
+            title="Cloud sync status"
+            aria-label="Cloud sync status"
+            style="display: none"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
             </svg>
             <span class="cloud-sync-dot header-cloud-dot" id="headerCloudDot"></span>
             <span class="header-btn-text">Cloud</span>
           </button>
           <!-- Secure mode: inline password popover (never auto-opens) -->
-          <div id="cloudSyncHeaderPopover" role="dialog" aria-label="Sync password" style="display:none;position:absolute;top:calc(100% + 6px);right:0;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:0.75rem;box-shadow:0 8px 32px rgba(0,0,0,0.5);z-index:999;min-width:240px">
-            <div style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;margin-bottom:0.5rem;color:var(--text-muted)"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:4px"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>Vault Password</div>
-            <div style="display:flex;gap:0.4rem">
-              <input type="password" id="cloudSyncPopoverInput" placeholder="Enter password"
-                     autocomplete="current-password"
-                     style="flex:1;font-size:0.85rem;padding:0.3rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary)">
-              <button class="btn success" id="cloudSyncPopoverUnlockBtn" style="font-size:0.8rem;padding:0.3rem 0.6rem">Unlock</button>
+          <div
+            id="cloudSyncHeaderPopover"
+            role="dialog"
+            aria-label="Sync password"
+            style="
+              display: none;
+              position: absolute;
+              top: calc(100% + 6px);
+              right: 0;
+              background: var(--bg-card);
+              border: 1px solid var(--border);
+              border-radius: 8px;
+              padding: 0.75rem;
+              box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+              z-index: 999;
+              min-width: 240px;
+            "
+          >
+            <div
+              style="
+                font-size: 0.75rem;
+                font-weight: 700;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                margin-bottom: 0.5rem;
+                color: var(--text-muted);
+              "
+            >
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="vertical-align: -1px; margin-right: 4px"
+              >
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" /></svg
+              >Vault Password
             </div>
-            <div id="cloudSyncPopoverError" style="color:var(--danger,#e74c3c);font-size:0.75rem;margin-top:0.3rem;display:none"></div>
-            <button id="cloudSyncPopoverCancelBtn" style="background:none;border:none;color:var(--text-secondary);font-size:0.75rem;margin-top:0.4rem;cursor:pointer;padding:0">Cancel</button>
+            <div style="display: flex; gap: 0.4rem">
+              <input
+                type="password"
+                id="cloudSyncPopoverInput"
+                placeholder="Enter password"
+                autocomplete="current-password"
+                style="
+                  flex: 1;
+                  font-size: 0.85rem;
+                  padding: 0.3rem 0.5rem;
+                  border: 1px solid var(--border);
+                  border-radius: 4px;
+                  background: var(--bg-tertiary);
+                  color: var(--text-primary);
+                "
+              />
+              <button
+                class="btn success"
+                id="cloudSyncPopoverUnlockBtn"
+                style="font-size: 0.8rem; padding: 0.3rem 0.6rem"
+              >
+                Unlock
+              </button>
+            </div>
+            <div
+              id="cloudSyncPopoverError"
+              style="
+                color: var(--danger, #e74c3c);
+                font-size: 0.75rem;
+                margin-top: 0.3rem;
+                display: none;
+              "
+            ></div>
+            <button
+              id="cloudSyncPopoverCancelBtn"
+              style="
+                background: none;
+                border: none;
+                color: var(--text-secondary);
+                font-size: 0.75rem;
+                margin-top: 0.4rem;
+                cursor: pointer;
+                padding: 0;
+              "
+            >
+              Cancel
+            </button>
           </div>
         </div>
         <!-- Vault backup button — order: 6 (STAK-314) -->
-        <button class="btn theme-btn header-toggle-btn" id="headerVaultBtn"
-                title="Backup" aria-label="Backup" style="display:none">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerVaultBtn"
+          title="Backup"
+          aria-label="Backup"
+          style="display: none"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
           </svg>
           <span class="header-btn-text">Backup</span>
         </button>
         <!-- Restore button — order: 7 (STAK-314) -->
-        <button class="btn theme-btn header-toggle-btn" id="headerRestoreBtn"
-                title="Restore" aria-label="Restore" style="display:none">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="1 4 1 10 7 10"/>
-            <path d="M3.51 15a9 9 0 1 0 .49-4.51"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerRestoreBtn"
+          title="Restore"
+          aria-label="Restore"
+          style="display: none"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="1 4 1 10 7 10" />
+            <path d="M3.51 15a9 9 0 1 0 .49-4.51" />
           </svg>
           <span class="header-btn-text">Restore</span>
         </button>
         <!-- Theme cycle button — order: 8 (STACK-54) -->
-        <button class="btn theme-btn header-toggle-btn" id="headerThemeBtn"
-                title="Cycle theme" aria-label="Cycle theme">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="5"/>
-            <line x1="12" y1="1" x2="12" y2="3"/>
-            <line x1="12" y1="21" x2="12" y2="23"/>
-            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-            <line x1="1" y1="12" x2="3" y2="12"/>
-            <line x1="21" y1="12" x2="23" y2="12"/>
-            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="headerThemeBtn"
+          title="Cycle theme"
+          aria-label="Cycle theme"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="5" />
+            <line x1="12" y1="1" x2="12" y2="3" />
+            <line x1="12" y1="21" x2="12" y2="23" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="1" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="12" x2="23" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
           </svg>
           <span class="header-btn-text">Theme</span>
         </button>
         <!-- Info button — order: 9 -->
-        <button class="btn theme-btn header-toggle-btn" id="aboutBtn" title="About" aria-label="About">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-               stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"/>
-            <line x1="12" y1="16" x2="12" y2="12"/>
-            <line x1="12" y1="8" x2="12.01" y2="8"/>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="aboutBtn"
+          title="About"
+          aria-label="About"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="16" x2="12" y2="12" />
+            <line x1="12" y1="8" x2="12.01" y2="8" />
           </svg>
           <span class="header-btn-text">Info</span>
         </button>
-        <button class="btn theme-btn header-toggle-btn" id="settingsBtn" title="Settings" aria-label="Settings">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        <button
+          class="btn theme-btn header-toggle-btn"
+          id="settingsBtn"
+          title="Settings"
+          aria-label="Settings"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path
+              d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+            />
+          </svg>
           <span class="header-btn-text">Settings</span>
         </button>
       </div>
-    </div>
-    <div class="container">
+    </header>
+    <main class="container">
       <!-- =============================================================================
          SPOT PRICES SECTION
          
@@ -475,7 +880,12 @@
                 <div class="spot-card-label">Silver Spot Price</div>
                 <span class="spot-card-period" id="spotPeriodSilver">90d</span>
                 <div class="spot-card-controls">
-                  <select class="spot-range-select" id="spotRangeSilver" title="Trend period">
+                  <select
+                    class="spot-range-select"
+                    id="spotRangeSilver"
+                    title="Trend period"
+                    aria-label="Silver trend period"
+                  >
                     <option value="1">1d</option>
                     <option value="7">7d</option>
                     <option value="14">14d</option>
@@ -488,11 +898,27 @@
                     <option value="3650">10Y</option>
                   </select>
                   <button class="spot-sync-icon" id="syncIconSilver" title="Sync from API" disabled>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M21.5 2v6h-6" />
+                      <path d="M2.5 22v-6h6" />
+                      <path d="M2.5 11.5a10 10 0 0 1 18.4-4.5" />
+                      <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5" />
+                    </svg>
                   </button>
                 </div>
               </div>
-              <div class="spot-card-value" id="spotPriceDisplaySilver" title="Shift+click to edit">—</div>
+              <div class="spot-card-value" id="spotPriceDisplaySilver" title="Shift+click to edit">
+                —
+              </div>
               <div class="spot-card-change" id="spotChangeSilver"></div>
               <div class="spot-card-timestamp" id="spotTimestampSilver">No data</div>
             </div>
@@ -505,7 +931,12 @@
                 <div class="spot-card-label">Gold Spot Price</div>
                 <span class="spot-card-period" id="spotPeriodGold">90d</span>
                 <div class="spot-card-controls">
-                  <select class="spot-range-select" id="spotRangeGold" title="Trend period">
+                  <select
+                    class="spot-range-select"
+                    id="spotRangeGold"
+                    title="Trend period"
+                    aria-label="Gold trend period"
+                  >
                     <option value="1">1d</option>
                     <option value="7">7d</option>
                     <option value="14">14d</option>
@@ -518,11 +949,27 @@
                     <option value="3650">10Y</option>
                   </select>
                   <button class="spot-sync-icon" id="syncIconGold" title="Sync from API" disabled>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M21.5 2v6h-6" />
+                      <path d="M2.5 22v-6h6" />
+                      <path d="M2.5 11.5a10 10 0 0 1 18.4-4.5" />
+                      <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5" />
+                    </svg>
                   </button>
                 </div>
               </div>
-              <div class="spot-card-value" id="spotPriceDisplayGold" title="Shift+click to edit">—</div>
+              <div class="spot-card-value" id="spotPriceDisplayGold" title="Shift+click to edit">
+                —
+              </div>
               <div class="spot-card-change" id="spotChangeGold"></div>
               <div class="spot-card-timestamp" id="spotTimestampGold">No data</div>
             </div>
@@ -535,7 +982,12 @@
                 <div class="spot-card-label">Platinum Spot Price</div>
                 <span class="spot-card-period" id="spotPeriodPlatinum">90d</span>
                 <div class="spot-card-controls">
-                  <select class="spot-range-select" id="spotRangePlatinum" title="Trend period">
+                  <select
+                    class="spot-range-select"
+                    id="spotRangePlatinum"
+                    title="Trend period"
+                    aria-label="Platinum trend period"
+                  >
                     <option value="1">1d</option>
                     <option value="7">7d</option>
                     <option value="14">14d</option>
@@ -547,12 +999,37 @@
                     <option value="1825">5Y</option>
                     <option value="3650">10Y</option>
                   </select>
-                  <button class="spot-sync-icon" id="syncIconPlatinum" title="Sync from API" disabled>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                  <button
+                    class="spot-sync-icon"
+                    id="syncIconPlatinum"
+                    title="Sync from API"
+                    disabled
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M21.5 2v6h-6" />
+                      <path d="M2.5 22v-6h6" />
+                      <path d="M2.5 11.5a10 10 0 0 1 18.4-4.5" />
+                      <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5" />
+                    </svg>
                   </button>
                 </div>
               </div>
-              <div class="spot-card-value" id="spotPriceDisplayPlatinum" title="Shift+click to edit">—</div>
+              <div
+                class="spot-card-value"
+                id="spotPriceDisplayPlatinum"
+                title="Shift+click to edit"
+              >
+                —
+              </div>
               <div class="spot-card-change" id="spotChangePlatinum"></div>
               <div class="spot-card-timestamp" id="spotTimestampPlatinum">No data</div>
             </div>
@@ -565,7 +1042,12 @@
                 <div class="spot-card-label">Palladium Spot Price</div>
                 <span class="spot-card-period" id="spotPeriodPalladium">90d</span>
                 <div class="spot-card-controls">
-                  <select class="spot-range-select" id="spotRangePalladium" title="Trend period">
+                  <select
+                    class="spot-range-select"
+                    id="spotRangePalladium"
+                    title="Trend period"
+                    aria-label="Palladium trend period"
+                  >
                     <option value="1">1d</option>
                     <option value="7">7d</option>
                     <option value="14">14d</option>
@@ -577,12 +1059,37 @@
                     <option value="1825">5Y</option>
                     <option value="3650">10Y</option>
                   </select>
-                  <button class="spot-sync-icon" id="syncIconPalladium" title="Sync from API" disabled>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6"/><path d="M2.5 22v-6h6"/><path d="M2.5 11.5a10 10 0 0 1 18.4-4.5"/><path d="M21.5 12.5a10 10 0 0 1-18.4 4.5"/></svg>
+                  <button
+                    class="spot-sync-icon"
+                    id="syncIconPalladium"
+                    title="Sync from API"
+                    disabled
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M21.5 2v6h-6" />
+                      <path d="M2.5 22v-6h6" />
+                      <path d="M2.5 11.5a10 10 0 0 1 18.4-4.5" />
+                      <path d="M21.5 12.5a10 10 0 0 1-18.4 4.5" />
+                    </svg>
                   </button>
                 </div>
               </div>
-              <div class="spot-card-value" id="spotPriceDisplayPalladium" title="Shift+click to edit">—</div>
+              <div
+                class="spot-card-value"
+                id="spotPriceDisplayPalladium"
+                title="Shift+click to edit"
+              >
+                —
+              </div>
               <div class="spot-card-change" id="spotChangePalladium"></div>
               <div class="spot-card-timestamp" id="spotTimestampPalladium">No data</div>
             </div>
@@ -606,212 +1113,218 @@
          ============================================================================= -->
       <section class="totals-section" id="totalsSectionEl">
         <div class="totals-wrapper">
-          <button class="totals-nav-btn totals-prev" id="totalsPrev" aria-label="Previous card">&#8249;</button>
+          <button class="totals-nav-btn totals-prev" id="totalsPrev" aria-label="Previous card">
+            &#8249;
+          </button>
           <div class="totals" id="totalsCarousel">
-          <!-- Silver totals card -->
-          <div class="total-card silver">
-            <div class="total-title" data-metal="Silver">Silver</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsSilver">0</span>
+            <!-- Silver totals card -->
+            <div class="total-card silver">
+              <div class="total-title" data-metal="Silver">Silver</div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Items:</span>
+                  <span class="total-value" id="totalItemsSilver">0</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Weight (oz):</span>
+                  <span class="total-value" id="totalWeightSilver">0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Avg Cost/oz:</span>
+                  <span class="total-value" id="avgCostPerOzSilver">$0.00</span>
+                </div>
               </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightSilver">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzSilver">$0.00</span>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Purchase Price:</span>
+                  <span class="total-value" id="totalPurchasedSilver">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Melt Value:</span>
+                  <span class="total-value" id="currentValueSilver">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Retail Value:</span>
+                  <span class="total-value" id="retailValueSilver">$0.00</span>
+                </div>
+                <div class="total-item total-item-bottom-line">
+                  <span class="total-label">Gain:</span>
+                  <span class="total-value" id="lossProfitSilver">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Realized:</span>
+                  <span class="total-value" id="realizedGainLossSilver">$0.00</span>
+                </div>
               </div>
             </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedSilver">$0.00</span>
+            <!-- Gold totals card -->
+            <div class="total-card gold">
+              <div class="total-title" data-metal="Gold">Gold</div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Items:</span>
+                  <span class="total-value" id="totalItemsGold">0</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Weight (oz):</span>
+                  <span class="total-value" id="totalWeightGold">0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Avg Cost/oz:</span>
+                  <span class="total-value" id="avgCostPerOzGold">$0.00</span>
+                </div>
               </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValueSilver">$0.00</span>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Purchase Price:</span>
+                  <span class="total-value" id="totalPurchasedGold">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Melt Value:</span>
+                  <span class="total-value" id="currentValueGold">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Retail Value:</span>
+                  <span class="total-value" id="retailValueGold">$0.00</span>
+                </div>
+                <div class="total-item total-item-bottom-line">
+                  <span class="total-label">Gain:</span>
+                  <span class="total-value" id="lossProfitGold">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Realized:</span>
+                  <span class="total-value" id="realizedGainLossGold">$0.00</span>
+                </div>
               </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValueSilver">$0.00</span>
+            </div>
+            <!-- Platinum totals card -->
+            <div class="total-card platinum">
+              <div class="total-title" data-metal="Platinum">Platinum</div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Items:</span>
+                  <span class="total-value" id="totalItemsPlatinum">0</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Weight (oz):</span>
+                  <span class="total-value" id="totalWeightPlatinum">0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Avg Cost/oz:</span>
+                  <span class="total-value" id="avgCostPerOzPlatinum">$0.00</span>
+                </div>
               </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain:</span>
-                <span class="total-value" id="lossProfitSilver">$0.00</span>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Purchase Price:</span>
+                  <span class="total-value" id="totalPurchasedPlatinum">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Melt Value:</span>
+                  <span class="total-value" id="currentValuePlatinum">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Retail Value:</span>
+                  <span class="total-value" id="retailValuePlatinum">$0.00</span>
+                </div>
+                <div class="total-item total-item-bottom-line">
+                  <span class="total-label">Gain:</span>
+                  <span class="total-value" id="lossProfitPlatinum">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Realized:</span>
+                  <span class="total-value" id="realizedGainLossPlatinum">$0.00</span>
+                </div>
               </div>
-              <div class="total-item">
-                <span class="total-label">Realized:</span>
-                <span class="total-value" id="realizedGainLossSilver">$0.00</span>
+            </div>
+            <!-- Palladium totals card -->
+            <div class="total-card palladium">
+              <div class="total-title" data-metal="Palladium">Palladium</div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Items:</span>
+                  <span class="total-value" id="totalItemsPalladium">0</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Weight (oz):</span>
+                  <span class="total-value" id="totalWeightPalladium">0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Avg Cost/oz:</span>
+                  <span class="total-value" id="avgCostPerOzPalladium">$0.00</span>
+                </div>
+              </div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Purchase Price:</span>
+                  <span class="total-value" id="totalPurchasedPalladium">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Melt Value:</span>
+                  <span class="total-value" id="currentValuePalladium">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Retail Value:</span>
+                  <span class="total-value" id="retailValuePalladium">$0.00</span>
+                </div>
+                <div class="total-item total-item-bottom-line">
+                  <span class="total-label">Gain:</span>
+                  <span class="total-value" id="lossProfitPalladium">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Realized:</span>
+                  <span class="total-value" id="realizedGainLossPalladium">$0.00</span>
+                </div>
+              </div>
+            </div>
+            <!-- All metals combined totals card -->
+            <div class="total-card total-card-all">
+              <div class="total-title" data-metal="All">All Metals</div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Items:</span>
+                  <span class="total-value" id="totalItemsAll">0</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Weight (oz):</span>
+                  <span class="total-value" id="totalWeightAll">0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Avg Cost/oz:</span>
+                  <span class="total-value" id="avgCostPerOzAll">$0.00</span>
+                </div>
+              </div>
+              <div class="total-group">
+                <div class="total-item">
+                  <span class="total-label">Purchase Price:</span>
+                  <span class="total-value" id="totalPurchasedAll">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Melt Value:</span>
+                  <span class="total-value" id="currentValueAll">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Retail Value:</span>
+                  <span class="total-value" id="retailValueAll">$0.00</span>
+                </div>
+                <div class="total-item total-item-bottom-line">
+                  <span class="total-label">Gain:</span>
+                  <span class="total-value" id="lossProfitAll">$0.00</span>
+                </div>
+                <div class="total-item">
+                  <span class="total-label">Realized:</span>
+                  <span class="total-value" id="realizedGainLossAll">$0.00</span>
+                </div>
               </div>
             </div>
           </div>
-          <!-- Gold totals card -->
-          <div class="total-card gold">
-            <div class="total-title" data-metal="Gold">Gold</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsGold">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightGold">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzGold">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedGold">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValueGold">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValueGold">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain:</span>
-                <span class="total-value" id="lossProfitGold">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Realized:</span>
-                <span class="total-value" id="realizedGainLossGold">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- Platinum totals card -->
-          <div class="total-card platinum">
-            <div class="total-title" data-metal="Platinum">Platinum</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsPlatinum">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightPlatinum">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzPlatinum">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedPlatinum">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValuePlatinum">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValuePlatinum">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain:</span>
-                <span class="total-value" id="lossProfitPlatinum">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Realized:</span>
-                <span class="total-value" id="realizedGainLossPlatinum">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- Palladium totals card -->
-          <div class="total-card palladium">
-            <div class="total-title" data-metal="Palladium">Palladium</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsPalladium">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightPalladium">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzPalladium">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedPalladium">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValuePalladium">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValuePalladium">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain:</span>
-                <span class="total-value" id="lossProfitPalladium">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Realized:</span>
-                <span class="total-value" id="realizedGainLossPalladium">$0.00</span>
-              </div>
-            </div>
-          </div>
-          <!-- All metals combined totals card -->
-          <div class="total-card total-card-all">
-            <div class="total-title" data-metal="All">All Metals</div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Items:</span>
-                <span class="total-value" id="totalItemsAll">0</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Weight (oz):</span>
-                <span class="total-value" id="totalWeightAll">0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Avg Cost/oz:</span>
-                <span class="total-value" id="avgCostPerOzAll">$0.00</span>
-              </div>
-            </div>
-            <div class="total-group">
-              <div class="total-item">
-                <span class="total-label">Purchase Price:</span>
-                <span class="total-value" id="totalPurchasedAll">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Melt Value:</span>
-                <span class="total-value" id="currentValueAll">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Retail Value:</span>
-                <span class="total-value" id="retailValueAll">$0.00</span>
-              </div>
-              <div class="total-item total-item-bottom-line">
-                <span class="total-label">Gain:</span>
-                <span class="total-value" id="lossProfitAll">$0.00</span>
-              </div>
-              <div class="total-item">
-                <span class="total-label">Realized:</span>
-                <span class="total-value" id="realizedGainLossAll">$0.00</span>
-              </div>
-            </div>
-          </div>
-          </div><!-- /.totals -->
-          <button class="totals-nav-btn totals-next" id="totalsNext" aria-label="Next card">&#8250;</button>
+          <!-- /.totals -->
+          <button class="totals-nav-btn totals-next" id="totalsNext" aria-label="Next card">
+            &#8250;
+          </button>
           <div class="totals-dots" id="totalsDots"></div>
-        </div><!-- /.totals-wrapper -->
+        </div>
+        <!-- /.totals-wrapper -->
       </section>
       <!-- =============================================================================
          INVENTORY FORM SECTION
@@ -836,7 +1349,7 @@
 
          Wrapper containing search and inventory table
          ============================================================================= -->
-        <!-- =============================================================================
+      <!-- =============================================================================
            SEARCH FUNCTIONALITY
 
            Live search interface that filters inventory table in real-time.
@@ -847,109 +1360,166 @@
            Search is case-insensitive and supports partial matches
            Implementation in search.js with filterInventory() function
            ============================================================================= -->
-        <section class="search-section" id="searchSectionEl">
-          <div class="search-container">
-            <button
-              class="btn search-action-btn add-btn"
-              id="newItemBtn"
-              title="Add new item"
-              aria-label="Add new item"
+      <section class="search-section" id="searchSectionEl">
+        <div class="search-container">
+          <button
+            class="btn search-action-btn add-btn"
+            id="newItemBtn"
+            title="Add new item"
+            aria-label="Add new item"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="10"/>
-                <line x1="12" y1="8" x2="12" y2="16"/>
-                <line x1="8" y1="12" x2="16" y2="12"/>
-              </svg>
-              <span>Add Item</span>
-            </button>
-            <input
-              id="searchInput"
-              placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
-              type="text"
-            />
-            <button
-              class="btn search-action-btn clear-btn"
-              id="clearBtn"
-              title="Clear search"
-              aria-label="Clear search"
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="16" />
+              <line x1="8" y1="12" x2="16" y2="12" />
+            </svg>
+            <span>Add Item</span>
+          </button>
+          <input
+            id="searchInput"
+            placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
+            type="text"
+          />
+          <button
+            class="btn search-action-btn clear-btn"
+            id="clearBtn"
+            title="Clear search"
+            aria-label="Clear search"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"/>
-                <line x1="6" y1="6" x2="18" y2="18"/>
-              </svg>
-              <span>Clear</span>
-            </button>
-            <button
-              class="btn search-action-btn log-btn" id="changeLogBtn" title="Change log" aria-label="Change log">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-                <polyline points="14,2 14,8 20,8"/>
-                <line x1="16" y1="13" x2="8" y2="13"/>
-                <line x1="16" y1="17" x2="8" y2="17"/>
-                <polyline points="10,9 9,9 8,9"/>
-              </svg>
-              <span>Log</span>
-            </button>
-          </div>
-          
-          <!-- Integrated Filters -->
-          <div class="search-filters">
-            <div class="filter-controls">
-              <div class="control-group">
-                <label for="chipMinCount" class="control-label">Filter Chips:</label>
-                <select id="chipMinCount" class="control-select" title="Minimum number of items before showing a filter chip">
-                  <option value="2">2+</option>
-                  <option value="3" selected>3+</option>
-                  <option value="5">5+</option>
-                  <option value="10">10+</option>
-                  <option value="100">100+</option>
-                </select>
-              </div>
-              <div class="control-group">
-                <label for="chipMaxCount" class="control-label">Max chips:</label>
-                <select id="chipMaxCount" class="control-select" title="Maximum number of filter chips to display">
-                  <option value="25">25</option>
-                  <option value="50">50</option>
-                  <option value="100">100</option>
-                  <option value="500">500</option>
-                  <option value="0" selected>All</option>
-                </select>
-              </div>
-              <div class="control-group">
-                <span class="control-label">Smart Grouping:</span>
-                <div class="chip-sort-toggle" id="groupNameChips" title="Group similar item names (e.g., 'American Silver Eagle (3)' instead of separate year chips)">
-                  <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
-                  <button type="button" class="chip-sort-btn" data-val="no">Off</button>
-                </div>
-              </div>
-              <div class="control-group">
-                <span class="control-label">Chip Sort:</span>
-                <div class="chip-sort-toggle" id="chipSortOrder" title="Sort chips within each category">
-                  <button type="button" class="chip-sort-btn active" data-sort="alpha">A-Z</button>
-                  <button type="button" class="chip-sort-btn" data-sort="count">Qty</button>
-                </div>
-              </div>
-              <div class="control-group" id="saveSearchPatternGroup" style="display:none">
-                <button type="button" class="chip-sort-btn save-filter-btn" id="saveSearchPatternBtn" title="Save current search as a custom filter chip">Save Filter</button>
-              </div>
-              <div class="control-group">
-                <span class="control-label">Disposed:</span>
-                <div class="chip-sort-toggle" id="disposedFilterGroup" title="Filter disposed items">
-                  <button type="button" class="chip-sort-btn active" data-disposed-mode="hide">Hide</button>
-                  <button type="button" class="chip-sort-btn" data-disposed-mode="show-all">Show All</button>
-                  <button type="button" class="chip-sort-btn" data-disposed-mode="show-only">Disposed Only</button>
-                </div>
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+            <span>Clear</span>
+          </button>
+          <button
+            class="btn search-action-btn log-btn"
+            id="changeLogBtn"
+            title="Change log"
+            aria-label="Change log"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14,2 14,8 20,8" />
+              <line x1="16" y1="13" x2="8" y2="13" />
+              <line x1="16" y1="17" x2="8" y2="17" />
+              <polyline points="10,9 9,9 8,9" />
+            </svg>
+            <span>Log</span>
+          </button>
+        </div>
+
+        <!-- Integrated Filters -->
+        <div class="search-filters">
+          <div class="filter-controls">
+            <div class="control-group">
+              <label for="chipMinCount" class="control-label">Filter Chips:</label>
+              <select
+                id="chipMinCount"
+                class="control-select"
+                title="Minimum number of items before showing a filter chip"
+              >
+                <option value="2">2+</option>
+                <option value="3" selected>3+</option>
+                <option value="5">5+</option>
+                <option value="10">10+</option>
+                <option value="100">100+</option>
+              </select>
+            </div>
+            <div class="control-group">
+              <label for="chipMaxCount" class="control-label">Max chips:</label>
+              <select
+                id="chipMaxCount"
+                class="control-select"
+                title="Maximum number of filter chips to display"
+              >
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+                <option value="500">500</option>
+                <option value="0" selected>All</option>
+              </select>
+            </div>
+            <div class="control-group">
+              <span class="control-label">Smart Grouping:</span>
+              <div
+                class="chip-sort-toggle"
+                id="groupNameChips"
+                title="Group similar item names (e.g., 'American Silver Eagle (3)' instead of separate year chips)"
+              >
+                <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
+                <button type="button" class="chip-sort-btn" data-val="no">Off</button>
               </div>
             </div>
-            <div class="filter-row">
-              <div class="active-filters" id="activeFilters"></div>
-              <div class="search-results-info" id="searchResultsInfo"></div>
+            <div class="control-group">
+              <span class="control-label">Chip Sort:</span>
+              <div
+                class="chip-sort-toggle"
+                id="chipSortOrder"
+                title="Sort chips within each category"
+              >
+                <button type="button" class="chip-sort-btn active" data-sort="alpha">A-Z</button>
+                <button type="button" class="chip-sort-btn" data-sort="count">Qty</button>
+              </div>
+            </div>
+            <div class="control-group" id="saveSearchPatternGroup" style="display: none">
+              <button
+                type="button"
+                class="chip-sort-btn save-filter-btn"
+                id="saveSearchPatternBtn"
+                title="Save current search as a custom filter chip"
+              >
+                Save Filter
+              </button>
+            </div>
+            <div class="control-group">
+              <span class="control-label">Disposed:</span>
+              <div class="chip-sort-toggle" id="disposedFilterGroup" title="Filter disposed items">
+                <button type="button" class="chip-sort-btn active" data-disposed-mode="hide">
+                  Hide
+                </button>
+                <button type="button" class="chip-sort-btn" data-disposed-mode="show-all">
+                  Show All
+                </button>
+                <button type="button" class="chip-sort-btn" data-disposed-mode="show-only">
+                  Disposed Only
+                </button>
+              </div>
             </div>
           </div>
-          <!-- Portfolio summary: Buy / Melt / Market / G/L — full-width bottom row -->
-          <div class="card-sort-summary" id="cardSortSummary"></div>
-        </section>
-        <!-- =============================================================================
+          <div class="filter-row">
+            <div class="active-filters" id="activeFilters"></div>
+            <div class="search-results-info" id="searchResultsInfo"></div>
+          </div>
+        </div>
+        <!-- Portfolio summary: Buy / Melt / Market / G/L — full-width bottom row -->
+        <div class="card-sort-summary" id="cardSortSummary"></div>
+      </section>
+      <!-- =============================================================================
            INVENTORY TABLE SECTION
 
            Main data display table showing all inventory items with:
@@ -961,188 +1531,258 @@
         Table rendering handled by renderTable() in inventory.js
          Portal view shows all items in a scrollable table with sticky headers
          ============================================================================= -->
-        <section class="table-section" id="tableSectionEl">
-          <!-- PROTOTYPE: Sort bar always visible. Style D = table view. -->
-          <div class="card-sort-bar" id="cardSortBar">
-            <div class="card-sort-left">
-              <span class="control-label">Sort:</span>
-              <select id="cardSortColumn" class="control-select" title="Sort cards by column">
-                <option value="0">Date</option>
-                <option value="1">Metal</option>
-                <option value="2">Type</option>
-                <option value="4">Name</option>
-                <option value="5">Qty</option>
-                <option value="6">Weight</option>
-                <option value="7">Purchase</option>
-                <option value="8">Melt Value</option>
-                <option value="9">Retail</option>
-                <option value="10">Gain/Loss</option>
-                <option value="11">Source</option>
-              </select>
-              <button type="button" class="card-sort-dir-btn" id="cardSortDirBtn" title="Toggle sort direction">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline class="sort-arrow-up" points="18 15 12 9 6 15"/>
-                  <polyline class="sort-arrow-down" points="6 9 12 15 18 9"/>
-                </svg>
-              </button>
-            </div>
-            <div class="card-sort-right">
-              <span class="control-label">View:</span>
-              <div class="chip-sort-toggle" id="cardStyleToggle">
-                <button type="button" class="chip-sort-btn active" data-style="A" title="Sparkline cards">A</button>
-                <button type="button" class="chip-sort-btn" data-style="B" title="Hero cards">B</button>
-                <button type="button" class="chip-sort-btn" data-style="C" title="Split cards">C</button>
-                <button type="button" class="chip-sort-btn" data-style="D" title="Table view">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="9" x2="9" y2="21"/><line x1="15" y1="9" x2="15" y2="21"/>
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div class="card-view-grid" id="cardViewGrid"></div>
-          <div class="portal-scroll">
-          <table id="inventoryTable">
-          <thead>
-            <tr>
-              <th class="shrink" data-column="date">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
-                  <line x1="16" y1="2" x2="16" y2="6"/>
-                  <line x1="8" y1="2" x2="8" y2="6"/>
-                  <line x1="3" y1="10" x2="21" y2="10"/>
-                </svg>
-                <span class="header-text">Date</span>
-              </th>
-              <th class="shrink" data-column="metal">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <circle cx="12" cy="12" r="10"/>
-                  <circle cx="12" cy="12" r="6"/>
-                  <circle cx="12" cy="12" r="2"/>
-                </svg>
-                <span class="header-text">Metal</span>
-              </th>
-              <th class="shrink" data-column="type">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <polygon points="12,2 22,8.5 22,15.5 12,22 2,15.5 2,8.5"/>
-                </svg>
-                <span class="header-text">Type</span>
-              </th>
-              <th class="shrink" data-column="image">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-                  <circle cx="8.5" cy="8.5" r="1.5"/>
-                  <polyline points="21 15 16 10 5 21"/>
-                </svg>
-                <span class="header-text">Image</span>
-              </th>
-              <th class="expand" data-column="name">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
-                  <circle cx="12" cy="7" r="4"/>
-                </svg>
-                <span class="header-text">Name</span>
-              </th>
-              <th class="shrink center-align" data-column="qty">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <line x1="8" y1="6" x2="21" y2="6"/>
-                  <line x1="8" y1="12" x2="21" y2="12"/>
-                  <line x1="8" y1="18" x2="21" y2="18"/>
-                  <line x1="3" y1="6" x2="3.01" y2="6"/>
-                  <line x1="3" y1="12" x2="3.01" y2="12"/>
-                  <line x1="3" y1="18" x2="3.01" y2="18"/>
-                </svg>
-                <span class="header-text">Qty</span>
-              </th>
-              <th class="shrink" data-column="weight">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                </svg>
-                <span class="header-text">Weight</span>
-              </th>
-              <th class="shrink" data-column="purchasePrice" title="USD">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <line x1="12" y1="1" x2="12" y2="23"/>
-                  <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
-                </svg>
-                <span class="header-text">Purchase</span>
-              </th>
-              <th class="shrink" data-column="meltValue" title="USD">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2z"/>
-                  <path d="M12 6v6l4 2"/>
-                </svg>
-                <span class="header-text">Melt</span>
-              </th>
-              <th class="shrink" data-column="retailPrice" title="USD">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
-                </svg>
-                <span class="header-text">Retail</span>
-              </th>
-              <th class="shrink" data-column="gainLoss" title="USD">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/>
-                  <polyline points="17 6 23 6 23 12"/>
-                </svg>
-                <span class="header-text">Gain/Loss</span>
-              </th>
-              <th class="shrink" data-column="purchaseLocation">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <path d="M3 9l1.5-5h15L21 9"/>
-                  <path d="M3 9v11a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V9"/>
-                  <path d="M9 21V13h6v8"/>
-                </svg>
-                <span class="header-text">Source</span>
-              </th>
-              <th class="icon-col actions-col" data-column="actions" aria-label="Actions" title="Actions">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <circle cx="12" cy="5" r="1.5"/>
-                  <circle cx="12" cy="12" r="1.5"/>
-                  <circle cx="12" cy="19" r="1.5"/>
-                </svg>
-                <span class="header-text">Actions</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-          </table>
-          </div>
-          <div class="table-footer-controls">
-            <select id="itemsPerPage" class="control-select" title="Visible rows">
-              <option value="3">3</option>
-              <option value="6">6</option>
-              <option value="12" selected>12</option>
-              <option value="24">24</option>
-              <option value="48">48</option>
-              <option value="96">96</option>
-              <option value="128">128</option>
-              <option value="512">512</option>
-              <option value="all">All</option>
+      <section class="table-section" id="tableSectionEl">
+        <!-- PROTOTYPE: Sort bar always visible. Style D = table view. -->
+        <div class="card-sort-bar" id="cardSortBar">
+          <div class="card-sort-left">
+            <span class="control-label">Sort:</span>
+            <select
+              id="cardSortColumn"
+              class="control-select"
+              title="Sort cards by column"
+              aria-label="Sort by column"
+            >
+              <option value="0">Date</option>
+              <option value="1">Metal</option>
+              <option value="2">Type</option>
+              <option value="4">Name</option>
+              <option value="5">Qty</option>
+              <option value="6">Weight</option>
+              <option value="7">Purchase</option>
+              <option value="8">Melt Value</option>
+              <option value="9">Retail</option>
+              <option value="10">Gain/Loss</option>
+              <option value="11">Source</option>
             </select>
+            <button
+              type="button"
+              class="card-sort-dir-btn"
+              id="cardSortDirBtn"
+              title="Toggle sort direction"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline class="sort-arrow-up" points="18 15 12 9 6 15" />
+                <polyline class="sort-arrow-down" points="6 9 12 15 18 9" />
+              </svg>
+            </button>
           </div>
-          
-          <!-- Bulk Edit Control Panel -->
-          <div class="bulk-edit-panel" id="bulkEditPanel" style="display: none;">
-            <div class="bulk-edit-controls">
-              <button class="bulk-edit-btn toggle-all-btn" id="bulkToggleAll" title="Toggle all items edit mode">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="bulk-edit-icon">
-                  <path d="M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z"/>
-                </svg>
+          <div class="card-sort-right">
+            <span class="control-label">View:</span>
+            <div class="chip-sort-toggle" id="cardStyleToggle">
+              <button
+                type="button"
+                class="chip-sort-btn active"
+                data-style="A"
+                title="Sparkline cards"
+              >
+                A
               </button>
-              <button class="bulk-edit-btn save-all-btn" id="bulkSaveAll" title="Save all changes">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="bulk-edit-icon">
-                  <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
-                </svg>
+              <button type="button" class="chip-sort-btn" data-style="B" title="Hero cards">
+                B
               </button>
-              <button class="bulk-edit-btn cancel-all-btn" id="bulkCancelAll" title="Cancel all changes">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="bulk-edit-icon">
-                  <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/>
+              <button type="button" class="chip-sort-btn" data-style="C" title="Split cards">
+                C
+              </button>
+              <button type="button" class="chip-sort-btn" data-style="D" title="Table view">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <line x1="3" y1="9" x2="21" y2="9" />
+                  <line x1="3" y1="15" x2="21" y2="15" />
+                  <line x1="9" y1="9" x2="9" y2="21" />
+                  <line x1="15" y1="9" x2="15" y2="21" />
                 </svg>
               </button>
             </div>
           </div>
-        </section>
+        </div>
+        <div class="card-view-grid" id="cardViewGrid"></div>
+        <div class="portal-scroll">
+          <table id="inventoryTable">
+            <thead>
+              <tr>
+                <th class="shrink" data-column="date">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" />
+                    <line x1="8" y1="2" x2="8" y2="6" />
+                    <line x1="3" y1="10" x2="21" y2="10" />
+                  </svg>
+                  <span class="header-text">Date</span>
+                </th>
+                <th class="shrink" data-column="metal">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <circle cx="12" cy="12" r="10" />
+                    <circle cx="12" cy="12" r="6" />
+                    <circle cx="12" cy="12" r="2" />
+                  </svg>
+                  <span class="header-text">Metal</span>
+                </th>
+                <th class="shrink" data-column="type">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <polygon points="12,2 22,8.5 22,15.5 12,22 2,15.5 2,8.5" />
+                  </svg>
+                  <span class="header-text">Type</span>
+                </th>
+                <th class="shrink" data-column="image">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                    <circle cx="8.5" cy="8.5" r="1.5" />
+                    <polyline points="21 15 16 10 5 21" />
+                  </svg>
+                  <span class="header-text">Image</span>
+                </th>
+                <th class="expand" data-column="name">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                    <circle cx="12" cy="7" r="4" />
+                  </svg>
+                  <span class="header-text">Name</span>
+                </th>
+                <th class="shrink center-align" data-column="qty">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <line x1="8" y1="6" x2="21" y2="6" />
+                    <line x1="8" y1="12" x2="21" y2="12" />
+                    <line x1="8" y1="18" x2="21" y2="18" />
+                    <line x1="3" y1="6" x2="3.01" y2="6" />
+                    <line x1="3" y1="12" x2="3.01" y2="12" />
+                    <line x1="3" y1="18" x2="3.01" y2="18" />
+                  </svg>
+                  <span class="header-text">Qty</span>
+                </th>
+                <th class="shrink" data-column="weight">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <path
+                      d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+                    />
+                  </svg>
+                  <span class="header-text">Weight</span>
+                </th>
+                <th class="shrink" data-column="purchasePrice" title="USD">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <line x1="12" y1="1" x2="12" y2="23" />
+                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+                  </svg>
+                  <span class="header-text">Purchase</span>
+                </th>
+                <th class="shrink" data-column="meltValue" title="USD">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2z" />
+                    <path d="M12 6v6l4 2" />
+                  </svg>
+                  <span class="header-text">Melt</span>
+                </th>
+                <th class="shrink" data-column="retailPrice" title="USD">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                  </svg>
+                  <span class="header-text">Retail</span>
+                </th>
+                <th class="shrink" data-column="gainLoss" title="USD">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+                    <polyline points="17 6 23 6 23 12" />
+                  </svg>
+                  <span class="header-text">Gain/Loss</span>
+                </th>
+                <th class="shrink" data-column="purchaseLocation">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <path d="M3 9l1.5-5h15L21 9" />
+                    <path d="M3 9v11a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V9" />
+                    <path d="M9 21V13h6v8" />
+                  </svg>
+                  <span class="header-text">Source</span>
+                </th>
+                <th
+                  class="icon-col actions-col"
+                  data-column="actions"
+                  aria-label="Actions"
+                  title="Actions"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
+                    <circle cx="12" cy="5" r="1.5" />
+                    <circle cx="12" cy="12" r="1.5" />
+                    <circle cx="12" cy="19" r="1.5" />
+                  </svg>
+                  <span class="header-text">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="table-footer-controls">
+          <select
+            id="itemsPerPage"
+            class="control-select"
+            title="Visible rows"
+            aria-label="Items per page"
+          >
+            <option value="3">3</option>
+            <option value="6">6</option>
+            <option value="12" selected>12</option>
+            <option value="24">24</option>
+            <option value="48">48</option>
+            <option value="96">96</option>
+            <option value="128">128</option>
+            <option value="512">512</option>
+            <option value="all">All</option>
+          </select>
+        </div>
+
+        <!-- Bulk Edit Control Panel -->
+        <div class="bulk-edit-panel" id="bulkEditPanel" style="display: none">
+          <div class="bulk-edit-controls">
+            <button
+              class="bulk-edit-btn toggle-all-btn"
+              id="bulkToggleAll"
+              title="Toggle all items edit mode"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="bulk-edit-icon">
+                <path
+                  d="M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z"
+                />
+              </svg>
+            </button>
+            <button class="bulk-edit-btn save-all-btn" id="bulkSaveAll" title="Save all changes">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="bulk-edit-icon">
+                <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+              </svg>
+            </button>
+            <button
+              class="bulk-edit-btn cancel-all-btn"
+              id="bulkCancelAll"
+              title="Cancel all changes"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="bulk-edit-icon">
+                <path
+                  d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </section>
       <!-- ── Vendor Prices (STAK-504) ── -->
       <section class="vendor-prices-section" id="vendorPricesSectionEl">
         <div id="vendorPricesContainer"></div>
@@ -1165,9 +1805,16 @@
          All import/export functions include data validation and error handling
          Implementation in inventory.js with format-specific parsing
       ============================================================================= -->
-    </div>
+    </main>
     <!-- UNIFIED ITEM MODAL (Add / Edit) -->
-    <div class="modal" id="itemModal" style="display: none">
+    <div
+      class="modal"
+      id="itemModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="itemModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="itemModalTitle">Add Inventory Item</h2>
@@ -1210,7 +1857,9 @@
             <!-- Row: Purity, Quantity, Weight, Unit -->
             <div class="grid grid-purity-row">
               <div>
-                <label for="itemPuritySelect">Purity <span style="font-weight:normal;opacity:0.6;">(fineness)</span></label>
+                <label for="itemPuritySelect"
+                  >Purity <span style="font-weight: normal; opacity: 0.6">(fineness)</span></label
+                >
                 <select id="itemPuritySelect">
                   <option value="1.0">100% — Pure</option>
                   <option value="0.9999">.9999 — Four Nines</option>
@@ -1232,8 +1881,15 @@
               </div>
               <div>
                 <label for="itemWeight" id="itemWeightLabel">Weight</label>
-                <input id="itemWeight" inputmode="decimal" placeholder="1, 0.5, 1/10" required type="text" value="1" />
-                <select id="itemGbDenom" style="display:none;">
+                <input
+                  id="itemWeight"
+                  inputmode="decimal"
+                  placeholder="1, 0.5, 1/10"
+                  required
+                  type="text"
+                  value="1"
+                />
+                <select id="itemGbDenom" style="display: none" aria-label="Goldback denomination">
                   <option value="0.5">½ Goldback</option>
                   <option value="1" selected>1 Goldback</option>
                   <option value="2">2 Goldback</option>
@@ -1245,7 +1901,7 @@
                 </select>
               </div>
               <div>
-                <label>&nbsp;</label>
+                <label for="itemWeightUnit" class="sr-only">Weight unit</label>
                 <select id="itemWeightUnit">
                   <option value="oz">ounce</option>
                   <option value="g">gram</option>
@@ -1255,10 +1911,17 @@
                 </select>
               </div>
             </div>
-            <div id="purityCustomWrapper" class="grid grid-2" style="display:none;">
+            <div id="purityCustomWrapper" class="grid grid-2" style="display: none">
               <div>
                 <label for="itemPurity">Custom Purity</label>
-                <input id="itemPurity" type="number" min="0.001" max="1" step="0.0001" placeholder="e.g. 0.9995" />
+                <input
+                  id="itemPurity"
+                  type="number"
+                  min="0.001"
+                  max="1"
+                  step="0.0001"
+                  placeholder="e.g. 0.9995"
+                />
               </div>
             </div>
             <!-- Row: Name & Year -->
@@ -1267,38 +1930,81 @@
                 <label for="itemName">Name</label>
                 <div class="input-with-action">
                   <input id="itemName" required type="text" />
-                  <button class="inline-search-btn" id="searchNumistaNameBtn" type="button"
-                          title="Search Numista catalog by name">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                         stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                      <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
+                  <button
+                    class="inline-search-btn"
+                    id="searchNumistaNameBtn"
+                    type="button"
+                    title="Search Numista catalog by name"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <circle cx="11" cy="11" r="7" />
+                      <line x1="16.5" y1="16.5" x2="21" y2="21" />
                     </svg>
                   </button>
                 </div>
               </div>
               <div>
-                <label for="itemYear">Year <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <label for="itemYear"
+                  >Year <span style="font-weight: normal; opacity: 0.6">(optional)</span></label
+                >
                 <input id="itemYear" type="text" placeholder="e.g. 2024" />
               </div>
             </div>
             <!-- Row: Purchase Date & Purchase Price -->
             <div class="grid grid-2">
               <div id="dateField">
-                <label for="itemDate">Purchase Date <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                <label for="itemDate"
+                  >Purchase Date
+                  <span style="font-weight: normal; opacity: 0.6">(optional)</span></label
+                >
                 <div class="input-with-action">
                   <input id="itemDate" type="date" />
-                  <button type="button" id="itemDateNABtn" class="inline-search-btn date-na-btn" title="Clear date (N/A)" aria-pressed="false" aria-controls="itemDate">N/A</button>
+                  <button
+                    type="button"
+                    id="itemDateNABtn"
+                    class="inline-search-btn date-na-btn"
+                    title="Clear date (N/A)"
+                    aria-pressed="false"
+                    aria-controls="itemDate"
+                  >
+                    N/A
+                  </button>
                 </div>
               </div>
               <div>
                 <label for="itemPrice">Purchase Price</label>
                 <div class="currency-input input-with-action">
                   <input id="itemPrice" min="0" step="0.01" type="number" />
-                  <button class="inline-search-btn" id="spotLookupBtn" type="button" disabled
-                          title="Search for spot price on purchase date">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                         stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                      <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+                  <button
+                    class="inline-search-btn"
+                    id="spotLookupBtn"
+                    type="button"
+                    disabled
+                    title="Search for spot price on purchase date"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <line x1="12" y1="1" x2="12" y2="23" />
+                      <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
                     </svg>
                   </button>
                 </div>
@@ -1316,57 +2022,147 @@
               </div>
             </div>
             <!-- Images — Unified upload / camera / URL per slot -->
-            <div id="imageUploadGroup" class="image-upload-group" style="display:none">
+            <div id="imageUploadGroup" class="image-upload-group" style="display: none">
               <label>Images</label>
               <div class="image-upload-sides">
                 <!-- Obverse -->
                 <div class="image-upload-side">
                   <span class="image-side-label">Obverse</span>
                   <div class="image-card">
-                    <div id="itemImagePreviewObv" class="image-upload-preview" style="display:none">
+                    <div
+                      id="itemImagePreviewObv"
+                      class="image-upload-preview"
+                      style="display: none"
+                    >
                       <img id="itemImagePreviewImgObv" alt="Obverse preview" />
                     </div>
                     <div class="image-card-actions">
-                      <input type="file" id="itemImageFileObv" accept="image/jpeg,image/png,image/webp" style="display:none" />
-                      <button class="btn img-btn img-btn-upload" id="itemImageUploadBtnObv" type="button">Upload</button>
-                      <button class="btn img-btn img-btn-url" id="itemImageUrlBtnObv" type="button" style="display:none">URL</button>
-                      <button class="btn img-btn img-btn-camera" id="itemImageCameraBtnObv" type="button" style="display:none">Camera</button>
-                      <button class="btn img-btn img-btn-remove" id="itemImageRemoveBtnObv" type="button" style="display:none">Remove</button>
+                      <input
+                        type="file"
+                        id="itemImageFileObv"
+                        accept="image/jpeg,image/png,image/webp"
+                        style="display: none"
+                      />
+                      <button
+                        class="btn img-btn img-btn-upload"
+                        id="itemImageUploadBtnObv"
+                        type="button"
+                      >
+                        Upload
+                      </button>
+                      <button
+                        class="btn img-btn img-btn-url"
+                        id="itemImageUrlBtnObv"
+                        type="button"
+                        style="display: none"
+                      >
+                        URL
+                      </button>
+                      <button
+                        class="btn img-btn img-btn-camera"
+                        id="itemImageCameraBtnObv"
+                        type="button"
+                        style="display: none"
+                      >
+                        Camera
+                      </button>
+                      <button
+                        class="btn img-btn img-btn-remove"
+                        id="itemImageRemoveBtnObv"
+                        type="button"
+                        style="display: none"
+                      >
+                        Remove
+                      </button>
                     </div>
                   </div>
                   <span id="itemImageSizeInfoObv" class="image-size-info"></span>
-                  <div id="itemImageUrlInputObv" class="image-url-input" style="display:none">
-                    <input id="itemObverseImageUrl" type="url" class="form-control" placeholder="https://example.com/obverse.jpg" />
+                  <div id="itemImageUrlInputObv" class="image-url-input" style="display: none">
+                    <input
+                      id="itemObverseImageUrl"
+                      type="url"
+                      class="form-control"
+                      placeholder="https://example.com/obverse.jpg"
+                    />
                   </div>
                 </div>
                 <!-- Swap obverse/reverse button (STAK-341) -->
                 <div class="image-swap-wrapper d-none" id="swapImagesBtnWrapper">
-                  <button type="button" class="btn btn-icon" id="swapImagesBtn" title="Swap obverse &amp; reverse" aria-label="Swap obverse and reverse images">⇄</button>
+                  <button
+                    type="button"
+                    class="btn btn-icon"
+                    id="swapImagesBtn"
+                    title="Swap obverse &amp; reverse"
+                    aria-label="Swap obverse and reverse images"
+                  >
+                    ⇄
+                  </button>
                 </div>
                 <!-- Reverse -->
                 <div class="image-upload-side">
                   <span class="image-side-label">Reverse</span>
                   <div class="image-card">
-                    <div id="itemImagePreviewRev" class="image-upload-preview" style="display:none">
+                    <div
+                      id="itemImagePreviewRev"
+                      class="image-upload-preview"
+                      style="display: none"
+                    >
                       <img id="itemImagePreviewImgRev" alt="Reverse preview" />
                     </div>
                     <div class="image-card-actions">
-                      <input type="file" id="itemImageFileRev" accept="image/jpeg,image/png,image/webp" style="display:none" />
-                      <button class="btn img-btn img-btn-upload" id="itemImageUploadBtnRev" type="button">Upload</button>
-                      <button class="btn img-btn img-btn-url" id="itemImageUrlBtnRev" type="button" style="display:none">URL</button>
-                      <button class="btn img-btn img-btn-camera" id="itemImageCameraBtnRev" type="button" style="display:none">Camera</button>
-                      <button class="btn img-btn img-btn-remove" id="itemImageRemoveBtnRev" type="button" style="display:none">Remove</button>
+                      <input
+                        type="file"
+                        id="itemImageFileRev"
+                        accept="image/jpeg,image/png,image/webp"
+                        style="display: none"
+                      />
+                      <button
+                        class="btn img-btn img-btn-upload"
+                        id="itemImageUploadBtnRev"
+                        type="button"
+                      >
+                        Upload
+                      </button>
+                      <button
+                        class="btn img-btn img-btn-url"
+                        id="itemImageUrlBtnRev"
+                        type="button"
+                        style="display: none"
+                      >
+                        URL
+                      </button>
+                      <button
+                        class="btn img-btn img-btn-camera"
+                        id="itemImageCameraBtnRev"
+                        type="button"
+                        style="display: none"
+                      >
+                        Camera
+                      </button>
+                      <button
+                        class="btn img-btn img-btn-remove"
+                        id="itemImageRemoveBtnRev"
+                        type="button"
+                        style="display: none"
+                      >
+                        Remove
+                      </button>
                     </div>
                   </div>
                   <span id="itemImageSizeInfoRev" class="image-size-info"></span>
-                  <div id="itemImageUrlInputRev" class="image-url-input" style="display:none">
-                    <input id="itemReverseImageUrl" type="url" class="form-control" placeholder="https://example.com/reverse.jpg" />
+                  <div id="itemImageUrlInputRev" class="image-url-input" style="display: none">
+                    <input
+                      id="itemReverseImageUrl"
+                      type="url"
+                      class="form-control"
+                      placeholder="https://example.com/reverse.jpg"
+                    />
                   </div>
                 </div>
               </div>
               <!-- Hidden wrappers preserved for JS compatibility -->
-              <div id="imageUrlGroup" style="display:none">
-                <input id="itemIgnorePatternImages" type="checkbox" style="display:none" />
+              <div id="imageUrlGroup" style="display: none">
+                <input id="itemIgnorePatternImages" type="checkbox" style="display: none" />
               </div>
             </div>
 
@@ -1376,9 +2172,19 @@
             <div class="form-section">
               <div class="form-section-header">
                 <span class="form-section-icon">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <circle cx="12" cy="8" r="7"/><polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88"/>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="12" cy="8" r="7" />
+                    <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
                   </svg>
                 </span>
                 Grading &amp; Certification
@@ -1386,7 +2192,10 @@
               <div class="form-section-body">
                 <div class="grid grid-grade">
                   <div>
-                    <label for="itemGrade">Grade <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                    <label for="itemGrade"
+                      >Grade
+                      <span style="font-weight: normal; opacity: 0.6">(optional)</span></label
+                    >
                     <select id="itemGrade">
                       <option value="">-- None --</option>
                       <optgroup label="Standard">
@@ -1429,7 +2238,10 @@
                     </select>
                   </div>
                   <div>
-                    <label for="itemGradingAuthority">Authority <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                    <label for="itemGradingAuthority"
+                      >Authority
+                      <span style="font-weight: normal; opacity: 0.6">(optional)</span></label
+                    >
                     <select id="itemGradingAuthority">
                       <option value="">-- None --</option>
                       <option value="PCGS">PCGS</option>
@@ -1439,16 +2251,54 @@
                     </select>
                   </div>
                   <div>
-                    <label for="itemCertNumber">Cert #
-                      <span id="certVerifiedIcon" style="display:none;color:#16a34a;margin-left:0.25rem;vertical-align:middle;" title="PCGS Verified"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg></span>
-                      <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
+                    <label for="itemCertNumber"
+                      >Cert #
+                      <span
+                        id="certVerifiedIcon"
+                        style="
+                          display: none;
+                          color: var(--success);
+                          margin-left: 0.25rem;
+                          vertical-align: middle;
+                        "
+                        title="PCGS Verified"
+                        ><svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="3"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                          <polyline points="22 4 12 14.01 9 11.01" /></svg
+                      ></span>
+                      <span style="font-weight: normal; opacity: 0.6">(optional)</span></label
+                    >
                     <div class="input-with-action">
                       <input id="itemCertNumber" type="text" placeholder="e.g. 12345678" />
-                      <button class="inline-search-btn" id="lookupPcgsBtn" type="button"
-                              title="Look up coin via PCGS Cert# or PCGS#">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                             stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                          <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
+                      <button
+                        class="inline-search-btn"
+                        id="lookupPcgsBtn"
+                        type="button"
+                        title="Look up coin via PCGS Cert# or PCGS#"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <circle cx="11" cy="11" r="7" />
+                          <line x1="16.5" y1="16.5" x2="21" y2="21" />
                         </svg>
                       </button>
                     </div>
@@ -1459,20 +2309,60 @@
                     <label for="itemCatalog">Numista #</label>
                     <div class="input-with-action">
                       <input id="itemCatalog" type="text" placeholder="e.g. 95694" />
-                      <button class="inline-search-btn" id="searchNumistaBtn" type="button"
-                              title="Search Numista catalog by N#">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                             stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                          <circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/>
+                      <button
+                        class="inline-search-btn"
+                        id="searchNumistaBtn"
+                        type="button"
+                        title="Search Numista catalog by N#"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <circle cx="11" cy="11" r="7" />
+                          <line x1="16.5" y1="16.5" x2="21" y2="21" />
                         </svg>
-                        <span id="numistaModalStatusDot" class="api-status-dot disconnected" title="Numista API: disconnected"></span>
+                        <span
+                          id="numistaModalStatusDot"
+                          class="api-status-dot disconnected"
+                          title="Numista API: disconnected"
+                        ></span>
                       </button>
                     </div>
                   </div>
                   <div>
-                    <label for="itemPcgsNumber">PCGS # <span style="font-weight:normal;opacity:0.6;">(optional)</span>
-                      <a href="https://www.pcgs.com/pcgsnolookup" target="_blank" rel="noopener" title="Look up PCGS coin numbers" class="form-info-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+                    <label for="itemPcgsNumber"
+                      >PCGS # <span style="font-weight: normal; opacity: 0.6">(optional)</span>
+                      <a
+                        href="https://www.pcgs.com/pcgsnolookup"
+                        target="_blank"
+                        rel="noopener"
+                        title="Look up PCGS coin numbers"
+                        class="form-info-icon"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          style="vertical-align: middle"
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                          <line x1="12" y1="16" x2="12" y2="12" />
+                          <line x1="12" y1="8" x2="12.01" y2="8" />
+                        </svg>
                       </a>
                     </label>
                     <input id="itemPcgsNumber" type="text" placeholder="e.g. 786060" />
@@ -1487,9 +2377,19 @@
             <div class="form-section">
               <div class="form-section-header">
                 <span class="form-section-icon">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <line x1="12" y1="1" x2="12" y2="23" />
+                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
                   </svg>
                 </span>
                 Pricing &amp; Details
@@ -1497,19 +2397,39 @@
               <div class="form-section-body">
                 <div class="grid grid-2">
                   <div id="marketValueField">
-                    <label for="itemMarketValue">Retail Price <span style="font-weight:normal;opacity:0.6;">(optional)</span>
-                      <span id="retailPriceHistoryLink" class="field-history-link" title="View price history">&#x1f4c8;</span>
+                    <label for="itemMarketValue"
+                      >Retail Price
+                      <span style="font-weight: normal; opacity: 0.6">(optional)</span>
+                      <span
+                        id="retailPriceHistoryLink"
+                        class="field-history-link"
+                        title="View price history"
+                        >&#x1f4c8;</span
+                      >
                     </label>
                     <div class="currency-input">
-                      <input id="itemMarketValue" min="0" step="0.01" type="number" placeholder="Defaults to melt value" />
+                      <input
+                        id="itemMarketValue"
+                        min="0"
+                        step="0.01"
+                        type="number"
+                        placeholder="Defaults to melt value"
+                      />
                     </div>
                   </div>
                   <div>
-                    <label for="itemSerialNumber">Serial # <span style="font-weight:normal;opacity:0.6;">(optional)</span></label>
-                    <input id="itemSerialNumber" type="text" placeholder="Bar or note serial number" />
+                    <label for="itemSerialNumber"
+                      >Serial #
+                      <span style="font-weight: normal; opacity: 0.6">(optional)</span></label
+                    >
+                    <input
+                      id="itemSerialNumber"
+                      type="text"
+                      placeholder="Bar or note serial number"
+                    />
                   </div>
                 </div>
-                <div class="grid grid-2" style="margin-top:0.35rem;">
+                <div class="grid grid-2" style="margin-top: 0.35rem">
                   <div>
                     <label class="settings-checkbox-label estimate-retail-label">
                       <input type="checkbox" id="estimateRetailFromSpot" />
@@ -1517,8 +2437,17 @@
                     </label>
                   </div>
                   <div>
-                    <label for="retailSpotModifier">Modifier <span style="font-weight:normal;opacity:0.6;">(%)</span></label>
-                    <input id="retailSpotModifier" type="number" min="0" step="0.1" placeholder="e.g. 5" disabled />
+                    <label for="retailSpotModifier"
+                      >Modifier <span style="font-weight: normal; opacity: 0.6">(%)</span></label
+                    >
+                    <input
+                      id="retailSpotModifier"
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      placeholder="e.g. 5"
+                      disabled
+                    />
                   </div>
                 </div>
               </div>
@@ -1530,9 +2459,20 @@
             <div class="form-section" id="numistaDataSection">
               <div class="form-section-header">
                 <span class="form-section-icon">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="10" />
+                    <path d="M12 16v-4" />
+                    <path d="M12 8h.01" />
                   </svg>
                 </span>
                 Catalog Data
@@ -1566,19 +2506,27 @@
                 </div>
                 <div class="grid grid-3-equal">
                   <div id="numistaDiameterWrap">
-                    <label for="numistaDiameter">Diameter <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
+                    <label for="numistaDiameter"
+                      >Diameter <span style="font-weight: normal; opacity: 0.6">(mm)</span></label
+                    >
                     <input id="numistaDiameter" type="text" placeholder="e.g. 40.6" />
                   </div>
-                  <div id="numistaLengthWrap" style="display:none">
-                    <label for="numistaLength">Length <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
+                  <div id="numistaLengthWrap" style="display: none">
+                    <label for="numistaLength"
+                      >Length <span style="font-weight: normal; opacity: 0.6">(mm)</span></label
+                    >
                     <input id="numistaLength" type="text" placeholder="e.g. 105.0" />
                   </div>
-                  <div id="numistaWidthWrap" style="display:none">
-                    <label for="numistaWidth">Width <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
+                  <div id="numistaWidthWrap" style="display: none">
+                    <label for="numistaWidth"
+                      >Width <span style="font-weight: normal; opacity: 0.6">(mm)</span></label
+                    >
                     <input id="numistaWidth" type="text" placeholder="e.g. 74.0" />
                   </div>
                   <div>
-                    <label for="numistaThickness">Thickness <span style="font-weight:normal;opacity:0.6;">(mm)</span></label>
+                    <label for="numistaThickness"
+                      >Thickness <span style="font-weight: normal; opacity: 0.6">(mm)</span></label
+                    >
                     <input id="numistaThickness" type="text" placeholder="e.g. 2.98" />
                   </div>
                   <div>
@@ -1612,21 +2560,37 @@
                     Commemorative
                   </label>
                 </div>
-                <div id="numistaCommemorativeDescWrap" style="display:none;">
+                <div id="numistaCommemorativeDescWrap" style="display: none">
                   <label for="numistaCommemorativeDesc">Commemorative Description</label>
-                  <input id="numistaCommemorativeDesc" type="text" placeholder="What this coin commemorates..." />
+                  <input
+                    id="numistaCommemorativeDesc"
+                    type="text"
+                    placeholder="What this coin commemorates..."
+                  />
                 </div>
                 <div>
                   <label for="numistaObverseDesc">Obverse Description</label>
-                  <input id="numistaObverseDesc" type="text" placeholder="Obverse design description..." />
+                  <input
+                    id="numistaObverseDesc"
+                    type="text"
+                    placeholder="Obverse design description..."
+                  />
                 </div>
                 <div>
                   <label for="numistaReverseDesc">Reverse Description</label>
-                  <input id="numistaReverseDesc" type="text" placeholder="Reverse design description..." />
+                  <input
+                    id="numistaReverseDesc"
+                    type="text"
+                    placeholder="Reverse design description..."
+                  />
                 </div>
                 <div>
                   <label for="numistaEdgeDesc">Edge Description</label>
-                  <input id="numistaEdgeDesc" type="text" placeholder="Edge design description..." />
+                  <input
+                    id="numistaEdgeDesc"
+                    type="text"
+                    placeholder="Edge design description..."
+                  />
                 </div>
               </div>
             </div>
@@ -1637,9 +2601,21 @@
             <div class="form-section">
               <div class="form-section-header">
                 <span class="form-section-icon">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="16" y1="13" x2="8" y2="13" />
+                    <line x1="16" y1="17" x2="8" y2="17" />
                   </svg>
                 </span>
                 Notes
@@ -1658,9 +2634,21 @@
             <div class="form-section" id="tagsSection">
               <div class="form-section-header">
                 <span class="form-section-icon">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path
+                      d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"
+                    />
+                    <line x1="7" y1="7" x2="7.01" y2="7" />
                   </svg>
                 </span>
                 Tags
@@ -1679,11 +2667,31 @@
                       <span class="tag-empty-hint">No custom tags</span>
                     </div>
                     <div class="tags-add-row">
-                      <input type="text" id="newTagInput" placeholder="Add a tag..." class="form-control tag-input" />
-                      <button type="button" id="addTagBtn" class="btn secondary btn-sm" title="Add tag">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                             stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                          <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+                      <input
+                        type="text"
+                        id="newTagInput"
+                        placeholder="Add a tag..."
+                        class="form-control tag-input"
+                      />
+                      <button
+                        type="button"
+                        id="addTagBtn"
+                        class="btn secondary btn-sm"
+                        title="Add tag"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <line x1="12" y1="5" x2="12" y2="19" />
+                          <line x1="5" y1="12" x2="19" y2="12" />
                         </svg>
                       </button>
                     </div>
@@ -1695,37 +2703,94 @@
             <!-- Form action buttons -->
             <div class="item-modal-actions">
               <div class="item-modal-actions-left">
-                <button class="btn danger" id="deleteFromEditBtn" type="button" style="display:none"
-                        title="Delete or dispose this item">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                       style="vertical-align: -2px; margin-right: 0.2rem;">
-                    <path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/>
-                  </svg>Remove
+                <button
+                  class="btn danger"
+                  id="deleteFromEditBtn"
+                  type="button"
+                  style="display: none"
+                  title="Delete or dispose this item"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    style="vertical-align: -2px; margin-right: 0.2rem"
+                  >
+                    <path d="M3 6h18" />
+                    <path d="M8 6V4h8v2" />
+                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /></svg
+                  >Remove
                 </button>
               </div>
               <div class="item-modal-actions-right">
-                <span id="clonePickerCount" class="clone-picker-count" style="display:none"></span>
-                <button class="btn" id="undoChangeBtn" type="button" style="display:none">Undo</button>
-                <button class="btn secondary" id="viewItemFromEditBtn" type="button" style="display:none"
-                        title="View this item in read-only mode">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                       style="vertical-align: -2px; margin-right: 0.2rem;">
-                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
-                  </svg>View
+                <span id="clonePickerCount" class="clone-picker-count" style="display: none"></span>
+                <button class="btn" id="undoChangeBtn" type="button" style="display: none">
+                  Undo
                 </button>
-                <button class="btn secondary" id="cloneItemBtn" type="button" style="display:none"
-                        title="Clone this item as a new entry">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-                       stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                       style="vertical-align: -2px; margin-right: 0.2rem;">
-                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-                  </svg>Clone
+                <button
+                  class="btn secondary"
+                  id="viewItemFromEditBtn"
+                  type="button"
+                  style="display: none"
+                  title="View this item in read-only mode"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    style="vertical-align: -2px; margin-right: 0.2rem"
+                  >
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" /></svg
+                  >View
                 </button>
-                <button class="btn" id="cloneItemSaveAnotherBtn" type="button" style="display:none">Save &amp; Clone Another</button>
+                <button
+                  class="btn secondary"
+                  id="cloneItemBtn"
+                  type="button"
+                  style="display: none"
+                  title="Clone this item as a new entry"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    style="vertical-align: -2px; margin-right: 0.2rem"
+                  >
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg
+                  >Clone
+                </button>
+                <button
+                  class="btn"
+                  id="cloneItemSaveAnotherBtn"
+                  type="button"
+                  style="display: none"
+                >
+                  Save &amp; Clone Another
+                </button>
                 <button class="btn" id="cancelItem" type="button">Cancel</button>
-                <button class="btn premium" id="itemModalSubmit" type="submit">Add to Inventory</button>
+                <button class="btn premium" id="itemModalSubmit" type="submit">
+                  Add to Inventory
+                </button>
               </div>
             </div>
           </form>
@@ -1740,10 +2805,17 @@
        button is clicked in the inventory table. Allows users to update the
        notes field without opening the full edit form.
        ============================================================================= -->
-    <div class="modal" id="notesModal" style="display: none">
+    <div
+      class="modal"
+      id="notesModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="notesModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Item Notes</h2>
+          <h2 id="notesModalTitle">Item Notes</h2>
           <button aria-label="Close modal" class="modal-close" id="notesCloseBtn">×</button>
         </div>
         <div class="modal-body">
@@ -1762,14 +2834,30 @@
        Read-only view of item notes. Click the notes indicator icon to open.
        Shift+click the indicator to open the full edit modal instead.
        ============================================================================= -->
-    <div class="modal" id="notesViewModal" style="display: none">
-      <div class="modal-content" style="max-width: 32rem;">
+    <div
+      class="modal"
+      id="notesViewModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="notesViewTitle"
+    >
+      <div class="modal-content" style="max-width: 32rem">
         <div class="modal-header">
           <h2 id="notesViewTitle">Notes</h2>
           <button aria-label="Close modal" class="modal-close" id="notesViewCloseBtn">×</button>
         </div>
         <div class="modal-body">
-          <div id="notesViewContent" style="white-space: pre-wrap; line-height: 1.5; min-height: 3rem; max-height: 20rem; overflow-y: auto;"></div>
+          <div
+            id="notesViewContent"
+            style="
+              white-space: pre-wrap;
+              line-height: 1.5;
+              min-height: 3rem;
+              max-height: 20rem;
+              overflow-y: auto;
+            "
+          ></div>
           <div style="margin-top: 1rem; text-align: right">
             <button class="btn" type="button" id="notesViewEditBtn">Edit</button>
           </div>
@@ -1783,10 +2871,17 @@
        Displays the 10 most recent inventory cell changes tracked by the system.
        Data is populated dynamically from localStorage and rendered as a table.
        ============================================================================= -->
-    <div class="modal" id="changeLogModal" style="display: none">
+    <div
+      class="modal"
+      id="changeLogModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="changeLogModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Change Log</h2>
+          <h2 id="changeLogModalTitle">Change Log</h2>
           <button aria-label="Close modal" class="modal-close" id="changeLogCloseBtn">×</button>
         </div>
         <div class="modal-body">
@@ -1810,19 +2905,19 @@
             id="changeLogClearBtn"
             title="Clear log"
             aria-label="Clear log"
-          >↺</button>
+          >
+            ↺
+          </button>
         </div>
       </div>
     </div>
-  </div>
 
     <!-- =============================================================================
        STORAGE REPORT MODAL
 
        Displays the generated storage report inside an iframe for in-app viewing.
        ============================================================================= -->
-    
-    
+
     <!-- =============================================================================
        DETAILS MODAL WITH PIE CHARTS
        
@@ -1842,7 +2937,14 @@
        Modal implementation in detailsModal.js with Chart.js integration
        Data preparation and chart rendering handled by charts.js
        ============================================================================= -->
-    <div class="modal" id="detailsModal" style="display: none">
+    <div
+      class="modal"
+      id="detailsModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="detailsModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="detailsModalTitle"></h2>
@@ -1860,7 +2962,9 @@
               </div>
             </div>
             <div class="details-panel">
-              <h3 class="details-panel-title" id="locationPanelTitle">Breakdown by Purchase Location</h3>
+              <h3 class="details-panel-title" id="locationPanelTitle">
+                Breakdown by Purchase Location
+              </h3>
               <div class="chart-canvas-container">
                 <canvas class="chart-canvas" id="locationChart"></canvas>
               </div>
@@ -1875,19 +2979,79 @@
     <footer class="app-footer">
       <!-- Badges: repo (shields.io imgs) + status (CSS-rendered) on one row -->
       <div class="footer-badges">
-        <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener"><img src="https://img.shields.io/github/license/lbruton/StakTrakr?style=flat-square" alt="MIT License" height="20"></a>
-        <a href="https://app.codacy.com/gh/lbruton/StakTrakr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade" target="_blank" rel="noopener"><img src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8" alt="Codacy Badge" height="20"></a>
-        <a href="https://github.com/lbruton/StakTrakr/issues" target="_blank" rel="noopener"><img src="https://img.shields.io/github/issues/lbruton/StakTrakr?style=flat-square" alt="GitHub Issues" height="20"></a>
-        <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"><img src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community" alt="Community" height="20"></a>
-        <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/sponsor-%E2%99%A1-ea4aaa?style=flat-square" alt="Sponsor" height="20"></a>
-        <a id="versionBadge" class="shield-badge" style="display: none"><span class="shield-badge-label">version</span><span class="shield-badge-value shield-badge-value--green" id="versionBadgeValue"></span></a>
-        <a href="https://beta.staktrakr.com" target="_blank" rel="noopener" class="shield-badge"><span class="shield-badge-label">beta</span><span class="shield-badge-value shield-badge-value--yellow">available</span></a>
-        <a href="#" class="shield-badge" onclick="if(window.showFaqModal){event.preventDefault();window.showFaqModal();}"><span class="shield-badge-label">help</span><span class="shield-badge-value shield-badge-value--blue">FAQ</span></a>
-        <button type="button" class="shield-badge" id="apiHealthBadge" onclick="if(window.showApiHealthModal)window.showApiHealthModal()"><span class="shield-badge-label" id="apiHealthLabel">status</span><span class="shield-badge-value shield-badge-value--grey" id="apiHealthValue">checking&hellip;</span></button>
+        <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener"
+          ><img
+            src="https://img.shields.io/github/license/lbruton/StakTrakr?style=flat-square"
+            alt="MIT License"
+            height="20"
+        /></a>
+        <a
+          href="https://app.codacy.com/gh/lbruton/StakTrakr/dashboard?utm_source=gh&amp;utm_medium=referral&amp;utm_content=&amp;utm_campaign=Badge_grade"
+          target="_blank"
+          rel="noopener"
+          ><img
+            src="https://app.codacy.com/project/badge/Grade/b8d30126676546cb958fa6a7e0174da8"
+            alt="Codacy Badge"
+            height="20"
+        /></a>
+        <a href="https://github.com/lbruton/StakTrakr/issues" target="_blank" rel="noopener"
+          ><img
+            src="https://img.shields.io/github/issues/lbruton/StakTrakr?style=flat-square"
+            alt="GitHub Issues"
+            height="20"
+        /></a>
+        <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener"
+          ><img
+            src="https://img.shields.io/reddit/subreddit-subscribers/staktrakr?style=flat-square&amp;label=community"
+            alt="Community"
+            height="20"
+        /></a>
+        <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener"
+          ><img
+            src="https://img.shields.io/badge/sponsor-%E2%99%A1-ea4aaa?style=flat-square"
+            alt="Sponsor"
+            height="20"
+        /></a>
+        <a id="versionBadge" class="shield-badge" style="display: none"
+          ><span class="shield-badge-label">version</span
+          ><span class="shield-badge-value shield-badge-value--green" id="versionBadgeValue"></span
+        ></a>
+        <a href="https://beta.staktrakr.com" target="_blank" rel="noopener" class="shield-badge"
+          ><span class="shield-badge-label">beta</span
+          ><span class="shield-badge-value shield-badge-value--yellow">available</span></a
+        >
+        <a
+          href="#"
+          class="shield-badge"
+          onclick="
+            if (window.showFaqModal) {
+              event.preventDefault();
+              window.showFaqModal();
+            }
+          "
+          ><span class="shield-badge-label">help</span
+          ><span class="shield-badge-value shield-badge-value--blue">FAQ</span></a
+        >
+        <button
+          type="button"
+          class="shield-badge"
+          id="apiHealthBadge"
+          onclick="if (window.showApiHealthModal) window.showApiHealthModal();"
+        >
+          <span class="shield-badge-label" id="apiHealthLabel">status</span
+          ><span class="shield-badge-value shield-badge-value--grey" id="apiHealthValue"
+            >checking&hellip;</span
+          >
+        </button>
       </div>
       <!-- Row 3: Attribution text -->
       <div class="footer-meta">
-        Thank you for using <span id="footerBrand">StakTrakr</span> &middot; &copy; 2025-2026 <a id="footerDomain" href="https://staktrakr.com" target="_blank" rel="noopener">staktrakr.com</a> &middot; Created by <a href="https://www.lbruton.cc" target="_blank" rel="noopener">lbruton.cc</a>
+        Thank you for using <span id="footerBrand">StakTrakr</span> &middot; &copy; 2025-2026
+        <a id="footerDomain" href="https://staktrakr.com" target="_blank" rel="noopener"
+          >staktrakr.com</a
+        >
+        &middot; Created by
+        <a href="https://www.lbruton.cc" target="_blank" rel="noopener">lbruton.cc</a>
       </div>
     </footer>
     <!-- =============================================================================
@@ -1895,47 +3059,85 @@
        Shows per-feed freshness: market prices (manifest.json), spot prices
        (spot-history-YYYY.json), and Goldback daily scrape (goldback-spot.json).
        ============================================================================= -->
-    <div class="modal" id="apiHealthModal" style="display: none; z-index: 10000">
-      <div class="modal-content" style="max-width:580px">
+    <div
+      class="modal"
+      id="apiHealthModal"
+      style="display: none; z-index: 10000"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="apiHealthModalTitle"
+    >
+      <div class="modal-content" style="max-width: 580px">
         <div class="modal-header">
-          <h3>API Health Status</h3>
-          <button aria-label="Close modal" class="modal-close" id="apiHealthCloseBtn">&times;</button>
+          <h3 id="apiHealthModalTitle">API Health Status</h3>
+          <button aria-label="Close modal" class="modal-close" id="apiHealthCloseBtn">
+            &times;
+          </button>
         </div>
-        <div class="modal-body" style="padding:1rem 1.5rem">
+        <div class="modal-body" style="padding: 1rem 1.5rem">
           <div class="about-section">
             <div class="section-title">Status: <span id="apiHealthStatus">Checking…</span></div>
-            <table style="width:100%;font-size:0.9rem;border-collapse:collapse;margin-top:0.5rem">
+            <table
+              style="width: 100%; font-size: 0.9rem; border-collapse: collapse; margin-top: 0.5rem"
+            >
               <thead>
                 <tr>
-                  <th style="padding:0.3rem 0;text-align:left;color:var(--text-muted);font-weight:normal">Feed</th>
-                  <th style="padding:0.3rem 0;text-align:right;color:var(--text-muted);font-weight:normal">api (primary)</th>
-                  <th style="padding:0.3rem 0;text-align:right;color:var(--text-muted);font-weight:normal">api2 (backup)</th>
+                  <th
+                    style="
+                      padding: 0.3rem 0;
+                      text-align: left;
+                      color: var(--text-muted);
+                      font-weight: normal;
+                    "
+                  >
+                    Feed
+                  </th>
+                  <th
+                    style="
+                      padding: 0.3rem 0;
+                      text-align: right;
+                      color: var(--text-muted);
+                      font-weight: normal;
+                    "
+                  >
+                    api (primary)
+                  </th>
+                  <th
+                    style="
+                      padding: 0.3rem 0;
+                      text-align: right;
+                      color: var(--text-muted);
+                      font-weight: normal;
+                    "
+                  >
+                    api2 (backup)
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td style="padding:0.3rem 0;color:var(--text-muted)">Market prices</td>
-                  <td id="apiHealthMarket" style="text-align:right">&#x2014;</td>
-                  <td id="apiHealthMarket2" style="text-align:right">&#x2014;</td>
+                  <td style="padding: 0.3rem 0; color: var(--text-muted)">Market prices</td>
+                  <td id="apiHealthMarket" style="text-align: right">&#x2014;</td>
+                  <td id="apiHealthMarket2" style="text-align: right">&#x2014;</td>
                 </tr>
                 <tr>
-                  <td style="padding:0.3rem 0;color:var(--text-muted)">Spot prices</td>
-                  <td id="apiHealthSpot" style="text-align:right">&#x2014;</td>
-                  <td id="apiHealthSpot2" style="text-align:right">&#x2014;</td>
+                  <td style="padding: 0.3rem 0; color: var(--text-muted)">Spot prices</td>
+                  <td id="apiHealthSpot" style="text-align: right">&#x2014;</td>
+                  <td id="apiHealthSpot2" style="text-align: right">&#x2014;</td>
                 </tr>
                 <tr>
-                  <td style="padding:0.3rem 0;color:var(--text-muted)">Goldback (daily)</td>
-                  <td id="apiHealthGoldback" style="text-align:right">&#x2014;</td>
-                  <td id="apiHealthGoldback2" style="text-align:right">&#x2014;</td>
+                  <td style="padding: 0.3rem 0; color: var(--text-muted)">Goldback (daily)</td>
+                  <td id="apiHealthGoldback" style="text-align: right">&#x2014;</td>
+                  <td id="apiHealthGoldback2" style="text-align: right">&#x2014;</td>
                 </tr>
                 <tr>
-                  <td style="padding:0.3rem 0;color:var(--text-muted)">Coverage</td>
-                  <td id="apiHealthCoins" colspan="2" style="text-align:right">&#x2014;</td>
+                  <td style="padding: 0.3rem 0; color: var(--text-muted)">Coverage</td>
+                  <td id="apiHealthCoins" colspan="2" style="text-align: right">&#x2014;</td>
                 </tr>
               </tbody>
             </table>
           </div>
-          <div class="about-alert about-alert-compact" style="margin-top:1rem">
+          <div class="about-alert about-alert-compact" style="margin-top: 1rem">
             <span id="apiHealthVerdict">Fetching status…</span>
           </div>
         </div>
@@ -1951,108 +3153,389 @@
        Sub-modals (apiInfoModal, apiHistoryModal, catalogHistoryModal, apiQuotaModal,
        goldbackHistoryModal) remain as stacking overlays.
        ============================================================================= -->
-    <div class="modal" id="settingsModal" style="display: none">
+    <div
+      class="modal"
+      id="settingsModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settingsModalTitle"
+    >
       <div class="modal-content settings-modal-content">
         <div class="modal-header">
-          <h2>Settings</h2>
-          <button aria-label="Close modal" class="modal-close" id="settingsCloseBtn">&times;</button>
+          <h2 id="settingsModalTitle">Settings</h2>
+          <button aria-label="Close modal" class="modal-close" id="settingsCloseBtn">
+            &times;
+          </button>
         </div>
         <div class="settings-modal-layout">
           <!-- Sidebar Navigation -->
           <nav class="settings-sidebar">
             <button class="settings-nav-item active" data-section="about">
-              <svg viewBox="0 0 512 512" width="16" height="16" fill="none"><rect width="512" height="512" rx="96" fill="#0f1729"/><rect x="170" y="120" width="180" height="28" rx="14" fill="#94a3b8" opacity="0.45"/><rect x="140" y="165" width="140" height="28" rx="14" fill="#94a3b8" opacity="0.68"/><rect x="150" y="216" width="200" height="32" rx="16" fill="#d4a017"/><rect x="222" y="268" width="140" height="28" rx="14" fill="#94a3b8" opacity="0.68"/><rect x="142" y="313" width="180" height="28" rx="14" fill="#94a3b8" opacity="0.45"/></svg>
+              <svg viewBox="0 0 512 512" width="16" height="16" fill="none">
+                <rect width="512" height="512" rx="96" fill="#0f1729" />
+                <rect
+                  x="170"
+                  y="120"
+                  width="180"
+                  height="28"
+                  rx="14"
+                  fill="#94a3b8"
+                  opacity="0.45"
+                />
+                <rect
+                  x="140"
+                  y="165"
+                  width="140"
+                  height="28"
+                  rx="14"
+                  fill="#94a3b8"
+                  opacity="0.68"
+                />
+                <rect x="150" y="216" width="200" height="32" rx="16" fill="#d4a017" />
+                <rect
+                  x="222"
+                  y="268"
+                  width="140"
+                  height="28"
+                  rx="14"
+                  fill="#94a3b8"
+                  opacity="0.68"
+                />
+                <rect
+                  x="142"
+                  y="313"
+                  width="180"
+                  height="28"
+                  rx="14"
+                  fill="#94a3b8"
+                  opacity="0.45"
+                />
+              </svg>
               About
             </button>
-            <hr class="stk-nav-separator">
+            <hr class="stk-nav-separator" />
             <button class="settings-nav-item" data-section="site">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="2.5"/><circle cx="19" cy="13" r="2.5"/><circle cx="16" cy="20" r="2.5"/><circle cx="7" cy="20" r="2.5"/><circle cx="4" cy="13" r="2.5"/><circle cx="12" cy="13" r="3"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="13.5" cy="6.5" r="2.5" />
+                <circle cx="19" cy="13" r="2.5" />
+                <circle cx="16" cy="20" r="2.5" />
+                <circle cx="7" cy="20" r="2.5" />
+                <circle cx="4" cy="13" r="2.5" />
+                <circle cx="12" cy="13" r="3" />
+              </svg>
               Appearance
             </button>
             <button class="settings-nav-item" data-section="system">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
               Inventory
             </button>
             <button class="settings-nav-item" data-section="search">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
               Search
             </button>
             <button class="settings-nav-item" data-section="grouping">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="3" y="3" width="7" height="7" />
+                <rect x="14" y="3" width="7" height="7" />
+                <rect x="3" y="14" width="7" height="7" />
+                <rect x="14" y="14" width="7" height="7" />
+              </svg>
               Filters
             </button>
             <button class="settings-nav-item" data-section="images">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <circle cx="8.5" cy="8.5" r="1.5" />
+                <path d="m21 15-5-5L5 21" />
+              </svg>
               Images
             </button>
             <button class="settings-nav-item" data-section="currency">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="12" y1="1" x2="12" y2="23" />
+                <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+              </svg>
               Currency
             </button>
             <button class="settings-nav-item" data-section="goldback">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v12"/><path d="M9 9a3 3 0 0 1 3-1.5c2 0 3 1 3 2.5s-1 2.5-3 2.5-3 1-3 2.5a3 3 0 0 0 3 2.5"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 6v12" />
+                <path
+                  d="M9 9a3 3 0 0 1 3-1.5c2 0 3 1 3 2.5s-1 2.5-3 2.5-3 1-3 2.5a3 3 0 0 0 3 2.5"
+                />
+              </svg>
               Goldback
             </button>
             <button class="settings-nav-item" data-section="market">
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-                <path d="M0 0h1v15h15v1H0V0Zm14.817 3.113a.5.5 0 0 1 .07.704l-4.5 5.5a.5.5 0 0 1-.74.037L7.06 6.767l-3.656 5.027a.5.5 0 0 1-.808-.588l4-5.5a.5.5 0 0 1 .76-.063l2.573 2.565 4.15-5.073a.5.5 0 0 1 .704-.07z"/>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="M0 0h1v15h15v1H0V0Zm14.817 3.113a.5.5 0 0 1 .07.704l-4.5 5.5a.5.5 0 0 1-.74.037L7.06 6.767l-3.656 5.027a.5.5 0 0 1-.808-.588l4-5.5a.5.5 0 0 1 .76-.063l2.573 2.565 4.15-5.073a.5.5 0 0 1 .704-.07z"
+                />
               </svg>
               Market
             </button>
             <button class="settings-nav-item" data-section="storage">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <ellipse cx="12" cy="5" rx="9" ry="3" />
+                <path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5" />
+                <path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3" />
+              </svg>
               Storage
             </button>
             <button class="settings-nav-item" data-section="api">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"
+                />
+              </svg>
               API
             </button>
             <button class="settings-nav-item" data-section="cloud">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
+              </svg>
               Cloud
             </button>
             <button class="settings-nav-item" data-section="changelog">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v4l3 3"/><circle cx="12" cy="12" r="10"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 8v4l3 3" />
+                <circle cx="12" cy="12" r="10" />
+              </svg>
               Log
             </button>
             <button class="settings-nav-item" data-section="faq">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
               FAQ
             </button>
           </nav>
 
           <!-- Content Area -->
           <div class="settings-content-area">
-
             <!-- ===== ABOUT PANEL ===== -->
             <div class="settings-section-panel" id="settingsPanel_about" style="display: block">
-
               <!-- Hero -->
               <div class="about-hero layout-left">
                 <div class="about-logo-wrap">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="80" height="80">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 512 512"
+                    width="80"
+                    height="80"
+                  >
                     <defs>
-                      <linearGradient id="bgAbout" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f1729"/><stop offset="100%" stop-color="#1a2744"/></linearGradient>
-                      <linearGradient id="silverAbout" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#64748b"/><stop offset="50%" stop-color="#cbd5e1"/><stop offset="100%" stop-color="#94a3b8"/></linearGradient>
-                      <linearGradient id="goldAbout" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#92700c"/><stop offset="50%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#d4a017"/></linearGradient>
+                      <linearGradient id="bgAbout" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0%" stop-color="#0f1729" />
+                        <stop offset="100%" stop-color="#1a2744" />
+                      </linearGradient>
+                      <linearGradient id="silverAbout" x1="0" y1="0" x2="1" y2="0">
+                        <stop offset="0%" stop-color="#64748b" />
+                        <stop offset="50%" stop-color="#cbd5e1" />
+                        <stop offset="100%" stop-color="#94a3b8" />
+                      </linearGradient>
+                      <linearGradient id="goldAbout" x1="0" y1="0" x2="1" y2="0">
+                        <stop offset="0%" stop-color="#92700c" />
+                        <stop offset="50%" stop-color="#fbbf24" />
+                        <stop offset="100%" stop-color="#d4a017" />
+                      </linearGradient>
                     </defs>
-                    <rect width="512" height="512" rx="96" fill="url(#bgAbout)"/>
+                    <rect width="512" height="512" rx="96" fill="url(#bgAbout)" />
                     <!-- S-stack (scaled down with wordmark below) -->
-                    <rect x="188" y="90" width="180" height="26" rx="13" fill="url(#silverAbout)" opacity="0.45"/>
-                    <rect x="152" y="128" width="145" height="26" rx="13" fill="url(#silverAbout)" opacity="0.68"/>
-                    <rect x="156" y="172" width="200" height="30" rx="15" fill="url(#goldAbout)"/>
-                    <rect x="215" y="218" width="145" height="26" rx="13" fill="url(#silverAbout)" opacity="0.68"/>
-                    <rect x="144" y="256" width="192" height="26" rx="13" fill="url(#silverAbout)" opacity="0.45"/>
+                    <rect
+                      x="188"
+                      y="90"
+                      width="180"
+                      height="26"
+                      rx="13"
+                      fill="url(#silverAbout)"
+                      opacity="0.45"
+                    />
+                    <rect
+                      x="152"
+                      y="128"
+                      width="145"
+                      height="26"
+                      rx="13"
+                      fill="url(#silverAbout)"
+                      opacity="0.68"
+                    />
+                    <rect x="156" y="172" width="200" height="30" rx="15" fill="url(#goldAbout)" />
+                    <rect
+                      x="215"
+                      y="218"
+                      width="145"
+                      height="26"
+                      rx="13"
+                      fill="url(#silverAbout)"
+                      opacity="0.68"
+                    />
+                    <rect
+                      x="144"
+                      y="256"
+                      width="192"
+                      height="26"
+                      rx="13"
+                      fill="url(#silverAbout)"
+                      opacity="0.45"
+                    />
                     <!-- Wordmark -->
-                    <text x="256" y="348" text-anchor="middle" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="52" font-weight="700" letter-spacing="4">
-                      <tspan fill="#e2e8f0">STAK</tspan><tspan fill="#d4a017">TRAKR</tspan>
+                    <text
+                      x="256"
+                      y="348"
+                      text-anchor="middle"
+                      font-family="-apple-system, 'Segoe UI', sans-serif"
+                      font-size="52"
+                      font-weight="700"
+                      letter-spacing="4"
+                    >
+                      <tspan fill="#e2e8f0">STAK</tspan>
+                      <tspan fill="#d4a017">TRAKR</tspan>
                     </text>
                     <!-- Tagline -->
-                    <text x="256" y="386" text-anchor="middle" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="13" fill="#475569" letter-spacing="3">TRACK YOUR STACK</text>
+                    <text
+                      x="256"
+                      y="386"
+                      text-anchor="middle"
+                      font-family="-apple-system, 'Segoe UI', sans-serif"
+                      font-size="13"
+                      fill="#475569"
+                      letter-spacing="3"
+                    >
+                      TRACK YOUR STACK
+                    </text>
                   </svg>
                 </div>
                 <div class="about-hero-text">
-                  <div class="about-app-name" id="aboutAppName"><span class="stak">STAK</span><span class="trakr">TRAKR</span></div>
+                  <div class="about-app-name" id="aboutAppName">
+                    <span class="stak">STAK</span><span class="trakr">TRAKR</span>
+                  </div>
                   <div class="about-version" id="aboutVersion"></div>
                   <div class="about-tagline">Track Your Stack</div>
                   <p class="about-desc">
@@ -2062,28 +3545,113 @@
                     to a server.
                   </p>
                   <div class="about-badges">
-                    <a id="aboutSiteLink" href="https://www.staktrakr.com" target="_blank" rel="noopener" class="about-badge-item">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="13" height="13"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    <a
+                      id="aboutSiteLink"
+                      href="https://www.staktrakr.com"
+                      target="_blank"
+                      rel="noopener"
+                      class="about-badge-item"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        width="13"
+                        height="13"
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                        <path d="M2 12h20" />
+                        <path
+                          d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+                        />
+                      </svg>
                       <span id="aboutSiteDomain">staktrakr.com</span>
                     </a>
-                    <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener" class="about-badge-item">
-                      <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+                    <a
+                      href="https://github.com/lbruton/StakTrakr"
+                      target="_blank"
+                      rel="noopener"
+                      class="about-badge-item"
+                    >
+                      <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13">
+                        <path
+                          d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"
+                        />
+                      </svg>
                       Source
                     </a>
-                    <a href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener" class="about-badge-item">
-                      <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
+                    <a
+                      href="https://www.reddit.com/r/staktrakr/"
+                      target="_blank"
+                      rel="noopener"
+                      class="about-badge-item"
+                    >
+                      <svg viewBox="0 0 24 24" fill="currentColor" width="13" height="13">
+                        <path
+                          d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"
+                        />
+                      </svg>
                       Community
                     </a>
-                    <a href="https://github.com/lbruton/StakTrakr/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="about-badge-item">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="13" height="13"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                    <a
+                      href="https://github.com/lbruton/StakTrakr/blob/main/LICENSE"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="about-badge-item"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        width="13"
+                        height="13"
+                      >
+                        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                      </svg>
                       MIT License
                     </a>
-                    <a href="https://github.com/sponsors/lbruton" target="_blank" rel="noopener" class="about-badge-item">
-                      <svg viewBox="0 0 24 24" fill="currentColor" stroke="none" width="13" height="13"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+                    <a
+                      href="https://github.com/sponsors/lbruton"
+                      target="_blank"
+                      rel="noopener"
+                      class="about-badge-item"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                        stroke="none"
+                        width="13"
+                        height="13"
+                      >
+                        <path
+                          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+                        />
+                      </svg>
                       Sponsor
                     </a>
-                    <button class="about-badge-item" id="apiHealthBadgeAbout" onclick="if(window.showApiHealthModal)showApiHealthModal()">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="13" height="13"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+                    <button
+                      class="about-badge-item"
+                      id="apiHealthBadgeAbout"
+                      onclick="if (window.showApiHealthModal) showApiHealthModal();"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        width="13"
+                        height="13"
+                      >
+                        <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                      </svg>
                       API Status
                     </button>
                   </div>
@@ -2092,10 +3660,18 @@
 
               <!-- What's New -->
               <div class="about-section">
-                <div class="about-section-title">WHAT'S NEW IN <span id="aboutCurrentVersion"></span></div>
+                <div class="about-section-title">
+                  WHAT'S NEW IN <span id="aboutCurrentVersion"></span>
+                </div>
                 <ul id="aboutChangelogLatest" class="about-whats-new-list"></ul>
-                <div class="about-section-footer" style="margin-top:8px;">
-                  <button class="about-card-link" id="aboutShowChangelogBtn" onclick="if(window.showFullChangelog)showFullChangelog()">View Full Changelog</button>
+                <div class="about-section-footer" style="margin-top: 8px">
+                  <button
+                    class="about-card-link"
+                    id="aboutShowChangelogBtn"
+                    onclick="if (window.showFullChangelog) showFullChangelog();"
+                  >
+                    View Full Changelog
+                  </button>
                 </div>
               </div>
 
@@ -2107,18 +3683,58 @@
 
               <!-- Disclaimer -->
               <div class="about-disclaimer" id="aboutDisclaimer">
-                <strong>Disclaimer:</strong> Data is stored locally in your browser. Export regularly to keep a backup.
-                Spot prices are for reference only and may not reflect real-time market conditions.
-                Use at your own risk. <a href="#" onclick="var d=document.getElementById('aboutDisclaimerFull');if(d){d.style.display=d.style.display==='none'?'block':'none';this.textContent=d.style.display==='none'?'Show full disclaimer':'Hide disclaimer'}return false;" style="color:var(--primary,#3b82f6);">Show full disclaimer</a>
-                <div id="aboutDisclaimerFull" style="display:none;margin-top:10px;padding-top:10px;border-top:1px solid var(--border);">
-                  <p style="margin:0 0 8px"><strong>Your Privacy is Protected:</strong> All data is stored locally in your browser using localStorage and <em>never transmitted to any server</em>. Your precious metals inventory information remains completely private and under your control.</p>
-                  <p style="margin:0 0 8px"><strong>Data Backup Responsibility:</strong> Since data is stored locally, it will be lost if you clear browser history, reset browser data, or use private browsing mode. Remember to export your data regularly to keep a copy.</p>
-                  <p style="margin:0 0 8px"><strong>Use at Your Own Risk:</strong> This tool is provided for informational and organizational purposes only. The developer assumes no responsibility for any financial decisions, investment choices, or data loss. Always verify spot prices and calculations independently.</p>
-                  <p style="margin:0"><strong>Spot Price Accuracy:</strong> Prices displayed are for reference only and may not reflect real-time market conditions. Always confirm current pricing with your dealer or official market sources before making transactions.</p>
+                <strong>Disclaimer:</strong> Data is stored locally in your browser. Export
+                regularly to keep a backup. Spot prices are for reference only and may not reflect
+                real-time market conditions. Use at your own risk.
+                <a
+                  href="#"
+                  onclick="
+                    var d = document.getElementById('aboutDisclaimerFull');
+                    if (d) {
+                      d.style.display = d.style.display === 'none' ? 'block' : 'none';
+                      this.textContent =
+                        d.style.display === 'none' ? 'Show full disclaimer' : 'Hide disclaimer';
+                    }
+                    return false;
+                  "
+                  style="color: var(--primary, #3b82f6)"
+                  >Show full disclaimer</a
+                >
+                <div
+                  id="aboutDisclaimerFull"
+                  style="
+                    display: none;
+                    margin-top: 10px;
+                    padding-top: 10px;
+                    border-top: 1px solid var(--border);
+                  "
+                >
+                  <p style="margin: 0 0 8px">
+                    <strong>Your Privacy is Protected:</strong> All data is stored locally in your
+                    browser using localStorage and <em>never transmitted to any server</em>. Your
+                    precious metals inventory information remains completely private and under your
+                    control.
+                  </p>
+                  <p style="margin: 0 0 8px">
+                    <strong>Data Backup Responsibility:</strong> Since data is stored locally, it
+                    will be lost if you clear browser history, reset browser data, or use private
+                    browsing mode. Remember to export your data regularly to keep a copy.
+                  </p>
+                  <p style="margin: 0 0 8px">
+                    <strong>Use at Your Own Risk:</strong> This tool is provided for informational
+                    and organizational purposes only. The developer assumes no responsibility for
+                    any financial decisions, investment choices, or data loss. Always verify spot
+                    prices and calculations independently.
+                  </p>
+                  <p style="margin: 0">
+                    <strong>Spot Price Accuracy:</strong> Prices displayed are for reference only
+                    and may not reflect real-time market conditions. Always confirm current pricing
+                    with your dealer or official market sources before making transactions.
+                  </p>
                 </div>
               </div>
-
-            </div><!-- #settingsPanel_about -->
+            </div>
+            <!-- #settingsPanel_about -->
 
             <!-- ===== APPEARANCE SETTINGS ===== -->
             <div class="settings-section-panel" id="settingsPanel_site" style="display: none">
@@ -2126,24 +3742,115 @@
 
               <!-- ── Card 1: Visual style pickers ── -->
               <div class="settings-fieldset">
-                <div style="display:grid; grid-template-columns: 1fr 1fr; gap:0.75rem 1.5rem; align-items:end;">
-                  <div style="display:flex; flex-direction:column; gap:0.35rem;">
+                <div
+                  style="
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 0.75rem 1.5rem;
+                    align-items: end;
+                  "
+                >
+                  <div style="display: flex; flex-direction: column; gap: 0.35rem">
                     <div class="settings-group-label">Color scheme</div>
-                    <div class="theme-picker" style="display:flex; flex-wrap:nowrap; gap:0;">
-                      <button class="theme-option" data-theme="light" title="Light" style="padding:0.55rem 1rem; font-size:0.8125rem; border-radius:var(--radius) 0 0 var(--radius); border-right-width:0;">&#9728;&#65039; Light</button>
-                      <button class="theme-option" data-theme="dark" title="Dark" style="padding:0.55rem 1rem; font-size:0.8125rem; border-radius:0; border-right-width:0;">&#127769; Dark</button>
-                      <button class="theme-option" data-theme="sepia" title="Sepia" style="padding:0.55rem 1rem; font-size:0.8125rem; border-radius:0 var(--radius) var(--radius) 0;">&#128220; Sepia</button>
+                    <div class="theme-picker" style="display: flex; flex-wrap: nowrap; gap: 0">
+                      <button
+                        class="theme-option"
+                        data-theme="light"
+                        title="Light"
+                        style="
+                          padding: 0.55rem 1rem;
+                          font-size: 0.8125rem;
+                          border-radius: var(--radius) 0 0 var(--radius);
+                          border-right-width: 0;
+                        "
+                      >
+                        &#9728;&#65039; Light
+                      </button>
+                      <button
+                        class="theme-option"
+                        data-theme="dark"
+                        title="Dark"
+                        style="
+                          padding: 0.55rem 1rem;
+                          font-size: 0.8125rem;
+                          border-radius: 0;
+                          border-right-width: 0;
+                        "
+                      >
+                        &#127769; Dark
+                      </button>
+                      <button
+                        class="theme-option"
+                        data-theme="sepia"
+                        title="Sepia"
+                        style="
+                          padding: 0.55rem 1rem;
+                          font-size: 0.8125rem;
+                          border-radius: 0 var(--radius) var(--radius) 0;
+                        "
+                      >
+                        &#128220; Sepia
+                      </button>
                     </div>
                   </div>
-                  <div style="display:flex; flex-direction:column; gap:0.35rem;">
+                  <div style="display: flex; flex-direction: column; gap: 0.35rem">
                     <div class="settings-group-label">Inventory View</div>
-                    <div class="chip-sort-toggle" id="settingsCardStyleToggle" style="width:fit-content;">
-                      <button type="button" class="chip-sort-btn active" data-style="A" title="Sparkline cards" style="padding:0.55rem 1rem; font-size:0.8125rem; min-width:2.5rem;">A</button>
-                      <button type="button" class="chip-sort-btn" data-style="B" title="Hero cards" style="padding:0.55rem 1rem; font-size:0.8125rem; min-width:2.5rem;">B</button>
-                      <button type="button" class="chip-sort-btn" data-style="C" title="Split cards" style="padding:0.55rem 1rem; font-size:0.8125rem; min-width:2.5rem;">C</button>
-                      <button type="button" class="chip-sort-btn" data-style="D" title="Table view" style="padding:0.55rem 0.9rem; font-size:0.8125rem; min-width:2.5rem;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                          <rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="9" x2="9" y2="21"/><line x1="15" y1="9" x2="15" y2="21"/>
+                    <div
+                      class="chip-sort-toggle"
+                      id="settingsCardStyleToggle"
+                      style="width: fit-content"
+                    >
+                      <button
+                        type="button"
+                        class="chip-sort-btn active"
+                        data-style="A"
+                        title="Sparkline cards"
+                        style="padding: 0.55rem 1rem; font-size: 0.8125rem; min-width: 2.5rem"
+                      >
+                        A
+                      </button>
+                      <button
+                        type="button"
+                        class="chip-sort-btn"
+                        data-style="B"
+                        title="Hero cards"
+                        style="padding: 0.55rem 1rem; font-size: 0.8125rem; min-width: 2.5rem"
+                      >
+                        B
+                      </button>
+                      <button
+                        type="button"
+                        class="chip-sort-btn"
+                        data-style="C"
+                        title="Split cards"
+                        style="padding: 0.55rem 1rem; font-size: 0.8125rem; min-width: 2.5rem"
+                      >
+                        C
+                      </button>
+                      <button
+                        type="button"
+                        class="chip-sort-btn"
+                        data-style="D"
+                        title="Table view"
+                        style="padding: 0.55rem 0.9rem; font-size: 0.8125rem; min-width: 2.5rem"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <rect x="3" y="3" width="18" height="18" rx="2" />
+                          <line x1="3" y1="9" x2="21" y2="9" />
+                          <line x1="3" y1="15" x2="21" y2="15" />
+                          <line x1="9" y1="9" x2="9" y2="21" />
+                          <line x1="15" y1="9" x2="15" y2="21" />
                         </svg>
                       </button>
                     </div>
@@ -2153,8 +3860,15 @@
 
               <!-- ── Card 2: Display preference dropdowns ── -->
               <div class="settings-fieldset">
-                <div style="display:grid; grid-template-columns: repeat(3, 1fr); gap:0.75rem 1rem; align-items:end;">
-                  <div style="display:flex; flex-direction:column; gap:0.35rem;">
+                <div
+                  style="
+                    display: grid;
+                    grid-template-columns: repeat(3, 1fr);
+                    gap: 0.75rem 1rem;
+                    align-items: end;
+                  "
+                >
+                  <div style="display: flex; flex-direction: column; gap: 0.35rem">
                     <div class="settings-group-label">Timezone</div>
                     <select id="settingsTimezone" class="form-control">
                       <option value="auto">Auto</option>
@@ -2180,10 +3894,10 @@
                       </optgroup>
                     </select>
                   </div>
-                  <div style="display:flex; flex-direction:column; gap:0.35rem;">
+                  <div style="display: flex; flex-direction: column; gap: 0.35rem">
                     <div class="settings-group-label">Default Sort</div>
-                    <div style="display:flex; gap:0.5rem; align-items:center;">
-                      <select id="settingsDefaultSortColumn" style="flex:1;">
+                    <div style="display: flex; gap: 0.5rem; align-items: center">
+                      <select id="settingsDefaultSortColumn" style="flex: 1">
                         <option value="0">Date</option>
                         <option value="1">Metal</option>
                         <option value="2">Type</option>
@@ -2197,12 +3911,14 @@
                         <option value="11">Source</option>
                       </select>
                       <div id="settingsDefaultSortDir" class="chip-sort-toggle">
-                        <button type="button" class="chip-sort-btn active" data-val="asc">Asc</button>
+                        <button type="button" class="chip-sort-btn active" data-val="asc">
+                          Asc
+                        </button>
                         <button type="button" class="chip-sort-btn" data-val="desc">Desc</button>
                       </div>
                     </div>
                   </div>
-                  <div style="display:flex; flex-direction:column; gap:0.35rem;">
+                  <div style="display: flex; flex-direction: column; gap: 0.35rem">
                     <div class="settings-group-label">Visible Items</div>
                     <select id="settingsItemsPerPage">
                       <option value="3">3</option>
@@ -2223,17 +3939,28 @@
 
               <!-- ── Header Buttons ── -->
               <div class="settings-fieldset">
-                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.25rem">
-                  <div class="settings-fieldset-title" style="margin-bottom:0">Header Buttons</div>
-                  <div style="display:flex;align-items:center;gap:0.5rem">
-                    <span style="font-size:0.75rem;color:var(--text-secondary);font-weight:500">Show text</span>
+                <div
+                  style="
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    margin-bottom: 0.25rem;
+                  "
+                >
+                  <div class="settings-fieldset-title" style="margin-bottom: 0">Header Buttons</div>
+                  <div style="display: flex; align-items: center; gap: 0.5rem">
+                    <span style="font-size: 0.75rem; color: var(--text-secondary); font-weight: 500"
+                      >Show text</span
+                    >
                     <div class="chip-sort-toggle" id="settingsHeaderShowText_hdr">
                       <button type="button" class="chip-sort-btn" data-val="yes">On</button>
                       <button type="button" class="chip-sort-btn" data-val="no">Off</button>
                     </div>
                   </div>
                 </div>
-                <p class="settings-subtext">Optional buttons shown in the top-right of the app header.</p>
+                <p class="settings-subtext">
+                  Optional buttons shown in the top-right of the app header.
+                </p>
                 <div id="headerBtnConfigTable"></div>
               </div>
 
@@ -2243,14 +3970,18 @@
                 <div class="settings-card-grid">
                   <div class="settings-card">
                     <div class="settings-group-label">Metal Order</div>
-                    <p class="settings-subtext">Reorder and show/hide spot price and summary cards. Drag rows to reorder.</p>
+                    <p class="settings-subtext">
+                      Reorder and show/hide spot price and summary cards. Drag rows to reorder.
+                    </p>
                     <div class="chip-grouping-table-container" id="metalOrderConfigContainer">
                       <div class="chip-grouping-empty">Loading...</div>
                     </div>
                   </div>
                   <div class="settings-card">
                     <div class="settings-group-label">Inline Name Chips</div>
-                    <p class="settings-subtext">Choose which badges appear next to item names in the table.</p>
+                    <p class="settings-subtext">
+                      Choose which badges appear next to item names in the table.
+                    </p>
                     <div class="chip-grouping-table-container" id="inlineChipConfigContainer">
                       <div class="chip-grouping-empty">Loading...</div>
                     </div>
@@ -2275,10 +4006,16 @@
                 <div class="settings-fieldset-title">Summary Totals</div>
                 <div class="settings-group">
                   <div class="settings-group-label">Show realized gains/losses</div>
-                  <p class="settings-subtext">Display the "Realized" line on summary cards for disposed items.</p>
-                  <label class="dispose-toggle-card" for="settingsShowRealized" style="width:fit-content">
+                  <p class="settings-subtext">
+                    Display the "Realized" line on summary cards for disposed items.
+                  </p>
+                  <label
+                    class="dispose-toggle-card"
+                    for="settingsShowRealized"
+                    style="width: fit-content"
+                  >
                     <span class="toggle-switch">
-                      <input type="checkbox" id="settingsShowRealized">
+                      <input type="checkbox" id="settingsShowRealized" />
                       <span class="toggle-track"></span>
                     </span>
                     <span>Realized row</span>
@@ -2290,14 +4027,14 @@
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">Item Detail Modal</div>
                 <div class="settings-group">
-                  <p class="settings-subtext">Reorder and toggle sections in the item view modal.</p>
+                  <p class="settings-subtext">
+                    Reorder and toggle sections in the item view modal.
+                  </p>
                   <div class="chip-grouping-table-container" id="viewModalSectionConfigContainer">
                     <div class="chip-grouping-empty">Loading...</div>
                   </div>
                 </div>
               </div>
-
-
             </div>
 
             <!-- ===== TABLE SETTINGS ===== -->
@@ -2319,7 +4056,9 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Filter chip max count</div>
-                <p class="settings-subtext">Maximum number of filter chips to display. All = no limit.</p>
+                <p class="settings-subtext">
+                  Maximum number of filter chips to display. All = no limit.
+                </p>
                 <select id="settingsChipMaxCount">
                   <option value="25">25</option>
                   <option value="50">50</option>
@@ -2331,7 +4070,9 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Smart name grouping</div>
-                <p class="settings-subtext">Group item names by base name (e.g., "American Silver Eagle (3)").</p>
+                <p class="settings-subtext">
+                  Group item names by base name (e.g., "American Silver Eagle (3)").
+                </p>
                 <div class="chip-sort-toggle" id="settingsGroupNameChips">
                   <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
                   <button type="button" class="chip-sort-btn" data-val="no">Off</button>
@@ -2340,7 +4081,10 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Dynamic name chips</div>
-                <p class="settings-subtext">Auto-extract text from parentheses and quotes in item names as additional filter chips.</p>
+                <p class="settings-subtext">
+                  Auto-extract text from parentheses and quotes in item names as additional filter
+                  chips.
+                </p>
                 <div class="chip-sort-toggle" id="settingsDynamicChips">
                   <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
                   <button type="button" class="chip-sort-btn" data-val="no">Off</button>
@@ -2349,7 +4093,10 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Filter chip categories</div>
-                <p class="settings-subtext">Enable, disable, and reorder chip categories. Assign the same Group letter to merge categories so their chips sort together.</p>
+                <p class="settings-subtext">
+                  Enable, disable, and reorder chip categories. Assign the same Group letter to
+                  merge categories so their chips sort together.
+                </p>
                 <div class="chip-grouping-table-container" id="filterChipCategoryContainer">
                   <div class="chip-grouping-empty">Loading…</div>
                 </div>
@@ -2357,7 +4104,9 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Chip quantity badge</div>
-                <p class="settings-subtext">Show item count on each filter chip (e.g., "Gold (13)").</p>
+                <p class="settings-subtext">
+                  Show item count on each filter chip (e.g., "Gold (13)").
+                </p>
                 <div class="chip-sort-toggle" id="settingsChipQtyBadge">
                   <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
                   <button type="button" class="chip-sort-btn" data-val="no">Off</button>
@@ -2375,7 +4124,9 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Chip blacklist</div>
-                <p class="settings-subtext">Suppressed auto-generated chips. Right-click any name chip to add it here.</p>
+                <p class="settings-subtext">
+                  Suppressed auto-generated chips. Right-click any name chip to add it here.
+                </p>
                 <div class="chip-grouping-controls">
                   <select id="blacklistInput" class="chip-grouping-input">
                     <option value="">Select a chip to suppress…</option>
@@ -2389,10 +4140,22 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Custom grouping rules</div>
-                <p class="settings-subtext">Define chip labels with comma or semicolon-separated name patterns.</p>
+                <p class="settings-subtext">
+                  Define chip labels with comma or semicolon-separated name patterns.
+                </p>
                 <div class="chip-grouping-controls">
-                  <input type="text" id="customGroupLabelInput" class="chip-grouping-input" placeholder="Chip label">
-                  <input type="text" id="customGroupPatternsInput" class="chip-grouping-input-wide" placeholder="Patterns (comma-separated)">
+                  <input
+                    type="text"
+                    id="customGroupLabelInput"
+                    class="chip-grouping-input"
+                    placeholder="Chip label"
+                  />
+                  <input
+                    type="text"
+                    id="customGroupPatternsInput"
+                    class="chip-grouping-input-wide"
+                    placeholder="Patterns (comma-separated)"
+                  />
                   <button type="button" class="btn" id="addCustomGroupBtn">Add Rule</button>
                 </div>
                 <div class="chip-grouping-table-container" id="customGroupTableContainer">
@@ -2407,7 +4170,10 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Fuzzy autocomplete</div>
-                <p class="settings-subtext">Show smart suggestions when typing in the Name, Purchase Location, and Storage Location fields.</p>
+                <p class="settings-subtext">
+                  Show smart suggestions when typing in the Name, Purchase Location, and Storage
+                  Location fields.
+                </p>
                 <div class="chip-sort-toggle" id="settingsFuzzyAutocomplete">
                   <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
                   <button type="button" class="chip-sort-btn" data-val="no">Off</button>
@@ -2416,7 +4182,10 @@
 
               <div class="settings-group">
                 <div class="settings-group-label">Numista name matching</div>
-                <p class="settings-subtext">Rewrite common coin names (e.g. "ASE") into Numista-optimized search queries with direct lookups for known catalog IDs.</p>
+                <p class="settings-subtext">
+                  Rewrite common coin names (e.g. "ASE") into Numista-optimized search queries with
+                  direct lookups for known catalog IDs.
+                </p>
                 <div class="chip-sort-toggle" id="settingsNumistaLookup">
                   <button type="button" class="chip-sort-btn active" data-val="yes">On</button>
                   <button type="button" class="chip-sort-btn" data-val="no">Off</button>
@@ -2424,20 +4193,52 @@
               </div>
 
               <div class="settings-group">
-                <div class="settings-group-label">Built-in patterns <span id="seedRuleCount" style="font-size:0.8em;opacity:0.6;margin-left:0.3em;"></span></div>
-                <p class="settings-subtext">Pre-configured lookup rules shipped with StakTrakr. Toggle individual rules on or off.</p>
-                <div class="chip-grouping-table-container" id="seedRuleTableContainer" style="max-height:220px;overflow-y:auto;">
+                <div class="settings-group-label">
+                  Built-in patterns
+                  <span
+                    id="seedRuleCount"
+                    style="font-size: 0.8em; opacity: 0.6; margin-left: 0.3em"
+                  ></span>
+                </div>
+                <p class="settings-subtext">
+                  Pre-configured lookup rules shipped with StakTrakr. Toggle individual rules on or
+                  off.
+                </p>
+                <div
+                  class="chip-grouping-table-container"
+                  id="seedRuleTableContainer"
+                  style="max-height: 220px; overflow-y: auto"
+                >
                   <div class="chip-grouping-empty">Loading…</div>
                 </div>
               </div>
 
               <div class="settings-group">
                 <div class="settings-group-label">Custom patterns</div>
-                <p class="settings-subtext">Add your own regex patterns to rewrite Numista search queries. Custom rules override built-in patterns.</p>
+                <p class="settings-subtext">
+                  Add your own regex patterns to rewrite Numista search queries. Custom rules
+                  override built-in patterns.
+                </p>
                 <div class="chip-grouping-controls">
-                  <input type="text" id="numistaRulePatternInput" class="chip-grouping-input" placeholder="Regex pattern">
-                  <input type="text" id="numistaRuleReplacementInput" class="chip-grouping-input-wide" placeholder="Numista query">
-                  <input type="text" id="numistaRuleIdInput" class="chip-grouping-input" placeholder="N# (optional)" style="width:90px;">
+                  <input
+                    type="text"
+                    id="numistaRulePatternInput"
+                    class="chip-grouping-input"
+                    placeholder="Regex pattern"
+                  />
+                  <input
+                    type="text"
+                    id="numistaRuleReplacementInput"
+                    class="chip-grouping-input-wide"
+                    placeholder="Numista query"
+                  />
+                  <input
+                    type="text"
+                    id="numistaRuleIdInput"
+                    class="chip-grouping-input"
+                    placeholder="N# (optional)"
+                    style="width: 90px"
+                  />
                   <button type="button" class="btn" id="addNumistaRuleBtn">Add</button>
                 </div>
                 <div class="chip-grouping-table-container" id="customRuleTableContainer">
@@ -2452,7 +4253,9 @@
 
               <div class="settings-actions">
                 <button type="button" class="btn success" id="syncAllBtn">Sync Metals</button>
-                <button type="button" class="btn danger" id="flushCacheBtn">Flush Metals Cache</button>
+                <button type="button" class="btn danger" id="flushCacheBtn">
+                  Flush Metals Cache
+                </button>
                 <button type="button" class="btn" id="apiHistoryBtn">Metals History</button>
                 <button type="button" class="btn" id="catalogHistoryBtn">Catalog History</button>
               </div>
@@ -2461,13 +4264,21 @@
 
               <!-- Provider Tabs — StakTrakr & Numista pinned, metals draggable -->
               <div class="settings-provider-tabs">
-                <button class="settings-provider-tab pinned active" data-provider="STAKTRAKR">StakTrakr</button>
-                <button class="settings-provider-tab pinned" data-provider="NUMISTA">Numista</button>
+                <button class="settings-provider-tab pinned active" data-provider="STAKTRAKR">
+                  StakTrakr
+                </button>
+                <button class="settings-provider-tab pinned" data-provider="NUMISTA">
+                  Numista
+                </button>
                 <button class="settings-provider-tab pinned" data-provider="PCGS">PCGS</button>
                 <button class="settings-provider-tab" data-provider="METALS_DEV">Metals.dev</button>
                 <button class="settings-provider-tab" data-provider="METALS_API">Metals-API</button>
-                <button class="settings-provider-tab" data-provider="METAL_PRICE_API">MetalPriceAPI</button>
-                <button class="settings-provider-tab" data-provider="CUSTOM">Custom Spot API</button>
+                <button class="settings-provider-tab" data-provider="METAL_PRICE_API">
+                  MetalPriceAPI
+                </button>
+                <button class="settings-provider-tab" data-provider="CUSTOM">
+                  Custom Spot API
+                </button>
               </div>
 
               <!-- Numista Provider Panel -->
@@ -2478,91 +4289,251 @@
                   </div>
                   <div class="api-key-row">
                     <label for="numistaApiKey">API Key:</label>
-                    <input type="password" id="numistaApiKey" placeholder="Enter your Numista API key" />
+                    <input
+                      type="password"
+                      id="numistaApiKey"
+                      placeholder="Enter your Numista API key"
+                    />
                   </div>
                   <div class="api-key-note">
-                    <p>Get a free API key at <a href="https://en.numista.com/api/" target="_blank" rel="noopener">numista.com/api</a> (2,000 requests/month free tier). Your key is stored locally in your browser.</p>
+                    <p>
+                      Get a free API key at
+                      <a href="https://en.numista.com/api/" target="_blank" rel="noopener"
+                        >numista.com/api</a
+                      >
+                      (2,000 requests/month free tier). Your key is stored locally in your browser.
+                    </p>
                   </div>
-                  <div id="numistaUsageBar" class="api-usage" style="margin-top: 0.75rem;"></div>
+                  <div id="numistaUsageBar" class="api-usage" style="margin-top: 0.75rem"></div>
                   <div class="provider-info">
-                    <div class="provider-status" id="numistaProviderStatus"><span class="status-dot"></span><span class="status-text">Disconnected</span></div>
+                    <div class="provider-status" id="numistaProviderStatus">
+                      <span class="status-dot"></span><span class="status-text">Disconnected</span>
+                    </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button class="btn api-save-btn success" id="saveNumistaBtn" data-provider="NUMISTA">Save Key</button>
-                      <button class="btn api-sync-btn info" id="testNumistaBtn" data-provider="NUMISTA">Test Connection</button>
-                      <button class="btn api-clear-btn warning" id="clearNumistaBtn" data-provider="NUMISTA">Clear Key</button>
+                      <button
+                        class="btn api-save-btn success"
+                        id="saveNumistaBtn"
+                        data-provider="NUMISTA"
+                      >
+                        Save Key
+                      </button>
+                      <button
+                        class="btn api-sync-btn info"
+                        id="testNumistaBtn"
+                        data-provider="NUMISTA"
+                      >
+                        Test Connection
+                      </button>
+                      <button
+                        class="btn api-clear-btn warning"
+                        id="clearNumistaBtn"
+                        data-provider="NUMISTA"
+                      >
+                        Clear Key
+                      </button>
                     </div>
                   </div>
-                  <div id="numistaStatus" class="api-status" style="margin-top: 0.5rem;"></div>
+                  <div id="numistaStatus" class="api-status" style="margin-top: 0.5rem"></div>
 
                   <!-- Numista Bulk Sync (STACK-87/88) -->
-                  <div class="settings-group" id="numistaBulkSyncGroup" style="margin-top: 1rem; border-top: 1px solid var(--border); padding-top: 0.75rem; display: none;">
+                  <div
+                    class="settings-group"
+                    id="numistaBulkSyncGroup"
+                    style="
+                      margin-top: 1rem;
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.75rem;
+                      display: none;
+                    "
+                  >
                     <div class="settings-group-label">Metadata Sync</div>
                     <p class="settings-subtext">
-                      Sync metadata for all inventory items with Numista catalog IDs.
-                      Uses your API key (counts toward monthly quota).
+                      Sync metadata for all inventory items with Numista catalog IDs. Uses your API
+                      key (counts toward monthly quota).
                     </p>
 
                     <!-- Stats bar -->
-                    <div id="numistaSyncStats" class="settings-subtext" style="margin-bottom:0.25rem;"></div>
+                    <div
+                      id="numistaSyncStats"
+                      class="settings-subtext"
+                      style="margin-bottom: 0.25rem"
+                    ></div>
 
                     <!-- Eligible items table (collapsible) -->
                     <!-- View modal fields (collapsible) -->
-                    <details style="margin-bottom:0.5rem;">
-                      <summary style="font-size:0.8rem;cursor:pointer;opacity:0.7;">View modal fields</summary>
-                      <div id="numistaViewFieldToggles" class="chip-grouping-table-container" style="margin-top:0.35rem;">
+                    <details style="margin-bottom: 0.5rem">
+                      <summary style="font-size: 0.8rem; cursor: pointer; opacity: 0.7">
+                        View modal fields
+                      </summary>
+                      <div
+                        id="numistaViewFieldToggles"
+                        class="chip-grouping-table-container"
+                        style="margin-top: 0.35rem"
+                      >
                         <table class="chip-grouping-table">
                           <tbody>
                             <tr>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="denomination" checked> Denomination</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="shape" checked> Shape</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="diameter" checked> Diameter</label></td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="denomination" checked />
+                                  Denomination</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="shape" checked /> Shape</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="diameter" checked />
+                                  Diameter</label
+                                >
+                              </td>
                             </tr>
                             <tr>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="thickness" checked> Thickness</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="orientation" checked> Orientation</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="composition" checked> Composition</label></td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="thickness" checked />
+                                  Thickness</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="orientation" checked />
+                                  Orientation</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="composition" checked />
+                                  Composition</label
+                                >
+                              </td>
                             </tr>
                             <tr>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="country" checked> Country</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="technique" checked> Technique</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="references" checked> References (KM#)</label></td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="country" checked />
+                                  Country</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="technique" checked />
+                                  Technique</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="references" checked /> References
+                                  (KM#)</label
+                                >
+                              </td>
                             </tr>
                             <tr>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="edge" checked> Edge</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="tags" checked> Tags</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="commemorative" checked> Commemorative</label></td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="edge" checked /> Edge</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="tags" checked /> Tags</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="commemorative" checked />
+                                  Commemorative</label
+                                >
+                              </td>
                             </tr>
                             <tr>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="rarity" checked> Rarity</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="mintage" checked> Mintage</label></td>
-                              <td><label class="settings-checkbox-label"><input type="checkbox" data-nf="imageTooltips" checked> Image tooltips</label></td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="rarity" checked /> Rarity</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="mintage" checked />
+                                  Mintage</label
+                                >
+                              </td>
+                              <td>
+                                <label class="settings-checkbox-label"
+                                  ><input type="checkbox" data-nf="imageTooltips" checked /> Image
+                                  tooltips</label
+                                >
+                              </td>
                             </tr>
                           </tbody>
                         </table>
                       </div>
                     </details>
 
-                    <details style="margin-bottom:0.5rem;">
-                      <summary style="font-size:0.8rem;cursor:pointer;opacity:0.7;">Show eligible items</summary>
-                      <div id="numistaSyncTableContainer" class="chip-grouping-table-container" style="max-height:165px;overflow-y:auto;margin-top:0.35rem;"></div>
+                    <details style="margin-bottom: 0.5rem">
+                      <summary style="font-size: 0.8rem; cursor: pointer; opacity: 0.7">
+                        Show eligible items
+                      </summary>
+                      <div
+                        id="numistaSyncTableContainer"
+                        class="chip-grouping-table-container"
+                        style="max-height: 165px; overflow-y: auto; margin-top: 0.35rem"
+                      ></div>
                     </details>
 
                     <!-- Activity log (collapsible) -->
-                    <details style="margin-bottom:0.5rem;">
-                      <summary style="font-size:0.8rem;cursor:pointer;opacity:0.7;">Activity log</summary>
-                      <div id="numistaSyncLog" style="max-height:120px;overflow-y:auto;border:1px solid var(--border-color, #ddd);border-radius:4px;padding:0.4rem;margin-top:0.25rem;background:var(--bg-secondary, #f9f9f9);"></div>
+                    <details style="margin-bottom: 0.5rem">
+                      <summary style="font-size: 0.8rem; cursor: pointer; opacity: 0.7">
+                        Activity log
+                      </summary>
+                      <div
+                        id="numistaSyncLog"
+                        style="
+                          max-height: 120px;
+                          overflow-y: auto;
+                          border: 1px solid var(--border-color, var(--border));
+                          border-radius: 4px;
+                          padding: 0.4rem;
+                          margin-top: 0.25rem;
+                          background: var(--bg-secondary);
+                        "
+                      ></div>
                     </details>
 
                     <!-- Progress -->
-                    <progress id="numistaSyncProgress" value="0" max="0" style="display:none;width:100%;margin-bottom:0.5rem;"></progress>
+                    <progress
+                      id="numistaSyncProgress"
+                      value="0"
+                      max="0"
+                      style="display: none; width: 100%; margin-bottom: 0.5rem"
+                    ></progress>
 
                     <!-- Action buttons -->
-                    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
-                      <button type="button" class="btn info" id="numistaSyncStartBtn">Sync Metadata</button>
-                      <button type="button" class="btn warning" id="numistaSyncCancelBtn" style="display:none;">Cancel</button>
-                      <button type="button" class="btn secondary" id="clearNumistaCacheBtn" style="font-size:0.8rem;">Clear API Cache</button>
+                    <div style="display: flex; gap: 0.5rem; flex-wrap: wrap">
+                      <button type="button" class="btn info" id="numistaSyncStartBtn">
+                        Sync Metadata
+                      </button>
+                      <button
+                        type="button"
+                        class="btn warning"
+                        id="numistaSyncCancelBtn"
+                        style="display: none"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        class="btn secondary"
+                        id="clearNumistaCacheBtn"
+                        style="font-size: 0.8rem"
+                      >
+                        Clear API Cache
+                      </button>
                     </div>
                   </div>
 
@@ -2579,80 +4550,175 @@
                   </div>
                   <div class="api-key-row">
                     <label for="pcgsBearerToken">Bearer Token:</label>
-                    <input type="password" id="pcgsBearerToken" placeholder="Enter your PCGS API bearer token" />
+                    <input
+                      type="password"
+                      id="pcgsBearerToken"
+                      placeholder="Enter your PCGS API bearer token"
+                    />
                   </div>
                   <div class="api-key-note">
-                    <p>Requires a PCGS API account at <a href="https://api.pcgs.com" target="_blank" rel="noopener">api.pcgs.com</a> (1,000 requests/day). Token is stored locally in your browser.</p>
-                    <p style="margin-top:0.35rem;opacity:0.7;font-size:0.8rem;">HTTPS required — cert verification will not work on <code>file://</code> protocol.</p>
+                    <p>
+                      Requires a PCGS API account at
+                      <a href="https://api.pcgs.com" target="_blank" rel="noopener">api.pcgs.com</a>
+                      (1,000 requests/day). Token is stored locally in your browser.
+                    </p>
+                    <p style="margin-top: 0.35rem; opacity: 0.7; font-size: 0.8rem">
+                      HTTPS required — cert verification will not work on
+                      <code>file://</code> protocol.
+                    </p>
                   </div>
-                  <div id="pcgsUsageBar" class="api-usage" style="margin-top: 0.75rem;"></div>
+                  <div id="pcgsUsageBar" class="api-usage" style="margin-top: 0.75rem"></div>
                   <div class="provider-info">
-                    <div class="provider-status" id="pcgsProviderStatus"><span class="status-dot"></span><span class="status-text">Disconnected</span></div>
+                    <div class="provider-status" id="pcgsProviderStatus">
+                      <span class="status-dot"></span><span class="status-text">Disconnected</span>
+                    </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button class="btn api-save-btn success" id="savePcgsBtn" data-provider="PCGS">Save Token</button>
-                      <button class="btn api-sync-btn info" id="testPcgsBtn" data-provider="PCGS">Test Connection</button>
-                      <button class="btn api-clear-btn warning" id="clearPcgsBtn" data-provider="PCGS">Clear Token</button>
+                      <button
+                        class="btn api-save-btn success"
+                        id="savePcgsBtn"
+                        data-provider="PCGS"
+                      >
+                        Save Token
+                      </button>
+                      <button class="btn api-sync-btn info" id="testPcgsBtn" data-provider="PCGS">
+                        Test Connection
+                      </button>
+                      <button
+                        class="btn api-clear-btn warning"
+                        id="clearPcgsBtn"
+                        data-provider="PCGS"
+                      >
+                        Clear Token
+                      </button>
                     </div>
                   </div>
-                  <div id="pcgsStatus" class="api-status" style="margin-top: 0.5rem;"></div>
+                  <div id="pcgsStatus" class="api-status" style="margin-top: 0.5rem"></div>
 
                   <!-- STAK-222: PCGS Response Cache stat row -->
-                  <div class="settings-group" style="margin-top: 0.75rem; border-top: 1px solid var(--border); padding-top: 0.5rem;">
+                  <div
+                    class="settings-group"
+                    style="
+                      margin-top: 0.75rem;
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.5rem;
+                    "
+                  >
                     <div class="provider-setting-row api-cache-stat-row">
-                      <span id="pcgsResponseCacheStat" class="settings-stat">Cached lookups: <strong id="pcgsResponseCacheCount">0</strong> entries</span>
-                      <button id="clearPcgsCacheBtn" class="btn secondary btn-sm">Clear cache</button>
+                      <span id="pcgsResponseCacheStat" class="settings-stat"
+                        >Cached lookups:
+                        <strong id="pcgsResponseCacheCount">0</strong> entries</span
+                      >
+                      <button id="clearPcgsCacheBtn" class="btn secondary btn-sm">
+                        Clear cache
+                      </button>
                     </div>
                   </div>
                 </div>
               </div>
 
               <!-- StakTrakr Provider Panel -->
-              <div class="settings-provider-panel" id="providerPanel_STAKTRAKR" style="display: block">
+              <div
+                class="settings-provider-panel"
+                id="providerPanel_STAKTRAKR"
+                style="display: block"
+              >
                 <div class="api-provider" data-provider="STAKTRAKR">
                   <div class="provider-header">
                     <span class="provider-name">StakTrakr Spot API</span>
                     <span class="provider-badge free">Free</span>
-                    <a href="https://www.staktrakr.com" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="StakTrakr Website">Docs</a>
+                    <a
+                      href="https://www.staktrakr.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="provider-doc-link"
+                      title="StakTrakr Website"
+                      >Docs</a
+                    >
                   </div>
-                  <p class="provider-description" style="margin: 0.5rem 0; color: var(--text-muted);">Free hourly spot prices — no API key required.</p>
-                  <p class="provider-disclaimer" style="margin: 0.25rem 0 0.5rem; font-size: 0.75rem; color: var(--disclaimer-color);">This is a free, best-effort service. Prices may be delayed or temporarily unavailable. No guarantee of accuracy, uptime, or availability is provided.</p>
+                  <p
+                    class="provider-description"
+                    style="margin: 0.5rem 0; color: var(--text-muted)"
+                  >
+                    Free hourly spot prices — no API key required.
+                  </p>
+                  <p
+                    class="provider-disclaimer"
+                    style="
+                      margin: 0.25rem 0 0.5rem;
+                      font-size: 0.75rem;
+                      color: var(--disclaimer-color);
+                    "
+                  >
+                    This is a free, best-effort service. Prices may be delayed or temporarily
+                    unavailable. No guarantee of accuracy, uptime, or availability is provided.
+                  </p>
                   <div class="provider-settings">
                     <h4>Provider Settings</h4>
                     <div class="provider-setting-row">
                       <label for="enabled_STAKTRAKR">Enabled</label>
-                      <input type="checkbox" id="enabled_STAKTRAKR" checked>
+                      <input type="checkbox" id="enabled_STAKTRAKR" checked />
                       <span class="settings-hint">Free spot prices — no API key needed.</span>
                     </div>
                     <div class="provider-setting-row api-autorefresh-row">
                       <label for="autoRefresh_STAKTRAKR">Background auto-refresh</label>
-                      <input type="checkbox" id="autoRefresh_STAKTRAKR" class="api-autorefresh-toggle" data-provider="STAKTRAKR" checked>
+                      <input
+                        type="checkbox"
+                        id="autoRefresh_STAKTRAKR"
+                        class="api-autorefresh-toggle"
+                        data-provider="STAKTRAKR"
+                        checked
+                      />
                       <span class="settings-hint">Refreshes hourly. Free, on by default.</span>
                     </div>
                     <div class="provider-info">
-                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span><span class="status-last-used"></span></div>
+                      <div class="provider-status">
+                        <span class="status-dot"></span><span class="status-text">Disconnected</span
+                        ><span class="status-last-used"></span>
+                      </div>
                       <div class="provider-history"></div>
                     </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button type="button" class="btn api-sync-btn success" data-provider="STAKTRAKR">Test &amp; Sync</button>
+                      <button
+                        type="button"
+                        class="btn api-sync-btn success"
+                        data-provider="STAKTRAKR"
+                      >
+                        Test &amp; Sync
+                      </button>
                     </div>
                   </div>
                 </div>
               </div>
 
               <!-- Metals.dev Provider Panel -->
-              <div class="settings-provider-panel" id="providerPanel_METALS_DEV" style="display: none">
+              <div
+                class="settings-provider-panel"
+                id="providerPanel_METALS_DEV"
+                style="display: none"
+              >
                 <div class="api-provider" data-provider="METALS_DEV">
                   <div class="provider-header">
                     <span class="provider-name">Metals.dev</span>
-                    <a href="https://metals.dev/documentation" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="API Documentation">Docs</a>
+                    <a
+                      href="https://metals.dev/documentation"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="provider-doc-link"
+                      title="API Documentation"
+                      >Docs</a
+                    >
                   </div>
                   <div class="api-key-row">
                     <label for="apiKey_METALS_DEV">API Key:</label>
-                    <input type="password" id="apiKey_METALS_DEV" placeholder="Enter your API key" />
+                    <input
+                      type="password"
+                      id="apiKey_METALS_DEV"
+                      placeholder="Enter your API key"
+                    />
                   </div>
                   <div class="provider-settings">
                     <h4>Provider Settings</h4>
@@ -2670,12 +4736,21 @@
                     </div>
                     <div class="provider-setting-row api-autorefresh-row">
                       <label for="autoRefresh_METALS_DEV">Background auto-refresh</label>
-                      <input type="checkbox" id="autoRefresh_METALS_DEV" class="api-autorefresh-toggle" data-provider="METALS_DEV">
+                      <input
+                        type="checkbox"
+                        id="autoRefresh_METALS_DEV"
+                        class="api-autorefresh-toggle"
+                        data-provider="METALS_DEV"
+                      />
                       <span class="settings-hint">Polls on cache TTL interval.</span>
                     </div>
                     <div class="provider-setting-row">
                       <label for="providerPriority_METALS_DEV">Sync Priority:</label>
-                      <select class="provider-priority-select" id="providerPriority_METALS_DEV" data-provider="METALS_DEV">
+                      <select
+                        class="provider-priority-select"
+                        id="providerPriority_METALS_DEV"
+                        data-provider="METALS_DEV"
+                      >
                         <option value="1">1st</option>
                         <option value="2">2nd</option>
                         <option value="3">3rd</option>
@@ -2691,44 +4766,112 @@
                         <option value="14">14 days</option>
                         <option value="30" selected>30 days</option>
                       </select>
-                      <button type="button" class="btn api-history-btn" data-provider="METALS_DEV">Pull History</button>
+                      <button type="button" class="btn api-history-btn" data-provider="METALS_DEV">
+                        Pull History
+                      </button>
                       <span class="history-pull-cost" id="historyPullCost_METALS_DEV"></span>
                     </div>
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
                       <div class="metal-checkboxes">
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_DEV" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_DEV"
+                            data-metal="silver"
+                            checked
+                          /><span class="metal-name">Silver (AG)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_DEV"
+                            data-metal="gold"
+                            checked
+                          /><span class="metal-name">Gold (AU)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_DEV"
+                            data-metal="platinum"
+                            checked
+                          /><span class="metal-name">Platinum (PT)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_DEV"
+                            data-metal="palladium"
+                            checked
+                          /><span class="metal-name">Palladium (PD)</span></label
+                        >
                       </div>
                     </div>
                     <div class="provider-info">
-                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
-                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span><span class="status-last-used"></span></div>
+                      <div class="api-key-note">
+                        Your API key is stored locally and never shared.
+                      </div>
+                      <div class="provider-status">
+                        <span class="status-dot"></span><span class="status-text">Disconnected</span
+                        ><span class="status-last-used"></span>
+                      </div>
                       <div class="provider-history"></div>
                     </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button type="button" class="btn api-save-btn" data-provider="METALS_DEV">Save</button>
-                      <button type="button" class="btn api-sync-btn success" data-provider="METALS_DEV">Save and Test</button>
-                      <button type="button" class="btn api-clear-btn warning" data-provider="METALS_DEV">Clear Key</button>
+                      <button type="button" class="btn api-save-btn" data-provider="METALS_DEV">
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-sync-btn success"
+                        data-provider="METALS_DEV"
+                      >
+                        Save and Test
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-clear-btn warning"
+                        data-provider="METALS_DEV"
+                      >
+                        Clear Key
+                      </button>
                     </div>
                   </div>
                 </div>
               </div>
 
               <!-- Metals-API Provider Panel -->
-              <div class="settings-provider-panel" id="providerPanel_METALS_API" style="display: none">
+              <div
+                class="settings-provider-panel"
+                id="providerPanel_METALS_API"
+                style="display: none"
+              >
                 <div class="api-provider" data-provider="METALS_API">
                   <div class="provider-header">
                     <span class="provider-name">Metals-API.com</span>
-                    <a href="https://metals-api.com/documentation" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="API Documentation">Docs</a>
+                    <a
+                      href="https://metals-api.com/documentation"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="provider-doc-link"
+                      title="API Documentation"
+                      >Docs</a
+                    >
                   </div>
                   <div class="api-key-row">
                     <label for="apiKey_METALS_API">API Key:</label>
-                    <input type="password" id="apiKey_METALS_API" placeholder="Enter your API key" />
+                    <input
+                      type="password"
+                      id="apiKey_METALS_API"
+                      placeholder="Enter your API key"
+                    />
                   </div>
                   <div class="provider-settings">
                     <h4>Provider Settings</h4>
@@ -2746,12 +4889,21 @@
                     </div>
                     <div class="provider-setting-row api-autorefresh-row">
                       <label for="autoRefresh_METALS_API">Background auto-refresh</label>
-                      <input type="checkbox" id="autoRefresh_METALS_API" class="api-autorefresh-toggle" data-provider="METALS_API">
+                      <input
+                        type="checkbox"
+                        id="autoRefresh_METALS_API"
+                        class="api-autorefresh-toggle"
+                        data-provider="METALS_API"
+                      />
                       <span class="settings-hint">Polls on cache TTL interval.</span>
                     </div>
                     <div class="provider-setting-row">
                       <label for="providerPriority_METALS_API">Sync Priority:</label>
-                      <select class="provider-priority-select" id="providerPriority_METALS_API" data-provider="METALS_API">
+                      <select
+                        class="provider-priority-select"
+                        id="providerPriority_METALS_API"
+                        data-provider="METALS_API"
+                      >
                         <option value="1">1st</option>
                         <option value="2">2nd</option>
                         <option value="3">3rd</option>
@@ -2771,44 +4923,112 @@
                         <option value="180">180 days</option>
                         <option value="365">365 days</option>
                       </select>
-                      <button type="button" class="btn api-history-btn" data-provider="METALS_API">Pull History</button>
+                      <button type="button" class="btn api-history-btn" data-provider="METALS_API">
+                        Pull History
+                      </button>
                       <span class="history-pull-cost" id="historyPullCost_METALS_API"></span>
                     </div>
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
                       <div class="metal-checkboxes">
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METALS_API" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_API"
+                            data-metal="silver"
+                            checked
+                          /><span class="metal-name">Silver (AG)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_API"
+                            data-metal="gold"
+                            checked
+                          /><span class="metal-name">Gold (AU)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_API"
+                            data-metal="platinum"
+                            checked
+                          /><span class="metal-name">Platinum (PT)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METALS_API"
+                            data-metal="palladium"
+                            checked
+                          /><span class="metal-name">Palladium (PD)</span></label
+                        >
                       </div>
                     </div>
                     <div class="provider-info">
-                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
-                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span><span class="status-last-used"></span></div>
+                      <div class="api-key-note">
+                        Your API key is stored locally and never shared.
+                      </div>
+                      <div class="provider-status">
+                        <span class="status-dot"></span><span class="status-text">Disconnected</span
+                        ><span class="status-last-used"></span>
+                      </div>
                       <div class="provider-history"></div>
                     </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button type="button" class="btn api-save-btn" data-provider="METALS_API">Save</button>
-                      <button type="button" class="btn api-sync-btn success" data-provider="METALS_API">Save and Test</button>
-                      <button type="button" class="btn api-clear-btn warning" data-provider="METALS_API">Clear Key</button>
+                      <button type="button" class="btn api-save-btn" data-provider="METALS_API">
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-sync-btn success"
+                        data-provider="METALS_API"
+                      >
+                        Save and Test
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-clear-btn warning"
+                        data-provider="METALS_API"
+                      >
+                        Clear Key
+                      </button>
                     </div>
                   </div>
                 </div>
               </div>
 
               <!-- MetalPriceAPI Provider Panel -->
-              <div class="settings-provider-panel" id="providerPanel_METAL_PRICE_API" style="display: none">
+              <div
+                class="settings-provider-panel"
+                id="providerPanel_METAL_PRICE_API"
+                style="display: none"
+              >
                 <div class="api-provider" data-provider="METAL_PRICE_API">
                   <div class="provider-header">
                     <span class="provider-name">MetalPriceAPI.com</span>
-                    <a href="https://metalpriceapi.com/documentation" target="_blank" rel="noopener noreferrer" class="provider-doc-link" title="API Documentation">Docs</a>
+                    <a
+                      href="https://metalpriceapi.com/documentation"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="provider-doc-link"
+                      title="API Documentation"
+                      >Docs</a
+                    >
                   </div>
                   <div class="api-key-row">
                     <label for="apiKey_METAL_PRICE_API">API Key:</label>
-                    <input type="password" id="apiKey_METAL_PRICE_API" placeholder="Enter your API key" />
+                    <input
+                      type="password"
+                      id="apiKey_METAL_PRICE_API"
+                      placeholder="Enter your API key"
+                    />
                   </div>
                   <div class="provider-settings">
                     <h4>Provider Settings</h4>
@@ -2826,12 +5046,21 @@
                     </div>
                     <div class="provider-setting-row api-autorefresh-row">
                       <label for="autoRefresh_METAL_PRICE_API">Background auto-refresh</label>
-                      <input type="checkbox" id="autoRefresh_METAL_PRICE_API" class="api-autorefresh-toggle" data-provider="METAL_PRICE_API">
+                      <input
+                        type="checkbox"
+                        id="autoRefresh_METAL_PRICE_API"
+                        class="api-autorefresh-toggle"
+                        data-provider="METAL_PRICE_API"
+                      />
                       <span class="settings-hint">Polls on cache TTL interval.</span>
                     </div>
                     <div class="provider-setting-row">
                       <label for="providerPriority_METAL_PRICE_API">Sync Priority:</label>
-                      <select class="provider-priority-select" id="providerPriority_METAL_PRICE_API" data-provider="METAL_PRICE_API">
+                      <select
+                        class="provider-priority-select"
+                        id="providerPriority_METAL_PRICE_API"
+                        data-provider="METAL_PRICE_API"
+                      >
                         <option value="1">1st</option>
                         <option value="2">2nd</option>
                         <option value="3">3rd</option>
@@ -2851,9 +5080,20 @@
                         <option value="180">180 days</option>
                         <option value="365">365 days</option>
                       </select>
-                      <button type="button" class="btn api-history-btn" data-provider="METAL_PRICE_API">Pull History</button>
-                      <label class="metal-checkbox" style="margin-left: 0.5rem;">
-                        <input type="checkbox" id="hourlyPull_METAL_PRICE_API" class="provider-hourly-toggle" data-provider="METAL_PRICE_API">
+                      <button
+                        type="button"
+                        class="btn api-history-btn"
+                        data-provider="METAL_PRICE_API"
+                      >
+                        Pull History
+                      </button>
+                      <label class="metal-checkbox" style="margin-left: 0.5rem">
+                        <input
+                          type="checkbox"
+                          id="hourlyPull_METAL_PRICE_API"
+                          class="provider-hourly-toggle"
+                          data-provider="METAL_PRICE_API"
+                        />
                         <span class="metal-name">Hourly</span>
                       </label>
                       <span class="history-pull-cost" id="historyPullCost_METAL_PRICE_API"></span>
@@ -2861,23 +5101,78 @@
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
                       <div class="metal-checkboxes">
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="METAL_PRICE_API" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METAL_PRICE_API"
+                            data-metal="silver"
+                            checked
+                          /><span class="metal-name">Silver (AG)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METAL_PRICE_API"
+                            data-metal="gold"
+                            checked
+                          /><span class="metal-name">Gold (AU)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METAL_PRICE_API"
+                            data-metal="platinum"
+                            checked
+                          /><span class="metal-name">Platinum (PT)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="METAL_PRICE_API"
+                            data-metal="palladium"
+                            checked
+                          /><span class="metal-name">Palladium (PD)</span></label
+                        >
                       </div>
                     </div>
                     <div class="provider-info">
-                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
-                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span><span class="status-last-used"></span></div>
+                      <div class="api-key-note">
+                        Your API key is stored locally and never shared.
+                      </div>
+                      <div class="provider-status">
+                        <span class="status-dot"></span><span class="status-text">Disconnected</span
+                        ><span class="status-last-used"></span>
+                      </div>
                       <div class="provider-history"></div>
                     </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button type="button" class="btn api-save-btn" data-provider="METAL_PRICE_API">Save</button>
-                      <button type="button" class="btn api-sync-btn success" data-provider="METAL_PRICE_API">Save and Test</button>
-                      <button type="button" class="btn api-clear-btn warning" data-provider="METAL_PRICE_API">Clear Key</button>
+                      <button
+                        type="button"
+                        class="btn api-save-btn"
+                        data-provider="METAL_PRICE_API"
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-sync-btn success"
+                        data-provider="METAL_PRICE_API"
+                      >
+                        Save and Test
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-clear-btn warning"
+                        data-provider="METAL_PRICE_API"
+                      >
+                        Clear Key
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -2895,7 +5190,11 @@
                   </div>
                   <div class="api-field-row">
                     <label for="apiEndpoint_CUSTOM">Endpoint:</label>
-                    <input type="text" id="apiEndpoint_CUSTOM" placeholder="/latest?key={API_KEY}&metal={METAL}" />
+                    <input
+                      type="text"
+                      id="apiEndpoint_CUSTOM"
+                      placeholder="/latest?key={API_KEY}&metal={METAL}"
+                    />
                   </div>
                   <div class="api-field-row">
                     <label for="apiFormat_CUSTOM">Metal Format:</label>
@@ -2924,12 +5223,21 @@
                     </div>
                     <div class="provider-setting-row api-autorefresh-row">
                       <label for="autoRefresh_CUSTOM">Background auto-refresh</label>
-                      <input type="checkbox" id="autoRefresh_CUSTOM" class="api-autorefresh-toggle" data-provider="CUSTOM">
+                      <input
+                        type="checkbox"
+                        id="autoRefresh_CUSTOM"
+                        class="api-autorefresh-toggle"
+                        data-provider="CUSTOM"
+                      />
                       <span class="settings-hint">Polls on cache TTL interval.</span>
                     </div>
                     <div class="provider-setting-row">
                       <label for="providerPriority_CUSTOM">Sync Priority:</label>
-                      <select class="provider-priority-select" id="providerPriority_CUSTOM" data-provider="CUSTOM">
+                      <select
+                        class="provider-priority-select"
+                        id="providerPriority_CUSTOM"
+                        data-provider="CUSTOM"
+                      >
                         <option value="1">1st</option>
                         <option value="2">2nd</option>
                         <option value="3">3rd</option>
@@ -2942,23 +5250,70 @@
                     <div class="metal-selection">
                       <label>Select Metals to Track:</label>
                       <div class="metal-checkboxes">
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="silver" checked><span class="metal-name">Silver (AG)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="gold" checked><span class="metal-name">Gold (AU)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="platinum" checked><span class="metal-name">Platinum (PT)</span></label>
-                        <label class="metal-checkbox"><input type="checkbox" class="provider-metal" data-provider="CUSTOM" data-metal="palladium" checked><span class="metal-name">Palladium (PD)</span></label>
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="CUSTOM"
+                            data-metal="silver"
+                            checked
+                          /><span class="metal-name">Silver (AG)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="CUSTOM"
+                            data-metal="gold"
+                            checked
+                          /><span class="metal-name">Gold (AU)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="CUSTOM"
+                            data-metal="platinum"
+                            checked
+                          /><span class="metal-name">Platinum (PT)</span></label
+                        >
+                        <label class="metal-checkbox"
+                          ><input
+                            type="checkbox"
+                            class="provider-metal"
+                            data-provider="CUSTOM"
+                            data-metal="palladium"
+                            checked
+                          /><span class="metal-name">Palladium (PD)</span></label
+                        >
                       </div>
                     </div>
                     <div class="provider-info">
-                      <div class="api-key-note">Your API key is stored locally and never shared.</div>
-                      <div class="provider-status"><span class="status-dot"></span><span class="status-text">Disconnected</span><span class="status-last-used"></span></div>
+                      <div class="api-key-note">
+                        Your API key is stored locally and never shared.
+                      </div>
+                      <div class="provider-status">
+                        <span class="status-dot"></span><span class="status-text">Disconnected</span
+                        ><span class="status-last-used"></span>
+                      </div>
                       <div class="provider-history"></div>
                     </div>
                   </div>
                   <div class="provider-footer">
                     <div class="provider-actions">
-                      <button type="button" class="btn api-save-btn" data-provider="CUSTOM">Save</button>
-                      <button type="button" class="btn api-sync-btn success" data-provider="CUSTOM">Save and Test</button>
-                      <button type="button" class="btn api-clear-btn warning" data-provider="CUSTOM">Clear Key</button>
+                      <button type="button" class="btn api-save-btn" data-provider="CUSTOM">
+                        Save
+                      </button>
+                      <button type="button" class="btn api-sync-btn success" data-provider="CUSTOM">
+                        Save and Test
+                      </button>
+                      <button
+                        type="button"
+                        class="btn api-clear-btn warning"
+                        data-provider="CUSTOM"
+                      >
+                        Clear Key
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -2972,7 +5327,9 @@
               <!-- ── Image Display ── -->
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">Image Display</div>
-                <div class="settings-card-grid settings-card-grid--compact settings-card-grid--3col">
+                <div
+                  class="settings-card-grid settings-card-grid--compact settings-card-grid--3col"
+                >
                   <div class="settings-card">
                     <div class="settings-group-label">Table thumbnails</div>
                     <p class="settings-subtext">Show coin images in the table.</p>
@@ -2996,19 +5353,48 @@
               <!-- ── Add Pattern Image Rule ── -->
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">Add Pattern Image Rule</div>
-                <p class="settings-subtext">Create rules that automatically assign images to items matching a name pattern. Per-item uploads always take priority over pattern images on a per-side basis.</p>
+                <p class="settings-subtext">
+                  Create rules that automatically assign images to items matching a name pattern.
+                  Per-item uploads always take priority over pattern images on a per-side basis.
+                </p>
                 <div class="pattern-rule-form" id="patternRuleForm">
                   <div class="pattern-rule-form-row">
                     <div class="pattern-rule-field">
                       <label for="patternRulePattern">
                         Name Pattern
-                        <div class="chip-sort-toggle pattern-mode-toggle" id="patternModeToggle" style="display:inline-flex;margin-left:0.4rem;vertical-align:middle;">
-                          <button type="button" id="patternModeKeywords" class="chip-sort-btn active" title="Comma or semicolon separated keywords">Keywords</button>
-                          <button type="button" id="patternModeRegex" class="chip-sort-btn" title="Regular expression">Regex</button>
+                        <div
+                          class="chip-sort-toggle pattern-mode-toggle"
+                          id="patternModeToggle"
+                          style="display: inline-flex; margin-left: 0.4rem; vertical-align: middle"
+                        >
+                          <button
+                            type="button"
+                            id="patternModeKeywords"
+                            class="chip-sort-btn active"
+                            title="Comma or semicolon separated keywords"
+                          >
+                            Keywords
+                          </button>
+                          <button
+                            type="button"
+                            id="patternModeRegex"
+                            class="chip-sort-btn"
+                            title="Regular expression"
+                          >
+                            Regex
+                          </button>
                         </div>
                       </label>
-                      <input type="text" id="patternRulePattern" class="form-control" placeholder="e.g. morgan, peace, walking liberty" />
-                      <small id="patternRuleTip" class="pattern-rule-tip">Separate keywords with commas or semicolons. Matches item names containing any keyword.</small>
+                      <input
+                        type="text"
+                        id="patternRulePattern"
+                        class="form-control"
+                        placeholder="e.g. morgan, peace, walking liberty"
+                      />
+                      <small id="patternRuleTip" class="pattern-rule-tip"
+                        >Separate keywords with commas or semicolons. Matches item names containing
+                        any keyword.</small
+                      >
                     </div>
                   </div>
                   <div class="pattern-rule-form-row">
@@ -3016,23 +5402,80 @@
                       <label for="patternRuleObverse">Obverse Image</label>
                       <div class="image-input-row">
                         <input type="file" id="patternRuleObverse" accept="image/*" />
-                        <button type="button" class="btn btn-icon camera-capture-btn" id="patternRuleObverseCamera" title="Take photo" aria-label="Take photo with camera">
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+                        <button
+                          type="button"
+                          class="btn btn-icon camera-capture-btn"
+                          id="patternRuleObverseCamera"
+                          title="Take photo"
+                          aria-label="Take photo with camera"
+                        >
+                          <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path
+                              d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"
+                            />
+                            <circle cx="12" cy="13" r="4" />
+                          </svg>
                         </button>
-                        <input type="file" id="patternRuleObverseCapture" accept="image/*" capture="environment" style="display:none" aria-hidden="true" />
+                        <input
+                          type="file"
+                          id="patternRuleObverseCapture"
+                          accept="image/*"
+                          capture="environment"
+                          style="display: none"
+                          aria-hidden="true"
+                        />
                       </div>
                     </div>
                     <div class="pattern-rule-field">
                       <label for="patternRuleReverse">Reverse Image</label>
                       <div class="image-input-row">
                         <input type="file" id="patternRuleReverse" accept="image/*" />
-                        <button type="button" class="btn btn-icon camera-capture-btn" id="patternRuleReverseCamera" title="Take photo" aria-label="Take photo with camera">
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+                        <button
+                          type="button"
+                          class="btn btn-icon camera-capture-btn"
+                          id="patternRuleReverseCamera"
+                          title="Take photo"
+                          aria-label="Take photo with camera"
+                        >
+                          <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path
+                              d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"
+                            />
+                            <circle cx="12" cy="13" r="4" />
+                          </svg>
                         </button>
-                        <input type="file" id="patternRuleReverseCapture" accept="image/*" capture="environment" style="display:none" aria-hidden="true" />
+                        <input
+                          type="file"
+                          id="patternRuleReverseCapture"
+                          accept="image/*"
+                          capture="environment"
+                          style="display: none"
+                          aria-hidden="true"
+                        />
                       </div>
                     </div>
-                    <div class="pattern-rule-field pattern-rule-field-narrow" style="align-self:flex-end">
+                    <div
+                      class="pattern-rule-field pattern-rule-field-narrow"
+                      style="align-self: flex-end"
+                    >
                       <button class="btn" id="addPatternRuleBtn" type="button">Add Rule</button>
                     </div>
                   </div>
@@ -3057,7 +5500,9 @@
                 <div id="imageStorageStats" class="image-storage-stats">
                   <div class="storage-gauge-row">
                     <span class="storage-gauge-label">📷 Your Photos</span>
-                    <div class="storage-gauge-bar-wrap"><div id="gaugeUserBar" class="storage-gauge-bar"></div></div>
+                    <div class="storage-gauge-bar-wrap">
+                      <div id="gaugeUserBar" class="storage-gauge-bar"></div>
+                    </div>
                     <span id="gaugeUserSize" class="storage-gauge-size">—</span>
                   </div>
                   <div id="gaugePersistLine" class="storage-gauge-persist">—</div>
@@ -3070,21 +5515,62 @@
               <h3>Inventory</h3>
 
               <!-- ── Bulk Editor + Inventory Summary ── -->
-              <div class="settings-card-grid" style="margin-bottom:1rem">
+              <div class="settings-card-grid" style="margin-bottom: 1rem">
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px"
+                      >
+                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                      </svg>
                       Bulk Editor
                     </span>
                     <span class="cloud-provider-card-badges">
                       <span class="cloud-badge cloud-badge--beta">BETA</span>
                     </span>
                   </div>
-                  <p class="settings-subtext">Select multiple inventory items and apply batch operations — edit shared fields, duplicate entries, or remove items in bulk. This feature is actively developed; please report any issues on GitHub.</p>
-                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
-                    <button class="btn settings-action-btn" id="bulkEditBtn" type="button" style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.35rem;"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                  <p class="settings-subtext">
+                    Select multiple inventory items and apply batch operations — edit shared fields,
+                    duplicate entries, or remove items in bulk. This feature is actively developed;
+                    please report any issues on GitHub.
+                  </p>
+                  <div
+                    style="
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                      margin-top: 0.5rem;
+                    "
+                  >
+                    <button
+                      class="btn settings-action-btn"
+                      id="bulkEditBtn"
+                      type="button"
+                      style="font-size: 0.82rem; padding: 0.4rem 0.9rem; min-height: 0"
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px; margin-right: 0.35rem"
+                      >
+                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                      </svg>
                       Open Bulk Editor
                     </button>
                   </div>
@@ -3092,7 +5578,22 @@
                 <div class="cloud-provider-card" id="inventorySummaryCard">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px"
+                      >
+                        <rect x="3" y="3" width="7" height="7" />
+                        <rect x="14" y="3" width="7" height="7" />
+                        <rect x="14" y="14" width="7" height="7" />
+                        <rect x="3" y="14" width="7" height="7" />
+                      </svg>
                       Inventory
                     </span>
                   </div>
@@ -3118,24 +5619,67 @@
               </div>
 
               <!-- ── Import + Export ── -->
-              <div class="settings-card-grid" style="margin-bottom:1rem">
+              <div class="settings-card-grid" style="margin-bottom: 1rem">
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px"
+                      >
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                        <polyline points="7 10 12 15 17 10" />
+                        <line x1="12" y1="15" x2="12" y2="3" />
+                      </svg>
                       Import
                     </span>
                   </div>
-                  <p class="settings-subtext">Import your data files. New here? <a href="sample.csv" download="sample.csv">Download sample CSV</a> to try importing.</p>
-                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
+                  <p class="settings-subtext">
+                    Import your data files. New here?
+                    <a href="sample.csv" download="sample.csv">Download sample CSV</a> to try
+                    importing.
+                  </p>
+                  <div
+                    style="
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                      margin-top: 0.5rem;
+                    "
+                  >
                     <div class="import-block">
-                      <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:0.4rem">
-                        <button class="btn warning" id="importCsvOverride" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import CSV</button>
-                        <button class="btn warning" id="importJsonOverride" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import JSON</button>
+                      <div
+                        style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.4rem"
+                      >
+                        <button
+                          class="btn warning"
+                          id="importCsvOverride"
+                          style="font-size: 0.82rem; padding: 0.4rem 0.6rem; min-height: 0"
+                        >
+                          Import CSV
+                        </button>
+                        <button
+                          class="btn warning"
+                          id="importJsonOverride"
+                          style="font-size: 0.82rem; padding: 0.4rem 0.6rem; min-height: 0"
+                        >
+                          Import JSON
+                        </button>
                       </div>
                       <input accept=".csv" hidden id="importCsvFile" type="file" />
                       <input accept=".json" hidden id="importJsonFile" type="file" />
-                      <progress class="import-progress" id="importProgress" value="0" max="0"></progress>
+                      <progress
+                        class="import-progress"
+                        id="importProgress"
+                        value="0"
+                        max="0"
+                      ></progress>
                       <div class="import-progress-text" id="importProgressText"></div>
                     </div>
                   </div>
@@ -3143,23 +5687,116 @@
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px"
+                      >
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                        <polyline points="17 8 12 3 7 8" />
+                        <line x1="12" y1="3" x2="12" y2="15" />
+                      </svg>
                       Export
                     </span>
                   </div>
                   <p class="settings-subtext">Export your data files.</p>
-                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
+                  <div
+                    style="
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                      margin-top: 0.5rem;
+                    "
+                  >
                     <div class="export-block">
-                      <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:0.4rem">
-                        <button class="btn info" id="exportCsvBtn" aria-describedby="exportCsvDesc" title="Inventory items, CSV (includes metadata header)" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;width:100%">Export CSV</button>
-                        <span id="exportCsvDesc" class="sr-only">Inventory items, CSV (includes metadata header)</span>
-                        <button class="btn info" id="exportJsonBtn" aria-describedby="exportJsonDesc" title="Inventory items only — no settings or price history" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;width:100%">Export JSON</button>
-                        <span id="exportJsonDesc" class="sr-only">Inventory items only — no settings or price history</span>
-                        <button class="btn info" id="exportPdfBtn" aria-describedby="exportPdfDesc" title="Inventory items only — printable report" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;width:100%">Export PDF</button>
-                        <span id="exportPdfDesc" class="sr-only">Inventory items only — printable report</span>
-                        <button class="btn info" id="exportZipBtn" aria-describedby="exportZipDesc" title="Full backup — inventory, settings, price history, and images" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;width:100%">Export ZIP</button>
-                        <span id="exportZipDesc" class="sr-only">Full backup — inventory, settings, price history, and images</span>
-                        <button class="btn warning" id="importZipBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;grid-column:span 2">Restore ZIP Backup</button>
+                      <div
+                        style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.4rem"
+                      >
+                        <button
+                          class="btn info"
+                          id="exportCsvBtn"
+                          aria-describedby="exportCsvDesc"
+                          title="Inventory items, CSV (includes metadata header)"
+                          style="
+                            font-size: 0.82rem;
+                            padding: 0.4rem 0.6rem;
+                            min-height: 0;
+                            width: 100%;
+                          "
+                        >
+                          Export CSV
+                        </button>
+                        <span id="exportCsvDesc" class="sr-only"
+                          >Inventory items, CSV (includes metadata header)</span
+                        >
+                        <button
+                          class="btn info"
+                          id="exportJsonBtn"
+                          aria-describedby="exportJsonDesc"
+                          title="Inventory items only — no settings or price history"
+                          style="
+                            font-size: 0.82rem;
+                            padding: 0.4rem 0.6rem;
+                            min-height: 0;
+                            width: 100%;
+                          "
+                        >
+                          Export JSON
+                        </button>
+                        <span id="exportJsonDesc" class="sr-only"
+                          >Inventory items only — no settings or price history</span
+                        >
+                        <button
+                          class="btn info"
+                          id="exportPdfBtn"
+                          aria-describedby="exportPdfDesc"
+                          title="Inventory items only — printable report"
+                          style="
+                            font-size: 0.82rem;
+                            padding: 0.4rem 0.6rem;
+                            min-height: 0;
+                            width: 100%;
+                          "
+                        >
+                          Export PDF
+                        </button>
+                        <span id="exportPdfDesc" class="sr-only"
+                          >Inventory items only — printable report</span
+                        >
+                        <button
+                          class="btn info"
+                          id="exportZipBtn"
+                          aria-describedby="exportZipDesc"
+                          title="Full backup — inventory, settings, price history, and images"
+                          style="
+                            font-size: 0.82rem;
+                            padding: 0.4rem 0.6rem;
+                            min-height: 0;
+                            width: 100%;
+                          "
+                        >
+                          Export ZIP
+                        </button>
+                        <span id="exportZipDesc" class="sr-only"
+                          >Full backup — inventory, settings, price history, and images</span
+                        >
+                        <button
+                          class="btn warning"
+                          id="importZipBtn"
+                          style="
+                            font-size: 0.82rem;
+                            padding: 0.4rem 0.6rem;
+                            min-height: 0;
+                            grid-column: span 2;
+                          "
+                        >
+                          Restore ZIP Backup
+                        </button>
                         <input accept=".zip" hidden id="importZipFile" type="file" />
                       </div>
                     </div>
@@ -3168,193 +5805,528 @@
               </div>
 
               <!-- ── Third-Party + Encrypted Backup ── -->
-              <div class="settings-card-grid" style="margin-bottom:1rem">
+              <div class="settings-card-grid" style="margin-bottom: 1rem">
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px"
+                      >
+                        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                      </svg>
                       Third-Party
                     </span>
                   </div>
                   <p class="settings-subtext">Import data from external services like Numista.</p>
-                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
+                  <div
+                    style="
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                      margin-top: 0.5rem;
+                    "
+                  >
                     <div class="third-party-block">
-                      <div style="display:grid;grid-template-columns:1fr;gap:0.4rem">
-                        <button class="btn warning" id="importNumistaBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Import Numista</button>
+                      <div style="display: grid; grid-template-columns: 1fr; gap: 0.4rem">
+                        <button
+                          class="btn warning"
+                          id="importNumistaBtn"
+                          style="font-size: 0.82rem; padding: 0.4rem 0.6rem; min-height: 0"
+                        >
+                          Import Numista
+                        </button>
                       </div>
                       <input type="file" id="numistaImportFile" accept=".csv" hidden />
-                      <div class="beta-warning" style="margin-top:0.4rem">Numista import is a beta feature</div>
+                      <div class="beta-warning" style="margin-top: 0.4rem">
+                        Numista import is a beta feature
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div class="cloud-provider-card">
                   <div class="cloud-provider-card-header">
                     <span class="cloud-provider-card-title">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px"
+                      >
+                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                      </svg>
                       Encrypted Backup
                     </span>
                   </div>
-                  <p class="settings-subtext">AES-GCM encrypted vault file. Use to back up and restore all inventory data.</p>
-                  <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
-                    <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:0.4rem">
-                      <button class="btn" id="vaultExportBtn" aria-describedby="vaultExportDesc" title="Encrypted full backup — inventory, settings, price history, and images" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0;width:100%">Export Backup</button>
-                      <span id="vaultExportDesc" class="sr-only">Encrypted full backup — inventory, settings, price history, and images</span>
-                      <button class="btn info" id="vaultImportBtn" style="font-size:0.82rem;padding:0.4rem 0.6rem;min-height:0">Restore Backup</button>
+                  <p class="settings-subtext">
+                    AES-GCM encrypted vault file. Use to back up and restore all inventory data.
+                  </p>
+                  <div
+                    style="
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                      margin-top: 0.5rem;
+                    "
+                  >
+                    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.4rem">
+                      <button
+                        class="btn"
+                        id="vaultExportBtn"
+                        aria-describedby="vaultExportDesc"
+                        title="Encrypted full backup — inventory, settings, price history, and images"
+                        style="
+                          font-size: 0.82rem;
+                          padding: 0.4rem 0.6rem;
+                          min-height: 0;
+                          width: 100%;
+                        "
+                      >
+                        Export Backup
+                      </button>
+                      <span id="vaultExportDesc" class="sr-only"
+                        >Encrypted full backup — inventory, settings, price history, and
+                        images</span
+                      >
+                      <button
+                        class="btn info"
+                        id="vaultImportBtn"
+                        style="font-size: 0.82rem; padding: 0.4rem 0.6rem; min-height: 0"
+                      >
+                        Restore Backup
+                      </button>
                     </div>
                     <input type="file" id="vaultImportFile" accept=".stvault" hidden />
                   </div>
                 </div>
               </div>
 
-
               <!-- ── App Updates ── -->
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">App Updates</div>
-                <p class="settings-subtext">If the app appears stuck on an old version after an update, use this to clear the cached files and reload fresh. Your inventory data is not affected.</p>
+                <p class="settings-subtext">
+                  If the app appears stuck on an old version after an update, use this to clear the
+                  cached files and reload fresh. Your inventory data is not affected.
+                </p>
                 <button class="btn theme-btn" id="forceRefreshBtn">Force Refresh</button>
               </div>
-
             </div>
 
             <!-- ===== CLOUD ===== -->
             <div class="settings-section-panel" id="settingsPanel_cloud" style="display: none">
               <h3>Cloud Backup</h3>
-                <div class="settings-card-grid" style="margin-bottom:1rem">
-
-                  <!-- Dropbox card -->
-                  <div class="cloud-provider-card" id="cloudCard_dropbox">
-                    <div class="cloud-provider-card-header">
-                      <span class="cloud-provider-card-title">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px"><path d="M6 2l6 3.6L6 9.2 0 5.6zm12 0l6 3.6-6 3.6-6-3.6zm-12 8l6 3.6-6 3.6-6-3.6zm12 0l6 3.6-6 3.6-6-3.6zM6 18.4l6-3.6 6 3.6-6 3.6z"/></svg>
-                        Dropbox
-                      </span>
-                      <span class="cloud-provider-card-badges">
-                        <span class="cloud-connected-badge" style="display:none">Connected</span>
-                        <span class="cloud-badge cloud-badge--beta">BETA</span>
-                      </span>
-                    </div>
-
-                    <!-- Connection status -->
-                    <div class="cloud-connection-status" id="cloudStatus_dropbox">
-                      <div class="cloud-status-row">
-                        <span class="cloud-status-label">Status</span>
-                        <span class="cloud-status-value cloud-status-indicator" data-state="disconnected">
-                          <span class="cloud-status-dot"></span>
-                          <span class="cloud-status-text">Not connected</span>
-                        </span>
-                      </div>
-                    </div>
-
-                    <!-- STAK-449: Account info row (visible when connected) -->
-                    <div class="cloud-status-row" id="cloudDropboxAccountInfo" style="display:none">
-                      <span class="cloud-status-label">Account</span>
-                      <span class="cloud-status-value" id="cloudDropboxAccountText"></span>
-                    </div>
-
-                    <!-- Connect button (shown when disconnected) -->
-                    <div class="cloud-login-area" style="margin-top:0.5rem;display:flex;gap:0.4rem;flex-wrap:wrap">
-                      <button class="btn cloud-connect-btn" data-provider="dropbox" style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
-                        Connect
-                      </button>
-                      <button id="cloudSwitchAccountBtn_dropbox" class="btn cloud-switch-account-btn" data-provider="dropbox" style="display:none;font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><polyline points="17 11 19 13 23 9"/></svg>
-                        Switch Account
-                      </button>
-                    </div>
-                    <div id="cloudDropboxSignoutLink" style="display:none;margin-top:0.3rem">
-                      <a href="https://www.dropbox.com/logout" target="_blank" rel="noopener noreferrer"
-                         style="font-size:0.72rem;color:var(--text-secondary);text-decoration:underline">Sign out of Dropbox</a>
-                    </div>
-
-                    <!-- Auto-sync toggle + sync status -->
-                    <div class="cloud-autosync-section" style="margin-top:0.6rem;border-top:1px solid var(--border);padding-top:0.6rem">
-                      <div class="cloud-status-row" style="align-items:center">
-                        <span class="cloud-status-label"><strong>Auto-sync</strong></span>
-                        <label class="settings-toggle-switch" style="margin-left:auto">
-                          <input type="checkbox" id="cloudAutoSyncToggle" onchange="if(this.checked){enableCloudSync('dropbox');}else{disableCloudSync();}">
-                          <span class="settings-toggle-slider"></span>
-                        </label>
-                      </div>
-                      <div class="cloud-status-row" id="cloudAutoSyncStatus" style="align-items:center">
-                        <span class="cloud-status-label">Sync</span>
-                        <span class="cloud-status-value" style="display:flex;align-items:center;gap:0.4rem">
-                          <span class="cloud-sync-dot"></span>
-                          <span class="cloud-sync-status-text">Auto-sync off</span>
-                        </span>
-                      </div>
-                      <div class="cloud-status-row" style="align-items:center">
-                        <span class="cloud-status-label">Last synced</span>
-                        <span class="cloud-status-value" id="cloudAutoSyncLastSync">Never</span>
-                      </div>
-                      <div style="margin-top:0.4rem">
-                        <button class="btn" id="cloudSyncNowBtn" disabled onclick="if(typeof syncNow==='function')syncNow();else if(typeof pushSyncVault==='function')pushSyncVault();" style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0;width:100%">
-                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
-                          Sync Now
-                        </button>
-                      </div>
-                    </div>
-
-                    <!-- Manual Backup & Restore -->
-                    <div class="settings-fieldset-title" style="font-size:0.75rem;margin-top:0.6rem">Manual Backup &amp; Restore</div>
-                    <div style="display:flex;gap:0.4rem;flex-wrap:wrap;margin-top:0.4rem;align-items:center">
-                      <button class="btn success cloud-backup-btn" data-provider="dropbox" disabled style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
-                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-                        Backup
-                      </button>
-                      <button class="btn cloud-restore-btn" data-provider="dropbox" disabled style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
-                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-                        Restore
-                      </button>
-                      <span class="cloud-backup-count" id="cloudBackupCount_dropbox" style="font-size:0.72rem;color:var(--text-secondary);margin-left:auto"></span>
-                    </div>
-
-                    <!-- Backup history depth -->
-                    <div style="display:flex;align-items:center;gap:0.5rem;margin-top:0.6rem;border-top:1px solid var(--border);padding-top:0.6rem">
-                      <span class="cloud-status-label" style="flex:1" title="Number of automatic sync snapshots to retain"><strong>Sync history</strong></span>
-                      <select id="cloudBackupHistoryDepth" style="width:auto;min-width:60px;font-size:0.82rem;padding:0.25rem 0.4rem">
-                        <option value="3">3</option>
-                        <option value="5" selected>5</option>
-                        <option value="10">10</option>
-                        <option value="20">20</option>
-                      </select>
-                    </div>
-
-                    <!-- View Sync Log + Advanced -->
-                    <div style="display:flex;gap:0.5rem;margin-top:0.6rem;align-items:center">
-                      <button class="btn" style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0;flex:1"
-                        onclick="if(typeof switchLogTab==='function'){switchLogTab('cloud');} if(typeof switchSettingsSection==='function'){switchSettingsSection('changelog');}">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-                        View Sync Log
-                      </button>
-                      <button class="btn" id="cloudSyncAdvancedBtn" onclick="if(typeof openModalById==='function')openModalById('cloudSyncAdvancedModal');" style="font-size:0.8rem;padding:0.35rem 0.75rem;min-height:0">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:0.3rem"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14"/></svg>
-                        Advanced
-                      </button>
-                    </div>
-
-                    <div class="cloud-status-detail"></div>
-                    <div class="cloud-backup-list" id="cloudBackupList_dropbox" style="display:none"></div>
+              <div class="settings-card-grid" style="margin-bottom: 1rem">
+                <!-- Dropbox card -->
+                <div class="cloud-provider-card" id="cloudCard_dropbox">
+                  <div class="cloud-provider-card-header">
+                    <span class="cloud-provider-card-title">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                        style="vertical-align: -2px"
+                      >
+                        <path
+                          d="M6 2l6 3.6L6 9.2 0 5.6zm12 0l6 3.6-6 3.6-6-3.6zm-12 8l6 3.6-6 3.6-6-3.6zm12 0l6 3.6-6 3.6-6-3.6zM6 18.4l6-3.6 6 3.6-6 3.6z"
+                        />
+                      </svg>
+                      Dropbox
+                    </span>
+                    <span class="cloud-provider-card-badges">
+                      <span class="cloud-connected-badge" style="display: none">Connected</span>
+                      <span class="cloud-badge cloud-badge--beta">BETA</span>
+                    </span>
                   </div>
 
-                  <!-- Beta info card -->
-                  <div class="cloud-provider-card">
-                    <div class="cloud-provider-card-header">
-                      <span class="cloud-provider-card-title">
-                        &#x1F409; Cloud Sync Beta
+                  <!-- Connection status -->
+                  <div class="cloud-connection-status" id="cloudStatus_dropbox">
+                    <div class="cloud-status-row">
+                      <span class="cloud-status-label">Status</span>
+                      <span
+                        class="cloud-status-value cloud-status-indicator"
+                        data-state="disconnected"
+                      >
+                        <span class="cloud-status-dot"></span>
+                        <span class="cloud-status-text">Not connected</span>
                       </span>
-                      <span class="cloud-provider-card-badges">
-                        <span class="cloud-badge cloud-badge--beta">BETA</span>
-                      </span>
-                    </div>
-                    <p class="settings-subtext">Cloud Sync lets you store <strong>encrypted vault backups</strong> on your own cloud storage account. Your data is encrypted with AES-256-GCM before it leaves StakTrakr &mdash; your provider never sees the plaintext.</p>
-                    <p class="settings-subtext">This feature is in <strong>early beta</strong>. It works, but rough edges remain. We are a small team and your patience means a lot.</p>
-                    <div style="border-top:1px solid var(--border);padding-top:0.6rem;margin-top:0.5rem">
-                      <button class="resource-btn" style="font-size:0.8rem;padding:0.35rem 0.75rem" onclick="if(window.openModalById)openModalById('privacyModal')">&#x1F512; Privacy Policy</button>
                     </div>
                   </div>
 
+                  <!-- STAK-449: Account info row (visible when connected) -->
+                  <div class="cloud-status-row" id="cloudDropboxAccountInfo" style="display: none">
+                    <span class="cloud-status-label">Account</span>
+                    <span class="cloud-status-value" id="cloudDropboxAccountText"></span>
+                  </div>
+
+                  <!-- Connect button (shown when disconnected) -->
+                  <div
+                    class="cloud-login-area"
+                    style="margin-top: 0.5rem; display: flex; gap: 0.4rem; flex-wrap: wrap"
+                  >
+                    <button
+                      class="btn cloud-connect-btn"
+                      data-provider="dropbox"
+                      style="font-size: 0.82rem; padding: 0.4rem 0.9rem; min-height: 0"
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px; margin-right: 0.3rem"
+                      >
+                        <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+                        <polyline points="10 17 15 12 10 7" />
+                        <line x1="15" y1="12" x2="3" y2="12" />
+                      </svg>
+                      Connect
+                    </button>
+                    <button
+                      id="cloudSwitchAccountBtn_dropbox"
+                      class="btn cloud-switch-account-btn"
+                      data-provider="dropbox"
+                      style="
+                        display: none;
+                        font-size: 0.82rem;
+                        padding: 0.4rem 0.9rem;
+                        min-height: 0;
+                      "
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px; margin-right: 0.3rem"
+                      >
+                        <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                        <circle cx="8.5" cy="7" r="4" />
+                        <polyline points="17 11 19 13 23 9" />
+                      </svg>
+                      Switch Account
+                    </button>
+                  </div>
+                  <div id="cloudDropboxSignoutLink" style="display: none; margin-top: 0.3rem">
+                    <a
+                      href="https://www.dropbox.com/logout"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style="
+                        font-size: 0.72rem;
+                        color: var(--text-secondary);
+                        text-decoration: underline;
+                      "
+                      >Sign out of Dropbox</a
+                    >
+                  </div>
+
+                  <!-- Auto-sync toggle + sync status -->
+                  <div
+                    class="cloud-autosync-section"
+                    style="
+                      margin-top: 0.6rem;
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                    "
+                  >
+                    <div class="cloud-status-row" style="align-items: center">
+                      <span class="cloud-status-label"><strong>Auto-sync</strong></span>
+                      <label class="settings-toggle-switch" style="margin-left: auto">
+                        <input
+                          type="checkbox"
+                          id="cloudAutoSyncToggle"
+                          onchange="
+                            if (this.checked) {
+                              enableCloudSync('dropbox');
+                            } else {
+                              disableCloudSync();
+                            }
+                          "
+                        />
+                        <span class="settings-toggle-slider"></span>
+                      </label>
+                    </div>
+                    <div
+                      class="cloud-status-row"
+                      id="cloudAutoSyncStatus"
+                      style="align-items: center"
+                    >
+                      <span class="cloud-status-label">Sync</span>
+                      <span
+                        class="cloud-status-value"
+                        style="display: flex; align-items: center; gap: 0.4rem"
+                      >
+                        <span class="cloud-sync-dot"></span>
+                        <span class="cloud-sync-status-text">Auto-sync off</span>
+                      </span>
+                    </div>
+                    <div class="cloud-status-row" style="align-items: center">
+                      <span class="cloud-status-label">Last synced</span>
+                      <span class="cloud-status-value" id="cloudAutoSyncLastSync">Never</span>
+                    </div>
+                    <div style="margin-top: 0.4rem">
+                      <button
+                        class="btn"
+                        id="cloudSyncNowBtn"
+                        disabled
+                        onclick="
+                          if (typeof syncNow === 'function') syncNow();
+                          else if (typeof pushSyncVault === 'function') pushSyncVault();
+                        "
+                        style="
+                          font-size: 0.8rem;
+                          padding: 0.35rem 0.75rem;
+                          min-height: 0;
+                          width: 100%;
+                        "
+                      >
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          style="vertical-align: -1px; margin-right: 0.3rem"
+                        >
+                          <polyline points="23 4 23 10 17 10" />
+                          <polyline points="1 20 1 14 7 14" />
+                          <path
+                            d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"
+                          />
+                        </svg>
+                        Sync Now
+                      </button>
+                    </div>
+                  </div>
+
+                  <!-- Manual Backup & Restore -->
+                  <div
+                    class="settings-fieldset-title"
+                    style="font-size: 0.75rem; margin-top: 0.6rem"
+                  >
+                    Manual Backup &amp; Restore
+                  </div>
+                  <div
+                    style="
+                      display: flex;
+                      gap: 0.4rem;
+                      flex-wrap: wrap;
+                      margin-top: 0.4rem;
+                      align-items: center;
+                    "
+                  >
+                    <button
+                      class="btn success cloud-backup-btn"
+                      data-provider="dropbox"
+                      disabled
+                      style="font-size: 0.82rem; padding: 0.4rem 0.9rem; min-height: 0"
+                    >
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px; margin-right: 0.3rem"
+                      >
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                        <polyline points="17 8 12 3 7 8" />
+                        <line x1="12" y1="3" x2="12" y2="15" />
+                      </svg>
+                      Backup
+                    </button>
+                    <button
+                      class="btn cloud-restore-btn"
+                      data-provider="dropbox"
+                      disabled
+                      style="font-size: 0.82rem; padding: 0.4rem 0.9rem; min-height: 0"
+                    >
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -2px; margin-right: 0.3rem"
+                      >
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                        <polyline points="7 10 12 15 17 10" />
+                        <line x1="12" y1="15" x2="12" y2="3" />
+                      </svg>
+                      Restore
+                    </button>
+                    <span
+                      class="cloud-backup-count"
+                      id="cloudBackupCount_dropbox"
+                      style="font-size: 0.72rem; color: var(--text-secondary); margin-left: auto"
+                    ></span>
+                  </div>
+
+                  <!-- Backup history depth -->
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 0.5rem;
+                      margin-top: 0.6rem;
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                    "
+                  >
+                    <span
+                      class="cloud-status-label"
+                      style="flex: 1"
+                      title="Number of automatic sync snapshots to retain"
+                      ><strong>Sync history</strong></span
+                    >
+                    <select
+                      id="cloudBackupHistoryDepth"
+                      style="
+                        width: auto;
+                        min-width: 60px;
+                        font-size: 0.82rem;
+                        padding: 0.25rem 0.4rem;
+                      "
+                    >
+                      <option value="3">3</option>
+                      <option value="5" selected>5</option>
+                      <option value="10">10</option>
+                      <option value="20">20</option>
+                    </select>
+                  </div>
+
+                  <!-- View Sync Log + Advanced -->
+                  <div style="display: flex; gap: 0.5rem; margin-top: 0.6rem; align-items: center">
+                    <button
+                      class="btn"
+                      style="font-size: 0.8rem; padding: 0.35rem 0.75rem; min-height: 0; flex: 1"
+                      onclick="
+                        if (typeof switchLogTab === 'function') {
+                          switchLogTab('cloud');
+                        }
+                        if (typeof switchSettingsSection === 'function') {
+                          switchSettingsSection('changelog');
+                        }
+                      "
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -1px; margin-right: 0.3rem"
+                      >
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                        <polyline points="14 2 14 8 20 8" />
+                        <line x1="16" y1="13" x2="8" y2="13" />
+                        <line x1="16" y1="17" x2="8" y2="17" />
+                        <polyline points="10 9 9 9 8 9" />
+                      </svg>
+                      View Sync Log
+                    </button>
+                    <button
+                      class="btn"
+                      id="cloudSyncAdvancedBtn"
+                      onclick="
+                        if (typeof openModalById === 'function')
+                          openModalById('cloudSyncAdvancedModal');
+                      "
+                      style="font-size: 0.8rem; padding: 0.35rem 0.75rem; min-height: 0"
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        style="vertical-align: -1px; margin-right: 0.3rem"
+                      >
+                        <circle cx="12" cy="12" r="3" />
+                        <path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14" />
+                      </svg>
+                      Advanced
+                    </button>
+                  </div>
+
+                  <div class="cloud-status-detail"></div>
+                  <div
+                    class="cloud-backup-list"
+                    id="cloudBackupList_dropbox"
+                    style="display: none"
+                  ></div>
                 </div>
+
+                <!-- Beta info card -->
+                <div class="cloud-provider-card">
+                  <div class="cloud-provider-card-header">
+                    <span class="cloud-provider-card-title"> &#x1F409; Cloud Sync Beta </span>
+                    <span class="cloud-provider-card-badges">
+                      <span class="cloud-badge cloud-badge--beta">BETA</span>
+                    </span>
+                  </div>
+                  <p class="settings-subtext">
+                    Cloud Sync lets you store <strong>encrypted vault backups</strong> on your own
+                    cloud storage account. Your data is encrypted with AES-256-GCM before it leaves
+                    StakTrakr &mdash; your provider never sees the plaintext.
+                  </p>
+                  <p class="settings-subtext">
+                    This feature is in <strong>early beta</strong>. It works, but rough edges
+                    remain. We are a small team and your patience means a lot.
+                  </p>
+                  <div
+                    style="
+                      border-top: 1px solid var(--border);
+                      padding-top: 0.6rem;
+                      margin-top: 0.5rem;
+                    "
+                  >
+                    <button
+                      class="resource-btn"
+                      style="font-size: 0.8rem; padding: 0.35rem 0.75rem"
+                      onclick="if (window.openModalById) openModalById('privacyModal');"
+                    >
+                      &#x1F512; Privacy Policy
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <!-- ===== STORAGE ===== -->
@@ -3375,7 +6347,10 @@
                   <div class="storage-stat-label">IndexedDB (Images)</div>
                   <div class="storage-stat-value" id="storageStat_idb">—</div>
                   <div class="storage-stat-bar-wrap">
-                    <div class="storage-stat-bar storage-stat-bar--idb" id="storageStatBar_idb"></div>
+                    <div
+                      class="storage-stat-bar storage-stat-bar--idb"
+                      id="storageStatBar_idb"
+                    ></div>
                   </div>
                   <div class="storage-stat-sub" id="storageStat_idb_sub">of 50 MB</div>
                 </div>
@@ -3383,8 +6358,14 @@
                   <div class="storage-stat-label">Combined</div>
                   <div class="storage-stat-value" id="storageStat_combined">—</div>
                   <div class="storage-stat-bar-wrap storage-stat-bar-wrap--stacked">
-                    <div class="storage-stat-bar storage-stat-bar--ls" id="storageStatBar_combined_ls"></div>
-                    <div class="storage-stat-bar storage-stat-bar--idb" id="storageStatBar_combined_idb"></div>
+                    <div
+                      class="storage-stat-bar storage-stat-bar--ls"
+                      id="storageStatBar_combined_ls"
+                    ></div>
+                    <div
+                      class="storage-stat-bar storage-stat-bar--idb"
+                      id="storageStatBar_combined_idb"
+                    ></div>
                   </div>
                   <div class="storage-stat-sub" id="storageStat_combined_sub">of ~55 MB cap</div>
                 </div>
@@ -3393,11 +6374,32 @@
               <!-- ── localStorage Keys ── -->
               <div class="settings-fieldset">
                 <div class="storage-fieldset-header">
-                  <div class="settings-fieldset-title" style="margin:0">localStorage Keys</div>
+                  <div class="settings-fieldset-title" style="margin: 0">localStorage Keys</div>
                   <div class="storage-fieldset-actions">
-                    <button class="storage-toggle-tiny btn-link" id="storageToggleTiny">Show minor keys</button>
-                    <button class="btn storage-refresh-btn" id="storageRefreshBtn" title="Refresh storage stats">
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M23 4v6h-6"/><path d="M1 20v-6h6"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+                    <button class="storage-toggle-tiny btn-link" id="storageToggleTiny">
+                      Show minor keys
+                    </button>
+                    <button
+                      class="btn storage-refresh-btn"
+                      id="storageRefreshBtn"
+                      title="Refresh storage stats"
+                    >
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="M23 4v6h-6" />
+                        <path d="M1 20v-6h6" />
+                        <path
+                          d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"
+                        />
+                      </svg>
                       Refresh
                     </button>
                   </div>
@@ -3420,15 +6422,19 @@
                 <div class="settings-fieldset-title">Data Reset</div>
                 <div class="settings-card-grid">
                   <div class="settings-card boating-accident-section">
-                    <p class="settings-subtext">Permanently remove inventory or wipe all app data. These actions cannot be undone.</p>
+                    <p class="settings-subtext">
+                      Permanently remove inventory or wipe all app data. These actions cannot be
+                      undone.
+                    </p>
                     <div class="settings-btn-row">
-                      <button class="btn warning" id="removeInventoryDataBtn">Remove Inventory</button>
+                      <button class="btn warning" id="removeInventoryDataBtn">
+                        Remove Inventory
+                      </button>
                       <button class="btn danger" id="boatingAccidentBtn">Wipe All Data</button>
                     </div>
                   </div>
                 </div>
               </div>
-
             </div>
 
             <!-- ===== CURRENCY & PRICING ===== -->
@@ -3438,7 +6444,10 @@
               <div class="settings-fieldset">
                 <div class="settings-group">
                   <div class="settings-group-label">Display currency</div>
-                  <p class="settings-subtext">All prices, spot values, and exports will use this currency. Spot prices are fetched in USD and converted using daily exchange rates.</p>
+                  <p class="settings-subtext">
+                    All prices, spot values, and exports will use this currency. Spot prices are
+                    fetched in USD and converted using daily exchange rates.
+                  </p>
                   <select id="settingsDisplayCurrency"></select>
                 </div>
                 <div class="settings-group">
@@ -3451,7 +6460,9 @@
                 </div>
                 <div class="settings-group">
                   <div class="settings-group-label">24h price comparison</div>
-                  <p class="settings-subtext">Choose how the 24h percentage change on spot cards is calculated.</p>
+                  <p class="settings-subtext">
+                    Choose how the 24h percentage change on spot cards is calculated.
+                  </p>
                   <select id="settingsSpotCompareMode">
                     <option value="close-close">Close / Close (default)</option>
                     <option value="open-open">Open / Open</option>
@@ -3465,14 +6476,16 @@
             <div class="settings-section-panel" id="settingsPanel_goldback" style="display: none">
               <h3>Goldback Denomination Pricing</h3>
               <p class="settings-subtext">
-                Set market prices for Goldback denominations manually or auto-estimate from gold spot.
-                Check current rates at
+                Set market prices for Goldback denominations manually or auto-estimate from gold
+                spot. Check current rates at
                 <a href="#" id="goldbackExchangeRateLink">goldback.com/exchange-rates</a>.
               </p>
 
               <div class="settings-group">
                 <label>Goldback Pricing</label>
-                <p class="settings-subtext">Use denomination prices as retail value for gb-unit items.</p>
+                <p class="settings-subtext">
+                  Use denomination prices as retail value for gb-unit items.
+                </p>
                 <div id="settingsGoldbackEnabled" class="chip-sort-group">
                   <button class="chip-sort-btn" data-val="on" type="button">On</button>
                   <button class="chip-sort-btn active" data-val="off" type="button">Off</button>
@@ -3482,39 +6495,81 @@
               <div class="settings-group">
                 <label>Real-Time Price Estimation</label>
                 <p class="settings-subtext">
-                  Auto-estimate prices from gold spot: <code>2 &times; (spot&thinsp;/&thinsp;1000) &times; modifier</code>.
-                  Manual edits will be overwritten on the next spot refresh.
+                  Auto-estimate prices from gold spot:
+                  <code>2 &times; (spot&thinsp;/&thinsp;1000) &times; modifier</code>. Manual edits
+                  will be overwritten on the next spot refresh.
                 </p>
                 <div id="settingsGoldbackEstimateEnabled" class="chip-sort-group">
                   <button class="chip-sort-btn" data-val="on" type="button">On</button>
                   <button class="chip-sort-btn active" data-val="off" type="button">Off</button>
                 </div>
-                <div id="goldbackEstimateModifierRow" style="display:none;margin-top:0.5rem;">
-                  <label style="font-size:0.85em;">
+                <div id="goldbackEstimateModifierRow" style="display: none; margin-top: 0.5rem">
+                  <label style="font-size: 0.85em">
                     Modifier
-                    <span class="settings-tooltip" title="Community research suggests Goldback pegs at roughly 2&times; gold spot + ~3% (modifier 1.03). The default is 1.0 (no premium). Adjust based on how your API spot price compares to Goldback's published rates.">&#9432;</span>
+                    <span
+                      class="settings-tooltip"
+                      title="Community research suggests Goldback pegs at roughly 2&times; gold spot + ~3% (modifier 1.03). The default is 1.0 (no premium). Adjust based on how your API spot price compares to Goldback's published rates."
+                      >&#9432;</span
+                    >
                   </label>
-                  <div style="display:flex;align-items:center;gap:0.4rem;margin-top:0.25rem;">
-                    <input type="number" id="goldbackEstimateModifierInput" min="0.5" max="2.0" step="0.01" value="1.0" style="width:80px;" />
-                    <span style="font-size:0.8em;color:var(--text-secondary);">(1.0 = no premium, 1.03 = ~3% premium)</span>
+                  <div style="display: flex; align-items: center; gap: 0.4rem; margin-top: 0.25rem">
+                    <input
+                      type="number"
+                      id="goldbackEstimateModifierInput"
+                      min="0.5"
+                      max="2.0"
+                      step="0.01"
+                      value="1.0"
+                      style="width: 80px"
+                    />
+                    <span style="font-size: 0.8em; color: var(--text-secondary)"
+                      >(1.0 = no premium, 1.03 = ~3% premium)</span
+                    >
                   </div>
                 </div>
-                <p id="goldbackEstimateInfo" class="settings-subtext" style="display:none;margin-top:0.5rem;"></p>
+                <p
+                  id="goldbackEstimateInfo"
+                  class="settings-subtext"
+                  style="display: none; margin-top: 0.5rem"
+                ></p>
               </div>
 
               <div class="settings-group">
                 <label>Refresh from API</label>
-                <p class="settings-subtext">Fetch today's official Goldback exchange rate from the StakTrakr API and populate all denomination prices automatically.</p>
-                <button class="btn premium" id="goldbackEstimateRefreshBtn" type="button" style="display:none;">Refresh from API</button>
+                <p class="settings-subtext">
+                  Fetch today's official Goldback exchange rate from the StakTrakr API and populate
+                  all denomination prices automatically.
+                </p>
+                <button
+                  class="btn premium"
+                  id="goldbackEstimateRefreshBtn"
+                  type="button"
+                  style="display: none"
+                >
+                  Refresh from API
+                </button>
               </div>
 
               <div class="settings-group">
                 <label>Quick Fill</label>
-                <p class="settings-subtext">Enter the 1 Goldback exchange rate to auto-fill all denominations.</p>
-                <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.75rem;">
-                  <span id="gbQuickFillSymbol" style="color:var(--text-secondary);">$</span>
-                  <input type="number" id="goldbackQuickFillInput" min="0" step="0.01" placeholder="1 GB rate" style="width:100px;" />
-                  <button class="btn premium" id="goldbackQuickFillBtn" type="button">Set All</button>
+                <p class="settings-subtext">
+                  Enter the 1 Goldback exchange rate to auto-fill all denominations.
+                </p>
+                <div
+                  style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem"
+                >
+                  <span id="gbQuickFillSymbol" style="color: var(--text-secondary)">$</span>
+                  <input
+                    type="number"
+                    id="goldbackQuickFillInput"
+                    min="0"
+                    step="0.01"
+                    placeholder="1 GB rate"
+                    style="width: 100px"
+                  />
+                  <button class="btn premium" id="goldbackQuickFillBtn" type="button">
+                    Set All
+                  </button>
                 </div>
               </div>
 
@@ -3533,60 +6588,155 @@
                     <!-- Rows rendered dynamically by syncGoldbackSettingsUI() -->
                   </tbody>
                 </table>
-                <button class="btn premium" id="goldbackSavePricesBtn" type="button" style="margin-top: 0.5rem;">Save Prices</button>
-                <button class="btn" id="goldbackHistoryBtn" type="button" style="margin-top: 0.5rem;">Goldback History</button>
+                <button
+                  class="btn premium"
+                  id="goldbackSavePricesBtn"
+                  type="button"
+                  style="margin-top: 0.5rem"
+                >
+                  Save Prices
+                </button>
+                <button
+                  class="btn"
+                  id="goldbackHistoryBtn"
+                  type="button"
+                  style="margin-top: 0.5rem"
+                >
+                  Goldback History
+                </button>
               </div>
             </div>
 
             <!-- ===== MARKET PRICES ===== -->
             <div id="settingsPanel_market" class="settings-section-panel" style="display: none">
               <!-- Market Filter Matrix (STAK-515) -->
-              <div class="market-header-row" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.25rem;">
-                <h3 style="margin:0;">Market Settings</h3>
-                <div class="market-header-sync-group" style="display:flex;align-items:center;gap:8px;">
-                  <button id="retailSyncBtn" class="retail-sync-btn market-sync-btn" type="button">Sync Now</button>
+              <div
+                class="market-header-row"
+                style="
+                  display: flex;
+                  justify-content: space-between;
+                  align-items: center;
+                  margin-bottom: 0.25rem;
+                "
+              >
+                <h3 style="margin: 0">Market Settings</h3>
+                <div
+                  class="market-header-sync-group"
+                  style="display: flex; align-items: center; gap: 8px"
+                >
+                  <button id="retailSyncBtn" class="retail-sync-btn market-sync-btn" type="button">
+                    Sync Now
+                  </button>
                   <span id="retailSyncStatus" class="settings-subtext"></span>
                 </div>
               </div>
-              <p class="settings-subtext" style="margin:0.5rem 0 0.75rem;">Filter which items appear in the ticker and market price table on the main page.</p>
+              <p class="settings-subtext" style="margin: 0.5rem 0 0.75rem">
+                Filter which items appear in the ticker and market price table on the main page.
+              </p>
               <div class="market-filter-pills" id="marketFilterMetalPills">
-                <button class="market-filter-pill active" data-metal="all" type="button" aria-pressed="true">All</button>
-                <button class="market-filter-pill" data-metal="silver" type="button" aria-pressed="false">Silver</button>
-                <button class="market-filter-pill" data-metal="gold" type="button" aria-pressed="false">Gold</button>
-                <button class="market-filter-pill" data-metal="platinum" type="button" aria-pressed="false">Platinum</button>
-                <button class="market-filter-pill" data-metal="palladium" type="button" aria-pressed="false">Palladium</button>
-                <button class="market-filter-pill" data-metal="goldback" type="button" aria-pressed="false">Goldback</button>
+                <button
+                  class="market-filter-pill active"
+                  data-metal="all"
+                  type="button"
+                  aria-pressed="true"
+                >
+                  All
+                </button>
+                <button
+                  class="market-filter-pill"
+                  data-metal="silver"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  Silver
+                </button>
+                <button
+                  class="market-filter-pill"
+                  data-metal="gold"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  Gold
+                </button>
+                <button
+                  class="market-filter-pill"
+                  data-metal="platinum"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  Platinum
+                </button>
+                <button
+                  class="market-filter-pill"
+                  data-metal="palladium"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  Palladium
+                </button>
+                <button
+                  class="market-filter-pill"
+                  data-metal="goldback"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  Goldback
+                </button>
               </div>
               <div id="marketFilterMatrixWrap" class="market-filter-matrix-wrap">
-                <table id="marketFilterMatrix" class="market-filter-matrix" aria-label="Market item filter matrix">
+                <table
+                  id="marketFilterMatrix"
+                  class="market-filter-matrix"
+                  aria-label="Market item filter matrix"
+                >
                   <thead id="marketFilterMatrixHead"></thead>
                   <tbody id="marketFilterMatrixBody"></tbody>
                 </table>
               </div>
-              <div id="marketFilterStatus" class="settings-subtext" style="margin-top:0.5rem;"></div>
+              <div
+                id="marketFilterStatus"
+                class="settings-subtext"
+                style="margin-top: 0.5rem"
+              ></div>
             </div>
 
             <!-- ===== ACTIVITY LOG ===== -->
             <div class="settings-section-panel" id="settingsPanel_changelog" style="display: none">
               <h3>Activity Log</h3>
-              <p class="settings-subtext">Browse inventory changes, spot price history, catalog lookups, and per-item price tracking.</p>
+              <p class="settings-subtext">
+                Browse inventory changes, spot price history, catalog lookups, and per-item price
+                tracking.
+              </p>
 
               <!-- Log sub-tab bar -->
               <div class="settings-log-tabs">
-                <button class="settings-log-tab active" data-log-tab="changelog" type="button">Changelog</button>
+                <button class="settings-log-tab active" data-log-tab="changelog" type="button">
+                  Changelog
+                </button>
                 <button class="settings-log-tab" data-log-tab="metals" type="button">Metals</button>
-                <button class="settings-log-tab" data-log-tab="lbma" type="button">LBMA History</button>
-                <button class="settings-log-tab" data-log-tab="catalogs" type="button">Catalogs</button>
-                <button class="settings-log-tab" data-log-tab="pricehistory" type="button">Price History</button>
+                <button class="settings-log-tab" data-log-tab="lbma" type="button">
+                  LBMA History
+                </button>
+                <button class="settings-log-tab" data-log-tab="catalogs" type="button">
+                  Catalogs
+                </button>
+                <button class="settings-log-tab" data-log-tab="pricehistory" type="button">
+                  Price History
+                </button>
                 <button class="settings-log-tab" data-log-tab="cloud" type="button">Cloud</button>
                 <button class="settings-log-tab" data-log-tab="market" type="button">Market</button>
               </div>
 
               <!-- Changelog panel (existing) -->
               <div class="settings-log-panel" id="logPanel_changelog">
-                <p class="settings-subtext">Recent inventory changes. Click a row to edit the item, or undo/redo individual changes.</p>
+                <p class="settings-subtext">
+                  Recent inventory changes. Click a row to edit the item, or undo/redo individual
+                  changes.
+                </p>
                 <div class="settings-changelog-actions">
-                  <button class="btn secondary" id="settingsChangeLogClearBtn" type="button">Clear Log</button>
+                  <button class="btn secondary" id="settingsChangeLogClearBtn" type="button">
+                    Clear Log
+                  </button>
                 </div>
                 <div class="settings-changelog-wrap">
                   <table id="settingsChangeLogTable">
@@ -3607,9 +6757,13 @@
 
               <!-- Metals (Spot History) panel -->
               <div class="settings-log-panel" id="logPanel_metals" style="display: none">
-                <p class="settings-subtext">Spot price updates recorded from API syncs and manual edits.</p>
+                <p class="settings-subtext">
+                  Spot price updates recorded from API syncs and manual edits.
+                </p>
                 <div class="settings-changelog-actions">
-                  <button class="btn secondary" id="settingsSpotHistoryClearBtn" type="button">Clear Spot History</button>
+                  <button class="btn secondary" id="settingsSpotHistoryClearBtn" type="button">
+                    Clear Spot History
+                  </button>
                 </div>
                 <div class="settings-changelog-wrap">
                   <table id="settingsSpotHistoryTable">
@@ -3629,7 +6783,9 @@
 
               <!-- LBMA History (Reference Seed Data) panel -->
               <div class="settings-log-panel" id="logPanel_lbma" style="display: none">
-                <p class="settings-subtext">Historical LBMA reference prices from bundled seed data (read-only).</p>
+                <p class="settings-subtext">
+                  Historical LBMA reference prices from bundled seed data (read-only).
+                </p>
                 <div class="settings-pricehistory-controls">
                   <select class="settings-filter-input" id="settingsLbmaMetalFilter">
                     <option value="all">All Metals</option>
@@ -3638,10 +6794,16 @@
                     <option value="platinum">Platinum</option>
                     <option value="palladium">Palladium</option>
                   </select>
-                  <input class="settings-filter-input" id="settingsLbmaStartDate" type="date">
-                  <input class="settings-filter-input" id="settingsLbmaEndDate" type="date">
-                  <button class="btn secondary" id="settingsLbmaResetBtn" type="button">Reset</button>
-                  <span class="settings-subtext" id="settingsLbmaResultCount" style="margin-left:auto;"></span>
+                  <input class="settings-filter-input" id="settingsLbmaStartDate" type="date" />
+                  <input class="settings-filter-input" id="settingsLbmaEndDate" type="date" />
+                  <button class="btn secondary" id="settingsLbmaResetBtn" type="button">
+                    Reset
+                  </button>
+                  <span
+                    class="settings-subtext"
+                    id="settingsLbmaResultCount"
+                    style="margin-left: auto"
+                  ></span>
                 </div>
                 <div class="settings-changelog-wrap">
                   <table id="settingsLbmaHistoryTable">
@@ -3660,9 +6822,13 @@
 
               <!-- Catalogs panel -->
               <div class="settings-log-panel" id="logPanel_catalogs" style="display: none">
-                <p class="settings-subtext">Catalog API call history. Failed lookups are highlighted in red.</p>
+                <p class="settings-subtext">
+                  Catalog API call history. Failed lookups are highlighted in red.
+                </p>
                 <div class="settings-changelog-actions">
-                  <button class="btn secondary" id="settingsCatalogHistoryClearBtn" type="button">Clear Catalog History</button>
+                  <button class="btn secondary" id="settingsCatalogHistoryClearBtn" type="button">
+                    Clear Catalog History
+                  </button>
                 </div>
                 <div class="settings-changelog-wrap">
                   <table id="settingsCatalogHistoryTable">
@@ -3684,10 +6850,19 @@
 
               <!-- Price History panel -->
               <div class="settings-log-panel" id="logPanel_pricehistory" style="display: none">
-                <p class="settings-subtext">Per-item price snapshots recorded on add, edit, and spot price sync.</p>
+                <p class="settings-subtext">
+                  Per-item price snapshots recorded on add, edit, and spot price sync.
+                </p>
                 <div class="settings-pricehistory-controls">
-                  <input class="settings-filter-input" id="priceHistoryFilterInput" placeholder="Filter by item name..." type="text">
-                  <button class="btn secondary" id="settingsPriceHistoryClearBtn" type="button">Clear Price History</button>
+                  <input
+                    class="settings-filter-input"
+                    id="priceHistoryFilterInput"
+                    placeholder="Filter by item name..."
+                    type="text"
+                  />
+                  <button class="btn secondary" id="settingsPriceHistoryClearBtn" type="button">
+                    Clear Price History
+                  </button>
                 </div>
                 <div class="settings-changelog-wrap">
                   <table id="settingsPriceHistoryTable">
@@ -3708,9 +6883,13 @@
 
               <!-- Cloud panel -->
               <div class="settings-log-panel" id="logPanel_cloud" style="display: none">
-                <p class="settings-subtext">Cloud sync activity — backups, restores, connections, and token refreshes.</p>
+                <p class="settings-subtext">
+                  Cloud sync activity — backups, restores, connections, and token refreshes.
+                </p>
                 <div class="settings-changelog-actions">
-                  <button class="btn secondary" id="settingsCloudActivityClearBtn" type="button">Clear Cloud Log</button>
+                  <button class="btn secondary" id="settingsCloudActivityClearBtn" type="button">
+                    Clear Cloud Log
+                  </button>
                 </div>
                 <div class="settings-changelog-wrap">
                   <table id="settingsCloudActivityTable">
@@ -3732,7 +6911,10 @@
               <div id="logPanel_market" class="settings-log-panel" style="display: none">
                 <div class="retail-history-controls">
                   <label for="retailHistorySlugSelect" class="retail-history-label">Coin:</label>
-                  <select id="retailHistorySlugSelect" class="form-select form-select-sm retail-history-select">
+                  <select
+                    id="retailHistorySlugSelect"
+                    class="form-select form-select-sm retail-history-select"
+                  >
                     <option value="ase">American Silver Eagle</option>
                     <option value="maple-silver">Silver Maple Leaf</option>
                     <option value="britannia-silver">Silver Britannia</option>
@@ -3746,10 +6928,18 @@
                     <option value="ape">American Platinum Eagle</option>
                   </select>
                   <div class="retail-timeframe-tabs">
-                    <button class="retail-tf-btn active" data-retail-timeframe="7" type="button">7d</button>
-                    <button class="retail-tf-btn" data-retail-timeframe="30" type="button">30d</button>
-                    <button class="retail-tf-btn" data-retail-timeframe="90" type="button">90d</button>
-                    <button class="retail-tf-btn" data-retail-timeframe="all" type="button">All</button>
+                    <button class="retail-tf-btn active" data-retail-timeframe="7" type="button">
+                      7d
+                    </button>
+                    <button class="retail-tf-btn" data-retail-timeframe="30" type="button">
+                      30d
+                    </button>
+                    <button class="retail-tf-btn" data-retail-timeframe="90" type="button">
+                      90d
+                    </button>
+                    <button class="retail-tf-btn" data-retail-timeframe="all" type="button">
+                      All
+                    </button>
                   </div>
                 </div>
                 <div id="retailSyncLogContainer"></div>
@@ -3760,7 +6950,6 @@
                   </table>
                 </div>
               </div>
-
             </div>
 
             <!-- ===== FAQ ===== -->
@@ -3774,21 +6963,42 @@
                 <details class="faq-item">
                   <summary class="faq-question">Who can see my inventory?</summary>
                   <div class="faq-answer">
-                    <p>Only you. Your inventory is stored entirely on your own device using your browser's localStorage (and IndexedDB for images). No data is ever sent to any server unless you explicitly choose to use a cloud backup feature like Dropbox.</p>
-                    <p>Even when you use cloud backup, the data is encrypted on your device <em>before</em> it leaves — the cloud provider receives an encrypted blob they cannot read.</p>
+                    <p>
+                      Only you. Your inventory is stored entirely on your own device using your
+                      browser's localStorage (and IndexedDB for images). No data is ever sent to any
+                      server unless you explicitly choose to use a cloud backup feature like
+                      Dropbox.
+                    </p>
+                    <p>
+                      Even when you use cloud backup, the data is encrypted on your device
+                      <em>before</em> it leaves — the cloud provider receives an encrypted blob they
+                      cannot read.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
                   <summary class="faq-question">Can the developer see my data?</summary>
                   <div class="faq-answer">
-                    <p>No. There is no server-side component, no database, and no analytics that transmit your inventory. The developer has no technical means to access your data.</p>
+                    <p>
+                      No. There is no server-side component, no database, and no analytics that
+                      transmit your inventory. The developer has no technical means to access your
+                      data.
+                    </p>
                     <p>The only outbound network requests the app makes are:</p>
                     <ul class="faq-list">
-                      <li>Spot price lookups from public metal pricing APIs (no inventory data included)</li>
+                      <li>
+                        Spot price lookups from public metal pricing APIs (no inventory data
+                        included)
+                      </li>
                       <li>Numista / PCGS catalog searches when you use those features</li>
-                      <li>Version check against <code>staktrakr.com/version.json</code> (no inventory data included)</li>
-                      <li>Exchange rate data from Open Exchange Rates (no inventory data included)</li>
+                      <li>
+                        Version check against <code>staktrakr.com/version.json</code> (no inventory
+                        data included)
+                      </li>
+                      <li>
+                        Exchange rate data from Open Exchange Rates (no inventory data included)
+                      </li>
                     </ul>
                   </div>
                 </details>
@@ -3796,34 +7006,90 @@
                 <details class="faq-item">
                   <summary class="faq-question">Does this app use cookies or tracking?</summary>
                   <div class="faq-answer">
-                    <p><strong>StakTrakr itself sets no cookies.</strong> No advertising SDKs. No tracking pixels. The app uses browser localStorage and IndexedDB solely to store your inventory and preferences on your own device.</p>
-                    <p>However, when you use the <strong>hosted version</strong> at staktrakr.com (served via Cloudflare Pages), two things happen at the infrastructure level:</p>
+                    <p>
+                      <strong>StakTrakr itself sets no cookies.</strong> No advertising SDKs. No
+                      tracking pixels. The app uses browser localStorage and IndexedDB solely to
+                      store your inventory and preferences on your own device.
+                    </p>
+                    <p>
+                      However, when you use the <strong>hosted version</strong> at staktrakr.com
+                      (served via Cloudflare Pages), two things happen at the infrastructure level:
+                    </p>
                     <ul>
-                      <li><strong>Cloudflare Web Analytics</strong> — collects aggregated, anonymous page view metrics (visit counts, countries, browser types) without cookies and without building individual user profiles. <a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener">Learn more</a>.</li>
-                      <li><strong>Cloudflare infrastructure cookie</strong> — Cloudflare may set a temporary cookie (e.g. <code>__cf_bm</code>) for bot protection. This is set by Cloudflare's CDN, not by StakTrakr. It contains no inventory data, is not used for tracking, and <strong>can be safely blocked</strong> without affecting the app.</li>
+                      <li>
+                        <strong>Cloudflare Web Analytics</strong> — collects aggregated, anonymous
+                        page view metrics (visit counts, countries, browser types) without cookies
+                        and without building individual user profiles.
+                        <a
+                          href="https://www.cloudflare.com/web-analytics/"
+                          target="_blank"
+                          rel="noopener"
+                          >Learn more</a
+                        >.
+                      </li>
+                      <li>
+                        <strong>Cloudflare infrastructure cookie</strong> — Cloudflare may set a
+                        temporary cookie (e.g. <code>__cf_bm</code>) for bot protection. This is set
+                        by Cloudflare's CDN, not by StakTrakr. It contains no inventory data, is not
+                        used for tracking, and <strong>can be safely blocked</strong> without
+                        affecting the app.
+                      </li>
                     </ul>
-                    <p>No inventory data is ever included in any of the above. If you download and run the app locally from a ZIP file, none of this applies — no analytics, no cookies, nothing.</p>
+                    <p>
+                      No inventory data is ever included in any of the above. If you download and
+                      run the app locally from a ZIP file, none of this applies — no analytics, no
+                      cookies, nothing.
+                    </p>
                     <details class="faq-technical">
                       <summary>What Cloudflare does and does not do on the hosted site</summary>
-                      <p><strong>Does not:</strong> use localStorage · fingerprint individuals · share data with advertisers · track you across sites · access your inventory<br><strong>Does:</strong> log page views at the network edge · process IP addresses server-side (not stored individually) · report aggregated metrics to the site owner only · may set a temporary infrastructure cookie for bot protection (safe to block)</p>
+                      <p>
+                        <strong>Does not:</strong> use localStorage · fingerprint individuals ·
+                        share data with advertisers · track you across sites · access your
+                        inventory<br /><strong>Does:</strong> log page views at the network edge ·
+                        process IP addresses server-side (not stored individually) · report
+                        aggregated metrics to the site owner only · may set a temporary
+                        infrastructure cookie for bot protection (safe to block)
+                      </p>
                     </details>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">What happens if I clear my browser history?</summary>
+                  <summary class="faq-question">
+                    What happens if I clear my browser history?
+                  </summary>
                   <div class="faq-answer">
-                    <p>If you clear browser storage (not just history), your inventory data stored in localStorage will be deleted. Browser history alone does not affect your data.</p>
-                    <p><strong>Recommendation:</strong> Export a backup regularly using the ZIP or vault export options. This gives you a file you control, independent of any browser.</p>
+                    <p>
+                      If you clear browser storage (not just history), your inventory data stored in
+                      localStorage will be deleted. Browser history alone does not affect your data.
+                    </p>
+                    <p>
+                      <strong>Recommendation:</strong> Export a backup regularly using the ZIP or
+                      vault export options. This gives you a file you control, independent of any
+                      browser.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
                   <summary class="faq-question">Is this app safe from viruses or malware?</summary>
                   <div class="faq-answer">
-                    <p>StakTrakr is open-source software — anyone can read the code at <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener">github.com/lbruton/StakTrakr</a>. There is no hidden code.</p>
-                    <p>The app loads several trusted third-party libraries (Chart.js, PapaParse, jsPDF, Bootstrap) from CDNs. These are industry-standard libraries used by millions of websites.</p>
-                    <p>Like any web app, your device's security is part of the equation. Keep your browser and operating system updated, and be cautious about browser extensions that have broad permissions.</p>
+                    <p>
+                      StakTrakr is open-source software — anyone can read the code at
+                      <a href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener"
+                        >github.com/lbruton/StakTrakr</a
+                      >. There is no hidden code.
+                    </p>
+                    <p>
+                      The app loads several trusted third-party libraries (Chart.js, PapaParse,
+                      jsPDF, Bootstrap) from CDNs. These are industry-standard libraries used by
+                      millions of websites.
+                    </p>
+                    <p>
+                      Like any web app, your device's security is part of the equation. Keep your
+                      browser and operating system updated, and be cautious about browser extensions
+                      that have broad permissions.
+                    </p>
                   </div>
                 </details>
               </div>
@@ -3833,14 +7099,26 @@
                 <div class="settings-fieldset-title">📦 Backups &amp; Export</div>
 
                 <details class="faq-item">
-                  <summary class="faq-question">How do I get my data out if I want to leave?</summary>
+                  <summary class="faq-question">
+                    How do I get my data out if I want to leave?
+                  </summary>
                   <div class="faq-answer">
-                    <p>Your data is never locked in. You can export at any time in multiple formats:</p>
+                    <p>
+                      Your data is never locked in. You can export at any time in multiple formats:
+                    </p>
                     <ul class="faq-list">
-                      <li><strong>CSV</strong> — opens in Excel, Google Sheets, or any spreadsheet app</li>
+                      <li>
+                        <strong>CSV</strong> — opens in Excel, Google Sheets, or any spreadsheet app
+                      </li>
                       <li><strong>PDF</strong> — a formatted report for printing or archiving</li>
-                      <li><strong>ZIP backup</strong> — a complete snapshot including settings, importable into any future StakTrakr install</li>
-                      <li><strong>Encrypted vault (.stvault)</strong> — a password-protected backup file</li>
+                      <li>
+                        <strong>ZIP backup</strong> — a complete snapshot including settings,
+                        importable into any future StakTrakr install
+                      </li>
+                      <li>
+                        <strong>Encrypted vault (.stvault)</strong> — a password-protected backup
+                        file
+                      </li>
                     </ul>
                     <p>All export options are in the <strong>Inventory → Export</strong> menu.</p>
                   </div>
@@ -3849,16 +7127,33 @@
                 <details class="faq-item">
                   <summary class="faq-question">Will this app keep working in the future?</summary>
                   <div class="faq-answer">
-                    <p>Yes. Because the app runs entirely in your browser with no server requirement, a downloaded copy will continue to work indefinitely — even without an internet connection — as long as browsers continue to support standard web APIs (localStorage, IndexedDB, JavaScript).</p>
-                    <p>You can always save a ZIP of the app and open it locally. The app is designed from the ground up to work with the <code>file://</code> protocol.</p>
+                    <p>
+                      Yes. Because the app runs entirely in your browser with no server requirement,
+                      a downloaded copy will continue to work indefinitely — even without an
+                      internet connection — as long as browsers continue to support standard web
+                      APIs (localStorage, IndexedDB, JavaScript).
+                    </p>
+                    <p>
+                      You can always save a ZIP of the app and open it locally. The app is designed
+                      from the ground up to work with the <code>file://</code> protocol.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">What if the developer stops maintaining it?</summary>
+                  <summary class="faq-question">
+                    What if the developer stops maintaining it?
+                  </summary>
                   <div class="faq-answer">
-                    <p>The app is MIT licensed and open source. If development stops, anyone in the community can fork the project and continue it. Your data remains yours in exportable formats regardless.</p>
-                    <p>The offline-first, single-file design means the app won't simply stop working the way a subscription service would.</p>
+                    <p>
+                      The app is MIT licensed and open source. If development stops, anyone in the
+                      community can fork the project and continue it. Your data remains yours in
+                      exportable formats regardless.
+                    </p>
+                    <p>
+                      The offline-first, single-file design means the app won't simply stop working
+                      the way a subscription service would.
+                    </p>
                   </div>
                 </details>
               </div>
@@ -3870,20 +7165,51 @@
                 <details class="faq-item">
                   <summary class="faq-question">If I use Dropbox, can Dropbox see my data?</summary>
                   <div class="faq-answer">
-                    <p>No. When you use the cloud backup feature, your inventory is encrypted on your device before it is uploaded. Dropbox only ever receives an encrypted file — they cannot read what's inside it.</p>
+                    <p>
+                      No. When you use the cloud backup feature, your inventory is encrypted on your
+                      device before it is uploaded. Dropbox only ever receives an encrypted file —
+                      they cannot read what's inside it.
+                    </p>
                     <details class="faq-technical">
                       <summary>Technical details</summary>
-                      <p>Encryption uses <strong>AES-256-GCM</strong> (symmetric authenticated encryption) with a key derived from your password via <strong>PBKDF2-SHA256 with 100,000 iterations</strong>. The encryption happens entirely in your browser using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API" target="_blank" rel="noopener">Web Crypto API</a> — the same cryptographic standard used by password managers and secure messaging apps. The cloud provider receives only the ciphertext and a random salt, never your password or plaintext data.</p>
+                      <p>
+                        Encryption uses <strong>AES-256-GCM</strong> (symmetric authenticated
+                        encryption) with a key derived from your password via
+                        <strong>PBKDF2-SHA256 with 100,000 iterations</strong>. The encryption
+                        happens entirely in your browser using the
+                        <a
+                          href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API"
+                          target="_blank"
+                          rel="noopener"
+                          >Web Crypto API</a
+                        >
+                        — the same cryptographic standard used by password managers and secure
+                        messaging apps. The cloud provider receives only the ciphertext and a random
+                        salt, never your password or plaintext data.
+                      </p>
                     </details>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">What is encryption and how does it protect me?</summary>
+                  <summary class="faq-question">
+                    What is encryption and how does it protect me?
+                  </summary>
                   <div class="faq-answer">
-                    <p>Encryption transforms your data into unreadable scrambled text using a secret key derived from your password. Without the correct password, the data is mathematically impossible to read — even if someone intercepts the file or the cloud provider is breached.</p>
-                    <p>Think of it like a safe deposit box: the bank (Dropbox) holds the box, but only you have the key. The bank has no way to open it.</p>
-                    <p><strong>Important:</strong> If you lose your vault password, the data cannot be recovered. Store your password somewhere safe.</p>
+                    <p>
+                      Encryption transforms your data into unreadable scrambled text using a secret
+                      key derived from your password. Without the correct password, the data is
+                      mathematically impossible to read — even if someone intercepts the file or the
+                      cloud provider is breached.
+                    </p>
+                    <p>
+                      Think of it like a safe deposit box: the bank (Dropbox) holds the box, but
+                      only you have the key. The bank has no way to open it.
+                    </p>
+                    <p>
+                      <strong>Important:</strong> If you lose your vault password, the data cannot
+                      be recovered. Store your password somewhere safe.
+                    </p>
                   </div>
                 </details>
               </div>
@@ -3895,14 +7221,21 @@
                 <details class="faq-item">
                   <summary class="faq-question">Is my data safe from hackers?</summary>
                   <div class="faq-answer">
-                    <p>Your local data (in localStorage/IndexedDB) is protected by your browser's same-origin security model — other websites cannot read it. The vault encryption protects backups with strong cryptography.</p>
+                    <p>
+                      Your local data (in localStorage/IndexedDB) is protected by your browser's
+                      same-origin security model — other websites cannot read it. The vault
+                      encryption protects backups with strong cryptography.
+                    </p>
                     <p>The practical risks are the same as any local software:</p>
                     <ul class="faq-list">
                       <li>Malware on your device that can read browser storage</li>
                       <li>Browser extensions with broad permissions</li>
                       <li>Physical access to an unlocked device</li>
                     </ul>
-                    <p>Standard device security hygiene — OS updates, reputable extensions only, device lock screens — provides strong protection.</p>
+                    <p>
+                      Standard device security hygiene — OS updates, reputable extensions only,
+                      device lock screens — provides strong protection.
+                    </p>
                   </div>
                 </details>
               </div>
@@ -3912,41 +7245,99 @@
                 <div class="settings-fieldset-title">💡 About the App</div>
 
                 <details class="faq-item">
-                  <summary class="faq-question">How is this different from other precious metals apps?</summary>
+                  <summary class="faq-question">
+                    How is this different from other precious metals apps?
+                  </summary>
                   <div class="faq-answer">
-                    <p>Most precious metals apps store your data on their servers and require accounts. StakTrakr is different:</p>
+                    <p>
+                      Most precious metals apps store your data on their servers and require
+                      accounts. StakTrakr is different:
+                    </p>
                     <ul class="faq-list">
-                      <li><strong>Fully local</strong> — your data never leaves your device unless you choose cloud backup</li>
-                      <li><strong>No account required</strong> — no email, no password to create, no profile</li>
-                      <li><strong>Open source</strong> — the code is publicly readable; there are no hidden behaviors</li>
-                      <li><strong>No subscription</strong> — the core app is free forever; optional sponsor perks cover infrastructure costs</li>
-                      <li><strong>Works offline</strong> — once loaded, the app works without internet (spot prices require connectivity)</li>
-                      <li><strong>Portable</strong> — download a ZIP, open <code>index.html</code>, and it runs anywhere</li>
+                      <li>
+                        <strong>Fully local</strong> — your data never leaves your device unless you
+                        choose cloud backup
+                      </li>
+                      <li>
+                        <strong>No account required</strong> — no email, no password to create, no
+                        profile
+                      </li>
+                      <li>
+                        <strong>Open source</strong> — the code is publicly readable; there are no
+                        hidden behaviors
+                      </li>
+                      <li>
+                        <strong>No subscription</strong> — the core app is free forever; optional
+                        sponsor perks cover infrastructure costs
+                      </li>
+                      <li>
+                        <strong>Works offline</strong> — once loaded, the app works without internet
+                        (spot prices require connectivity)
+                      </li>
+                      <li>
+                        <strong>Portable</strong> — download a ZIP, open <code>index.html</code>,
+                        and it runs anywhere
+                      </li>
                     </ul>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">Does this app have any subscriptions or costs?</summary>
+                  <summary class="faq-question">
+                    Does this app have any subscriptions or costs?
+                  </summary>
                   <div class="faq-answer">
-                    <p><strong>The core app is free and always will be.</strong> Every feature you see today — full inventory management, spot price sync, CSV/PDF/ZIP export, encrypted vault backups, Dropbox cloud sync, Numista/PCGS integration — is included with no account required and no paywall.</p>
-                    <p>Running the app costs real money: the domain renewal, and the API provider that supplies hourly live spot prices for all users on a best-effort basis. Sponsoring at $1/month or more on GitHub helps cover those costs directly.</p>
-                    <p>As a thank-you, sponsors will get access to <strong>optional infrastructure perks</strong> as they are built out:</p>
+                    <p>
+                      <strong>The core app is free and always will be.</strong> Every feature you
+                      see today — full inventory management, spot price sync, CSV/PDF/ZIP export,
+                      encrypted vault backups, Dropbox cloud sync, Numista/PCGS integration — is
+                      included with no account required and no paywall.
+                    </p>
+                    <p>
+                      Running the app costs real money: the domain renewal, and the API provider
+                      that supplies hourly live spot prices for all users on a best-effort basis.
+                      Sponsoring at $1/month or more on GitHub helps cover those costs directly.
+                    </p>
+                    <p>
+                      As a thank-you, sponsors will get access to
+                      <strong>optional infrastructure perks</strong> as they are built out:
+                    </p>
                     <ul class="faq-list">
                       <li><strong>Now:</strong> Dropbox cloud backup is free for everyone</li>
-                      <li><strong>Coming for sponsors:</strong> a hosted cloud storage key (Supabase-backed) — same encryption guarantees as Dropbox, no third-party account needed</li>
-                      <li><strong>Further out:</strong> early access to real-time encrypted cloud sync (live CRUD to the cloud, not just manual backup/restore), as the user base and infrastructure grows</li>
+                      <li>
+                        <strong>Coming for sponsors:</strong> a hosted cloud storage key
+                        (Supabase-backed) — same encryption guarantees as Dropbox, no third-party
+                        account needed
+                      </li>
+                      <li>
+                        <strong>Further out:</strong> early access to real-time encrypted cloud sync
+                        (live CRUD to the cloud, not just manual backup/restore), as the user base
+                        and infrastructure grows
+                      </li>
                     </ul>
-                    <p>None of these are features being removed from the free tier — they are new infrastructure that costs money to operate. If sponsorship never materializes, the core app stays exactly as it is. If it grows, everyone benefits from a more sustainable project.</p>
-                    <p>The hourly API spot prices are provided on a best-effort basis. If infrastructure costs become unsustainable, that service may be reduced — but the app itself, and Dropbox sync, will always remain free and open source.</p>
+                    <p>
+                      None of these are features being removed from the free tier — they are new
+                      infrastructure that costs money to operate. If sponsorship never materializes,
+                      the core app stays exactly as it is. If it grows, everyone benefits from a
+                      more sustainable project.
+                    </p>
+                    <p>
+                      The hourly API spot prices are provided on a best-effort basis. If
+                      infrastructure costs become unsustainable, that service may be reduced — but
+                      the app itself, and Dropbox sync, will always remain free and open source.
+                    </p>
                   </div>
                 </details>
               </div>
 
               <!-- Section 6: Honest Limitations -->
               <div class="settings-fieldset faq-limitations-section">
-                <div class="settings-fieldset-title faq-limitations-title">⚖️ Honest Limitations</div>
-                <p class="faq-limitations-intro">We believe in transparency. Here are real trade-offs you should know about.</p>
+                <div class="settings-fieldset-title faq-limitations-title">
+                  ⚖️ Honest Limitations
+                </div>
+                <p class="faq-limitations-intro">
+                  We believe in transparency. Here are real trade-offs you should know about.
+                </p>
 
                 <details class="faq-item">
                   <summary class="faq-question">localStorage can be cleared unexpectedly</summary>
@@ -3954,58 +7345,141 @@
                     <p>Browser localStorage is not permanent storage. It can be cleared by:</p>
                     <ul class="faq-list">
                       <li>"Clear site data" or "Clear browsing data" in browser settings</li>
-                      <li>Private/incognito browsing sessions (data is lost when the window closes)</li>
-                      <li><strong>iOS Safari storage eviction</strong> — Apple may automatically delete localStorage for apps that haven't been used recently if the device is low on storage</li>
+                      <li>
+                        Private/incognito browsing sessions (data is lost when the window closes)
+                      </li>
+                      <li>
+                        <strong>iOS Safari storage eviction</strong> — Apple may automatically
+                        delete localStorage for apps that haven't been used recently if the device
+                        is low on storage
+                      </li>
                     </ul>
-                    <p><strong>Mitigation:</strong> Export a ZIP or vault backup regularly, especially on iOS. Consider connecting a cloud backup provider.</p>
+                    <p>
+                      <strong>Mitigation:</strong> Export a ZIP or vault backup regularly,
+                      especially on iOS. Consider connecting a cloud backup provider.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">Opening via file:// protocol on some browsers</summary>
+                  <summary class="faq-question">
+                    Opening via file:// protocol on some browsers
+                  </summary>
                   <div class="faq-answer">
-                    <p>The app is designed to work with the <code>file://</code> protocol (opening <code>index.html</code> directly from your filesystem). However, a small number of browser configurations restrict localStorage persistence in <code>file://</code> contexts.</p>
-                    <p>If you experience data not persisting when opening the file directly, try serving it from a local web server (e.g., <code>python3 -m http.server</code>) or use the hosted version at staktrakr.com.</p>
+                    <p>
+                      The app is designed to work with the <code>file://</code> protocol (opening
+                      <code>index.html</code> directly from your filesystem). However, a small
+                      number of browser configurations restrict localStorage persistence in
+                      <code>file://</code> contexts.
+                    </p>
+                    <p>
+                      If you experience data not persisting when opening the file directly, try
+                      serving it from a local web server (e.g., <code>python3 -m http.server</code>)
+                      or use the hosted version at staktrakr.com.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">No formal third-party security audit — but here's what we do run</summary>
+                  <summary class="faq-question">
+                    No formal third-party security audit — but here's what we do run
+                  </summary>
                   <div class="faq-answer">
-                    <p>StakTrakr is a one-person project. A paid independent cryptographic audit hasn't been commissioned — that's the honest limitation. But the codebase is not unreviewed. Every commit runs through a layered set of automated security and quality checks:</p>
+                    <p>
+                      StakTrakr is a one-person project. A paid independent cryptographic audit
+                      hasn't been commissioned — that's the honest limitation. But the codebase is
+                      not unreviewed. Every commit runs through a layered set of automated security
+                      and quality checks:
+                    </p>
                     <ul class="faq-list">
-                      <li><strong>Codacy</strong> — continuous code quality gate, A+ rating maintained on every PR</li>
-                      <li><strong>CodeQL</strong> — GitHub's semantic code analysis, scans for security vulnerabilities on every push</li>
-                      <li><strong>Semgrep</strong> — static analysis for common security anti-patterns</li>
-                      <li><strong>PMD</strong> — additional static analysis for code quality issues</li>
-                      <li><strong>ESLint</strong> — JavaScript linting with security-aware rules</li>
-                      <li><strong>GitHub Copilot &amp; Codex</strong> — AI-assisted code review on pull requests</li>
+                      <li>
+                        <strong>Codacy</strong> — continuous code quality gate, A+ rating maintained
+                        on every PR
+                      </li>
+                      <li>
+                        <strong>CodeQL</strong> — GitHub's semantic code analysis, scans for
+                        security vulnerabilities on every push
+                      </li>
+                      <li>
+                        <strong>Semgrep</strong> — static analysis for common security anti-patterns
+                      </li>
+                      <li>
+                        <strong>PMD</strong> — additional static analysis for code quality issues
+                      </li>
+                      <li>
+                        <strong>ESLint</strong> — JavaScript linting with security-aware rules
+                      </li>
+                      <li>
+                        <strong>GitHub Copilot &amp; Codex</strong> — AI-assisted code review on
+                        pull requests
+                      </li>
                     </ul>
-                    <p>Development is also assisted by <strong>Claude Code</strong> (Anthropic's AI coding assistant), which is explicitly instructed to flag security concerns — SQL injection, XSS, insecure storage patterns, and similar issues — during implementation.</p>
-                    <p>This is the realistic security posture of a well-maintained open-source personal project: comprehensive automated tooling, no paid human audit. For most users tracking a personal collection, this is a reasonable level of assurance. Users with very high threat models may wish to verify the encryption implementation themselves — the source is fully public.</p>
+                    <p>
+                      Development is also assisted by <strong>Claude Code</strong> (Anthropic's AI
+                      coding assistant), which is explicitly instructed to flag security concerns —
+                      SQL injection, XSS, insecure storage patterns, and similar issues — during
+                      implementation.
+                    </p>
+                    <p>
+                      This is the realistic security posture of a well-maintained open-source
+                      personal project: comprehensive automated tooling, no paid human audit. For
+                      most users tracking a personal collection, this is a reasonable level of
+                      assurance. Users with very high threat models may wish to verify the
+                      encryption implementation themselves — the source is fully public.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">Only Dropbox is active — other cloud providers are coming soon</summary>
+                  <summary class="faq-question">
+                    Only Dropbox is active — other cloud providers are coming soon
+                  </summary>
                   <div class="faq-answer">
-                    <p><strong>Dropbox is the only fully active cloud backup provider.</strong> The Cloud tab in Settings also shows placeholder cards for four future providers: Google Drive, OneDrive, pCloud, and Box. These are shown to communicate the roadmap, not as functional options. All will use the same client-side AES-256-GCM encryption as Dropbox — the provider never sees your plaintext data.</p>
+                    <p>
+                      <strong>Dropbox is the only fully active cloud backup provider.</strong> The
+                      Cloud tab in Settings also shows placeholder cards for four future providers:
+                      Google Drive, OneDrive, pCloud, and Box. These are shown to communicate the
+                      roadmap, not as functional options. All will use the same client-side
+                      AES-256-GCM encryption as Dropbox — the provider never sees your plaintext
+                      data.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">Spot prices are reference data, not transaction prices</summary>
+                  <summary class="faq-question">
+                    Spot prices are reference data, not transaction prices
+                  </summary>
                   <div class="faq-answer">
-                    <p>The spot prices displayed are fetched from public metal pricing APIs and represent the theoretical melt value of metal at that moment. They are <strong>not</strong> buy/sell prices from a dealer.</p>
-                    <p>Actual transaction prices will differ due to dealer premiums, bid/ask spreads, and market conditions. The "Melt Value" shown is a reference floor, not a guaranteed sale price.</p>
+                    <p>
+                      The spot prices displayed are fetched from public metal pricing APIs and
+                      represent the theoretical melt value of metal at that moment. They are
+                      <strong>not</strong> buy/sell prices from a dealer.
+                    </p>
+                    <p>
+                      Actual transaction prices will differ due to dealer premiums, bid/ask spreads,
+                      and market conditions. The "Melt Value" shown is a reference floor, not a
+                      guaranteed sale price.
+                    </p>
                   </div>
                 </details>
 
                 <details class="faq-item">
-                  <summary class="faq-question">Numista only fills one dimension for bars and ingots</summary>
+                  <summary class="faq-question">
+                    Numista only fills one dimension for bars and ingots
+                  </summary>
                   <div class="faq-answer">
-                    <p>When you look up a rectangular item (bar, ingot) via Numista, the <strong>length</strong> auto-fills but the <strong>width</strong> is left blank. This is a limitation of the Numista API &mdash; their website shows both dimensions, but the API only returns one.</p>
-                    <p>Simply enter the width manually after the lookup. Your manual entry is preserved &mdash; future Numista syncs will not overwrite fields you have edited.</p>
+                    <p>
+                      When you look up a rectangular item (bar, ingot) via Numista, the
+                      <strong>length</strong> auto-fills but the <strong>width</strong> is left
+                      blank. This is a limitation of the Numista API &mdash; their website shows
+                      both dimensions, but the API only returns one.
+                    </p>
+                    <p>
+                      Simply enter the width manually after the lookup. Your manual entry is
+                      preserved &mdash; future Numista syncs will not overwrite fields you have
+                      edited.
+                    </p>
                   </div>
                 </details>
               </div>
@@ -4014,80 +7488,104 @@
               <div class="settings-fieldset">
                 <div class="settings-fieldset-title">📄 More Information</div>
                 <div class="resources-grid">
-                  <button class="resource-btn" onclick="if(window.openModalById)openModalById('privacyModal')">
+                  <button
+                    class="resource-btn"
+                    onclick="if (window.openModalById) openModalById('privacyModal');"
+                  >
                     🔒 Privacy Policy
                   </button>
-                  <a class="resource-btn" href="https://github.com/lbruton/StakTrakr" target="_blank" rel="noopener">
+                  <a
+                    class="resource-btn"
+                    href="https://github.com/lbruton/StakTrakr"
+                    target="_blank"
+                    rel="noopener"
+                  >
                     📁 Source Code
                   </a>
-                  <a class="resource-btn" href="https://www.reddit.com/r/staktrakr/" target="_blank" rel="noopener">
+                  <a
+                    class="resource-btn"
+                    href="https://www.reddit.com/r/staktrakr/"
+                    target="_blank"
+                    rel="noopener"
+                  >
                     💬 Community
                   </a>
                 </div>
               </div>
-
-            </div><!-- #settingsPanel_faq -->
-
-          </div><!-- .settings-content-area -->
-        </div><!-- .settings-modal-layout -->
+            </div>
+            <!-- #settingsPanel_faq -->
+          </div>
+          <!-- .settings-content-area -->
+        </div>
+        <!-- .settings-modal-layout -->
         <div class="settings-footer" id="settingsFooter"></div>
-      </div><!-- .settings-modal-content -->
-    </div><!-- #settingsModal -->
+      </div>
+      <!-- .settings-modal-content -->
+    </div>
+    <!-- #settingsModal -->
 
-    <div class="modal" id="cloudSyncModal" style="display: none">
+    <div
+      class="modal"
+      id="cloudSyncModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cloudSyncModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Cloud Sync</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="cloudSyncCloseBtn"
-          >
-            ×
-          </button>
+          <h2 id="cloudSyncModalTitle">Cloud Sync</h2>
+          <button aria-label="Close modal" class="modal-close" id="cloudSyncCloseBtn">×</button>
         </div>
-        <div class="modal-body">
-          ☁️ Feature coming soon ☁️
-        </div>
+        <div class="modal-body">☁️ Feature coming soon ☁️</div>
       </div>
     </div>
 
     <!-- Vault Encrypted Backup Modal -->
-    <div class="modal" id="vaultModal" style="display: none">
+    <div
+      class="modal"
+      id="vaultModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="vaultModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="vaultModalTitle">Encrypted Backup</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="vaultCloseBtn"
-          >
-            &times;
-          </button>
+          <button aria-label="Close modal" class="modal-close" id="vaultCloseBtn">&times;</button>
         </div>
         <div class="modal-body">
           <div id="vaultDescExport" class="encryption-info">
-            <strong>Included:</strong> All inventory data, settings, API keys, and price history. Your photos will be saved as a separate companion file.
+            <strong>Included:</strong> All inventory data, settings, API keys, and price history.
+            Your photos will be saved as a separate companion file.
           </div>
 
-          <div id="vaultDescImport" class="encryption-info" style="display:none">
-            <strong>Included:</strong> All inventory data, settings, API keys, and price history. To also restore photos, add the companion <em>-images.stvault</em> file below.
+          <div id="vaultDescImport" class="encryption-info" style="display: none">
+            <strong>Included:</strong> All inventory data, settings, API keys, and price history. To
+            also restore photos, add the companion <em>-images.stvault</em> file below.
           </div>
 
           <div id="vaultFileInfo" class="encryption-info" style="display: none">
-            <strong>File:</strong> <span id="vaultFileName"></span>
-            (<span id="vaultFileSize"></span>)
+            <strong>File:</strong> <span id="vaultFileName"></span> (<span id="vaultFileSize"></span
+            >)
           </div>
 
           <!-- Image vault companion file (import mode only) -->
-          <div id="vaultImageFileRow" style="display:none">
-            <div class="encryption-info" id="vaultImageFileInfo" style="display:none">
-              <strong>Photos:</strong> <span id="vaultImageFileName"></span>
-              (<span id="vaultImageFileSize"></span>)
+          <div id="vaultImageFileRow" style="display: none">
+            <div class="encryption-info" id="vaultImageFileInfo" style="display: none">
+              <strong>Photos:</strong> <span id="vaultImageFileName"></span> (<span
+                id="vaultImageFileSize"
+              ></span
+              >)
             </div>
             <div class="settings-btn-row" id="vaultImagePickerRow">
-              <label class="btn" style="cursor:pointer" for="vaultImageImportFile">+ Add Photos File</label>
-              <small style="opacity:0.65">Optional: <em>-images.stvault</em> from the same export</small>
+              <label class="btn" style="cursor: pointer" for="vaultImageImportFile"
+                >+ Add Photos File</label
+              >
+              <small style="opacity: 0.65"
+                >Optional: <em>-images.stvault</em> from the same export</small
+              >
             </div>
             <input type="file" id="vaultImageImportFile" accept=".stvault" hidden />
           </div>
@@ -4106,7 +7604,9 @@
                 class="password-toggle"
                 id="vaultPasswordToggle"
                 title="Show/hide password"
-              >&#9678;</button>
+              >
+                &#9678;
+              </button>
             </div>
           </div>
 
@@ -4131,7 +7631,9 @@
                 class="password-toggle"
                 id="vaultConfirmToggle"
                 title="Show/hide password"
-              >&#9678;</button>
+              >
+                &#9678;
+              </button>
             </div>
             <div class="password-match" id="vaultMatchIndicator"></div>
           </div>
@@ -4151,76 +7653,179 @@
     </div>
 
     <!-- Dropbox Advanced Settings Modal -->
-    <div class="modal" id="cloudSyncAdvancedModal" style="display:none" role="dialog" aria-modal="true" aria-labelledby="cloudSyncAdvancedModalTitle">
-      <div class="modal-content" style="max-width:480px;width:90%">
+    <div
+      class="modal"
+      id="cloudSyncAdvancedModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cloudSyncAdvancedModalTitle"
+    >
+      <div class="modal-content" style="max-width: 480px; width: 90%">
         <div class="modal-header">
           <h3 class="modal-title" id="cloudSyncAdvancedModalTitle">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="vertical-align:-2px;margin-right:0.4rem"><path d="M6 2l6 3.6L6 9.2 0 5.6zm12 0l6 3.6-6 3.6-6-3.6zm-12 8l6 3.6-6 3.6-6-3.6zm12 0l6 3.6-6 3.6-6-3.6zM6 18.4l6-3.6 6 3.6-6 3.6z"/></svg>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              style="vertical-align: -2px; margin-right: 0.4rem"
+            >
+              <path
+                d="M6 2l6 3.6L6 9.2 0 5.6zm12 0l6 3.6-6 3.6-6-3.6zm-12 8l6 3.6-6 3.6-6-3.6zm12 0l6 3.6-6 3.6-6-3.6zM6 18.4l6-3.6 6 3.6-6 3.6z"
+              />
+            </svg>
             Dropbox Settings
           </h3>
-          <button class="modal-close" onclick="if(typeof closeModalById==='function')closeModalById('cloudSyncAdvancedModal')" aria-label="Close">&times;</button>
+          <button
+            class="modal-close"
+            onclick="
+              if (typeof closeModalById === 'function') closeModalById('cloudSyncAdvancedModal');
+            "
+            aria-label="Close"
+          >
+            &times;
+          </button>
         </div>
         <div class="modal-body">
-
           <!-- Vault Password -->
-          <div class="settings-fieldset" style="margin-bottom:0.75rem">
+          <div class="settings-fieldset" style="margin-bottom: 0.75rem">
             <div class="settings-fieldset-title">Vault Password</div>
-            <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Remembered in this browser. Change it here — your next sync will re-encrypt your backup.</p>
-            <div style="display:flex;gap:0.4rem;align-items:flex-start">
-              <input type="password" id="cloudAdvancedNewPassword" placeholder="New password (min 8 chars)"
+            <p class="settings-subtext" style="margin: 0.3rem 0 0.5rem">
+              Remembered in this browser. Change it here — your next sync will re-encrypt your
+              backup.
+            </p>
+            <div style="display: flex; gap: 0.4rem; align-items: flex-start">
+              <input
+                type="password"
+                id="cloudAdvancedNewPassword"
+                placeholder="New password (min 8 chars)"
                 aria-label="New vault password"
                 autocomplete="new-password"
-                style="flex:1;font-size:0.85rem;padding:0.35rem 0.5rem;border:1px solid var(--border);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary)">
-              <button class="btn" id="cloudAdvancedSavePasswordBtn"
-                style="font-size:0.82rem;padding:0.35rem 0.75rem;min-height:0;white-space:nowrap"
-                onclick="if(typeof handleAdvancedSavePassword==='function')handleAdvancedSavePassword()">
+                style="
+                  flex: 1;
+                  font-size: 0.85rem;
+                  padding: 0.35rem 0.5rem;
+                  border: 1px solid var(--border);
+                  border-radius: 4px;
+                  background: var(--bg-tertiary);
+                  color: var(--text-primary);
+                "
+              />
+              <button
+                class="btn"
+                id="cloudAdvancedSavePasswordBtn"
+                style="
+                  font-size: 0.82rem;
+                  padding: 0.35rem 0.75rem;
+                  min-height: 0;
+                  white-space: nowrap;
+                "
+                onclick="
+                  if (typeof handleAdvancedSavePassword === 'function')
+                    handleAdvancedSavePassword();
+                "
+              >
                 Save
               </button>
             </div>
-            <div id="cloudAdvancedPasswordError" style="color:var(--danger,#e74c3c);font-size:0.75rem;margin-top:0.3rem;display:none"></div>
+            <div
+              id="cloudAdvancedPasswordError"
+              style="
+                color: var(--danger, #e74c3c);
+                font-size: 0.75rem;
+                margin-top: 0.3rem;
+                display: none;
+              "
+            ></div>
           </div>
 
           <!-- Sync History -->
-          <div class="settings-fieldset" style="margin-bottom:0.75rem">
+          <div class="settings-fieldset" style="margin-bottom: 0.75rem">
             <div class="settings-fieldset-title">Sync History</div>
             <div id="cloudSyncHistorySection">
-              <p class="settings-subtext" style="margin:0.3rem 0 0">No snapshot available.</p>
+              <p class="settings-subtext" style="margin: 0.3rem 0 0">No snapshot available.</p>
             </div>
           </div>
 
           <!-- Disconnect -->
-          <div class="settings-fieldset" style="border-color:var(--danger,#e74c3c);opacity:0.9">
-            <div class="settings-fieldset-title" style="color:var(--danger,#e74c3c)">Danger Zone</div>
-            <p class="settings-subtext" style="margin:0.3rem 0 0.5rem">Disconnecting removes Dropbox access from this device. Your encrypted backups on Dropbox are not deleted.</p>
-            <button class="btn danger cloud-disconnect-btn" data-provider="dropbox"
-              style="font-size:0.82rem;padding:0.4rem 0.9rem;min-height:0">
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:0.3rem"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+          <div class="settings-fieldset" style="border-color: var(--danger, #e74c3c); opacity: 0.9">
+            <div class="settings-fieldset-title" style="color: var(--danger, #e74c3c)">
+              Danger Zone
+            </div>
+            <p class="settings-subtext" style="margin: 0.3rem 0 0.5rem">
+              Disconnecting removes Dropbox access from this device. Your encrypted backups on
+              Dropbox are not deleted.
+            </p>
+            <button
+              class="btn danger cloud-disconnect-btn"
+              data-provider="dropbox"
+              style="font-size: 0.82rem; padding: 0.4rem 0.9rem; min-height: 0"
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="vertical-align: -2px; margin-right: 0.3rem"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
               Disconnect Dropbox
             </button>
           </div>
 
           <!-- Disclaimer -->
-          <p class="settings-subtext" style="margin:0.75rem 0 0;font-size:0.72rem">
-            Backups stored in <strong>/StakTrakr</strong> on your Dropbox. If you forget your vault password, backups cannot be recovered from Dropbox (your local data is unaffected).
+          <p class="settings-subtext" style="margin: 0.75rem 0 0; font-size: 0.72rem">
+            Backups stored in <strong>/StakTrakr</strong> on your Dropbox. If you forget your vault
+            password, backups cannot be recovered from Dropbox (your local data is unaffected).
           </p>
         </div>
       </div>
     </div>
 
     <!-- STAK-149: Sync Password Modal -->
-    <div class="modal" id="cloudSyncPasswordModal" style="display: none">
+    <div
+      class="modal"
+      id="cloudSyncPasswordModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="syncPasswordModalTitle"
+    >
       <div class="modal-content" style="max-width: 400px">
         <div class="modal-header">
           <h2 id="syncPasswordModalTitle">Sync Password</h2>
-          <button aria-label="Close modal" class="modal-close" id="syncPasswordCancelBtn">&times;</button>
+          <button aria-label="Close modal" class="modal-close" id="syncPasswordCancelBtn">
+            &times;
+          </button>
         </div>
         <div class="modal-body">
-          <p id="syncPasswordModalSubtitle" class="settings-subtext" style="margin-bottom:1rem">Enter your vault password to encrypt your inventory before syncing. Your password is stored in this browser and combined with your Dropbox account ID to create the encryption key — it is never transmitted over the network.</p>
+          <p id="syncPasswordModalSubtitle" class="settings-subtext" style="margin-bottom: 1rem">
+            Enter your vault password to encrypt your inventory before syncing. Your password is
+            stored in this browser and combined with your Dropbox account ID to create the
+            encryption key — it is never transmitted over the network.
+          </p>
           <div class="password-input-group">
-            <input type="password" id="syncPasswordInput" placeholder="Vault password" autocomplete="current-password" style="width:100%"/>
+            <input
+              type="password"
+              id="syncPasswordInput"
+              placeholder="Vault password"
+              autocomplete="current-password"
+              style="width: 100%"
+            />
           </div>
-          <div id="syncPasswordError" style="color:var(--danger);font-size:0.8rem;margin-top:0.4rem;display:none"></div>
-          <div class="encryption-actions" style="margin-top:1rem">
+          <div
+            id="syncPasswordError"
+            style="color: var(--danger); font-size: 0.8rem; margin-top: 0.4rem; display: none"
+          ></div>
+          <div class="encryption-actions" style="margin-top: 1rem">
             <button class="btn success" id="syncPasswordConfirmBtn">Encrypt &amp; Sync</button>
             <button class="btn" id="syncPasswordCancelBtn2">Cancel</button>
           </div>
@@ -4229,24 +7834,60 @@
     </div>
 
     <!-- STAK-186: Restore Preview Modal (Layer 5 — DiffEngine preview before sync restore) -->
-    <div class="modal" id="restorePreviewModal" style="display: none">
+    <div
+      class="modal"
+      id="restorePreviewModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="restorePreviewModalTitle"
+    >
       <div class="modal-content" style="max-width: 600px">
         <div class="modal-header">
-          <h2>Restore Preview</h2>
-          <button aria-label="Close modal" class="modal-close" id="restorePreviewDismissX">&times;</button>
+          <h2 id="restorePreviewModalTitle">Restore Preview</h2>
+          <button aria-label="Close modal" class="modal-close" id="restorePreviewDismissX">
+            &times;
+          </button>
         </div>
         <div class="modal-body">
           <div class="cloud-sync-update-meta" id="restorePreviewMeta">
-            <div class="cloud-sync-update-row"><span>Remote items</span><strong id="restorePreviewRemoteCount">&mdash;</strong></div>
-            <div class="cloud-sync-update-row"><span>Local items</span><strong id="restorePreviewLocalCount">&mdash;</strong></div>
-            <div class="cloud-sync-update-row"><span>Device</span><strong id="restorePreviewDevice">&mdash;</strong></div>
-            <div class="cloud-sync-update-row"><span>Version</span><strong id="restorePreviewVersion">&mdash;</strong></div>
+            <div class="cloud-sync-update-row">
+              <span>Remote items</span><strong id="restorePreviewRemoteCount">&mdash;</strong>
+            </div>
+            <div class="cloud-sync-update-row">
+              <span>Local items</span><strong id="restorePreviewLocalCount">&mdash;</strong>
+            </div>
+            <div class="cloud-sync-update-row">
+              <span>Device</span><strong id="restorePreviewDevice">&mdash;</strong>
+            </div>
+            <div class="cloud-sync-update-row">
+              <span>Version</span><strong id="restorePreviewVersion">&mdash;</strong>
+            </div>
           </div>
-          <div id="restorePreviewSummary" class="settings-subtext" style="margin:0.75rem 0;font-weight:600;"></div>
-          <div id="restorePreviewDiffList" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color,#ddd);border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem;"></div>
-          <div id="restorePreviewSettingsDiff" style="margin-bottom:1rem;"></div>
-          <div id="restorePreviewError" class="encryption-warning" style="display:none;margin-bottom:1rem;"></div>
-          <div class="encryption-actions" style="gap:0.5rem;flex-wrap:wrap">
+          <div
+            id="restorePreviewSummary"
+            class="settings-subtext"
+            style="margin: 0.75rem 0; font-weight: 600"
+          ></div>
+          <div
+            id="restorePreviewDiffList"
+            style="
+              max-height: 320px;
+              overflow-y: auto;
+              border: 1px solid var(--border-color, #ddd);
+              border-radius: 6px;
+              padding: 0.5rem;
+              margin-bottom: 1rem;
+              font-size: 0.9rem;
+            "
+          ></div>
+          <div id="restorePreviewSettingsDiff" style="margin-bottom: 1rem"></div>
+          <div
+            id="restorePreviewError"
+            class="encryption-warning"
+            style="display: none; margin-bottom: 1rem"
+          ></div>
+          <div class="encryption-actions" style="gap: 0.5rem; flex-wrap: wrap">
             <button class="btn success" id="restorePreviewApplyBtn">Apply Changes</button>
             <button class="btn" id="restorePreviewCancelBtn">Cancel</button>
           </div>
@@ -4271,222 +7912,529 @@
       }
       /* STAK-454: Card-based item rendering (from playground/diffmodal-item-cards.html) */
       #diffReviewModal .dm-card {
-        background: var(--bg-card,#1a1d27); border: 1px solid var(--border-color,rgba(255,255,255,0.08));
-        border-radius: 12px; padding: 1rem;
-        transition: border-color 0.2s, box-shadow 0.2s;
+        background: var(--bg-card, #1a1d27);
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+        border-radius: 12px;
+        padding: 1rem;
+        transition:
+          border-color 0.2s,
+          box-shadow 0.2s;
       }
-      #diffReviewModal .dm-card:hover { border-color: rgba(99,102,241,0.4); box-shadow: 0 4px 24px rgba(0,0,0,0.3); }
+      #diffReviewModal .dm-card:hover {
+        border-color: rgba(99, 102, 241, 0.4);
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+      }
       #diffReviewModal .dm-orphan-card {
-        display: flex; align-items: center; gap: 0.75rem;
-        margin-bottom: 0.5rem; padding: 0.75rem 1rem; cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.5rem;
+        padding: 0.75rem 1rem;
+        cursor: pointer;
       }
-      #diffReviewModal .dm-orphan-card.skipped { opacity: 0.4; transition: opacity 0.3s; }
-      #diffReviewModal .dm-orphan-actions { display: flex; gap: 0.4rem; flex-shrink: 0; }
-      #diffReviewModal .dm-conflict-card { margin-bottom: 0.75rem; }
+      #diffReviewModal .dm-orphan-card.skipped {
+        opacity: 0.4;
+        transition: opacity 0.3s;
+      }
+      #diffReviewModal .dm-orphan-actions {
+        display: flex;
+        gap: 0.4rem;
+        flex-shrink: 0;
+      }
+      #diffReviewModal .dm-conflict-card {
+        margin-bottom: 0.75rem;
+      }
       #diffReviewModal .dm-conflict-card-header {
-        display: flex; align-items: center; gap: 0.75rem;
-        padding-bottom: 0.75rem; margin-bottom: 0.75rem;
-        border-bottom: 1px solid var(--border-color,rgba(255,255,255,0.08));
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding-bottom: 0.75rem;
+        margin-bottom: 0.75rem;
+        border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
       }
       #diffReviewModal .dm-item-thumb {
-        width: 44px; height: 44px; border-radius: 8px;
-        background: var(--bg-tertiary,#262a3a); display: flex; align-items: center;
-        justify-content: center; font-size: 1.2rem; flex-shrink: 0;
-        border: 1px solid var(--border-color,rgba(255,255,255,0.08));
+        width: 44px;
+        height: 44px;
+        border-radius: 8px;
+        background: var(--bg-tertiary, #262a3a);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.2rem;
+        flex-shrink: 0;
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
       }
-      #diffReviewModal .dm-item-thumb-pair { display: flex; gap: 4px; flex-shrink: 0; }
+      #diffReviewModal .dm-item-thumb-pair {
+        display: flex;
+        gap: 4px;
+        flex-shrink: 0;
+      }
       #diffReviewModal .dm-item-thumb-pair .dm-item-thumb {
-        width: 40px; height: 40px; font-size: 0.6rem;
-        color: var(--text-muted,#6b7094); text-align: center;
-        line-height: 1.2; padding: 2px;
+        width: 40px;
+        height: 40px;
+        font-size: 0.6rem;
+        color: var(--text-muted, #6b7094);
+        text-align: center;
+        line-height: 1.2;
+        padding: 2px;
       }
-      #diffReviewModal .dm-item-identity { flex: 1; min-width: 0; }
+      #diffReviewModal .dm-item-identity {
+        flex: 1;
+        min-width: 0;
+      }
       #diffReviewModal .dm-item-name {
-        font-weight: 600; font-size: 0.9rem; white-space: nowrap;
-        overflow: hidden; text-overflow: ellipsis;
+        font-weight: 600;
+        font-size: 0.9rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       #diffReviewModal .dm-item-meta {
-        font-size: 0.72rem; color: var(--text-muted,#6b7094);
-        display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.15rem;
+        font-size: 0.72rem;
+        color: var(--text-muted, #6b7094);
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        margin-top: 0.15rem;
       }
       #diffReviewModal .dm-field-diff {
-        display: grid; grid-template-columns: 120px 1fr auto 1fr; gap: 0.5rem;
-        align-items: center; padding: 0.5rem 0;
-        border-bottom: 1px solid rgba(255,255,255,0.03);
+        display: grid;
+        grid-template-columns: 120px 1fr auto 1fr;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.03);
       }
-      #diffReviewModal .dm-field-diff:last-child { border-bottom: none; }
+      #diffReviewModal .dm-field-diff:last-child {
+        border-bottom: none;
+      }
       #diffReviewModal .dm-field-label {
-        font-size: 0.72rem; color: var(--text-muted,#6b7094); text-transform: uppercase;
-        letter-spacing: 0.06em; font-weight: 500;
+        font-size: 0.72rem;
+        color: var(--text-muted, #6b7094);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-weight: 500;
       }
       #diffReviewModal .dm-field-value {
-        padding: 0.35rem 0.6rem; border-radius: 8px; min-height: 1.8rem;
-        font-size: 0.82rem; cursor: pointer; transition: all 0.15s;
-        border: 2px solid transparent; text-align: center;
+        padding: 0.35rem 0.6rem;
+        border-radius: 8px;
+        min-height: 1.8rem;
+        font-size: 0.82rem;
+        cursor: pointer;
+        transition: all 0.15s;
+        border: 2px solid transparent;
+        text-align: center;
         word-break: break-word;
       }
-      #diffReviewModal .dm-field-value.local { background: rgba(99,102,241,0.15); }
-      #diffReviewModal .dm-field-value.remote { background: rgba(59,130,246,0.12); }
-      #diffReviewModal .dm-field-value.selected {
-        border-color: var(--gain,#22c55e); box-shadow: 0 0 0 1px var(--gain,#22c55e);
-        background: rgba(34,197,94,0.12); color: var(--gain,#22c55e); font-weight: 600;
+      #diffReviewModal .dm-field-value.local {
+        background: rgba(99, 102, 241, 0.15);
       }
-      #diffReviewModal .dm-field-value:hover:not(.selected) { border-color: var(--text-muted,#6b7094); }
-      #diffReviewModal .dm-field-arrow { color: var(--text-muted,#6b7094); font-size: 0.8rem; text-align: center; }
+      #diffReviewModal .dm-field-value.remote {
+        background: rgba(59, 130, 246, 0.12);
+      }
+      #diffReviewModal .dm-field-value.selected {
+        border-color: var(--gain, #22c55e);
+        box-shadow: 0 0 0 1px var(--gain, #22c55e);
+        background: rgba(34, 197, 94, 0.12);
+        color: var(--gain, #22c55e);
+        font-weight: 600;
+      }
+      #diffReviewModal .dm-field-value:hover:not(.selected) {
+        border-color: var(--text-muted, #6b7094);
+      }
+      #diffReviewModal .dm-field-arrow {
+        color: var(--text-muted, #6b7094);
+        font-size: 0.8rem;
+        text-align: center;
+      }
       #diffReviewModal .dm-card-actions {
-        display: flex; gap: 0.5rem; margin-top: 0.75rem; padding-top: 0.75rem;
-        border-top: 1px solid var(--border-color,rgba(255,255,255,0.08)); justify-content: flex-end;
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+        justify-content: flex-end;
       }
       #diffReviewModal .dm-section-header {
-        display: flex; align-items: center; justify-content: space-between;
-        margin-bottom: 0.75rem; padding-bottom: 0.5rem;
-        border-bottom: 1px solid var(--border-color,rgba(255,255,255,0.08));
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.75rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
       }
       #diffReviewModal .dm-section-title {
-        font-size: 0.9rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem;
+        font-size: 0.9rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
       }
-      #diffReviewModal .dm-section-actions { display: flex; gap: 0.5rem; }
+      #diffReviewModal .dm-section-actions {
+        display: flex;
+        gap: 0.5rem;
+      }
       #diffReviewModal .dm-collapse-toggle {
-        cursor: pointer; font-size: 0.7rem; color: var(--text-muted,#6b7094);
-        transition: transform 0.2s; user-select: none;
+        cursor: pointer;
+        font-size: 0.7rem;
+        color: var(--text-muted, #6b7094);
+        transition: transform 0.2s;
+        user-select: none;
       }
-      #diffReviewModal .dm-collapse-toggle.collapsed { transform: rotate(-90deg); }
-      #diffReviewModal .dm-section-body.collapsed { display: none; }
-      #diffReviewModal .dm-conflict-details { transition: all 0.3s ease; }
+      #diffReviewModal .dm-collapse-toggle.collapsed {
+        transform: rotate(-90deg);
+      }
+      #diffReviewModal .dm-section-body.collapsed {
+        display: none;
+      }
+      #diffReviewModal .dm-conflict-details {
+        transition: all 0.3s ease;
+      }
       #diffReviewModal .dm-conflict-details.collapsed {
-        max-height: 0; overflow: hidden; margin: 0; padding: 0; opacity: 0;
+        max-height: 0;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        opacity: 0;
       }
       #diffReviewModal .dm-chip {
-        display: inline-flex; align-items: center; gap: 0.25rem;
-        padding: 0.2rem 0.5rem; border-radius: 999px;
-        font-size: 0.7rem; background: var(--bg-tertiary,#262a3a); color: var(--text-secondary,#b0b3c6);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.2rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        background: var(--bg-tertiary, #262a3a);
+        color: var(--text-secondary, #b0b3c6);
       }
       #diffReviewModal .dm-pill {
-        display: inline-flex; align-items: center; gap: 0.3rem;
-        padding: 0.25rem 0.65rem; border-radius: 999px;
-        font-size: 0.75rem; font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
       }
-      #diffReviewModal .dm-pill-warning { background: rgba(217,119,6,0.12); color: var(--warning,#d97706); }
-      #diffReviewModal .dm-pill-gain { background: rgba(34,197,94,0.12); color: var(--gain,#22c55e); }
+      #diffReviewModal .dm-pill-warning {
+        background: rgba(217, 119, 6, 0.12);
+        color: var(--warning, #d97706);
+      }
+      #diffReviewModal .dm-pill-gain {
+        background: rgba(34, 197, 94, 0.12);
+        color: var(--gain, #22c55e);
+      }
       #diffReviewModal .dm-resolve-status {
-        display: flex; align-items: center; gap: 0.75rem;
-        padding: 0.6rem 1rem; background: var(--bg-tertiary,#262a3a);
-        border-radius: 999px; margin-bottom: 1rem; font-size: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.6rem 1rem;
+        background: var(--bg-tertiary, #262a3a);
+        border-radius: 999px;
+        margin-bottom: 1rem;
+        font-size: 0.8rem;
       }
-      #diffReviewModal .dm-status-text { flex: 1; color: var(--text-secondary,#b0b3c6); }
+      #diffReviewModal .dm-status-text {
+        flex: 1;
+        color: var(--text-secondary, #b0b3c6);
+      }
       #diffReviewModal .dm-progress-bar {
-        height: 4px; background: var(--bg-tertiary,#262a3a); border-radius: 2px;
-        overflow: hidden; margin-bottom: 1rem;
+        height: 4px;
+        background: var(--bg-tertiary, #262a3a);
+        border-radius: 2px;
+        overflow: hidden;
+        margin-bottom: 1rem;
       }
       #diffReviewModal .dm-progress-fill {
-        height: 100%; border-radius: 2px; transition: width 0.4s ease;
+        height: 100%;
+        border-radius: 2px;
+        transition: width 0.4s ease;
         background: linear-gradient(90deg, #6366f1, #22c55e);
       }
       #diffReviewModal .dm-btn {
-        padding: 0.5rem 1.1rem; border: none; border-radius: 999px;
-        font-size: 0.82rem; font-weight: 600; cursor: pointer; transition: all 0.2s;
-        display: inline-flex; align-items: center; gap: 0.4rem;
+        padding: 0.5rem 1.1rem;
+        border: none;
+        border-radius: 999px;
+        font-size: 0.82rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
       }
-      #diffReviewModal .dm-btn-sm { padding: 0.3rem 0.7rem; font-size: 0.75rem; }
-      #diffReviewModal .dm-btn-primary { background: var(--primary,#6366f1); color: #fff; }
-      #diffReviewModal .dm-btn-primary:hover { background: #818cf8; box-shadow: 0 2px 12px rgba(99,102,241,0.4); }
+      #diffReviewModal .dm-btn-sm {
+        padding: 0.3rem 0.7rem;
+        font-size: 0.75rem;
+      }
+      #diffReviewModal .dm-btn-primary {
+        background: var(--primary, #6366f1);
+        color: #fff;
+      }
+      #diffReviewModal .dm-btn-primary:hover {
+        background: #818cf8;
+        box-shadow: 0 2px 12px rgba(99, 102, 241, 0.4);
+      }
       #diffReviewModal .dm-btn-secondary {
-        background: var(--bg-tertiary,#262a3a); color: var(--text-secondary,#b0b3c6);
-        border: 1px solid var(--border-color,rgba(255,255,255,0.08));
+        background: var(--bg-tertiary, #262a3a);
+        color: var(--text-secondary, #b0b3c6);
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
       }
-      #diffReviewModal .dm-btn-secondary:hover { background: #22253a; color: var(--text-primary,#f0f0f5); }
-      #diffReviewModal .dm-btn-loss { background: var(--loss,#ef4444); color: #fff; }
-      #diffReviewModal .dm-btn-gain { background: var(--gain,#22c55e); color: #fff; }
-      #diffReviewModal .dm-btn-gain:hover { background: #16a34a; box-shadow: 0 2px 12px rgba(34,197,94,0.4); }
+      #diffReviewModal .dm-btn-secondary:hover {
+        background: #22253a;
+        color: var(--text-primary, #f0f0f5);
+      }
+      #diffReviewModal .dm-btn-loss {
+        background: var(--loss, #ef4444);
+        color: #fff;
+      }
+      #diffReviewModal .dm-btn-gain {
+        background: var(--gain, #22c55e);
+        color: #fff;
+      }
+      #diffReviewModal .dm-btn-gain:hover {
+        background: #16a34a;
+        box-shadow: 0 2px 12px rgba(34, 197, 94, 0.4);
+      }
       #diffReviewModal .dm-btn-muted {
-        background: var(--bg-tertiary,#262a3a); color: var(--text-muted,#64748b);
-        border: 1px solid var(--border-color,rgba(255,255,255,0.08)); opacity: 0.7;
+        background: var(--bg-tertiary, #262a3a);
+        color: var(--text-muted, #64748b);
+        border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+        opacity: 0.7;
       }
-      #diffReviewModal .dm-btn-muted:hover { opacity: 1; }
-      #diffReviewModal .dm-setting-expanded { display:flex; flex-wrap:wrap; gap:0.3rem; margin-bottom:0.4rem; }
-      #diffReviewModal .dm-setting-sides { display:flex; align-items:flex-start; gap:0.5rem; }
-      #diffReviewModal .dm-setting-side { flex:1; min-width:0; }
-      #diffReviewModal .dm-setting-side-label { font-size:0.7rem; font-weight:600; margin-bottom:0.25rem; }
-      #diffReviewModal .dm-setting-arrow { padding-top:1.2rem; opacity:0.3; font-size:0.8rem; }
+      #diffReviewModal .dm-btn-muted:hover {
+        opacity: 1;
+      }
+      #diffReviewModal .dm-setting-expanded {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3rem;
+        margin-bottom: 0.4rem;
+      }
+      #diffReviewModal .dm-setting-sides {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
+      }
+      #diffReviewModal .dm-setting-side {
+        flex: 1;
+        min-width: 0;
+      }
+      #diffReviewModal .dm-setting-side-label {
+        font-size: 0.7rem;
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+      }
+      #diffReviewModal .dm-setting-arrow {
+        padding-top: 1.2rem;
+        opacity: 0.3;
+        font-size: 0.8rem;
+      }
       #diffReviewModal .dm-chip-matched {
-        display:inline-flex; align-items:center; gap:0.2rem;
-        padding:0.15rem 0.45rem; border-radius:999px; font-size:0.68rem;
-        background:var(--bg-tertiary,#262a3a); color:var(--text-muted,#64748b); opacity:0.5;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+        padding: 0.15rem 0.45rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        background: var(--bg-tertiary, #262a3a);
+        color: var(--text-muted, #64748b);
+        opacity: 0.5;
       }
       #diffReviewModal .dm-chip-local,
       #diffReviewModal .dm-chip-remote {
-        display:inline-flex; align-items:center; gap:0.2rem;
-        padding:0.15rem 0.45rem; border-radius:999px; font-size:0.68rem;
-        cursor:pointer; transition:all 0.15s; border:1px solid transparent;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+        padding: 0.15rem 0.45rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        cursor: pointer;
+        transition: all 0.15s;
+        border: 1px solid transparent;
       }
-      #diffReviewModal .dm-chip-local.dm-chip-enabled { background:rgba(99,102,241,0.1); color:var(--primary,#6366f1); }
-      #diffReviewModal .dm-chip-local.dm-chip-disabled { background:rgba(99,102,241,0.05); color:var(--primary,#6366f1); opacity:0.6; }
-      #diffReviewModal .dm-chip-remote.dm-chip-enabled { background:rgba(59,130,246,0.1); color:var(--info,#3b82f6); }
-      #diffReviewModal .dm-chip-remote.dm-chip-disabled { background:rgba(59,130,246,0.05); color:var(--info,#3b82f6); opacity:0.6; }
+      #diffReviewModal .dm-chip-local.dm-chip-enabled {
+        background: rgba(99, 102, 241, 0.1);
+        color: var(--primary, #6366f1);
+      }
+      #diffReviewModal .dm-chip-local.dm-chip-disabled {
+        background: rgba(99, 102, 241, 0.05);
+        color: var(--primary, #6366f1);
+        opacity: 0.6;
+      }
+      #diffReviewModal .dm-chip-remote.dm-chip-enabled {
+        background: rgba(59, 130, 246, 0.1);
+        color: var(--info, #3b82f6);
+      }
+      #diffReviewModal .dm-chip-remote.dm-chip-disabled {
+        background: rgba(59, 130, 246, 0.05);
+        color: var(--info, #3b82f6);
+        opacity: 0.6;
+      }
       #diffReviewModal .dm-chip-local.dm-selected,
       #diffReviewModal .dm-chip-remote.dm-selected {
-        border-color:#22c55e; background:rgba(34,197,94,0.08); opacity:1;
+        border-color: #22c55e;
+        background: rgba(34, 197, 94, 0.08);
+        opacity: 1;
       }
       #diffReviewModal .dm-kv-pill {
-        display:inline-flex; align-items:center; gap:0.2rem;
-        padding:0.15rem 0.45rem; border-radius:999px; font-size:0.68rem;
-        cursor:pointer; transition:all 0.15s; border:1px solid transparent;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+        padding: 0.15rem 0.45rem;
+        border-radius: 999px;
+        font-size: 0.68rem;
+        cursor: pointer;
+        transition: all 0.15s;
+        border: 1px solid transparent;
       }
-      #diffReviewModal .dm-kv-pill.local { background:rgba(99,102,241,0.1); color:var(--primary,#6366f1); }
-      #diffReviewModal .dm-kv-pill.remote { background:rgba(59,130,246,0.1); color:var(--info,#3b82f6); }
-      #diffReviewModal .dm-kv-pill.matched { background:var(--bg-tertiary,#262a3a); color:var(--text-muted,#64748b); opacity:0.5; cursor:default; }
-      #diffReviewModal .dm-kv-pill.dm-selected { border-color:#22c55e; background:rgba(34,197,94,0.08); }
+      #diffReviewModal .dm-kv-pill.local {
+        background: rgba(99, 102, 241, 0.1);
+        color: var(--primary, #6366f1);
+      }
+      #diffReviewModal .dm-kv-pill.remote {
+        background: rgba(59, 130, 246, 0.1);
+        color: var(--info, #3b82f6);
+      }
+      #diffReviewModal .dm-kv-pill.matched {
+        background: var(--bg-tertiary, #262a3a);
+        color: var(--text-muted, #64748b);
+        opacity: 0.5;
+        cursor: default;
+      }
+      #diffReviewModal .dm-kv-pill.dm-selected {
+        border-color: #22c55e;
+        background: rgba(34, 197, 94, 0.08);
+      }
       #diffReviewModal .dm-show-more {
-        display:inline-block; font-size:0.68rem; color:var(--primary,#3b82f6);
-        cursor:pointer; padding:0.15rem 0.3rem; margin-top:0.2rem;
+        display: inline-block;
+        font-size: 0.68rem;
+        color: var(--primary, #3b82f6);
+        cursor: pointer;
+        padding: 0.15rem 0.3rem;
+        margin-top: 0.2rem;
       }
-      #diffReviewModal .dm-show-more:hover { text-decoration:underline; }
-      #diffReviewModal .dm-expandable { display:none; }
-      #diffReviewModal .dm-expandable.expanded { display:contents; }
+      #diffReviewModal .dm-show-more:hover {
+        text-decoration: underline;
+      }
+      #diffReviewModal .dm-expandable {
+        display: none;
+      }
+      #diffReviewModal .dm-expandable.expanded {
+        display: contents;
+      }
       #diffReviewModal .dm-count-summary {
-        display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
       }
       #diffReviewModal .dm-count-summary .dm-count-badge {
-        font-size:0.75rem; padding:0.2rem 0.5rem; border-radius:4px;
-        background:var(--bg-tertiary,#262a3a); color:var(--text-secondary,#b0b3c6);
+        font-size: 0.75rem;
+        padding: 0.2rem 0.5rem;
+        border-radius: 4px;
+        background: var(--bg-tertiary, #262a3a);
+        color: var(--text-secondary, #b0b3c6);
       }
       #diffReviewModal .dm-count-summary .dm-count-btn {
-        padding:0.25rem 0.6rem; border-radius:4px; cursor:pointer; font-size:0.75rem;
-        border:1px solid transparent; transition:all 0.15s;
+        padding: 0.25rem 0.6rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.75rem;
+        border: 1px solid transparent;
+        transition: all 0.15s;
       }
       #diffReviewModal .dm-count-summary .dm-count-btn.active {
-        border-color:#22c55e; background:rgba(34,197,94,0.08);
+        border-color: #22c55e;
+        background: rgba(34, 197, 94, 0.08);
       }
-      #diffReviewModal .dm-card.resolved { opacity: 0.5; transform: scale(0.98); transition: all 0.3s; }
-      #diffReviewModal .fade-in { animation: dmFadeIn 0.3s ease; }
-      @keyframes dmFadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+      #diffReviewModal .dm-card.resolved {
+        opacity: 0.5;
+        transform: scale(0.98);
+        transition: all 0.3s;
+      }
+      #diffReviewModal .fade-in {
+        animation: dmFadeIn 0.3s ease;
+      }
+      @keyframes dmFadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(6px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
       @media (max-width: 700px) {
-        #diffReviewModal .dm-field-diff { grid-template-columns: 80px 1fr auto 1fr; }
+        #diffReviewModal .dm-field-diff {
+          grid-template-columns: 80px 1fr auto 1fr;
+        }
       }
       @media (max-width: 480px) {
-        #diffReviewModal .dm-field-diff { grid-template-columns: 1fr; gap: 0.25rem; }
+        #diffReviewModal .dm-field-diff {
+          grid-template-columns: 1fr;
+          gap: 0.25rem;
+        }
       }
     </style>
-    <div class="modal" id="diffReviewModal" style="display: none">
+    <div
+      class="modal"
+      id="diffReviewModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="diffReviewTitle"
+    >
       <div class="modal-content" style="max-width: 860px">
         <div class="modal-header">
           <h2 id="diffReviewTitle">Review Changes</h2>
-          <button aria-label="Close modal" class="modal-close" id="diffReviewDismissX">&times;</button>
+          <button aria-label="Close modal" class="modal-close" id="diffReviewDismissX">
+            &times;
+          </button>
         </div>
         <div class="modal-body">
           <div class="cloud-sync-update-meta" id="diffReviewSource"></div>
-          <div id="diffReviewCountRow" style="display:none;margin:0.5rem 0 0.25rem;font-size:0.8rem;color:var(--text-muted,#64748b)"></div>
-          <div id="diffReviewCountWarning" style="display:none;margin:0.2rem 0 0.5rem;font-size:0.78rem;color:var(--warning,#d97706)"></div>
-          <div id="diffSummaryDashboard" style="margin:0.75rem 0"></div>
-          <div id="diffProgressTracker" style="margin:0.5rem 0"></div>
-          <div id="diffSectionConflicts" style="margin-bottom:1rem"></div>
-          <div id="diffSectionOrphans" style="margin-bottom:1rem"></div>
-          <div id="diffSectionModified" style="max-height:500px;overflow-y:auto;border-radius:6px;padding:0.5rem;margin-bottom:1rem;font-size:0.9rem"></div>
-          <div id="diffReviewSettings" style="margin-bottom:1rem"></div>
-          <div class="encryption-actions" style="gap:0.5rem;flex-wrap:wrap">
+          <div
+            id="diffReviewCountRow"
+            style="
+              display: none;
+              margin: 0.5rem 0 0.25rem;
+              font-size: 0.8rem;
+              color: var(--text-muted, #64748b);
+            "
+          ></div>
+          <div
+            id="diffReviewCountWarning"
+            style="
+              display: none;
+              margin: 0.2rem 0 0.5rem;
+              font-size: 0.78rem;
+              color: var(--warning, #d97706);
+            "
+          ></div>
+          <div id="diffSummaryDashboard" style="margin: 0.75rem 0"></div>
+          <div id="diffProgressTracker" style="margin: 0.5rem 0"></div>
+          <div id="diffSectionConflicts" style="margin-bottom: 1rem"></div>
+          <div id="diffSectionOrphans" style="margin-bottom: 1rem"></div>
+          <div
+            id="diffSectionModified"
+            style="
+              max-height: 500px;
+              overflow-y: auto;
+              border-radius: 6px;
+              padding: 0.5rem;
+              margin-bottom: 1rem;
+              font-size: 0.9rem;
+            "
+          ></div>
+          <div id="diffReviewSettings" style="margin-bottom: 1rem"></div>
+          <div class="encryption-actions" style="gap: 0.5rem; flex-wrap: wrap">
             <button class="btn btn-sm" id="diffReviewSelectAll">Select All</button>
             <button class="btn btn-sm" id="diffReviewDeselectAll">Deselect All</button>
-            <button class="btn btn-sm" id="diffReviewSelectAllToggle" style="display:none">Select All</button>
+            <button class="btn btn-sm" id="diffReviewSelectAllToggle" style="display: none">
+              Select All
+            </button>
             <button class="btn success" id="diffReviewApplyBtn">Apply Changes</button>
             <button class="btn" id="diffReviewCancelBtn">Cancel</button>
           </div>
@@ -4494,17 +8442,18 @@
       </div>
     </div>
 
-    <div class="modal" id="apiQuotaModal" style="display: none">
+    <div
+      class="modal"
+      id="apiQuotaModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="apiQuotaModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>API Quota</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="apiQuotaCloseBtn"
-          >
-            ×
-          </button>
+          <h2 id="apiQuotaModalTitle">API Quota</h2>
+          <button aria-label="Close modal" class="modal-close" id="apiQuotaCloseBtn">×</button>
         </div>
         <div class="modal-body" style="text-align: center">
           <label for="apiQuotaInput">Monthly quota:</label>
@@ -4516,7 +8465,14 @@
       </div>
     </div>
 
-    <div class="modal" id="apiInfoModal" style="display: none">
+    <div
+      class="modal"
+      id="apiInfoModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="apiInfoTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
           <h3 id="apiInfoTitle">Provider Information</h3>
@@ -4527,32 +8483,25 @@
         </div>
       </div>
     </div>
-    <div class="modal" id="apiHistoryModal" style="display: none">
+    <div
+      class="modal"
+      id="apiHistoryModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="apiHistoryModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Metals Price History</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="apiHistoryCloseBtn"
-          >
-            ×
-          </button>
+          <h2 id="apiHistoryModalTitle">Metals Price History</h2>
+          <button aria-label="Close modal" class="modal-close" id="apiHistoryCloseBtn">×</button>
         </div>
         <div class="modal-body">
           <div class="api-history-body">
             <div class="api-history-table">
               <div class="api-history-filter">
-                <input
-                  type="text"
-                  id="apiHistoryFilter"
-                  placeholder="Filter history..."
-                />
-                <button
-                  type="button"
-                  class="btn secondary"
-                  id="apiHistoryClearFilterBtn"
-                >
+                <input type="text" id="apiHistoryFilter" placeholder="Filter history..." />
+                <button type="button" class="btn secondary" id="apiHistoryClearFilterBtn">
                   Clear
                 </button>
               </div>
@@ -4565,8 +8514,10 @@
         <div class="modal-footer api-history-footer">
           <button type="button" class="btn" id="exportSpotHistoryBtn">Export History</button>
           <button type="button" class="btn" id="importSpotHistoryBtn">Import History</button>
-          <button type="button" class="btn secondary" id="restoreHistoricalDataBtn">Restore Historical Data</button>
-          <input type="file" id="importSpotHistoryFile" accept=".csv,.json" style="display:none">
+          <button type="button" class="btn secondary" id="restoreHistoricalDataBtn">
+            Restore Historical Data
+          </button>
+          <input type="file" id="importSpotHistoryFile" accept=".csv,.json" style="display: none" />
         </div>
       </div>
     </div>
@@ -4577,15 +8528,18 @@
        Modal for viewing Goldback denomination price history.
        Mirrors the apiHistoryModal structure with sortable/filterable table.
        ============================================================================= -->
-    <div class="modal" id="goldbackHistoryModal" style="display: none">
+    <div
+      class="modal"
+      id="goldbackHistoryModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="goldbackHistoryModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Goldback Price History</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="goldbackHistoryCloseBtn"
-          >
+          <h2 id="goldbackHistoryModalTitle">Goldback Price History</h2>
+          <button aria-label="Close modal" class="modal-close" id="goldbackHistoryCloseBtn">
             &times;
           </button>
         </div>
@@ -4593,16 +8547,8 @@
           <div class="api-history-body">
             <div class="api-history-table">
               <div class="api-history-filter">
-                <input
-                  type="text"
-                  id="goldbackHistoryFilter"
-                  placeholder="Filter history..."
-                />
-                <button
-                  type="button"
-                  class="btn secondary"
-                  id="goldbackHistoryClearFilterBtn"
-                >
+                <input type="text" id="goldbackHistoryFilter" placeholder="Filter history..." />
+                <button type="button" class="btn secondary" id="goldbackHistoryClearFilterBtn">
                   Clear
                 </button>
               </div>
@@ -4625,15 +8571,18 @@
        Opens from the Retail Price field icon in the edit modal (STAK-109).
        Stacks above the edit modal (z-index: 10000).
        ============================================================================= -->
-    <div class="modal" id="itemPriceHistoryModal" style="display: none">
+    <div
+      class="modal"
+      id="itemPriceHistoryModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="itemPriceHistoryTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="itemPriceHistoryTitle">Item Price History</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="itemPriceHistoryCloseBtn"
-          >
+          <button aria-label="Close modal" class="modal-close" id="itemPriceHistoryCloseBtn">
             &times;
           </button>
         </div>
@@ -4641,16 +8590,8 @@
           <div class="api-history-body">
             <div class="api-history-table">
               <div class="api-history-filter">
-                <input
-                  type="text"
-                  id="itemPriceHistoryFilter"
-                  placeholder="Filter history..."
-                />
-                <button
-                  type="button"
-                  class="btn secondary"
-                  id="itemPriceHistoryClearFilterBtn"
-                >
+                <input type="text" id="itemPriceHistoryFilter" placeholder="Filter history..." />
+                <button type="button" class="btn secondary" id="itemPriceHistoryClearFilterBtn">
                   Clear
                 </button>
               </div>
@@ -4680,15 +8621,18 @@
        Modal for viewing catalog API call history (Numista lookups, searches).
        Mirrors the apiHistoryModal structure with sortable/filterable table.
        ============================================================================= -->
-    <div class="modal" id="catalogHistoryModal" style="display: none">
+    <div
+      class="modal"
+      id="catalogHistoryModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="catalogHistoryModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Catalog API History</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="catalogHistoryCloseBtn"
-          >
+          <h2 id="catalogHistoryModalTitle">Catalog API History</h2>
+          <button aria-label="Close modal" class="modal-close" id="catalogHistoryCloseBtn">
             &times;
           </button>
         </div>
@@ -4696,16 +8640,8 @@
           <div class="api-history-body">
             <div class="api-history-table">
               <div class="api-history-filter">
-                <input
-                  type="text"
-                  id="catalogHistoryFilter"
-                  placeholder="Filter history..."
-                />
-                <button
-                  type="button"
-                  class="btn secondary"
-                  id="catalogHistoryClearFilterBtn"
-                >
+                <input type="text" id="catalogHistoryFilter" placeholder="Filter history..." />
+                <button type="button" class="btn secondary" id="catalogHistoryClearFilterBtn">
                   Clear
                 </button>
               </div>
@@ -4726,11 +8662,20 @@
        Stacked modal (z-index 10000) that appears over the item Add/Edit form.
        Shows search results from Numista API and a field picker to fill form fields.
        ============================================================================= -->
-    <div class="modal" id="numistaResultsModal" style="display: none">
+    <div
+      class="modal"
+      id="numistaResultsModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="numistaResultsTitle"
+    >
       <div class="modal-content numista-results-modal-content">
         <div class="modal-header">
           <h2 id="numistaResultsTitle">Numista Results</h2>
-          <button aria-label="Close modal" class="modal-close" id="numistaResultsCloseBtn">&times;</button>
+          <button aria-label="Close modal" class="modal-close" id="numistaResultsCloseBtn">
+            &times;
+          </button>
         </div>
         <div class="modal-body">
           <!-- Search results list -->
@@ -4758,11 +8703,20 @@
        Stacked modal (z-index 10000) that appears over the item Add/Edit form.
        Shows the PCGS lookup result with images and a field picker to fill form fields.
        ============================================================================= -->
-    <div class="modal" id="pcgsFieldPickerModal" style="display: none">
+    <div
+      class="modal"
+      id="pcgsFieldPickerModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pcgsFieldPickerTitle"
+    >
       <div class="modal-content numista-results-modal-content">
         <div class="modal-header">
           <h2 id="pcgsFieldPickerTitle">PCGS Item Found</h2>
-          <button aria-label="Close modal" class="modal-close" id="pcgsFieldPickerCloseBtn">&times;</button>
+          <button aria-label="Close modal" class="modal-close" id="pcgsFieldPickerCloseBtn">
+            &times;
+          </button>
         </div>
         <div class="modal-body">
           <div id="pcgsSelectedItem" class="numista-selected-preview"></div>
@@ -4783,14 +8737,22 @@
        Stacked modal (z-index 10000) that appears over the item Add/Edit form.
        Shows historical spot prices near the purchase date for the selected metal.
        ============================================================================= -->
-    <div class="modal" id="spotLookupModal" style="display: none">
+    <div
+      class="modal"
+      id="spotLookupModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="spotLookupTitle"
+    >
       <div class="modal-content numista-results-modal-content">
         <div class="modal-header">
           <h2 id="spotLookupTitle">Spot Price Lookup</h2>
-          <button aria-label="Close modal" class="modal-close" id="spotLookupCloseBtn">&times;</button>
+          <button aria-label="Close modal" class="modal-close" id="spotLookupCloseBtn">
+            &times;
+          </button>
         </div>
-        <div class="modal-body" id="spotLookupBody">
-        </div>
+        <div class="modal-body" id="spotLookupBody"></div>
       </div>
     </div>
 
@@ -4801,10 +8763,19 @@
        inventory data, valuation, grading, and Numista enrichment data.
        Gated behind COIN_IMAGES feature flag.
        ============================================================================= -->
-    <div class="modal" id="viewItemModal" style="display: none">
+    <div
+      class="modal"
+      id="viewItemModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="viewModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <button class="view-modal-close" id="viewModalCloseX" aria-label="Close modal">&times;</button>
+          <button class="view-modal-close" id="viewModalCloseX" aria-label="Close modal">
+            &times;
+          </button>
           <div class="view-header-title-row">
             <h2 id="viewModalTitle"></h2>
             <div class="view-header-actions" id="viewHeaderActions"></div>
@@ -4824,10 +8795,17 @@
 
        Displays collected debug output when debug mode is enabled.
        ============================================================================= -->
-    <div class="modal" id="debugModal" style="display: none">
+    <div
+      class="modal"
+      id="debugModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="debugModalTitle"
+    >
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Debug Log</h2>
+          <h2 id="debugModalTitle">Debug Log</h2>
           <button aria-label="Close modal" class="modal-close" id="debugCloseBtn">×</button>
         </div>
         <div class="modal-body">
@@ -4841,11 +8819,20 @@
 
        Full-screen modal for multi-item editing, copying, and deletion.
        ============================================================================= -->
-    <div class="modal" id="bulkEditModal" style="display: none">
+    <div
+      class="modal"
+      id="bulkEditModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulkEditModalTitle"
+    >
       <div class="modal-content bulk-edit-content">
         <div class="modal-header">
-          <h2>Bulk Edit</h2>
-          <button aria-label="Close modal" class="modal-close" id="bulkEditCloseBtn">&times;</button>
+          <h2 id="bulkEditModalTitle">Bulk Edit</h2>
+          <button aria-label="Close modal" class="modal-close" id="bulkEditCloseBtn">
+            &times;
+          </button>
         </div>
         <div class="modal-body bulk-edit-body">
           <!-- Left: Field panel -->
@@ -4861,10 +8848,17 @@
     </div>
 
     <!-- Bulk Edit inline confirmation (replaces window.confirm suppressed by modal context) -->
-    <div class="modal" id="bulkConfirmModal" style="display: none; z-index: 10050">
+    <div
+      class="modal"
+      id="bulkConfirmModal"
+      style="display: none; z-index: 10050"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulkConfirmModalTitle"
+    >
       <div class="modal-content" style="max-width: 380px">
         <div class="modal-header">
-          <h2>Confirm</h2>
+          <h2 id="bulkConfirmModalTitle">Confirm</h2>
         </div>
         <div class="modal-body">
           <p id="bulkConfirmMessage" style="margin: 0 0 1.2rem"></p>
@@ -4877,18 +8871,37 @@
     </div>
 
     <!-- Privacy Policy Modal -->
-    <div class="modal" id="privacyModal" style="display: none">
-      <div class="modal-content" style="max-width:760px">
+    <div
+      class="modal"
+      id="privacyModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="privacyModalTitle"
+    >
+      <div class="modal-content" style="max-width: 760px">
         <div class="modal-header">
-          <h3>Privacy Policy</h3>
-          <button aria-label="Close modal" class="modal-close" onclick="if(window.closeModalById)closeModalById('privacyModal');else this.closest('.modal').style.display='none';">&times;</button>
+          <h3 id="privacyModalTitle">Privacy Policy</h3>
+          <button
+            aria-label="Close modal"
+            class="modal-close"
+            onclick="
+              if (window.closeModalById) closeModalById('privacyModal');
+              else this.closest('.modal').style.display = 'none';
+            "
+          >
+            &times;
+          </button>
         </div>
-        <div class="modal-body" style="padding:1rem 1.5rem;overflow-y:auto;max-height:70vh">
-
+        <div class="modal-body" style="padding: 1rem 1.5rem; overflow-y: auto; max-height: 70vh">
           <!-- Overview -->
           <div class="about-section">
             <div class="section-title">🏠 Overview</div>
-            <p style="font-size:0.95rem;line-height:1.6">StakTrakr is a client-side web application for tracking precious metals inventory. Your data stays on your device — we do not operate servers that store user data. <em>Last updated: February 17, 2026.</em></p>
+            <p style="font-size: 0.95rem; line-height: 1.6">
+              StakTrakr is a client-side web application for tracking precious metals inventory.
+              Your data stays on your device — we do not operate servers that store user data.
+              <em>Last updated: February 17, 2026.</em>
+            </p>
           </div>
 
           <!-- Your Data -->
@@ -4898,15 +8911,26 @@
             <details class="faq-item">
               <summary class="faq-question">Where is my data stored?</summary>
               <div class="faq-answer">
-                <p>All inventory data, settings, and preferences are stored locally in your browser using <strong>localStorage</strong> and <strong>IndexedDB</strong> (for images). Nothing is transmitted to StakTrakr servers.</p>
+                <p>
+                  All inventory data, settings, and preferences are stored locally in your browser
+                  using <strong>localStorage</strong> and <strong>IndexedDB</strong> (for images).
+                  Nothing is transmitted to StakTrakr servers.
+                </p>
               </div>
             </details>
 
             <details class="faq-item">
               <summary class="faq-question">Can this data be lost?</summary>
               <div class="faq-answer">
-                <p>Browser localStorage is not permanent storage. It can be cleared by browser settings, private/incognito sessions, or on iOS if the device is low on storage and the app hasn't been used recently.</p>
-                <p><strong>Recommendation:</strong> Export a ZIP or vault backup regularly, especially on iOS. Consider connecting a cloud backup provider.</p>
+                <p>
+                  Browser localStorage is not permanent storage. It can be cleared by browser
+                  settings, private/incognito sessions, or on iOS if the device is low on storage
+                  and the app hasn't been used recently.
+                </p>
+                <p>
+                  <strong>Recommendation:</strong> Export a ZIP or vault backup regularly,
+                  especially on iOS. Consider connecting a cloud backup provider.
+                </p>
               </div>
             </details>
           </div>
@@ -4916,23 +8940,47 @@
             <div class="section-title">☁️ Cloud Backup</div>
 
             <details class="faq-item">
-              <summary class="faq-question">What happens when I connect Dropbox, pCloud, or Box?</summary>
+              <summary class="faq-question">
+                What happens when I connect Dropbox, pCloud, or Box?
+              </summary>
               <div class="faq-answer">
-                <p>StakTrakr will request authorization to read and write files in a <code>/StakTrakr/</code> folder on your account. It stores an OAuth access token in your browser's localStorage to maintain the connection. StakTrakr does not access any other files in your cloud storage account.</p>
+                <p>
+                  StakTrakr will request authorization to read and write files in a
+                  <code>/StakTrakr/</code> folder on your account. It stores an OAuth access token
+                  in your browser's localStorage to maintain the connection. StakTrakr does not
+                  access any other files in your cloud storage account.
+                </p>
               </div>
             </details>
 
             <details class="faq-item">
               <summary class="faq-question">Can my cloud provider read my data?</summary>
               <div class="faq-answer">
-                <p>No. Your backup is encrypted on your device with <strong>AES-256-GCM</strong> before it is uploaded. The cloud provider receives only ciphertext and a random salt — never your password or plaintext data. The key is derived from your password via PBKDF2-SHA256 with 100,000 iterations using the browser's <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API" target="_blank" rel="noopener">Web Crypto API</a>.</p>
+                <p>
+                  No. Your backup is encrypted on your device with
+                  <strong>AES-256-GCM</strong> before it is uploaded. The cloud provider receives
+                  only ciphertext and a random salt — never your password or plaintext data. The key
+                  is derived from your password via PBKDF2-SHA256 with 100,000 iterations using the
+                  browser's
+                  <a
+                    href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API"
+                    target="_blank"
+                    rel="noopener"
+                    >Web Crypto API</a
+                  >.
+                </p>
               </div>
             </details>
 
             <details class="faq-item">
               <summary class="faq-question">How do I disconnect?</summary>
               <div class="faq-answer">
-                <p>You can disconnect at any time in <strong>Settings → Cloud</strong>. Disconnecting removes the stored OAuth token from your browser. Your cloud files are not automatically deleted — you can remove them manually from your cloud provider's file manager.</p>
+                <p>
+                  You can disconnect at any time in <strong>Settings → Cloud</strong>. Disconnecting
+                  removes the stored OAuth token from your browser. Your cloud files are not
+                  automatically deleted — you can remove them manually from your cloud provider's
+                  file manager.
+                </p>
               </div>
             </details>
           </div>
@@ -4944,11 +8992,18 @@
             <details class="faq-item">
               <summary class="faq-question">What external services does StakTrakr contact?</summary>
               <div class="faq-answer">
-                <p>StakTrakr may contact external services for spot price data, exchange rates, and catalog lookups. These requests contain no personal information — only metal type or coin identifiers. No cookies or tracking identifiers are sent. Specific services include:</p>
+                <p>
+                  StakTrakr may contact external services for spot price data, exchange rates, and
+                  catalog lookups. These requests contain no personal information — only metal type
+                  or coin identifiers. No cookies or tracking identifiers are sent. Specific
+                  services include:
+                </p>
                 <ul class="faq-list">
                   <li>Public metal pricing APIs (spot prices)</li>
                   <li>Open Exchange Rates (currency conversion)</li>
-                  <li>Numista &amp; PCGS APIs (coin catalog lookups, when you use those features)</li>
+                  <li>
+                    Numista &amp; PCGS APIs (coin catalog lookups, when you use those features)
+                  </li>
                   <li><code>staktrakr.com/version.json</code> (version update check)</li>
                 </ul>
               </div>
@@ -4962,14 +9017,29 @@
             <details class="faq-item">
               <summary class="faq-question">Does the app track me?</summary>
               <div class="faq-answer">
-                <p>No. The app itself does not use analytics, tracking pixels, fingerprinting, or advertising of any kind. There are no third-party scripts embedded in the app that collect user behavior.</p>
+                <p>
+                  No. The app itself does not use analytics, tracking pixels, fingerprinting, or
+                  advertising of any kind. There are no third-party scripts embedded in the app that
+                  collect user behavior.
+                </p>
               </div>
             </details>
 
             <details class="faq-item">
-              <summary class="faq-question">What about the hosted version at staktrakr.com?</summary>
+              <summary class="faq-question">
+                What about the hosted version at staktrakr.com?
+              </summary>
               <div class="faq-answer">
-                <p>When you use the hosted version at staktrakr.com (served via Cloudflare Pages), <a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener">Cloudflare Web Analytics</a> is active at the network edge. It collects aggregated, anonymous page-view metrics (visit counts, countries, browser types) <strong>without cookies</strong> and without building individual user profiles. No inventory data is ever included. If you run the app locally from a downloaded ZIP, no analytics run at all.</p>
+                <p>
+                  When you use the hosted version at staktrakr.com (served via Cloudflare Pages),
+                  <a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener"
+                    >Cloudflare Web Analytics</a
+                  >
+                  is active at the network edge. It collects aggregated, anonymous page-view metrics
+                  (visit counts, countries, browser types) <strong>without cookies</strong> and
+                  without building individual user profiles. No inventory data is ever included. If
+                  you run the app locally from a downloaded ZIP, no analytics run at all.
+                </p>
               </div>
             </details>
           </div>
@@ -4977,21 +9047,33 @@
           <!-- Cookies -->
           <div class="about-section">
             <div class="section-title">🍪 Cookies</div>
-            <p style="font-size:0.95rem;line-height:1.6">StakTrakr does not set cookies. OAuth providers may set their own cookies during the authorization flow in the popup window. Cloudflare Web Analytics does not use cookies.</p>
+            <p style="font-size: 0.95rem; line-height: 1.6">
+              StakTrakr does not set cookies. OAuth providers may set their own cookies during the
+              authorization flow in the popup window. Cloudflare Web Analytics does not use cookies.
+            </p>
           </div>
 
           <!-- Children -->
           <div class="about-section">
             <div class="section-title">👶 Children</div>
-            <p style="font-size:0.95rem;line-height:1.6">StakTrakr is not directed at children under 13 and does not knowingly collect information from children.</p>
+            <p style="font-size: 0.95rem; line-height: 1.6">
+              StakTrakr is not directed at children under 13 and does not knowingly collect
+              information from children.
+            </p>
           </div>
 
           <!-- Changes & Contact -->
           <div class="about-section">
             <div class="section-title">📝 Changes &amp; Contact</div>
-            <p style="font-size:0.95rem;line-height:1.6">If this policy changes, the updated version will appear in the app with a new date. Questions about this policy can be directed to the project's <a href="https://github.com/lbruton/StakTrakr/issues" target="_blank" rel="noopener">GitHub Issues</a> page.</p>
+            <p style="font-size: 0.95rem; line-height: 1.6">
+              If this policy changes, the updated version will appear in the app with a new date.
+              Questions about this policy can be directed to the project's
+              <a href="https://github.com/lbruton/StakTrakr/issues" target="_blank" rel="noopener"
+                >GitHub Issues</a
+              >
+              page.
+            </p>
           </div>
-
         </div>
       </div>
     </div>
@@ -5003,28 +9085,47 @@
        (unchecked) and disposition tracking (checked). Replaces the separate
        #dispositionModal and showAppConfirm() delete confirmation (STAK-72).
        ============================================================================= -->
-    <div class="modal" id="removeItemModal" style="display: none">
+    <div
+      class="modal"
+      id="removeItemModal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="removeItemModalTitle"
+    >
       <div class="modal-content" style="max-width: 440px">
         <div class="modal-header">
-          <h2>Remove Item</h2>
-          <button aria-label="Close modal" class="modal-close" onclick="closeModalById('removeItemModal')">&times;</button>
+          <h2 id="removeItemModalTitle">Remove Item</h2>
+          <button
+            aria-label="Close modal"
+            class="modal-close"
+            onclick="closeModalById('removeItemModal')"
+          >
+            &times;
+          </button>
         </div>
         <div class="modal-body">
-          <input type="hidden" id="removeItemIdx">
-          <p id="removeItemName" style="margin:0 0 0.75rem; font-weight:600"></p>
-          <p style="margin:0 0 1rem; color:var(--text-secondary); font-size:0.9rem">
-            This can be undone from the <a href="#" id="removeItemOpenLog" style="color:var(--primary); text-decoration:underline; cursor:pointer">Activity Log</a>.
+          <input type="hidden" id="removeItemIdx" />
+          <p id="removeItemName" style="margin: 0 0 0.75rem; font-weight: 600"></p>
+          <p style="margin: 0 0 1rem; color: var(--text-secondary); font-size: 0.9rem">
+            This can be undone from the
+            <a
+              href="#"
+              id="removeItemOpenLog"
+              style="color: var(--primary); text-decoration: underline; cursor: pointer"
+              >Activity Log</a
+            >.
           </p>
 
           <label class="dispose-toggle-card" for="removeItemDisposeCheck">
             <span class="toggle-switch">
-              <input type="checkbox" id="removeItemDisposeCheck">
+              <input type="checkbox" id="removeItemDisposeCheck" />
               <span class="toggle-track"></span>
             </span>
             <span>Track this item as disposed</span>
           </label>
 
-          <div id="removeItemDisposeFields" style="display:none">
+          <div id="removeItemDisposeFields" style="display: none">
             <div class="form-group">
               <label for="dispositionType">Type</label>
               <select id="dispositionType">
@@ -5038,17 +9139,17 @@
 
             <div class="form-group">
               <label for="dispositionDate">Date</label>
-              <input type="date" id="dispositionDate">
+              <input type="date" id="dispositionDate" />
             </div>
 
             <div class="form-group" id="dispositionAmountGroup">
               <label for="dispositionAmount">Amount</label>
-              <input type="number" id="dispositionAmount" min="0" step="0.01" placeholder="0.00">
+              <input type="number" id="dispositionAmount" min="0" step="0.01" placeholder="0.00" />
             </div>
 
             <div class="form-group">
               <label for="dispositionRecipient">Recipient</label>
-              <input type="text" id="dispositionRecipient" placeholder="Optional">
+              <input type="text" id="dispositionRecipient" placeholder="Optional" />
             </div>
 
             <div class="form-group">
@@ -5057,10 +9158,14 @@
             </div>
           </div>
         </div>
-        <div class="modal-footer" style="justify-content:space-between">
-          <button class="btn secondary" type="button" onclick="closeModalById('removeItemModal')">Cancel</button>
+        <div class="modal-footer" style="justify-content: space-between">
+          <button class="btn secondary" type="button" onclick="closeModalById('removeItemModal')">
+            Cancel
+          </button>
           <button class="btn danger" type="button" id="removeItemDeleteBtn">Delete</button>
-          <button class="btn premium" type="button" id="removeItemDisposeBtn" style="display:none">Confirm Disposition</button>
+          <button class="btn premium" type="button" id="removeItemDisposeBtn" style="display: none">
+            Confirm Disposition
+          </button>
         </div>
       </div>
     </div>
@@ -5081,24 +9186,24 @@
        External libraries (Chart.js, jsPDF, PapaParse, JSZip) loaded via CDN
        ============================================================================= -->
 
-  <script defer src="js/debug-log.js"></script>
-  <script defer src="./js/constants.js"></script>
-  <script defer src="./js/field-meta.js"></script>
-  <script defer src="./js/state.js"></script>
-  <script defer src="./js/utils.js"></script>
-  <script defer src="./js/dialogs.js"></script>
-  <script defer src="./js/image-processor.js"></script>
-  <script defer src="./js/image-cache.js"></script>
-  <script defer src="./js/bulk-image-cache.js"></script>
-  <script defer src="./js/image-cache-modal.js"></script>
-  <script defer src="./js/fuzzy-search.js"></script>
-  <script defer src="./js/autocomplete.js"></script>
-  <script defer src="./js/numista-lookup.js"></script>
-  <script defer src="./js/seed-images.js"></script>
-  <script defer src="./js/versionCheck.js"></script>
-  <script defer src="./js/changeLog.js"></script>
-  <script defer src="./js/diff-engine.js"></script>
-  <script defer src="./js/diff-modal.js"></script>
+    <script defer src="js/debug-log.js"></script>
+    <script defer src="./js/constants.js"></script>
+    <script defer src="./js/field-meta.js"></script>
+    <script defer src="./js/state.js"></script>
+    <script defer src="./js/utils.js"></script>
+    <script defer src="./js/dialogs.js"></script>
+    <script defer src="./js/image-processor.js"></script>
+    <script defer src="./js/image-cache.js"></script>
+    <script defer src="./js/bulk-image-cache.js"></script>
+    <script defer src="./js/image-cache-modal.js"></script>
+    <script defer src="./js/fuzzy-search.js"></script>
+    <script defer src="./js/autocomplete.js"></script>
+    <script defer src="./js/numista-lookup.js"></script>
+    <script defer src="./js/seed-images.js"></script>
+    <script defer src="./js/versionCheck.js"></script>
+    <script defer src="./js/changeLog.js"></script>
+    <script defer src="./js/diff-engine.js"></script>
+    <script defer src="./js/diff-modal.js"></script>
     <script defer src="./js/chart-utils.js"></script>
     <script defer src="./js/market-charts.js"></script>
     <script defer src="./js/market-data.js"></script>
@@ -5144,7 +9249,7 @@
     <script defer src="./js/bulkEdit.js"></script>
     <script defer src="./js/clone-picker.js"></script>
     <script defer src="./js/events.js"></script>
-    
+
     <!-- Test Scripts (Development) -->
     <script defer src="./js/test-loader.js"></script>
 
@@ -5152,89 +9257,163 @@
 
     <!-- Back to top floating button -->
     <button id="backToTopBtn" class="back-to-top" title="Back to top" aria-label="Scroll to top">
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="18 15 12 9 6 15"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="18 15 12 9 6 15" />
       </svg>
     </button>
 
     <!-- PROTOTYPE: STAK-144 — sync Settings card style dropdown with view toggle on open -->
     <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        var modal = document.getElementById('settingsModal');
+      document.addEventListener("DOMContentLoaded", function () {
+        var modal = document.getElementById("settingsModal");
         if (modal) {
           new MutationObserver(function () {
-            if (modal.classList.contains('show')) {
+            if (modal.classList.contains("show")) {
               // Reflect current style (A/B/C/D) in settings card style dropdown
               // D is not in the dropdown; for D mode show nothing selected / keep last
-              var cur = localStorage.getItem('cardViewStyle') || 'A';
-              var sel = document.getElementById('settingsCardStyle');
-              if (sel && cur !== 'D') sel.value = cur;
+              var cur = localStorage.getItem("cardViewStyle") || "A";
+              var sel = document.getElementById("settingsCardStyle");
+              if (sel && cur !== "D") sel.value = cur;
             }
-          }).observe(modal, { attributes: true, attributeFilter: ['class'] });
+          }).observe(modal, { attributes: true, attributeFilter: ["class"] });
         }
       });
     </script>
 
-  <!-- ===== RETAIL VIEW MODAL ===== -->
-  <div id="retailViewModal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="retailViewCoinName">
-    <div class="modal-content">
-      <div class="modal-header">
-        <div>
-          <h2 id="retailViewCoinName"></h2>
-          <span id="retailViewModalSubtitle" class="settings-subtext"></span>
+    <!-- ===== RETAIL VIEW MODAL ===== -->
+    <div
+      id="retailViewModal"
+      class="modal"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="retailViewCoinName"
+    >
+      <div class="modal-content">
+        <div class="modal-header">
+          <div>
+            <h2 id="retailViewCoinName"></h2>
+            <span id="retailViewModalSubtitle" class="settings-subtext"></span>
+          </div>
+          <button
+            class="modal-close"
+            onclick="closeRetailViewModal()"
+            aria-label="Close market price detail"
+          >
+            &times;
+          </button>
         </div>
-        <button class="modal-close" onclick="closeRetailViewModal()" aria-label="Close market price detail">&times;</button>
-      </div>
-      <div class="modal-body">
-        <div id="retailViewVendorLegend" class="retail-vendor-legend"></div>
-        <div class="retail-view-tabs">
-          <button id="retailViewTabIntraday" class="retail-view-tab active" type="button" onclick="_switchRetailViewTab('intraday')">24h Chart</button>
-          <button id="retailViewTabHistory" class="retail-view-tab" type="button" onclick="_switchRetailViewTab('history')">Price History</button>
+        <div class="modal-body">
+          <div id="retailViewVendorLegend" class="retail-vendor-legend"></div>
+          <div class="retail-view-tabs">
+            <button
+              id="retailViewTabIntraday"
+              class="retail-view-tab active"
+              type="button"
+              onclick="_switchRetailViewTab('intraday')"
+            >
+              24h Chart
+            </button>
+            <button
+              id="retailViewTabHistory"
+              class="retail-view-tab"
+              type="button"
+              onclick="_switchRetailViewTab('history')"
+            >
+              Price History
+            </button>
+          </div>
+          <div id="retailViewIntradaySection">
+            <div class="retail-intraday-chart-wrap">
+              <canvas id="retailViewIntradayChart" aria-label="24h intraday price chart"></canvas>
+            </div>
+            <p
+              id="retailViewIntradayNoData"
+              class="settings-subtext"
+              style="display: none; text-align: center; padding: 1rem"
+            >
+              No intraday data — check back after the next 15-minute sync.
+            </p>
+            <div class="d-flex align-items-center justify-content-between mb-1" style="gap: 8px">
+              <label
+                for="retailViewIntradayRowCount"
+                class="settings-subtext"
+                id="retailViewIntradayTableLabel"
+                >Recent windows</label
+              >
+              <select
+                id="retailViewIntradayRowCount"
+                class="form-select form-select-sm"
+                style="width: auto"
+              >
+                <option value="12">12 rows</option>
+                <option value="24" selected>24 rows</option>
+                <option value="48">48 rows</option>
+              </select>
+            </div>
+            <div style="max-height: 360px; overflow-y: auto">
+              <table class="table table-sm table-borderless mb-0">
+                <thead id="retailViewIntradayTableHead"></thead>
+                <tbody id="retailViewIntradayTableBody"></tbody>
+              </table>
+            </div>
+          </div>
+          <div id="retailViewHistorySection" style="display: none">
+            <div class="retail-view-chart-wrap">
+              <canvas id="retailViewChart" aria-label="Retail price history chart"></canvas>
+            </div>
+            <div class="retail-view-table-wrap">
+              <table id="retailViewHistoryTable" class="retail-view-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Avg Median</th>
+                    <th>Avg Low</th>
+                    <th>APMEX</th>
+                    <th>Monument</th>
+                    <th>SDB</th>
+                    <th>JM</th>
+                  </tr>
+                </thead>
+                <tbody id="retailViewHistoryTableBody"></tbody>
+              </table>
+            </div>
+          </div>
+          <p class="retail-view-disclaimer">
+            Prices sourced from StakTrakr's 15-minute retail price API. Data is for informational
+            purposes only and may not reflect current market rates.
+          </p>
         </div>
-        <div id="retailViewIntradaySection">
-          <div class="retail-intraday-chart-wrap">
-            <canvas id="retailViewIntradayChart" aria-label="24h intraday price chart"></canvas>
-          </div>
-          <p id="retailViewIntradayNoData" class="settings-subtext" style="display:none;text-align:center;padding:1rem;">No intraday data — check back after the next 15-minute sync.</p>
-          <div class="d-flex align-items-center justify-content-between mb-1" style="gap:8px;">
-            <label for="retailViewIntradayRowCount" class="settings-subtext" id="retailViewIntradayTableLabel">Recent windows</label>
-            <select id="retailViewIntradayRowCount" class="form-select form-select-sm" style="width:auto;">
-              <option value="12">12 rows</option>
-              <option value="24" selected>24 rows</option>
-              <option value="48">48 rows</option>
-            </select>
-          </div>
-          <div style="max-height:360px;overflow-y:auto;">
-            <table class="table table-sm table-borderless mb-0">
-              <thead id="retailViewIntradayTableHead"></thead>
-              <tbody id="retailViewIntradayTableBody"></tbody>
-            </table>
-          </div>
-        </div>
-        <div id="retailViewHistorySection" style="display:none;">
-          <div class="retail-view-chart-wrap">
-            <canvas id="retailViewChart" aria-label="Retail price history chart"></canvas>
-          </div>
-          <div class="retail-view-table-wrap">
-            <table id="retailViewHistoryTable" class="retail-view-table">
-              <thead>
-                <tr>
-                  <th>Date</th><th>Avg Median</th><th>Avg Low</th>
-                  <th>APMEX</th><th>Monument</th><th>SDB</th><th>JM</th>
-                </tr>
-              </thead>
-              <tbody id="retailViewHistoryTableBody"></tbody>
-            </table>
-          </div>
-        </div>
-        <p class="retail-view-disclaimer">Prices sourced from StakTrakr's 15-minute retail price API. Data is for informational purposes only and may not reflect current market rates.</p>
       </div>
     </div>
-  </div>
     <!-- ── Market Detail Modal (STAK-504) ── -->
-    <div id="marketDetailModal" class="market-detail-overlay" role="dialog" aria-modal="true" aria-labelledby="marketDetailTitle" hidden>
+    <div
+      id="marketDetailModal"
+      class="market-detail-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="marketDetailTitle"
+      hidden
+    >
       <div class="market-detail-modal">
-        <button class="market-detail-close" id="marketDetailCloseBtn" title="Close" aria-label="Close modal">&times;</button>
+        <button
+          class="market-detail-close"
+          id="marketDetailCloseBtn"
+          title="Close"
+          aria-label="Close modal"
+        >
+          &times;
+        </button>
         <div id="marketDetailContent"></div>
       </div>
     </div>

--- a/js/dialogs.js
+++ b/js/dialogs.js
@@ -33,6 +33,9 @@
     root = document.createElement("div");
     root.id = "appDialogModal";
     root.className = "modal";
+    root.setAttribute("role", "dialog");
+    root.setAttribute("aria-modal", "true");
+    root.setAttribute("aria-labelledby", "appDialogTitle");
     root.style.display = "none";
     root.style.zIndex = "10060";
     root.innerHTML = `
@@ -90,6 +93,7 @@
     }
 
     const cleanup = () => {
+      if (typeof window.releaseFocus === "function") window.releaseFocus(modal);
       modal.style.display = "none";
       closeBtn.onclick = null;
       cancelBtn.onclick = null;
@@ -126,6 +130,7 @@
     document.addEventListener("keydown", onKeyDown);
 
     modal.style.display = "flex";
+    if (typeof window.trapFocus === "function") window.trapFocus(modal);
     if (mode === "prompt") inputEl.focus();
     else okBtn.focus();
   };

--- a/js/utils.js
+++ b/js/utils.js
@@ -1607,7 +1607,10 @@ const openStorageReportPopup = async () => {
 const closeModalById = (id) => {
   try {
     const modal = document.getElementById(id);
-    if (modal) modal.style.display = "none";
+    if (modal) {
+      releaseFocus(modal);
+      modal.style.display = "none";
+    }
   } catch (e) {
     /* ignore */
   }
@@ -1615,6 +1618,68 @@ const closeModalById = (id) => {
     if (document && document.body) document.body.style.overflow = "";
   } catch (e) {}
 };
+// ---------------------------------------------------------------------------
+// Focus trap — confines Tab/Shift+Tab within the topmost open modal
+// ---------------------------------------------------------------------------
+const _FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/** Stack of { modal, previousFocus, handler } for nested modals */
+const _focusTrapStack = [];
+
+/**
+ * Activate a focus trap on a modal element.
+ * @param {HTMLElement} modal
+ */
+const trapFocus = (modal) => {
+  const previousFocus = document.activeElement;
+
+  const handler = (e) => {
+    if (e.key !== "Tab") return;
+    const focusable = Array.from(modal.querySelectorAll(_FOCUSABLE_SELECTOR)).filter(
+      (el) => el.offsetParent !== null
+    );
+    if (focusable.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  modal.addEventListener("keydown", handler);
+  _focusTrapStack.push({ modal, previousFocus, handler });
+};
+
+/**
+ * Release the focus trap on a modal and restore previous focus.
+ * @param {HTMLElement} modal
+ */
+const releaseFocus = (modal) => {
+  const idx = _focusTrapStack.findIndex((entry) => entry.modal === modal);
+  if (idx === -1) return;
+  const entry = _focusTrapStack.splice(idx, 1)[0];
+  modal.removeEventListener("keydown", entry.handler);
+  if (entry.previousFocus && entry.previousFocus.focus) {
+    try {
+      entry.previousFocus.focus();
+    } catch (e) {
+      /* element may have been removed */
+    }
+  }
+};
+
 /**
  * Opens a modal by id and sets body overflow to hidden.
  * Also initializes a click-outside-to-close handler once.
@@ -1637,11 +1702,11 @@ const openModalById = (id) => {
     try {
       if (document && document.body) document.body.style.overflow = "hidden";
     } catch (e) {}
+    // activate focus trap
+    trapFocus(modal);
     // focus first focusable element for a11y
     try {
-      const focusable = modal.querySelector(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
+      const focusable = modal.querySelector(_FOCUSABLE_SELECTOR);
       if (focusable && focusable.focus) focusable.focus();
     } catch (e) {}
   } catch (e) {
@@ -3203,6 +3268,8 @@ if (typeof window !== "undefined") {
     }, duration);
   };
 
+  window.trapFocus = trapFocus;
+  window.releaseFocus = releaseFocus;
   window.cleanupStorage = cleanupStorage;
   window.closeModalById = closeModalById;
   window.openModalById = openModalById;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1622,7 +1622,7 @@ const closeModalById = (id) => {
 // Focus trap — confines Tab/Shift+Tab within the topmost open modal
 // ---------------------------------------------------------------------------
 const _FOCUSABLE_SELECTOR =
-  'button:not([disabled]), [href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), summary, [tabindex]:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"])';
 
 /** Stack of { modal, previousFocus, handler } for nested modals */
 const _focusTrapStack = [];
@@ -1632,12 +1632,19 @@ const _focusTrapStack = [];
  * @param {HTMLElement} modal
  */
 const trapFocus = (modal) => {
+  // Idempotency: remove stale entry for this modal before re-registering
+  const existingIdx = _focusTrapStack.findIndex((entry) => entry.modal === modal);
+  if (existingIdx !== -1) {
+    const stale = _focusTrapStack.splice(existingIdx, 1)[0];
+    modal.removeEventListener("keydown", stale.handler);
+  }
+
   const previousFocus = document.activeElement;
 
   const handler = (e) => {
     if (e.key !== "Tab") return;
     const focusable = Array.from(modal.querySelectorAll(_FOCUSABLE_SELECTOR)).filter(
-      (el) => el.offsetParent !== null
+      (el) => el.offsetWidth > 0 || el.offsetHeight > 0
     );
     if (focusable.length === 0) {
       e.preventDefault();

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -112,6 +112,7 @@ async function showViewModal(index) {
 
   modal.style.display = "flex";
   document.body.style.overflow = "hidden";
+  if (typeof window.trapFocus === "function") window.trapFocus(modal);
 
   // Load images from stored URLs / user uploads only — no API fallback.
   // STAK-489: Stored URLs are the single source of truth for images everywhere.
@@ -146,7 +147,10 @@ async function showViewModal(index) {
  */
 function closeViewModal() {
   const modal = document.getElementById("viewItemModal");
-  if (modal) modal.style.display = "none";
+  if (modal) {
+    if (typeof window.releaseFocus === "function") window.releaseFocus(modal);
+    modal.style.display = "none";
+  }
   document.body.style.overflow = "";
 
   // Destroy price history chart to free canvas resources

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -113,6 +113,10 @@ async function showViewModal(index) {
   modal.style.display = "flex";
   document.body.style.overflow = "hidden";
   if (typeof window.trapFocus === "function") window.trapFocus(modal);
+  const firstFocusable = modal.querySelector(
+    'button:not([disabled]), [tabindex]:not([tabindex="-1"]), input:not([disabled])'
+  );
+  if (firstFocusable) firstFocusable.focus();
 
   // Load images from stored URLs / user uploads only — no API fallback.
   // STAK-489: Stored URLs are the single source of truth for images everywhere.


### PR DESCRIPTION
## Summary

Systematic accessibility hardening from `/impeccable:audit` (scored 2/4 → targeting 3+/4).

- **Focus trap utility** — `trapFocus`/`releaseFocus` in utils.js, wired into `openModalById`, `closeModalById`, `dialogs.js`, `viewModal.js`. Tab/Shift+Tab confined to open modal; focus restored on close.
- **Semantic landmarks** — `<header>` replaces `<div class="app-header">`, `<main>` replaces `<div class="container">`
- **Modal ARIA** — all 30 modals get `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to title element
- **Form labels** — 8 unlabelled selects get `aria-label` or proper `<label for>`
- **Focus indicators** — `:focus-visible` rings on `.spot-inline-input` and `td.editing .inline-input`
- **Reduced motion** — global `prefers-reduced-motion` rule covers all animations/transitions
- **Hardcoded colors** — `#16a34a` → `var(--success)`, `#ddd` → `var(--border)`
- **HTML fix** — removed orphan `</div>` (pre-existing nesting bug)

## Test plan

- [ ] Open app, Tab through interface — focus should be visible on all interactive elements
- [ ] Open any modal, Tab repeatedly — focus should cycle within modal, not escape to background
- [ ] Close modal — focus should return to the element that opened it
- [ ] Verify `prefers-reduced-motion: reduce` in browser DevTools disables all animations
- [ ] Check all 4 themes (light/dark/sepia/hello-kitty) — no hardcoded color leaks
- [ ] Screen reader (VoiceOver): modals should announce as dialogs with titles
- [ ] Spot range selects should announce metal name + "trend period"