### PR TITLE
v3.34.15 — STAK-562: goldback/silverback first-class type

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -56,6 +56,7 @@ reviews:
     - "!**/pnpm-lock.yaml"
     - "!**/yarn.lock"
     - "!**/screenshots/**"
+    - "!**/test-results/**"
     - "!**/*.png"
     - "!**/*.jpg"
     - "!**/*.svg"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.15] - 2026-04-19
+
+### Changed — STAK-562: Goldback and Silverback as first-class type
+
+- **Changed**: Added dedicated `Goldback` and `Silverback` type options in Add/Edit/Bulk Edit flows and made them available to quick filters, grouped filters, and type chip controls.
+- **Changed**: When metal is set to `Gold` or `Silver`, type options now include the corresponding backed note type (`Goldback`/`Silverback`) while preserving existing round filtering and default behavior.
+- **Changed**: Inventory cards/table rows now show backed notes using an icon-first display pattern, and type chips are grouped with map aliases for `gb`, `sb`, `goldbacks`, and `silverbacks`.
+- **Changed**: Added cross-flow regression coverage for STAK-562 in Playwright (`tests/playwright/goldback-type.spec.js`) to verify add/edit/filter/bulk-edit behaviors.
+
+---
+
 ## [3.34.14] - 2026-04-19
 
 ### Added — STAK-558: Comma and semicolon delimiters in tag input

--- a/css/styles.css
+++ b/css/styles.css
@@ -87,6 +87,12 @@
   --type-bar-text: #ffffff;
   --type-note-bg: #047857;
   --type-note-text: #f8fafc;
+  --type-aurum-bg: #6d28d9;
+  --type-aurum-text: #ffffff;
+  --type-goldback-bg: #b8860b;
+  --type-goldback-text: #ffffff;
+  --type-silverback-bg: #708090;
+  --type-silverback-text: #ffffff;
   --type-set-bg: #8b5cf6;
   --type-set-text: #ffffff;
   --type-other-bg: #6d35d0;
@@ -138,6 +144,12 @@
   --type-bar-text: #1e293b;
   --type-note-bg: #047857;
   --type-note-text: #ffffff;
+  --type-aurum-bg: #8b5cf6;
+  --type-aurum-text: #ffffff;
+  --type-goldback-bg: #d4a017;
+  --type-goldback-text: #1e293b;
+  --type-silverback-bg: #94a3b8;
+  --type-silverback-text: #1e293b;
   --type-set-bg: #a78bfa;
   --type-set-text: #1e293b;
   --type-other-bg: #8b5cf6;
@@ -200,6 +212,12 @@
   --type-bar-text: #ffffff;
   --type-note-bg: #066b52;
   --type-note-text: #ffffff;
+  --type-aurum-bg: #6d28d9;
+  --type-aurum-text: #ffffff;
+  --type-goldback-bg: #a66d00;
+  --type-goldback-text: #ffffff;
+  --type-silverback-bg: #6b7280;
+  --type-silverback-text: #ffffff;
   --type-set-bg: #7c3aed;
   --type-set-text: #ffffff;
   --type-other-bg: #6a3fa8;

--- a/index.html
+++ b/index.html
@@ -2030,6 +2030,8 @@
                   <option value="Round">Round</option>
                   <option value="Note">Note</option>
                   <option value="Aurum">Aurum</option>
+                  <option value="Goldback">Goldback</option>
+                  <option value="Silverback">Silverback</option>
                   <option value="Set">Set</option>
                   <option value="Other">Other</option>
                 </select>
@@ -2047,6 +2049,7 @@
                   <option value="0.9995">.9995 — Pure Platinum</option>
                   <option value="0.999">.999 — Fine</option>
                   <option value="0.925">.925 — Sterling</option>
+                  <option value="0.500">.500 — 12K</option>
                   <option value="0.9167">.9167 — 22K (Krugerrand)</option>
                   <option value="0.900">.900 — 90% Silver</option>
                   <option value="0.800">.800 — 80% (European)</option>

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.15 &ndash; STAK-562: Goldback and Silverback as first-class type</strong>: Goldback and Silverback are now first-class inventory types across Add, Edit, Bulk Edit, chips, and quick filters. Type options now follow metal selection rules (Gold &rarr; Goldback, Silver &rarr; Silverback), and backed notes render with a dedicated icon-first display in cards and table rows.</li>
     <li><strong>v3.34.14 &ndash; STAK-558: Comma and semicolon delimiters in tag input</strong>: Type or paste multiple tags separated by commas or semicolons in the Add a tag field — all tags are added at once. Empty tokens are skipped, whitespace is trimmed, and existing dedup/max-tag limits still apply per token.</li>
     <li><strong>v3.34.13 &ndash; STAK-556: Cherry-pick Numista tags + respect your edits</strong>: Numista search now uses per-tag checkboxes instead of all-or-none import; blacklisted and previously removed tags default unchecked, while edited fields can be restored by re-checking tagged values.</li>
     <li><strong>v3.34.12 &ndash; STAK-556: Cherry-pick Numista tags + respect your edits</strong>: Numista search now lets you pick individual tags instead of importing all or none. Fields you&rsquo;ve manually edited default to unchecked with a &ldquo;&#x270E; edited&rdquo; hint. Tags you&rsquo;ve previously removed default to unchecked. Bulk sync warns before overwriting and offers a &ldquo;skip user-edited&rdquo; option.</li>

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -179,7 +179,7 @@ const BULK_EDITABLE_FIELDS = [
     id: "type",
     label: "Type",
     inputType: "select",
-    options: ["Coin", "Bar", "Round", "Note", "Aurum", "Goldback", "Silverback", "Set", "Other"],
+    options: VALID_TYPES,
   },
   { id: "qty", label: "Quantity", inputType: "number", attrs: { min: "1", step: "1" } },
   { id: "weight", label: "Weight", inputType: "number", attrs: { min: "0", step: "0.001" } },
@@ -606,7 +606,7 @@ const renderBulkFieldPanel = () => {
       });
     };
 
-    const bulkTypeSelect = safeGetElement("bulkFieldVal_type");
+    const bulkTypeSelect = document.getElementById("bulkFieldVal_type");
     const bulkMetalSelect = safeGetElement("bulkFieldVal_metal");
 
     const filterBulkTypesByMetal = (metalValue) => {
@@ -621,6 +621,7 @@ const renderBulkFieldPanel = () => {
       const selectedOption = bulkTypeSelect.options[bulkTypeSelect.selectedIndex];
       if (selectedOption && selectedOption.hidden) {
         bulkTypeSelect.value = "Coin";
+        handleBulkTypeChange();
       }
     };
 

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -179,7 +179,7 @@ const BULK_EDITABLE_FIELDS = [
     id: "type",
     label: "Type",
     inputType: "select",
-    options: ["Coin", "Bar", "Round", "Note", "Aurum", "Set", "Other"],
+    options: ["Coin", "Bar", "Round", "Note", "Aurum", "Goldback", "Silverback", "Set", "Other"],
   },
   { id: "qty", label: "Quantity", inputType: "number", attrs: { min: "1", step: "1" } },
   { id: "weight", label: "Weight", inputType: "number", attrs: { min: "0", step: "0.001" } },
@@ -205,6 +205,7 @@ const BULK_EDITABLE_FIELDS = [
       { value: "0.9995", label: ".9995 — Pure Platinum" },
       { value: "0.999", label: ".999 — Fine" },
       { value: "0.925", label: ".925 — Sterling" },
+      { value: "0.500", label: ".500 — 12K" },
       { value: "0.9167", label: ".9167 — 22K (Krugerrand)" },
       { value: "0.900", label: ".900 — 90% Silver" },
       { value: "0.800", label: ".800 — 80% (European)" },
@@ -595,8 +596,66 @@ const renderBulkFieldPanel = () => {
       }
     };
 
+    const updateBulkDenomLabels = (typeValue = "") => {
+      const denominationLabel = typeValue === "Silverback" ? "Silverback" : "Goldback";
+      GOLDBACK_DENOMINATIONS.forEach((denomination, index) => {
+        const option = denomSelect.options[index];
+        if (!option) return;
+        const prefix = denomination.weight === 0.5 ? "½" : String(denomination.weight);
+        option.textContent = `${prefix} ${denominationLabel}`;
+      });
+    };
+
+    const bulkTypeSelect = safeGetElement("bulkFieldVal_type");
+    const bulkMetalSelect = safeGetElement("bulkFieldVal_metal");
+
+    const filterBulkTypesByMetal = (metalValue) => {
+      if (!bulkTypeSelect || typeof TYPE_METAL_FILTER === "undefined") return;
+      Array.from(bulkTypeSelect.options).forEach((option) => {
+        const allowedMetals = TYPE_METAL_FILTER[option.value];
+        const isAllowed = !Array.isArray(allowedMetals) || allowedMetals.includes(metalValue);
+        option.hidden = !isAllowed;
+        option.disabled = !isAllowed;
+      });
+
+      const selectedOption = bulkTypeSelect.options[bulkTypeSelect.selectedIndex];
+      if (selectedOption && selectedOption.hidden) {
+        bulkTypeSelect.value = "Coin";
+      }
+    };
+
+    const handleBulkTypeChange = () => {
+      if (!bulkTypeSelect) return;
+      const typeValue = bulkTypeSelect.value;
+      const isGbType = typeValue === "Goldback" || typeValue === "Silverback";
+
+      if (isGbType) {
+        bwUnitSelect.value = "gb";
+        bulkFieldValues["weightUnit"] = "gb";
+        updateBulkDenomLabels(typeValue);
+      } else if (bwUnitSelect.value === "gb") {
+        bwUnitSelect.value = "oz";
+        bulkFieldValues["weightUnit"] = "oz";
+      }
+
+      toggleBulkGbPicker();
+    };
+
     // Listen for unit changes
     bwUnitSelect.addEventListener("change", toggleBulkGbPicker);
+
+    if (bulkMetalSelect) {
+      bulkMetalSelect.addEventListener("change", () => {
+        filterBulkTypesByMetal(bulkMetalSelect.value);
+        handleBulkTypeChange();
+      });
+    }
+
+    if (bulkTypeSelect) {
+      bulkTypeSelect.addEventListener("change", () => {
+        handleBulkTypeChange();
+      });
+    }
 
     // Sync disabled state when weight checkbox toggles
     if (bwCheckbox) {
@@ -609,6 +668,13 @@ const renderBulkFieldPanel = () => {
     if (bulkFieldValues["weightUnit"] === "gb") {
       bwUnitSelect.value = "gb";
       toggleBulkGbPicker();
+    }
+
+    if (bulkMetalSelect) {
+      filterBulkTypesByMetal(bulkMetalSelect.value);
+    }
+    if (bulkTypeSelect) {
+      handleBulkTypeChange();
     }
   }
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.14";
+const APP_VERSION = "3.34.15";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.
@@ -583,6 +583,12 @@ const GOLDBACK_DENOMINATIONS = [
   { weight: 50, label: "50 Goldback", goldOz: 0.05 },
   { weight: 100, label: "100 Goldback", goldOz: 0.1 },
 ];
+
+/** @constant {Object<string, string[]>} TYPE_METAL_FILTER - Type visibility constraints by selected metal */
+const TYPE_METAL_FILTER = {
+  Goldback: ["Gold"],
+  Silverback: ["Silver"],
+};
 
 /** @constant {string} ITEM_TAGS_KEY - LocalStorage key for item tags mapping (STAK-126) */
 const ITEM_TAGS_KEY = "itemTags"; // nosemgrep: codacy.javascript.security.hard-coded-password

--- a/js/events.js
+++ b/js/events.js
@@ -1431,6 +1431,81 @@ const buildNumistaSearchQuery = (nameVal, metalVal) => {
 };
 
 /**
+ * Updates denomination option labels based on selected type.
+ * @param {string} [typeValue=""]
+ */
+const updateDenomLabels = (typeValue = "") => {
+  const denomSelect = safeGetElement("itemGbDenom");
+  if (!denomSelect || typeof GOLDBACK_DENOMINATIONS === "undefined") return;
+
+  const denominationLabel = typeValue === "Silverback" ? "Silverback" : "Goldback";
+  GOLDBACK_DENOMINATIONS.forEach((denomination, index) => {
+    const option = denomSelect.options[index];
+    if (!option) return;
+    const prefix = denomination.weight === 0.5 ? "½" : String(denomination.weight);
+    option.textContent = `${prefix} ${denominationLabel}`;
+  });
+};
+
+/**
+ * Handles type-driven denomination/weight UI state changes.
+ */
+const handleTypeChange = () => {
+  const selectedType = elements.itemType?.value || "";
+  const unitSelect = elements.itemWeightUnit;
+  if (!unitSelect) return;
+
+  const unitGroup = unitSelect.closest(".form-group") || unitSelect.parentElement;
+  const isGoldbackType = selectedType === "Goldback" || selectedType === "Silverback";
+
+  if (isGoldbackType) {
+    unitSelect.value = "gb";
+    if (unitGroup) unitGroup.classList.add("hidden");
+    updateDenomLabels(selectedType);
+  } else {
+    if (unitSelect.value === "gb") {
+      unitSelect.value = "oz";
+    }
+    if (unitGroup) unitGroup.classList.remove("hidden");
+  }
+
+  if (typeof toggleGbDenomPicker === "function") {
+    toggleGbDenomPicker();
+  }
+};
+
+/**
+ * Filters type dropdown options based on selected metal.
+ * @param {string} metalValue
+ */
+const filterTypesByMetal = (metalValue) => {
+  const typeSelect = safeGetElement("itemType");
+  if (!typeSelect || typeof TYPE_METAL_FILTER === "undefined") return;
+
+  Array.from(typeSelect.options).forEach((option) => {
+    const allowedMetals = TYPE_METAL_FILTER[option.value];
+    const isAllowed = !Array.isArray(allowedMetals) || allowedMetals.includes(metalValue);
+    option.hidden = !isAllowed;
+    option.disabled = !isAllowed;
+  });
+
+  const selectedOption = typeSelect.options[typeSelect.selectedIndex];
+  if (selectedOption && selectedOption.hidden) {
+    typeSelect.value = "Coin";
+    const fallbackOption = typeSelect.options[typeSelect.selectedIndex];
+    if (!fallbackOption || fallbackOption.hidden) {
+      const firstVisible = Array.from(typeSelect.options).find((option) => !option.hidden);
+      if (firstVisible) typeSelect.value = firstVisible.value;
+    }
+    handleTypeChange();
+  }
+};
+
+window.updateDenomLabels = updateDenomLabels;
+window.handleTypeChange = handleTypeChange;
+window.filterTypesByMetal = filterTypesByMetal;
+
+/**
  * Sets up item form submission and related button listeners
  */
 const setupItemFormListeners = () => {
@@ -2097,8 +2172,20 @@ const setupItemFormListeners = () => {
       "change",
       () => {
         if (elements.itemSpotPrice) elements.itemSpotPrice.value = "";
+        filterTypesByMetal(elements.itemMetal.value);
       },
-      "Metal change clears spot lookup"
+      "Metal change clears spot lookup and filters type options"
+    );
+  }
+
+  if (elements.itemType) {
+    safeAttachListener(
+      elements.itemType,
+      "change",
+      () => {
+        handleTypeChange();
+      },
+      "Type change updates denomination picker"
     );
   }
 
@@ -3196,6 +3283,10 @@ const setupSearch = () => {
           if (elements.itemPurity) elements.itemPurity.value = "";
           // Reset gb denomination picker (STACK-45)
           if (typeof toggleGbDenomPicker === "function") toggleGbDenomPicker();
+          if (elements.itemMetal && typeof filterTypesByMetal === "function") {
+            filterTypesByMetal(elements.itemMetal.value);
+          }
+          if (typeof handleTypeChange === "function") handleTypeChange();
           // Hide PCGS verified icon in add mode
           const certVerifiedIcon = document.getElementById("certVerifiedIcon");
           if (certVerifiedIcon) certVerifiedIcon.style.display = "none";

--- a/js/events.js
+++ b/js/events.js
@@ -1435,7 +1435,7 @@ const buildNumistaSearchQuery = (nameVal, metalVal) => {
  * @param {string} [typeValue=""]
  */
 const updateDenomLabels = (typeValue = "") => {
-  const denomSelect = safeGetElement("itemGbDenom");
+  const denomSelect = document.getElementById("itemGbDenom");
   if (!denomSelect || typeof GOLDBACK_DENOMINATIONS === "undefined") return;
 
   const denominationLabel = typeValue === "Silverback" ? "Silverback" : "Goldback";
@@ -1453,7 +1453,7 @@ const updateDenomLabels = (typeValue = "") => {
 const handleTypeChange = () => {
   const selectedType = elements.itemType?.value || "";
   const unitSelect = elements.itemWeightUnit;
-  if (!unitSelect) return;
+  if (!(unitSelect instanceof HTMLElement)) return;
 
   const unitGroup = unitSelect.closest(".form-group") || unitSelect.parentElement;
   const isGoldbackType = selectedType === "Goldback" || selectedType === "Silverback";
@@ -1479,7 +1479,7 @@ const handleTypeChange = () => {
  * @param {string} metalValue
  */
 const filterTypesByMetal = (metalValue) => {
-  const typeSelect = safeGetElement("itemType");
+  const typeSelect = document.getElementById("itemType");
   if (!typeSelect || typeof TYPE_METAL_FILTER === "undefined") return;
 
   Array.from(typeSelect.options).forEach((option) => {

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -63,6 +63,9 @@
     Round: "var(--type-round-bg)",
     Bar: "var(--type-bar-bg)",
     Note: "var(--type-note-bg)",
+    Aurum: "var(--type-aurum-bg)",
+    Goldback: "var(--type-goldback-bg)",
+    Silverback: "var(--type-silverback-bg)",
     Set: "var(--type-set-bg)",
     Other: "var(--type-other-bg)",
   };

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -231,7 +231,17 @@ const validateFieldValue = (field, value) => {
       return date >= minDate && date <= today;
 
     case "type":
-      const validTypes = ["Coin", "Bar", "Round", "Note", "Aurum", "Set", "Other"];
+      const validTypes = [
+        "Coin",
+        "Bar",
+        "Round",
+        "Note",
+        "Aurum",
+        "Goldback",
+        "Silverback",
+        "Set",
+        "Other",
+      ];
       return validTypes.includes(trimmedValue);
 
     case "metal":
@@ -274,7 +284,17 @@ const startCellEdit = (idx, field, element) => {
     input.className = "inline-select";
 
     if (field === "type") {
-      const types = ["Coin", "Bar", "Round", "Note", "Aurum", "Set", "Other"];
+      const types = [
+        "Coin",
+        "Bar",
+        "Round",
+        "Note",
+        "Aurum",
+        "Goldback",
+        "Silverback",
+        "Set",
+        "Other",
+      ];
       types.forEach((type) => {
         const option = document.createElement("option");
         option.value = type;
@@ -726,6 +746,15 @@ const editItem = (idx, logIdx = null) => {
   elements.itemQty.value = item.qty;
   elements.itemType.value = item.type;
 
+  const isGoldbackType = item.type === "Goldback" || item.type === "Silverback";
+  const selectedMetal = item.metal || elements.itemMetal.value;
+  if (typeof filterTypesByMetal === "function") {
+    filterTypesByMetal(selectedMetal);
+  }
+  if (typeof handleTypeChange === "function") {
+    handleTypeChange();
+  }
+
   // Weight: use real <select> instead of dataset.unit (BUG FIX)
   if (item.weightUnit === "gb") {
     const denomSelect = elements.itemGbDenom || safeGetElement("itemGbDenom");
@@ -750,6 +779,13 @@ const editItem = (idx, logIdx = null) => {
     elements.itemWeight.value = parseFloat(item.weight).toFixed(2);
     elements.itemWeightUnit.value = "oz";
     if (typeof toggleGbDenomPicker === "function") toggleGbDenomPicker();
+  }
+
+  if (isGoldbackType) {
+    const denomSelect = safeGetElement("itemGbDenom");
+    if (denomSelect && item.weight !== null && typeof item.weight !== "undefined") {
+      denomSelect.value = String(item.weight);
+    }
   }
 
   // Convert stored USD values to display currency for the form (STACK-50)

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -231,18 +231,7 @@ const validateFieldValue = (field, value) => {
       return date >= minDate && date <= today;
 
     case "type":
-      const validTypes = [
-        "Coin",
-        "Bar",
-        "Round",
-        "Note",
-        "Aurum",
-        "Goldback",
-        "Silverback",
-        "Set",
-        "Other",
-      ];
-      return validTypes.includes(trimmedValue);
+      return VALID_TYPES.includes(trimmedValue);
 
     case "metal":
       const validMetals = ["Silver", "Gold", "Platinum", "Palladium"];
@@ -284,24 +273,23 @@ const startCellEdit = (idx, field, element) => {
     input.className = "inline-select";
 
     if (field === "type") {
-      const types = [
-        "Coin",
-        "Bar",
-        "Round",
-        "Note",
-        "Aurum",
-        "Goldback",
-        "Silverback",
-        "Set",
-        "Other",
-      ];
-      types.forEach((type) => {
+      VALID_TYPES.forEach((type) => {
         const option = document.createElement("option");
         option.value = type;
         option.textContent = type;
         if (type === current) option.selected = true;
         input.appendChild(option);
       });
+      // Filter type options based on the item's metal (T21)
+      if (typeof TYPE_METAL_FILTER !== "undefined") {
+        Array.from(input.options).forEach((option) => {
+          const allowedMetals = TYPE_METAL_FILTER[option.value];
+          if (Array.isArray(allowedMetals) && !allowedMetals.includes(item.metal)) {
+            option.hidden = true;
+            option.disabled = true;
+          }
+        });
+      }
     } else if (field === "metal") {
       const metals = ["Silver", "Gold", "Platinum", "Palladium", "Alloy/Other"];
       metals.forEach((metal) => {
@@ -746,7 +734,6 @@ const editItem = (idx, logIdx = null) => {
   elements.itemQty.value = item.qty;
   elements.itemType.value = item.type;
 
-  const isGoldbackType = item.type === "Goldback" || item.type === "Silverback";
   const selectedMetal = item.metal || elements.itemMetal.value;
   if (typeof filterTypesByMetal === "function") {
     filterTypesByMetal(selectedMetal);
@@ -779,13 +766,6 @@ const editItem = (idx, logIdx = null) => {
     elements.itemWeight.value = parseFloat(item.weight).toFixed(2);
     elements.itemWeightUnit.value = "oz";
     if (typeof toggleGbDenomPicker === "function") toggleGbDenomPicker();
-  }
-
-  if (isGoldbackType) {
-    const denomSelect = safeGetElement("itemGbDenom");
-    if (denomSelect && item.weight !== null && typeof item.weight !== "undefined") {
-      denomSelect.value = String(item.weight);
-    }
   }
 
   // Convert stored USD values to display currency for the form (STACK-50)

--- a/js/utils.js
+++ b/js/utils.js
@@ -992,7 +992,17 @@ const sanitizeObjectFields = (obj) => {
  * Allowed inventory item types
  * @constant {string[]}
  */
-const VALID_TYPES = ["Coin", "Bar", "Round", "Note", "Aurum", "Set", "Other"];
+const VALID_TYPES = [
+  "Coin",
+  "Bar",
+  "Round",
+  "Note",
+  "Aurum",
+  "Goldback",
+  "Silverback",
+  "Set",
+  "Other",
+];
 
 /**
  * Normalizes item type to one of the predefined options
@@ -1014,6 +1024,8 @@ const normalizeType = (type = "") => {
  */
 const mapNumistaType = (type = "") => {
   const t = type.toLowerCase();
+  if (t.includes("goldback")) return "Goldback";
+  if (t.includes("silverback")) return "Silverback";
   if (t.includes("aurum")) return "Aurum";
   if (t.includes("note")) return "Note";
   if (t.includes("bar") || t.includes("ingot")) return "Bar";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.14",
+  "version": "3.34.15",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.14-b1776630184";
+const CACHE_NAME = "staktrakr-v3.34.15-b1776647119";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.15-b1776647119";
+const CACHE_NAME = "staktrakr-v3.34.15-b1776648952";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/config-validation.spec.js
+++ b/tests/playwright/config-validation.spec.js
@@ -541,8 +541,8 @@ test.describe("CHANGELOG.md — new entries", () => {
     expect(content).toContain("## [3.34.03]");
   });
 
-  test("CL-24 — boundary: [3.34.15] does NOT exist (no phantom future entries)", () => {
-    expect(content).not.toContain("## [3.34.15]");
+  test("CL-24 — boundary: [3.34.16] does NOT exist (no phantom future entries)", () => {
+    expect(content).not.toContain("## [3.34.16]");
   });
 
   // ── 3.34.10 entry (STAK-553: Last Modified sort) ──────────────────────────

--- a/tests/playwright/goldback-type.spec.js
+++ b/tests/playwright/goldback-type.spec.js
@@ -1,0 +1,246 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_ITEMS = [
+  {
+    uuid: "stak562-goldback-item",
+    metal: "Gold",
+    composition: "Gold",
+    name: "STAK562 Goldback Existing",
+    qty: 1,
+    type: "Goldback",
+    weight: 5,
+    weightUnit: "gb",
+    price: 25,
+    marketValue: 0,
+    date: "2026-01-01",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "Safe",
+    serialNumber: "",
+    notes: "",
+    year: "2026",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 0,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 1,
+    numistaId: "",
+    serial: 1,
+  },
+  {
+    uuid: "stak562-silver-item",
+    metal: "Silver",
+    composition: "Silver",
+    name: "STAK562 Silver Coin",
+    qty: 1,
+    type: "Coin",
+    weight: 1,
+    weightUnit: "oz",
+    price: 30,
+    marketValue: 0,
+    date: "2026-01-01",
+    purchaseLocation: "staktrakr.com",
+    storageLocation: "Safe",
+    serialNumber: "",
+    notes: "",
+    year: "2026",
+    grade: "",
+    gradingAuthority: "",
+    certNumber: "",
+    pcgsNumber: "",
+    pcgsVerified: false,
+    spotPriceAtPurchase: 0,
+    premiumPerOz: 0,
+    totalPremium: 0,
+    purity: 0.999,
+    numistaId: "",
+    serial: 2,
+  },
+];
+
+async function seedData(page, inventory = BASE_ITEMS) {
+  await page.addInitScript(
+    ({ inv }) => {
+      localStorage.setItem("metalInventory", JSON.stringify(inv));
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          if (typeof APP_VERSION !== "undefined") {
+            localStorage.setItem("ackVersion", APP_VERSION);
+          }
+        },
+        { once: true }
+      );
+    },
+    { inv: inventory }
+  );
+}
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#newItemBtn", { state: "visible" });
+  await page.waitForFunction(
+    () =>
+      typeof window.editItem === "function" &&
+      typeof window.openBulkEdit === "function" &&
+      Array.isArray(window.inventory)
+  );
+  await page.waitForTimeout(500);
+}
+
+async function openAddModal(page) {
+  const whatsNew = page.locator("#whatsNewPopup");
+  if (await whatsNew.isVisible()) {
+    await page.click("#whatsNewDismissBtn");
+  }
+  await page.evaluate(() => document.getElementById("newItemBtn").click());
+  await expect(page.locator("#itemModal")).toBeVisible({ timeout: 10000 });
+}
+
+async function openBulkEditModal(page) {
+  const whatsNew = page.locator("#whatsNewPopup");
+  if (await whatsNew.isVisible()) {
+    await page.click("#whatsNewDismissBtn");
+  }
+  await page.evaluate(() => {
+    if (typeof window.openBulkEdit === "function") {
+      window.openBulkEdit();
+      return;
+    }
+    const btn = document.getElementById("bulkEditBtn");
+    if (btn) btn.click();
+  });
+  await expect(page.locator("#bulkEditModal")).toBeVisible({ timeout: 10000 });
+  await expect(page.locator("#bulkFieldVal_type")).toHaveCount(1);
+}
+
+async function readOptionState(page, selectId, value) {
+  return page.evaluate(
+    ({ sid, optionValue }) => {
+      const select = document.getElementById(sid);
+      if (!select) return { exists: false, hidden: true, disabled: true };
+      const option = Array.from(select.options).find((opt) => opt.value === optionValue);
+      if (!option) return { exists: false, hidden: true, disabled: true };
+      return {
+        exists: true,
+        hidden: Boolean(option.hidden),
+        disabled: Boolean(option.disabled),
+      };
+    },
+    { sid: selectId, optionValue: value }
+  );
+}
+
+test.describe("goldback-type — STAK-562 first-class type behavior", () => {
+  test("1. Type dropdown includes Goldback and Silverback", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await expect(page.locator('#itemType option[value="Goldback"]')).toHaveCount(1);
+    await expect(page.locator('#itemType option[value="Silverback"]')).toHaveCount(1);
+  });
+
+  test("2. Metal selection filters Goldback/Silverback options", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Gold");
+    const goldGoldback = await readOptionState(page, "itemType", "Goldback");
+    const goldSilverback = await readOptionState(page, "itemType", "Silverback");
+    expect(goldGoldback.exists).toBe(true);
+    expect(goldGoldback.hidden).toBe(false);
+    expect(goldSilverback.exists).toBe(true);
+    expect(goldSilverback.hidden).toBe(true);
+
+    await page.selectOption("#itemMetal", "Silver");
+    const silverGoldback = await readOptionState(page, "itemType", "Goldback");
+    const silverSilverback = await readOptionState(page, "itemType", "Silverback");
+    expect(silverGoldback.hidden).toBe(true);
+    expect(silverSilverback.hidden).toBe(false);
+
+    await page.selectOption("#itemMetal", "Platinum");
+    const platinumGoldback = await readOptionState(page, "itemType", "Goldback");
+    const platinumSilverback = await readOptionState(page, "itemType", "Silverback");
+    expect(platinumGoldback.hidden).toBe(true);
+    expect(platinumSilverback.hidden).toBe(true);
+  });
+
+  test("3. Goldback type swaps to denomination picker", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+
+    await expect(page.locator("#itemGbDenom")).toBeVisible();
+    await expect(page.locator("#itemWeight")).toBeHidden();
+    await expect(page.locator("#itemWeightLabel")).toHaveText("DENOMINATION");
+    await expect(page.locator("#itemWeightUnit")).toHaveValue("gb");
+  });
+
+  test("4. Switching away from Goldback reverts to weight/unit", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+    await page.selectOption("#itemType", "Coin");
+
+    await expect(page.locator("#itemGbDenom")).toBeHidden();
+    await expect(page.locator("#itemWeight")).toBeVisible();
+    await expect(page.locator("#itemWeightLabel")).toHaveText("Weight");
+    await expect(page.locator("#itemWeightUnit")).toHaveValue("oz");
+  });
+
+  test("5. Purity list includes .500 option", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await expect(page.locator('#itemPuritySelect option[value="0.500"]')).toHaveCount(1);
+  });
+
+  test("6. Edit modal restores Goldback type and denomination", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+
+    await page.evaluate(() => window.editItem(0));
+    await expect(page.locator("#itemModal")).toBeVisible();
+
+    await expect(page.locator("#itemType")).toHaveValue("Goldback");
+    await expect(page.locator("#itemGbDenom")).toBeVisible();
+    await expect(page.locator("#itemGbDenom")).toHaveValue("5");
+    await expect(page.locator("#itemWeightUnit")).toHaveValue("gb");
+  });
+
+  test("7. Bulk edit has same type filtering and denomination cascade", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openBulkEditModal(page);
+
+    await expect(page.locator('#bulkFieldVal_type option[value="Goldback"]')).toHaveCount(1);
+    await expect(page.locator('#bulkFieldVal_type option[value="Silverback"]')).toHaveCount(1);
+
+    await page.click("#bulkField_metal");
+    await page.selectOption("#bulkFieldVal_metal", "Gold");
+    const bulkGoldState = await readOptionState(page, "bulkFieldVal_type", "Goldback");
+    const bulkSilverState = await readOptionState(page, "bulkFieldVal_type", "Silverback");
+    expect(bulkGoldState.hidden).toBe(false);
+    expect(bulkSilverState.hidden).toBe(true);
+
+    await page.click("#bulkField_type");
+    await page.click("#bulkField_weight");
+    await page.click("#bulkField_weightUnit");
+    await page.selectOption("#bulkFieldVal_type", "Goldback");
+
+    await expect(page.locator("#bulkFieldVal_weightDenom")).toBeVisible();
+    await expect(page.locator("#bulkFieldVal_weight")).toBeHidden();
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.14",
+  "version": "3.34.15",
   "releaseDate": "2026-04-19",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- Promote `Goldback` and `Silverback` to first-class inventory types across add/edit/bulk-edit flows, quick filters, grouped chips, and table/card rendering.
- Add STAK-562 Playwright coverage for add/edit/filter/bulk-edit paths and update release-era config-validation boundary checks for the new version.
- Bump release artifacts to `3.34.15` and include a small CodeRabbit config update (`test-results` path filter) to reduce review noise.

## Verification
- `npm run lint` (passes; 2 existing warnings in unrelated files)
- `CI=1 npx playwright test tests/playwright/goldback-type.spec.js` (7 passed)
- `CI=1 npx playwright test tests/playwright/config-validation.spec.js` (109 passed)
- `CI=1 npm test` (248 passed / 11 failed / 15 skipped / 1 flaky; matches existing baseline failure profile)

## Notes
- `sw.js` cache stamp was auto-updated by pre-commit hook.
- This PR is left in draft so Copilot/automation review can run before final readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Goldback and Silverback as dedicated inventory types across Add, Edit, and Bulk Edit flows.
  * Type options now filter based on selected metal (Gold shows Goldback; Silver shows Silverback).
  * Goldback/Silverback items use denomination-based weight input instead of standard weight/unit fields.
  * Added new purity option: 0.500 (12K).
  * Added visual styling for new types across all themes.

* **Tests**
  * Added Playwright regression tests for Goldback/Silverback behaviors.

* **Chores**
  * Updated application version to 3.34.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->