### PR TITLE
v3.34.09 — STAK-548 hotfix: revert shared-sqld-client import in home-poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.09] - 2026-04-17
+
+### Fixed — STAK-548 hotfix: revert shared-sqld-client refactor in home-poller
+
+- **Fixed**: `dashboard.js` and `metrics-exporter.js` reverted to inline env-selection for sqld client creation. The `../shared/sqld-client.js` import failed at runtime because the home-poller Dockerfile flattens `shared/*.js` into `/app/` alongside the home-poller JS, so the relative `../shared/` path resolved outside `/app/` and hit `ERR_MODULE_NOT_FOUND` on container start. Containers were entering FATAL state after the v3.34.08 deploy.
+- **Kept**: `shared/sqld-client.js` continues to serve `spot-extract.js` and `migrate-providers.js`, which live in `shared/` and import it as `./sqld-client.js` — that path works in both source tree and the flattened container layout.
+
+---
+
 ## [3.34.08] - 2026-04-17
 
 ### Changed — STAK-548: Rename `TURSO_DATABASE_URL` → `SQLD_URL` in poller code

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -3413,7 +3413,13 @@ async function handleRequest(req, res) {
             const url = useSqld ? process.env.SQLD_URL : process.env.TURSO_DATABASE_URL;
             const authToken = useSqld ? process.env.SQLD_AUTH_TOKEN : process.env.TURSO_AUTH_TOKEN;
             if (!url) { console.error('SQLD_URL (or legacy TURSO_DATABASE_URL) must be set'); process.exit(1); }
-            const client = createClient({ url, ...(authToken ? { authToken } : {}) });
+            let client;
+            try {
+              client = createClient({ url, ...(authToken ? { authToken } : {}) });
+            } catch (err) {
+              console.error('retry-script createClient failed:', err?.message || err);
+              process.exit(1);
+            }
             const { getProvidersByCoin } = await import('./provider-db.js');
             const slug = process.env.RETRY_COIN_SLUG;
             const vid = process.env.RETRY_VENDOR_ID;

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -17,7 +17,6 @@ import { createServer as createHttpsServer } from "node:https";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { execSync, spawn } from "node:child_process";
 import { createClient } from "@libsql/client";
-import { createSqldClient as createSharedSqldClient } from "../shared/sqld-client.js";
 import {
   initProviderSchema,
   getProviders,
@@ -73,11 +72,11 @@ const DATA_DIR = new URL("data/", import.meta.url).pathname;
  */
 
 function getSqldClient() {
-  try {
-    return createSharedSqldClient();
-  } catch {
-    return null;
-  }
+  const useSqld = Boolean(process.env.SQLD_URL);
+  const url = useSqld ? process.env.SQLD_URL : process.env.TURSO_DATABASE_URL;
+  const authToken = useSqld ? process.env.SQLD_AUTH_TOKEN : process.env.TURSO_AUTH_TOKEN;
+  if (!url) return null;
+  return createClient({ url, ...(authToken ? { authToken } : {}) });
 }
 
 /**
@@ -3403,10 +3402,14 @@ async function handleRequest(req, res) {
         // Trigger immediate single-item scrape via child process
         // Pass user input via env vars — never interpolate into shell strings
         const script = `
-          import('./shared/price-extract.js').then(async m => {
-            const { createSqldClient } = await import('./shared/sqld-client.js');
-            const client = createSqldClient();
-            const { getProvidersByCoin } = await import('./shared/provider-db.js');
+          import('./price-extract.js').then(async m => {
+            const { createClient } = await import('@libsql/client');
+            const useSqld = Boolean(process.env.SQLD_URL);
+            const url = useSqld ? process.env.SQLD_URL : process.env.TURSO_DATABASE_URL;
+            const authToken = useSqld ? process.env.SQLD_AUTH_TOKEN : process.env.TURSO_AUTH_TOKEN;
+            if (!url) { console.error('SQLD_URL (or legacy TURSO_DATABASE_URL) must be set'); process.exit(1); }
+            const client = createClient({ url, ...(authToken ? { authToken } : {}) });
+            const { getProvidersByCoin } = await import('./provider-db.js');
             const slug = process.env.RETRY_COIN_SLUG;
             const vid = process.env.RETRY_VENDOR_ID;
             const vendors = await getProvidersByCoin(client, slug);

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -76,7 +76,12 @@ function getSqldClient() {
   const url = useSqld ? process.env.SQLD_URL : process.env.TURSO_DATABASE_URL;
   const authToken = useSqld ? process.env.SQLD_AUTH_TOKEN : process.env.TURSO_AUTH_TOKEN;
   if (!url) return null;
-  return createClient({ url, ...(authToken ? { authToken } : {}) });
+  try {
+    return createClient({ url, ...(authToken ? { authToken } : {}) });
+  } catch (err) {
+    console.error("[dashboard] getSqldClient failed:", err?.message || err);
+    return null;
+  }
 }
 
 /**

--- a/devops/pollers/home-poller/metrics-exporter.js
+++ b/devops/pollers/home-poller/metrics-exporter.js
@@ -40,7 +40,12 @@ function getSqldClient() {
   const url = useSqld ? process.env.SQLD_URL : process.env.TURSO_DATABASE_URL;
   const authToken = useSqld ? process.env.SQLD_AUTH_TOKEN : process.env.TURSO_AUTH_TOKEN;
   if (!url) return null;
-  return createClient({ url, ...(authToken ? { authToken } : {}) });
+  try {
+    return createClient({ url, ...(authToken ? { authToken } : {}) });
+  } catch (err) {
+    console.error("[metrics] getSqldClient failed:", err?.message || err);
+    return null;
+  }
 }
 
 // ── System collectors ────────────────────────────────────────────────────────

--- a/devops/pollers/home-poller/metrics-exporter.js
+++ b/devops/pollers/home-poller/metrics-exporter.js
@@ -15,7 +15,7 @@
 import { createServer } from "node:http";
 import { readFileSync, existsSync } from "node:fs";
 import { execSync } from "node:child_process";
-import { createSqldClient as createSharedSqldClient } from "../shared/sqld-client.js";
+import { createClient } from "@libsql/client";
 
 const PORT = parseInt(process.env.METRICS_PORT || "9100", 10);
 const IFACE = process.env.NET_IFACE || "ens18";
@@ -36,11 +36,11 @@ const IFACE = process.env.NET_IFACE || "ens18";
  * @returns {import('@libsql/client').Client|null}
  */
 function getSqldClient() {
-  try {
-    return createSharedSqldClient();
-  } catch {
-    return null;
-  }
+  const useSqld = Boolean(process.env.SQLD_URL);
+  const url = useSqld ? process.env.SQLD_URL : process.env.TURSO_DATABASE_URL;
+  const authToken = useSqld ? process.env.SQLD_AUTH_TOKEN : process.env.TURSO_AUTH_TOKEN;
+  if (!url) return null;
+  return createClient({ url, ...(authToken ? { authToken } : {}) });
 }
 
 // ── System collectors ────────────────────────────────────────────────────────

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-548 Hotfix: Home Poller Container Crash (v3.34.09)**: Reverted a late shared-helper refactor that broke the home poller's dashboard + metrics containers (ERR_MODULE_NOT_FOUND due to Dockerfile flattening `shared/*.js` into `/app/`). Internal infrastructure fix, no user-facing behavior change.
 - **STAK-548: Rename `TURSO_DATABASE_URL` → `SQLD_URL` in poller code (v3.34.08)**: Local sqld connections now read `SQLD_URL` / `SQLD_AUTH_TOKEN`. `TURSO_DATABASE_URL` / `TURSO_AUTH_TOKEN` remain supported as a legacy alias so existing deployments keep working through rollout, and can also point at Turso Cloud for self-hosters who prefer that setup. No user-facing behavior change.
 - **STAK-517: Invalidate market filter cache after vault restore (v3.34.07)**: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull — no page reload required.
 - **STAK-551: Fix filter chip predicate logic (v3.34.06)**: Scalar fields (metal, type, name, location) now use OR within-field — Silver+Gold shows both. Tags keep AND. Expansion chips (customGroup, dynamicName, groupedName) expand at predicate time. Chip threshold honored when filters active.

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.09 &ndash; STAK-548 Hotfix: Home Poller Container Crash</strong>: Reverted a late shared-helper refactor that broke the home poller's dashboard and metrics containers (ERR_MODULE_NOT_FOUND on startup due to Dockerfile flattening <code>shared/*.js</code> into <code>/app/</code>). Internal infrastructure fix, no user-facing behavior change.</li>
     <li><strong>v3.34.08 &ndash; STAK-548: Rename TURSO_DATABASE_URL to SQLD_URL in Poller Code</strong>: Local sqld connections now read <code>SQLD_URL</code> / <code>SQLD_AUTH_TOKEN</code>. <code>TURSO_DATABASE_URL</code> / <code>TURSO_AUTH_TOKEN</code> remain supported as a legacy alias so existing deployments keep working through rollout, and can also point at Turso Cloud for self-hosters who prefer that setup. No user-facing behavior change.</li>
     <li><strong>v3.34.07 &ndash; STAK-517: Invalidate Market Filter Cache After Restore</strong>: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull &mdash; no page reload required.</li>
     <li><strong>v3.34.06 &ndash; STAK-551: Fix Filter Chip Predicate Logic</strong>: Scalar fields (metal, type) now use OR within-field (Silver+Gold shows both). Tags keep AND (Red+Green = items with both). Expansion chips (customGroup, dynamicName, groupedName) store single constraints and expand at predicate time. Chip threshold honored when filters active.</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.08";
+const APP_VERSION = "3.34.09";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.08",
+  "version": "3.34.09",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.08",
+      "version": "3.34.09",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.08",
+  "version": "3.34.09",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.08-b1776439828";
+const CACHE_NAME = "staktrakr-v3.34.09-b1776446496";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.08",
+  "version": "3.34.09",
   "releaseDate": "2026-04-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Hotfix

v3.34.08 merged, Portainer auto-pulled, and the home poller containers (\`dashboard\`, \`metrics-exporter\`) entered FATAL state on startup with:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/shared/sqld-client.js' imported from /app/dashboard.js
\`\`\`

## Root cause

The T27 refactor in PR #987 changed \`dashboard.js\` and \`metrics-exporter.js\` to import \`../shared/sqld-client.js\`. That path works in the source tree (files live in \`devops/pollers/home-poller/\` and \`devops/pollers/shared/\`), but the **home-poller Dockerfile flattens \`shared/*.js\` into \`/app/\` alongside the home-poller JS** (\`COPY shared/*.js ./\`, then \`COPY home-poller/dashboard.js ./\`). At runtime \`/app/dashboard.js\` resolves \`../shared/sqld-client.js\` to \`/shared/sqld-client.js\` — outside \`/app\` — and crashes.

CodeRabbit flagged the "centralize" nit during PR review, I applied it without checking the container layout, tests pass locally, merge went through, deploy broke.

## Fix

- Revert \`dashboard.js\` + \`metrics-exporter.js\` to inline env-selection for the sqld client (3 sites — getSqldClient at line 72, inline retry script at line 3379, metrics-exporter getSqldClient).
- Fast-fail guard added to the inline retry script (since we lost the shared helper's throw).
- **Keep \`shared/sqld-client.js\`** — still used by \`spot-extract.js\` and \`migrate-providers.js\`, which live in \`shared/\` and import it as \`./sqld-client.js\` (works in both source tree and flattened container layout).

## Files

- \`devops/pollers/home-poller/dashboard.js\` — revert import, restore inline env-selection
- \`devops/pollers/home-poller/metrics-exporter.js\` — revert import, restore inline env-selection
- Version bump to v3.34.09 (package.json, js/constants.js, version.json, package-lock.json, sw.js auto-stamped)
- CHANGELOG, announcements.md, about.js — hotfix entry

## Rollout

Merge → dev → Portainer auto-pulls within 5 min → containers come back up. Nothing to do in Infisical/Fly — env vars from earlier are fine.

Issue: STAK-548 (the original rollout) — this is just a post-merge hotfix, not a new issue.