### PR TITLE
chore(tooling): STAK-550 — add .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,8 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
 # StakTrakr CodeRabbit config.
-# Extends the base at Devops/.coderabbit.base.yaml with repo-specific overrides:
+# Derived from Devops/.coderabbit.base.yaml with StakTrakr-specific overrides.
+# (CodeRabbit has no "extends" directive — this file is self-contained.)
 # - vanilla JS (no bundler) conventions in js/
 # - data/, vendor/, sw.js excluded from review (auto-generated or snapshot data)
 # - chore files (DESIGN.md, preview.html) excluded (known false-positive source)
@@ -74,7 +75,7 @@ reviews:
           the exports block at the bottom of the file.
         - Prefer existing helpers: `safeGetElement` (DOM), `saveData` /
           `loadData` (localStorage), `sanitizeHtml` (output).
-        - Only storage keys in `ALLOWED_STORAGE_KEYS` (constants.js:871) are
+        - Only storage keys in `ALLOWED_STORAGE_KEYS` in constants.js are
           permitted. A `typeof ALLOWED_STORAGE_KEYS !== 'undefined'` guard is
           defensive coding, NOT a bug — do not flag it as fail-open.
         - New JS files must be registered in both `sw.js` cache list and
@@ -126,7 +127,7 @@ reviews:
       enabled: true
     yamllint:
       enabled: true
-    opengrep:
+    ast-grep:
       enabled: true
 
 # Knowledge base — learn from feedback over time

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,139 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# StakTrakr CodeRabbit config.
+# Extends the base at Devops/.coderabbit.base.yaml with repo-specific overrides:
+# - vanilla JS (no bundler) conventions in js/
+# - data/, vendor/, sw.js excluded from review (auto-generated or snapshot data)
+# - chore files (DESIGN.md, preview.html) excluded (known false-positive source)
+#
+# Profile: assertive (solo-dev; nitpicks welcome)
+# Docs: https://docs.coderabbit.ai/reference/configuration
+
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "assertive"
+
+  # PR summary features
+  high_level_summary: true
+  review_status: true
+  poem: false
+  collapse_walkthrough: false
+
+  # Workflow
+  request_changes_workflow: false
+  abort_on_close: true
+
+  # Auto-review settings
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    base_branches: []
+
+  # Path filters — exclude noise (global + StakTrakr-specific)
+  path_filters:
+    # Global
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/.claude/**"
+    - "!**/.gemini/**"
+    - "!**/.agents/**"
+    - "!**/.spec-workflow/**"
+    - "!**/.codacy/**"
+    - "!**/.github/**"
+    - "!**/vendor/**"
+    - "!**/deprecated/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!**/package-lock.json"
+    - "!**/pnpm-lock.yaml"
+    - "!**/yarn.lock"
+    - "!**/screenshots/**"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.svg"
+    # StakTrakr-specific
+    - "!data/**"           # API snapshot bundles, excluded from prettier
+    - "!sw.js"             # auto-stamped by pre-commit hook
+    - "!preview.html"      # chore preview page
+    - "!DESIGN.md"         # chore/design notes
+    - "!devops/version.lock"  # gitignored coordination file
+
+  # Path-specific review instructions
+  path_instructions:
+    - path: "js/**/*.js"
+      instructions: |
+        - This is vanilla JS with NO bundler. Module-scope functions are not
+          accessible from tests unless explicitly assigned to `window.X = X` in
+          the exports block at the bottom of the file.
+        - Prefer existing helpers: `safeGetElement` (DOM), `saveData` /
+          `loadData` (localStorage), `sanitizeHtml` (output).
+        - Only storage keys in `ALLOWED_STORAGE_KEYS` (constants.js:871) are
+          permitted. A `typeof ALLOWED_STORAGE_KEYS !== 'undefined'` guard is
+          defensive coding, NOT a bug — do not flag it as fail-open.
+        - New JS files must be registered in both `sw.js` cache list and
+          `index.html` script load order.
+    - path: "css/**/*.css"
+      instructions: |
+        - Respect component scoping; global selectors can leak into
+          component-scoped DOM and are a common root cause of UI bugs.
+    - path: "devops/pollers/**/Dockerfile*"
+      instructions: |
+        - Check for pinned base image versions (no `:latest` tags).
+        - Verify multi-stage builds where appropriate.
+        - Flag any secrets or credentials in build args.
+    - path: "devops/pollers/home-poller/docker-entrypoint.sh"
+      instructions: |
+        - This file is the AUTHORITATIVE source of truth for poller cron
+          schedules. If DocVault docs disagree, the entrypoint wins.
+    - path: "tests/**"
+      instructions: |
+        - Verify meaningful assertions (not just "it runs without error").
+        - For Playwright tests on vanilla JS: internal state must be injected
+          via `localStorage` (`page.addInitScript`), not by patching
+          `window.X` post-load.
+    - path: "**/*.py"
+      instructions: |
+        - Check for proper exception handling (no bare `except`).
+        - Verify type hints on public function signatures.
+    - path: "**/*.sql"
+      instructions: |
+        - Check for SQL injection risks in dynamic queries.
+        - Verify migrations are reversible where possible.
+
+  # Finishing touches
+  finishing_touches:
+    docstrings:
+      enabled: false
+    autofix:
+      enabled: true
+
+  # Static analysis tools
+  tools:
+    eslint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    opengrep:
+      enabled: true
+
+# Knowledge base — learn from feedback over time
+knowledge_base:
+  learnings:
+    enabled: true
+
+# Chat — allow @coderabbitai interactions in PR comments
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary

Lands CodeRabbit config for StakTrakr. Extends the lbruton base config from `Devops/.coderabbit.base.yaml` with repo-specific overrides.

**StakTrakr-specific tweaks:**
- `path_filters` exclude `data/`, `sw.js`, `preview.html`, `DESIGN.md`
- `path_instructions` for vanilla-JS conventions:
  - `window.X = X` exports required for module-scope test access
  - `ALLOWED_STORAGE_KEYS` guard is defensive (not a fail-open bug)
  - New JS files must register in `sw.js` cache list + `index.html` load order
- poller cron source of truth = `devops/pollers/home-poller/docker-entrypoint.sh`
- Playwright tests inject state via `localStorage`, not post-load `window` patching

Profile: `assertive` (solo-dev, nitpicks welcome).

Closes STAK-550. Part of OPS-138.

## Test plan

- [ ] CodeRabbit posts a review on this PR within ~2 min (AC #2)
- [ ] YAML parses clean (no schema errors in CodeRabbit dashboard)
- [ ] Existing checks green (Codacy, pre-commit hooks)
- [ ] Review tone feels right — if too noisy/quiet, tune `path_instructions` in a follow-up (AC #3 deferred)