### PR TITLE
chore: GSD session 2026-04-18 — Last Modified sort + shared sort bar (STAK-553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.10] - 2026-04-18
+
+### Changed — STAK-553: Last Modified sort + sort bar in table view
+
+- **Added**: `Last Modified` sort option in the live sort dropdown and Settings > Default Sort
+- **Added**: `lastModified` ISO timestamp stamped on inventory items at create and edit time
+- **Added**: Sort bar (`cardSortBar`) now visible in table view (D mode), not just card views
+- **Changed**: `sortInventory()` handles new column 12; items without `lastModified` sort as oldest
+- **Changed**: Selecting `Last Modified` auto-switches sort direction to descending (newest-first default)
+
+---
+
 ## [3.34.09] - 2026-04-17
 
 ### Fixed — STAK-548 hotfix: revert shared-sqld-client refactor in home-poller

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,5 +1,6 @@
 ## What's New
 
+- **STAK-553: Last Modified sort + sort bar in table view (v3.34.10)**: Adds a `Last Modified` sort option to the live sort dropdown and default sort settings. Items now track a `lastModified` timestamp at create/edit time. The sort bar is now visible in table view (D mode). Selecting Last Modified auto-switches to descending order (newest first).
 - **STAK-548 Hotfix: Home Poller Container Crash (v3.34.09)**: Reverted a late shared-helper refactor that broke the home poller's dashboard + metrics containers (ERR_MODULE_NOT_FOUND due to Dockerfile flattening `shared/*.js` into `/app/`). Internal infrastructure fix, no user-facing behavior change.
 - **STAK-548: Rename `TURSO_DATABASE_URL` → `SQLD_URL` in poller code (v3.34.08)**: Local sqld connections now read `SQLD_URL` / `SQLD_AUTH_TOKEN`. `TURSO_DATABASE_URL` / `TURSO_AUTH_TOKEN` remain supported as a legacy alias so existing deployments keep working through rollout, and can also point at Turso Cloud for self-hosters who prefer that setup. No user-facing behavior change.
 - **STAK-517: Invalidate market filter cache after vault restore (v3.34.07)**: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull — no page reload required.

--- a/index.html
+++ b/index.html
@@ -1553,7 +1553,7 @@
               <option value="9">Retail</option>
               <option value="10">Gain/Loss</option>
               <option value="11">Source</option>
-              <option value="12">Last Modified</option>
+              <option value="99">Last Modified</option>
             </select>
             <button
               type="button"
@@ -3910,7 +3910,7 @@
                         <option value="9">Retail</option>
                         <option value="10">Gain/Loss</option>
                         <option value="11">Source</option>
-                        <option value="12">Last Modified</option>
+                        <option value="99">Last Modified</option>
                       </select>
                       <div id="settingsDefaultSortDir" class="chip-sort-toggle">
                         <button type="button" class="chip-sort-btn active" data-val="asc">

--- a/index.html
+++ b/index.html
@@ -1553,6 +1553,7 @@
               <option value="9">Retail</option>
               <option value="10">Gain/Loss</option>
               <option value="11">Source</option>
+              <option value="12">Last Modified</option>
             </select>
             <button
               type="button"
@@ -3909,6 +3910,7 @@
                         <option value="9">Retail</option>
                         <option value="10">Gain/Loss</option>
                         <option value="11">Source</option>
+                        <option value="12">Last Modified</option>
                       </select>
                       <div id="settingsDefaultSortDir" class="chip-sort-toggle">
                         <button type="button" class="chip-sort-btn active" data-val="asc">

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.10 &ndash; STAK-553: Last Modified Sort + Sort Bar in Table View</strong>: Adds a <code>Last Modified</code> sort option to the live sort dropdown and default sort settings. Items now track a <code>lastModified</code> timestamp at create/edit time. The sort bar is now visible in table view (D mode). Selecting Last Modified auto-switches to descending order (newest first).</li>
     <li><strong>v3.34.09 &ndash; STAK-548 Hotfix: Home Poller Container Crash</strong>: Reverted a late shared-helper refactor that broke the home poller's dashboard and metrics containers (ERR_MODULE_NOT_FOUND on startup due to Dockerfile flattening <code>shared/*.js</code> into <code>/app/</code>). Internal infrastructure fix, no user-facing behavior change.</li>
     <li><strong>v3.34.08 &ndash; STAK-548: Rename TURSO_DATABASE_URL to SQLD_URL in Poller Code</strong>: Local sqld connections now read <code>SQLD_URL</code> / <code>SQLD_AUTH_TOKEN</code>. <code>TURSO_DATABASE_URL</code> / <code>TURSO_AUTH_TOKEN</code> remain supported as a legacy alias so existing deployments keep working through rollout, and can also point at Turso Cloud for self-hosters who prefer that setup. No user-facing behavior change.</li>
     <li><strong>v3.34.07 &ndash; STAK-517: Invalidate Market Filter Cache After Restore</strong>: Market filter matrix now reflects restored settings immediately after vault restore or cloud sync pull &mdash; no page reload required.</li>

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -1182,8 +1182,9 @@ const initCardSortBar = () => {
   if (colSelect) {
     colSelect.addEventListener("change", () => {
       sortColumn = parseInt(colSelect.value, 10);
-      if (sortColumn === 12 && sortDirection === "asc") {
+      if (sortColumn === SORT_COL_LAST_MODIFIED && sortDirection === "asc") {
         sortDirection = "desc";
+        localStorage.setItem(DEFAULT_SORT_DIR_KEY, "desc");
       }
       if (typeof renderTable === "function") renderTable();
     });

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -86,10 +86,8 @@ function _syncSortBar() {
   // Always show the bar
   bar.style.display = "flex";
 
-  // Sort controls: invisible when in table view (D) — visibility:hidden preserves
-  // layout so the summary stays centered; display:none would shift it right.
   const sortLeft = bar.querySelector(".card-sort-left");
-  if (sortLeft) sortLeft.style.visibility = style === "D" ? "hidden" : "";
+  if (sortLeft) sortLeft.style.visibility = "";
 
   // Sync style toggle active state
   const styleToggle = document.getElementById("cardStyleToggle");
@@ -1184,6 +1182,9 @@ const initCardSortBar = () => {
   if (colSelect) {
     colSelect.addEventListener("change", () => {
       sortColumn = parseInt(colSelect.value, 10);
+      if (sortColumn === 12 && sortDirection === "asc") {
+        sortDirection = "desc";
+      }
       if (typeof renderTable === "function") renderTable();
     });
   }

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -85,6 +85,7 @@ const logItemChanges = (oldItem, newItem) => {
     "obverseSharedImageId",
     "reverseSharedImageId",
     "disposition",
+    "lastModified",
   ];
 
   const refItem = newItem || oldItem;

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.09";
+const APP_VERSION = "3.34.10";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-engine.js
+++ b/js/diff-engine.js
@@ -72,6 +72,8 @@ const DIFF_FIELDS = [
   "reverseSharedImageId",
   // Disposition
   "disposition",
+  // Metadata
+  "lastModified",
 ];
 
 // ---------------------------------------------------------------------------

--- a/js/events.js
+++ b/js/events.js
@@ -1223,6 +1223,7 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       numistaData: f.numistaData,
       fieldMeta: oldItem.fieldMeta || f.numistaData?.fieldMeta || undefined,
       currency: f.currency,
+      lastModified: new Date().toISOString(),
       // STAK-308: Use nullish coalescing — empty string is intentional (user cleared URL)
       obverseImageUrl:
         f.obverseImageUrl !== ""
@@ -1338,6 +1339,7 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       numistaData: f.numistaData,
       fieldMeta: window.selectedNumistaResult?.fieldMeta || f.numistaData?.fieldMeta || undefined,
       currency: f.currency,
+      lastModified: new Date().toISOString(),
       obverseImageUrl:
         f.obverseImageUrl !== ""
           ? f.obverseImageUrl || window.selectedNumistaResult?.imageUrl || ""

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -387,8 +387,10 @@
         cardGridEl.style.overflowY = "";
       }
       if (portalScrollEl) portalScrollEl.style.display = "";
-      if (cardSortBar) cardSortBar.style.display = "none";
+      if (cardSortBar) cardSortBar.style.display = "flex";
       if (footerSelect) footerSelect.style.display = "";
+      if (typeof initCardSortBar === "function") initCardSortBar();
+      if (typeof updateCardSortBar === "function") updateCardSortBar();
 
       const rows = [];
       const chipConfig = typeof getInlineChipConfig === "function" ? getInlineChipConfig() : [];

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -685,6 +685,15 @@ const bindCardAndTableImageListeners = () => {
       const val = parseInt(defaultSortColEl.value, 10);
       localStorage.setItem(DEFAULT_SORT_COL_KEY, String(val));
       sortColumn = val;
+      if (val === 12 && sortDirection === "asc") {
+        sortDirection = "desc";
+        localStorage.setItem(DEFAULT_SORT_DIR_KEY, "desc");
+        const dirEl = getExistingElement("settingsDefaultSortDir");
+        if (dirEl)
+          dirEl.querySelectorAll(".chip-sort-btn").forEach((b) => {
+            b.classList.toggle("active", b.dataset.val === "desc");
+          });
+      }
       if (typeof updateCardSortBar === "function") updateCardSortBar();
       if (typeof renderTable === "function") renderTable();
     });

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -685,7 +685,7 @@ const bindCardAndTableImageListeners = () => {
       const val = parseInt(defaultSortColEl.value, 10);
       localStorage.setItem(DEFAULT_SORT_COL_KEY, String(val));
       sortColumn = val;
-      if (val === 12 && sortDirection === "asc") {
+      if (val === SORT_COL_LAST_MODIFIED && sortDirection === "asc") {
         sortDirection = "desc";
         localStorage.setItem(DEFAULT_SORT_DIR_KEY, "desc");
         const dirEl = getExistingElement("settingsDefaultSortDir");

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -1,6 +1,8 @@
 // SORTING FUNCTIONALITY
 // =============================================================================
 
+const SORT_COL_LAST_MODIFIED = 99;
+
 /**
  * Sorts inventory based on the current sort column and direction.
  * Handles special cases for date, numeric, boolean, and string columns.
@@ -17,6 +19,7 @@ const sortInventory = (data = inventory) => {
   // Pre-calculate sort values (Schwartzian transform) to avoid repeated computation
   // Map column index to data property — must match <th> order in index.html
   // 0:Date 1:Metal 2:Type 3:Image 4:Name 5:Qty 6:Weight 7:Purchase 8:Melt 9:Retail 10:Gain/Loss 11:Source 12:Actions
+  // Virtual (no <th>): 99:Last Modified
   const mapped = data.map((item) => {
     let val;
     let secondaryVal = 0; // secondary sort key; only populated for column 4 (Name)
@@ -87,11 +90,11 @@ const sortInventory = (data = inventory) => {
       case 11:
         val = item.purchaseLocation;
         break; // Source
-      case 12: {
+      case SORT_COL_LAST_MODIFIED: {
         // Last Modified
         const lmStr = item.lastModified || "";
         val = lmStr ? new Date(lmStr).getTime() : 0;
-        if (isNaN(val)) val = 0;
+        if (Number.isNaN(val)) val = 0;
         break;
       }
       default:
@@ -105,7 +108,7 @@ const sortInventory = (data = inventory) => {
     const valB = bWrapper.val;
 
     // Special handling for date: empty/unknown dates sort as "infinitely old"
-    if (sortColumn === 0 || sortColumn === 12) {
+    if (sortColumn === 0 || sortColumn === SORT_COL_LAST_MODIFIED) {
       // Numeric timestamps: 0 (no date) treated as oldest
       if (valA === valB) return 0;
       const aIsEmpty = sortColumn === 0 ? valA === Infinity : valA === 0;
@@ -140,5 +143,7 @@ const sortInventory = (data = inventory) => {
 
   return mapped.map((wrapper) => wrapper.item);
 };
+
+window.SORT_COL_LAST_MODIFIED = SORT_COL_LAST_MODIFIED;
 
 // =============================================================================

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -87,6 +87,13 @@ const sortInventory = (data = inventory) => {
       case 11:
         val = item.purchaseLocation;
         break; // Source
+      case 12: {
+        // Last Modified
+        const lmStr = item.lastModified || "";
+        val = lmStr ? new Date(lmStr).getTime() : 0;
+        if (isNaN(val)) val = 0;
+        break;
+      }
       default:
         val = 0;
     }
@@ -98,12 +105,14 @@ const sortInventory = (data = inventory) => {
     const valB = bWrapper.val;
 
     // Special handling for date: empty/unknown dates sort as "infinitely old"
-    if (sortColumn === 0) {
-      // Simple numeric comparison for pre-calculated timestamps
-      // Dateless items = oldest: top when asc, bottom when desc
-      if (valA === Infinity && valB === Infinity) return 0;
-      if (valA === Infinity) return sortDirection === "asc" ? -1 : 1;
-      if (valB === Infinity) return sortDirection === "asc" ? 1 : -1;
+    if (sortColumn === 0 || sortColumn === 12) {
+      // Numeric timestamps: 0 (no date) treated as oldest
+      if (valA === valB) return 0;
+      const aIsEmpty = sortColumn === 0 ? valA === Infinity : valA === 0;
+      const bIsEmpty = sortColumn === 0 ? valB === Infinity : valB === 0;
+      if (aIsEmpty && bIsEmpty) return 0;
+      if (aIsEmpty) return sortDirection === "asc" ? -1 : 1;
+      if (bIsEmpty) return sortDirection === "asc" ? 1 : -1;
 
       return sortDirection === "asc" ? valA - valB : valB - valA;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.09",
+  "version": "3.34.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.09",
+      "version": "3.34.10",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.09",
+  "version": "3.34.10",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.09-b1776533044";
+const CACHE_NAME = "staktrakr-v3.34.09-b1776534409";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.09-b1776446496";
+const CACHE_NAME = "staktrakr-v3.34.09-b1776533044";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.09-b1776534409";
+const CACHE_NAME = "staktrakr-v3.34.10-b1776535912";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/about-page.spec.js
+++ b/tests/playwright/about-page.spec.js
@@ -1,0 +1,292 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Tests for about.html — the StakTrakr marketing/about page.
+ *
+ * This page was reformatted by Prettier in this PR. These tests verify that
+ * the reformatting did not break the page structure or content and that all
+ * key sections and links are intact.
+ */
+test.describe("about-page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/about.html");
+  });
+
+  // ── Document-level ────────────────────────────────────────────────────────
+
+  test("AP-1 — page loads with correct title", async ({ page }) => {
+    await expect(page).toHaveTitle("StakTrakr — Track Your Precious Metals Stack");
+  });
+
+  test("AP-2 — HTML lang attribute is set to en", async ({ page }) => {
+    const lang = await page.evaluate(() => document.documentElement.lang);
+    expect(lang).toBe("en");
+  });
+
+  test("AP-3 — meta description is present and non-empty", async ({ page }) => {
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute("content");
+    expect(description).toBeTruthy();
+    expect(description.length).toBeGreaterThan(20);
+  });
+
+  // ── Hero section ──────────────────────────────────────────────────────────
+
+  test("AP-4 — hero section is visible", async ({ page }) => {
+    await expect(page.locator("header.hero")).toBeVisible();
+  });
+
+  test("AP-5 — hero logo displays StakTrakr branding", async ({ page }) => {
+    const logo = page.locator(".hero-logo");
+    await expect(logo).toBeVisible();
+    const text = await logo.textContent();
+    expect(text.trim()).toContain("StakTrakr");
+  });
+
+  test("AP-6 — hero tagline is correct", async ({ page }) => {
+    const tagline = page.locator(".hero-tagline");
+    await expect(tagline).toBeVisible();
+    await expect(tagline).toContainText("Track your precious metals stack. Your way.");
+  });
+
+  test("AP-7 — hero sub-copy mentions key value propositions", async ({ page }) => {
+    const sub = page.locator(".hero-sub");
+    await expect(sub).toBeVisible();
+    const text = await sub.textContent();
+    expect(text).toContain("free");
+    expect(text).toContain("open-source");
+  });
+
+  // ── Hero buttons ──────────────────────────────────────────────────────────
+
+  test("AP-8 — 'Open StakTrakr' primary button is present", async ({ page }) => {
+    const btn = page.locator(".hero-buttons a.btn-primary");
+    await expect(btn).toBeVisible();
+    await expect(btn).toContainText("Open StakTrakr");
+  });
+
+  test("AP-9 — 'Open StakTrakr' button links to staktrakr.com", async ({ page }) => {
+    const href = await page.locator(".hero-buttons a.btn-primary").getAttribute("href");
+    expect(href).toContain("staktrakr.com");
+  });
+
+  test("AP-10 — 'View Source' outline button is present", async ({ page }) => {
+    const btn = page.locator(".hero-buttons a.btn-outline");
+    await expect(btn).toBeVisible();
+    await expect(btn).toContainText("View Source");
+  });
+
+  test("AP-11 — 'View Source' button links to GitHub repository", async ({ page }) => {
+    const href = await page.locator(".hero-buttons a.btn-outline").getAttribute("href");
+    expect(href).toContain("github.com");
+    expect(href).toContain("StakTrakr");
+  });
+
+  test("AP-12 — both hero buttons are present", async ({ page }) => {
+    const buttons = page.locator(".hero-buttons a");
+    await expect(buttons).toHaveCount(2);
+  });
+
+  // ── Pillars section ───────────────────────────────────────────────────────
+
+  test("AP-13 — pillars section heading is visible", async ({ page }) => {
+    const heading = page.locator("h2", { hasText: "What Makes StakTrakr Different" });
+    await expect(heading).toBeVisible();
+  });
+
+  test("AP-14 — exactly 4 pillars are rendered", async ({ page }) => {
+    const pillars = page.locator(".pillar");
+    await expect(pillars).toHaveCount(4);
+  });
+
+  test("AP-15 — 'Your Data Stays Yours' pillar is present", async ({ page }) => {
+    await expect(page.locator(".pillar h3", { hasText: "Your Data Stays Yours" })).toBeVisible();
+  });
+
+  test("AP-16 — 'Free, Always' pillar is present", async ({ page }) => {
+    await expect(page.locator(".pillar h3", { hasText: "Free, Always" })).toBeVisible();
+  });
+
+  test("AP-17 — 'Free Spot & Market API' pillar is present", async ({ page }) => {
+    await expect(
+      page.locator(".pillar h3", { hasText: "Free Spot & Market API" })
+    ).toBeVisible();
+  });
+
+  test("AP-18 — 'Truly Portable' pillar is present", async ({ page }) => {
+    await expect(page.locator(".pillar h3", { hasText: "Truly Portable" })).toBeVisible();
+  });
+
+  test("AP-19 — each pillar has a non-empty icon", async ({ page }) => {
+    const icons = page.locator(".pillar-icon");
+    const count = await icons.count();
+    expect(count).toBe(4);
+    for (let i = 0; i < count; i++) {
+      const text = await icons.nth(i).textContent();
+      expect(text.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  // ── Feature sections ──────────────────────────────────────────────────────
+
+  test("AP-20 — 'Live Market Prices' section heading is present", async ({ page }) => {
+    const heading = page.locator("h2", { hasText: "Live Market Prices" });
+    await expect(heading).toBeVisible();
+  });
+
+  test("AP-21 — at least 4 feature cards are rendered", async ({ page }) => {
+    const cards = page.locator(".feature-card");
+    const count = await cards.count();
+    expect(count).toBeGreaterThanOrEqual(4);
+  });
+
+  test("AP-22 — 'Best Price Ticker' feature card is present", async ({ page }) => {
+    await expect(page.locator(".feature-card h3", { hasText: "Best Price Ticker" })).toBeVisible();
+  });
+
+  test("AP-23 — 'Vendor Price Matrix' feature card is present", async ({ page }) => {
+    await expect(
+      page.locator(".feature-card h3", { hasText: "Vendor Price Matrix" })
+    ).toBeVisible();
+  });
+
+  // ── API table ─────────────────────────────────────────────────────────────
+
+  test("AP-24 — 'Optional API Integrations' section is present", async ({ page }) => {
+    const heading = page.locator("h2", { hasText: "Optional API Integrations" });
+    await expect(heading).toBeVisible();
+  });
+
+  test("AP-25 — api-table is rendered", async ({ page }) => {
+    await expect(page.locator("table.api-table")).toBeVisible();
+  });
+
+  test("AP-26 — api-table has expected column headers", async ({ page }) => {
+    const headers = page.locator("table.api-table th");
+    await expect(headers.nth(0)).toContainText("Integration");
+    await expect(headers.nth(1)).toContainText("What It Does");
+    await expect(headers.nth(2)).toContainText("Key");
+  });
+
+  test("AP-27 — StakTrakr API row is in the api-table", async ({ page }) => {
+    await expect(
+      page.locator("table.api-table td", { hasText: "StakTrakr API" })
+    ).toBeVisible();
+  });
+
+  test("AP-28 — 'Bundled' badge is visible in api-table", async ({ page }) => {
+    await expect(page.locator(".badge-free", { hasText: "Bundled" })).toBeVisible();
+  });
+
+  test("AP-29 — at least 3 rows exist in the api-table body", async ({ page }) => {
+    const rows = page.locator("table.api-table tbody tr");
+    const count = await rows.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── Privacy section ───────────────────────────────────────────────────────
+
+  test("AP-30 — privacy-box section is present", async ({ page }) => {
+    await expect(page.locator(".privacy-box")).toBeVisible();
+  });
+
+  test("AP-31 — privacy list items are rendered", async ({ page }) => {
+    const items = page.locator(".privacy-list li");
+    const count = await items.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── Getting Started section ───────────────────────────────────────────────
+
+  test("AP-32 — 'Get Started in 30 Seconds' section is present", async ({ page }) => {
+    const heading = page.locator("h2", { hasText: "Get Started in 30 Seconds" });
+    await expect(heading).toBeVisible();
+  });
+
+  test("AP-33 — Option A and Option B cards are present", async ({ page }) => {
+    await expect(page.locator(".feature-card h3", { hasText: "Option A: Just Open It" })).toBeVisible();
+    await expect(page.locator(".feature-card h3", { hasText: "Option B: Run It Locally" })).toBeVisible();
+  });
+
+  // ── Sponsor section ───────────────────────────────────────────────────────
+
+  test("AP-34 — sponsor section is visible", async ({ page }) => {
+    await expect(page.locator(".sponsor-section")).toBeVisible();
+  });
+
+  test("AP-35 — 'Sponsor on GitHub' button is present with correct link", async ({ page }) => {
+    const btn = page.locator("a.btn-sponsor");
+    await expect(btn).toBeVisible();
+    await expect(btn).toContainText("Sponsor on GitHub");
+    const href = await btn.getAttribute("href");
+    expect(href).toContain("github.com/sponsors");
+  });
+
+  // ── Thank You / shoutout section ──────────────────────────────────────────
+
+  test("AP-36 — 'Thank You' section with shoutout is present", async ({ page }) => {
+    await expect(page.locator("h2", { hasText: "Thank You" })).toBeVisible();
+    await expect(page.locator(".shoutout")).toBeVisible();
+  });
+
+  test("AP-37 — Reddit community link is in the shoutout", async ({ page }) => {
+    const link = page.locator(".shoutout a", { hasText: /r\/staktrakr/i });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toContain("reddit.com");
+  });
+
+  // ── Footer ────────────────────────────────────────────────────────────────
+
+  test("AP-38 — footer is visible", async ({ page }) => {
+    await expect(page.locator("footer")).toBeVisible();
+  });
+
+  test("AP-39 — footer contains MIT License mention", async ({ page }) => {
+    const footer = page.locator("footer");
+    await expect(footer).toContainText("MIT License");
+  });
+
+  test("AP-40 — footer has 5 navigation links", async ({ page }) => {
+    const links = page.locator(".footer-links a");
+    await expect(links).toHaveCount(5);
+  });
+
+  test("AP-41 — footer App link points to staktrakr.com", async ({ page }) => {
+    const link = page.locator(".footer-links a", { hasText: "App" });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toContain("staktrakr.com");
+  });
+
+  test("AP-42 — footer GitHub link points to lbruton/StakTrakr", async ({ page }) => {
+    const link = page.locator(".footer-links a", { hasText: "GitHub" });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toContain("github.com");
+  });
+
+  test("AP-43 — footer Privacy link points to privacy.html", async ({ page }) => {
+    const link = page.locator(".footer-links a", { hasText: "Privacy" });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toContain("privacy");
+  });
+
+  // ── CSS custom properties (regression: prettier should not break inline styles) ──
+
+  test("AP-44 — CSS custom properties are applied (body has non-default background)", async ({
+    page,
+  }) => {
+    const bgColor = await page.evaluate(() =>
+      getComputedStyle(document.body).getPropertyValue("background-color")
+    );
+    // Background should not be white (default) — the dark theme uses a near-black
+    expect(bgColor).not.toBe("rgb(255, 255, 255)");
+  });
+
+  test("AP-45 — metal-bar accent element is present", async ({ page }) => {
+    await expect(page.locator(".metal-bar")).toBeVisible();
+  });
+});

--- a/tests/playwright/config-validation.spec.js
+++ b/tests/playwright/config-validation.spec.js
@@ -1,0 +1,462 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Config file validation tests for files changed in this PR.
+ *
+ * These tests do NOT require a browser — they validate that the new/modified
+ * configuration files (.prettierrc, .prettierignore, .pre-commit-config.yaml,
+ * .coderabbit.yaml) and updated CHANGELOG.md have the correct content.
+ *
+ * Tests run as ordinary Playwright test cases (no browser fixture used) so they
+ * integrate with `npm test` and the existing Playwright infrastructure without
+ * needing a separate test runner.
+ */
+
+// Resolve paths relative to the repo root (two levels up from tests/playwright/)
+const ROOT = resolve(new URL(import.meta.url).pathname, "../../../");
+
+function readRoot(relativePath) {
+  return readFileSync(resolve(ROOT, relativePath), "utf-8");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// .prettierrc — new file added in this PR
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe(".prettierrc", () => {
+  let config;
+
+  test.beforeAll(() => {
+    config = JSON.parse(readRoot(".prettierrc"));
+  });
+
+  test("PR-1 — .prettierrc file exists at repo root", () => {
+    expect(existsSync(resolve(ROOT, ".prettierrc"))).toBe(true);
+  });
+
+  test("PR-2 — .prettierrc is valid JSON", () => {
+    // If JSON.parse above throws, this test will fail automatically
+    expect(typeof config).toBe("object");
+    expect(config).not.toBeNull();
+  });
+
+  test("PR-3 — singleQuote is false (project uses double quotes)", () => {
+    expect(config.singleQuote).toBe(false);
+  });
+
+  test("PR-4 — trailingComma is es5", () => {
+    expect(config.trailingComma).toBe("es5");
+  });
+
+  test("PR-5 — tabWidth is 2", () => {
+    expect(config.tabWidth).toBe(2);
+  });
+
+  test("PR-6 — semi is true (semicolons required)", () => {
+    expect(config.semi).toBe(true);
+  });
+
+  test("PR-7 — printWidth is 100", () => {
+    expect(config.printWidth).toBe(100);
+  });
+
+  test("PR-8 — no unexpected extra properties", () => {
+    const expectedKeys = ["singleQuote", "trailingComma", "tabWidth", "semi", "printWidth"];
+    const actualKeys = Object.keys(config);
+    // All actual keys should be in the expected set
+    actualKeys.forEach((key) => {
+      expect(expectedKeys).toContain(key);
+    });
+  });
+
+  test("PR-9 — all 5 expected properties are present", () => {
+    const expectedKeys = ["singleQuote", "trailingComma", "tabWidth", "semi", "printWidth"];
+    expectedKeys.forEach((key) => {
+      expect(key in config).toBe(true);
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// .prettierignore — new file added in this PR
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe(".prettierignore", () => {
+  let content;
+
+  test.beforeAll(() => {
+    content = readRoot(".prettierignore");
+  });
+
+  test("PI-1 — .prettierignore file exists at repo root", () => {
+    expect(existsSync(resolve(ROOT, ".prettierignore"))).toBe(true);
+  });
+
+  test("PI-2 — vendor/ is ignored (minified third-party libs)", () => {
+    expect(content).toContain("vendor/");
+  });
+
+  test("PI-3 — data/ is ignored (generated API snapshot bundles)", () => {
+    expect(content).toContain("data/");
+  });
+
+  test("PI-4 — devops/docs/scripts/ is ignored (vendored JSDoc scripts)", () => {
+    expect(content).toContain("devops/docs/scripts/");
+  });
+
+  test("PI-5 — node_modules/ is ignored (build artifacts)", () => {
+    expect(content).toContain("node_modules/");
+  });
+
+  test("PI-6 — test-results/ is ignored (test artifacts)", () => {
+    expect(content).toContain("test-results/");
+  });
+
+  test("PI-7 — .worktrees/ is ignored", () => {
+    expect(content).toContain(".worktrees/");
+  });
+
+  test("PI-8 — *.min.js is ignored (minified assets)", () => {
+    expect(content).toContain("*.min.js");
+  });
+
+  test("PI-9 — *.min.css is ignored (minified assets)", () => {
+    expect(content).toContain("*.min.css");
+  });
+
+  test("PI-10 — ignore file is non-empty", () => {
+    expect(content.trim().length).toBeGreaterThan(0);
+  });
+
+  test("PI-11 — ignore file has comment lines explaining each section", () => {
+    // The file should have at least one comment (lines starting with #)
+    const commentLines = content
+      .split("\n")
+      .filter((line) => line.trim().startsWith("#"));
+    expect(commentLines.length).toBeGreaterThan(0);
+  });
+
+  test("PI-12 — boundary check: sw.js is NOT in .prettierignore (it is formatted)", () => {
+    // sw.js is excluded from CodeRabbit review but should NOT be in .prettierignore
+    const lines = content
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => !l.startsWith("#"));
+    expect(lines).not.toContain("sw.js");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// .pre-commit-config.yaml — lint-staged hook added in this PR
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe(".pre-commit-config.yaml", () => {
+  let content;
+
+  test.beforeAll(() => {
+    content = readRoot(".pre-commit-config.yaml");
+  });
+
+  test("PC-1 — .pre-commit-config.yaml file exists", () => {
+    expect(existsSync(resolve(ROOT, ".pre-commit-config.yaml"))).toBe(true);
+  });
+
+  test("PC-2 — lint-staged hook id is declared", () => {
+    expect(content).toContain("id: lint-staged");
+  });
+
+  test("PC-3 — lint-staged hook name describes its purpose", () => {
+    expect(content).toContain("Format staged files with prettier");
+  });
+
+  test("PC-4 — lint-staged hook uses npx lint-staged as entry point", () => {
+    expect(content).toContain("entry: npx lint-staged");
+  });
+
+  test("PC-5 — lint-staged hook has always_run: true", () => {
+    // The hook should always run, not just on specific file patterns
+    const hookSection = content.substring(content.indexOf("id: lint-staged"));
+    expect(hookSection).toContain("always_run: true");
+  });
+
+  test("PC-6 — lint-staged hook uses system language", () => {
+    const hookSection = content.substring(content.indexOf("id: lint-staged"));
+    expect(hookSection).toContain("language: system");
+  });
+
+  test("PC-7 — pre-existing gitleaks hook is still present", () => {
+    expect(content).toContain("id: gitleaks");
+  });
+
+  test("PC-8 — pre-existing stamp-sw-cache hook is still present", () => {
+    expect(content).toContain("id: stamp-sw-cache");
+  });
+
+  test("PC-9 — pre-existing check-release-sync hook is still present", () => {
+    expect(content).toContain("id: check-release-sync");
+  });
+
+  test("PC-10 — pre-existing check-claude-md hook is still present", () => {
+    expect(content).toContain("id: check-claude-md");
+  });
+
+  test("PC-11 — lint-staged hook appears after other local hooks", () => {
+    const lintStagedIdx = content.indexOf("id: lint-staged");
+    const checkClaudeMdIdx = content.indexOf("id: check-claude-md");
+    expect(lintStagedIdx).toBeGreaterThan(checkClaudeMdIdx);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// .coderabbit.yaml — new file added in this PR
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe(".coderabbit.yaml", () => {
+  let content;
+
+  test.beforeAll(() => {
+    content = readRoot(".coderabbit.yaml");
+  });
+
+  test("CR-1 — .coderabbit.yaml file exists at repo root", () => {
+    expect(existsSync(resolve(ROOT, ".coderabbit.yaml"))).toBe(true);
+  });
+
+  test("CR-2 — schema reference is present for IDE support", () => {
+    expect(content).toContain("yaml-language-server");
+    expect(content).toContain("coderabbit.ai/integrations/schema");
+  });
+
+  test("CR-3 — language is set to en-US", () => {
+    expect(content).toContain('language: "en-US"');
+  });
+
+  test("CR-4 — review profile is assertive (solo-dev configuration)", () => {
+    expect(content).toContain('profile: "assertive"');
+  });
+
+  test("CR-5 — high_level_summary is enabled", () => {
+    expect(content).toContain("high_level_summary: true");
+  });
+
+  test("CR-6 — poem is disabled", () => {
+    expect(content).toContain("poem: false");
+  });
+
+  test("CR-7 — auto_review is enabled", () => {
+    expect(content).toContain("enabled: true");
+  });
+
+  test("CR-8 — auto_incremental_review is enabled", () => {
+    expect(content).toContain("auto_incremental_review: true");
+  });
+
+  test("CR-9 — WIP title keyword is in ignore list", () => {
+    expect(content).toContain('"WIP"');
+  });
+
+  test("CR-10 — DO NOT MERGE title keyword is in ignore list", () => {
+    expect(content).toContain('"DO NOT MERGE"');
+  });
+
+  test("CR-11 — node_modules path filter is excluded", () => {
+    expect(content).toContain("!**/node_modules/**");
+  });
+
+  test("CR-12 — data/ (StakTrakr-specific) path filter is excluded", () => {
+    expect(content).toContain("!data/**");
+  });
+
+  test("CR-13 — sw.js is excluded from review (auto-stamped)", () => {
+    expect(content).toContain("!sw.js");
+  });
+
+  test("CR-14 — DESIGN.md is excluded (known false-positive source)", () => {
+    expect(content).toContain("!DESIGN.md");
+  });
+
+  test("CR-15 — eslint tool is enabled", () => {
+    const toolsSection = content.substring(content.indexOf("tools:"));
+    expect(toolsSection).toContain("eslint:");
+    expect(toolsSection).toContain("enabled: true");
+  });
+
+  test("CR-16 — gitleaks tool is enabled (security scanning)", () => {
+    const toolsSection = content.substring(content.indexOf("tools:"));
+    expect(toolsSection).toContain("gitleaks:");
+  });
+
+  test("CR-17 — markdownlint tool is enabled", () => {
+    const toolsSection = content.substring(content.indexOf("tools:"));
+    expect(toolsSection).toContain("markdownlint:");
+  });
+
+  test("CR-18 — knowledge base learnings are enabled", () => {
+    expect(content).toContain("learnings:");
+    expect(content).toMatch(/learnings:\s*\n\s*enabled: true/);
+  });
+
+  test("CR-19 — chat auto_reply is enabled", () => {
+    expect(content).toContain("auto_reply: true");
+  });
+
+  test("CR-20 — path instructions include js/**/*.js guidance", () => {
+    expect(content).toContain('path: "js/**/*.js"');
+  });
+
+  test("CR-21 — path instructions include tests/** guidance", () => {
+    expect(content).toContain('path: "tests/**"');
+  });
+
+  test("CR-22 — abort_on_close is true", () => {
+    expect(content).toContain("abort_on_close: true");
+  });
+
+  test("CR-23 — early_access is false", () => {
+    expect(content).toContain("early_access: false");
+  });
+
+  test("CR-24 — finishing_touches docstrings are disabled", () => {
+    const ftSection = content.substring(content.indexOf("finishing_touches:"));
+    expect(ftSection).toContain("docstrings:");
+    expect(ftSection).toContain("enabled: false");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// CHANGELOG.md — new version entries added in this PR (3.34.04 – 3.34.09)
+// ────────────────────────────────────────────────────────────────────────────
+
+test.describe("CHANGELOG.md — new entries", () => {
+  let content;
+
+  test.beforeAll(() => {
+    content = readRoot("CHANGELOG.md");
+  });
+
+  test("CL-1 — CHANGELOG.md follows Keep a Changelog format header", () => {
+    expect(content).toContain("Keep a Changelog");
+    expect(content).toContain("Semantic Versioning");
+  });
+
+  test("CL-2 — [3.34.09] entry is present (STAK-548 hotfix)", () => {
+    expect(content).toContain("## [3.34.09]");
+  });
+
+  test("CL-3 — [3.34.09] has correct date 2026-04-17", () => {
+    expect(content).toContain("## [3.34.09] - 2026-04-17");
+  });
+
+  test("CL-4 — [3.34.09] mentions STAK-548", () => {
+    const entryStart = content.indexOf("## [3.34.09]");
+    const entryEnd = content.indexOf("## [3.34.08]");
+    const entry = content.substring(entryStart, entryEnd);
+    expect(entry).toContain("STAK-548");
+  });
+
+  test("CL-5 — [3.34.08] entry is present (STAK-548 SQLD rename)", () => {
+    expect(content).toContain("## [3.34.08]");
+  });
+
+  test("CL-6 — [3.34.08] has correct date 2026-04-17", () => {
+    expect(content).toContain("## [3.34.08] - 2026-04-17");
+  });
+
+  test("CL-7 — [3.34.08] describes SQLD_URL rename", () => {
+    const entryStart = content.indexOf("## [3.34.08]");
+    const entryEnd = content.indexOf("## [3.34.07]");
+    const entry = content.substring(entryStart, entryEnd);
+    expect(entry).toContain("SQLD_URL");
+  });
+
+  test("CL-8 — [3.34.07] entry is present (STAK-517 market filter cache)", () => {
+    expect(content).toContain("## [3.34.07]");
+  });
+
+  test("CL-9 — [3.34.07] has correct date 2026-04-17", () => {
+    expect(content).toContain("## [3.34.07] - 2026-04-17");
+  });
+
+  test("CL-10 — [3.34.07] mentions _invalidateMarketFilterCache", () => {
+    const entryStart = content.indexOf("## [3.34.07]");
+    const entryEnd = content.indexOf("## [3.34.06]");
+    const entry = content.substring(entryStart, entryEnd);
+    expect(entry).toContain("_invalidateMarketFilterCache");
+  });
+
+  test("CL-11 — [3.34.06] entry is present (STAK-551 filter chip logic)", () => {
+    expect(content).toContain("## [3.34.06]");
+  });
+
+  test("CL-12 — [3.34.06] has correct date 2026-04-17", () => {
+    expect(content).toContain("## [3.34.06] - 2026-04-17");
+  });
+
+  test("CL-13 — [3.34.06] describes isAccumulate rename", () => {
+    const entryStart = content.indexOf("## [3.34.06]");
+    const entryEnd = content.indexOf("## [3.34.05]");
+    const entry = content.substring(entryStart, entryEnd);
+    expect(entry).toContain("isAccumulate");
+  });
+
+  test("CL-14 — [3.34.05] entry is present (STAK-546 AND semantics)", () => {
+    expect(content).toContain("## [3.34.05]");
+  });
+
+  test("CL-15 — [3.34.05] has correct date 2026-04-16", () => {
+    expect(content).toContain("## [3.34.05] - 2026-04-16");
+  });
+
+  test("CL-16 — [3.34.04] entry is present (STAK-549 cloud sync)", () => {
+    expect(content).toContain("## [3.34.04]");
+  });
+
+  test("CL-17 — [3.34.04] has correct date 2026-04-15", () => {
+    expect(content).toContain("## [3.34.04] - 2026-04-15");
+  });
+
+  test("CL-18 — [3.34.04] describes syncNow return value change", () => {
+    const entryStart = content.indexOf("## [3.34.04]");
+    const entryEnd = content.indexOf("## [3.34.03]");
+    const entry = content.substring(entryStart, entryEnd);
+    expect(entry).toContain("syncNow");
+    expect(entry).toContain("STAK-549");
+  });
+
+  test("CL-19 — entries are in descending version order (3.34.09 before 3.34.08)", () => {
+    const idx09 = content.indexOf("## [3.34.09]");
+    const idx08 = content.indexOf("## [3.34.08]");
+    expect(idx09).toBeGreaterThanOrEqual(0);
+    expect(idx08).toBeGreaterThan(idx09);
+  });
+
+  test("CL-20 — entries are in descending version order (3.34.08 before 3.34.07)", () => {
+    const idx08 = content.indexOf("## [3.34.08]");
+    const idx07 = content.indexOf("## [3.34.07]");
+    expect(idx08).toBeGreaterThanOrEqual(0);
+    expect(idx07).toBeGreaterThan(idx08);
+  });
+
+  test("CL-21 — all 6 new versions present (3.34.04 through 3.34.09)", () => {
+    for (const version of ["3.34.04", "3.34.05", "3.34.06", "3.34.07", "3.34.08", "3.34.09"]) {
+      expect(content).toContain(`## [${version}]`);
+    }
+  });
+
+  test("CL-22 — [Unreleased] section still present at top", () => {
+    expect(content).toContain("## [Unreleased]");
+    const unreleasedIdx = content.indexOf("## [Unreleased]");
+    const v309Idx = content.indexOf("## [3.34.09]");
+    expect(unreleasedIdx).toBeLessThan(v309Idx);
+  });
+
+  test("CL-23 — [3.34.03] pre-existing entry is still intact", () => {
+    expect(content).toContain("## [3.34.03]");
+  });
+
+  test("CL-24 — boundary: [3.34.10] does NOT exist (no phantom entries)", () => {
+    expect(content).not.toContain("## [3.34.10]");
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.09",
-  "releaseDate": "2026-04-17",
+  "version": "3.34.10",
+  "releaseDate": "2026-04-18",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## GSD Session — Sort Bar + Last Modified

### Changes
- Show the live sort dropdown in **table view** (D mode), not just card views — reuses the existing `cardSortBar` control
- Add `Last Modified` as a new sort option (column 12) in both the live sort dropdown and Settings > Default Sort
- Stamp `lastModified` ISO timestamp on inventory items at **create** and **edit** time
- Extend `sortInventory()` to handle the new column — items without `lastModified` sort as oldest
- Auto-switch sort direction to **desc** when `Last Modified` is selected (newest-first is the expected default)
- Preserve existing table header click-sorting — no conflict since column 12 has no `<th>`

### Notes
- No version bump — rolls into next patch release
- No DocVault issue update — scoped below spec threshold per `/gsd` rules
- Refs STAK-553 (narrowed from original 4-behavior scope to just sort dropdown + `lastModified` field)
- 6 files, ~34 net lines added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Last Modified" sort option to inventory sorting and default settings
  * Last modified timestamps now tracked for all inventory items
  * Sort direction automatically switches to descending when selecting "Last Modified"

* **Improvements**
  * Enhanced sort bar behavior and visibility in table view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->