### PR TITLE
chore(STAK-563): Appearance tab UI cleanup — flat layout, section reorder, sort toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -3740,8 +3740,9 @@
             <div class="settings-section-panel" id="settingsPanel_site" style="display: none">
               <h3>Appearance</h3>
 
-              <!-- ── Card 1: Visual style pickers ── -->
+              <!-- ── Display ── -->
               <div class="settings-fieldset">
+                <div class="settings-fieldset-title">Display</div>
                 <div
                   style="
                     display: grid;
@@ -3911,12 +3912,28 @@
                         <option value="11">Source</option>
                         <option value="99">Last Modified</option>
                       </select>
-                      <div id="settingsDefaultSortDir" class="chip-sort-toggle">
-                        <button type="button" class="chip-sort-btn active" data-val="asc">
-                          Asc
-                        </button>
-                        <button type="button" class="chip-sort-btn" data-val="desc">Desc</button>
-                      </div>
+                      <button
+                        type="button"
+                        class="card-sort-dir-btn"
+                        id="settingsDefaultSortDir"
+                        data-dir="asc"
+                        title="Toggle sort direction"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <polyline class="sort-arrow-up" points="18 15 12 9 6 15" />
+                          <polyline class="sort-arrow-down" points="6 9 12 15 18 9" />
+                        </svg>
+                      </button>
                     </div>
                   </div>
                   <div style="display: flex; flex-direction: column; gap: 0.35rem">
@@ -3965,31 +3982,6 @@
                 <div id="headerBtnConfigTable"></div>
               </div>
 
-              <!-- ── Metals & Inline Chips ── -->
-              <div class="settings-fieldset">
-                <div class="settings-fieldset-title">Metals &amp; Inline Chips</div>
-                <div class="settings-card-grid">
-                  <div class="settings-card">
-                    <div class="settings-group-label">Metal Order</div>
-                    <p class="settings-subtext">
-                      Reorder and show/hide spot price and summary cards. Drag rows to reorder.
-                    </p>
-                    <div class="chip-grouping-table-container" id="metalOrderConfigContainer">
-                      <div class="chip-grouping-empty">Loading...</div>
-                    </div>
-                  </div>
-                  <div class="settings-card">
-                    <div class="settings-group-label">Inline Name Chips</div>
-                    <p class="settings-subtext">
-                      Choose which badges appear next to item names in the table.
-                    </p>
-                    <div class="chip-grouping-table-container" id="inlineChipConfigContainer">
-                      <div class="chip-grouping-empty">Loading...</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
               <!-- ── Layout ── -->
               <div class="settings-fieldset">
                 <div
@@ -4031,6 +4023,24 @@
                   <div class="settings-group-label">Visible sections</div>
                   <p class="settings-subtext">Toggle visibility and reorder major page sections.</p>
                   <div class="chip-grouping-table-container" id="layoutSectionConfigContainer">
+                    <div class="chip-grouping-empty">Loading...</div>
+                  </div>
+                </div>
+                <div class="settings-group">
+                  <div class="settings-group-label">Metal Order</div>
+                  <p class="settings-subtext">
+                    Reorder and show/hide spot price and summary cards. Drag rows to reorder.
+                  </p>
+                  <div class="chip-grouping-table-container" id="metalOrderConfigContainer">
+                    <div class="chip-grouping-empty">Loading...</div>
+                  </div>
+                </div>
+                <div class="settings-group">
+                  <div class="settings-group-label">Inline Name Chips</div>
+                  <p class="settings-subtext">
+                    Choose which badges appear next to item names in the table.
+                  </p>
+                  <div class="chip-grouping-table-container" id="inlineChipConfigContainer">
                     <div class="chip-grouping-empty">Loading...</div>
                   </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -3918,6 +3918,7 @@
                         id="settingsDefaultSortDir"
                         data-dir="asc"
                         title="Toggle sort direction"
+                        aria-label="Sort ascending — click to reverse"
                       >
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
@@ -3929,6 +3930,7 @@
                           stroke-width="2"
                           stroke-linecap="round"
                           stroke-linejoin="round"
+                          aria-hidden="true"
                         >
                           <polyline class="sort-arrow-up" points="18 15 12 9 6 15" />
                           <polyline class="sort-arrow-down" points="6 9 12 15 18 9" />

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -684,10 +684,7 @@ const bindCardAndTableImageListeners = () => {
       localStorage.setItem(DEFAULT_SORT_COL_KEY, String(val));
       sortColumn = val;
       if (val === SORT_COL_LAST_MODIFIED && sortDirection === "asc") {
-        sortDirection = "desc";
-        localStorage.setItem(DEFAULT_SORT_DIR_KEY, "desc");
-        const dirEl = getExistingElement("settingsDefaultSortDir");
-        if (dirEl) dirEl.dataset.dir = "desc";
+        applyDefaultSortDir("desc");
       }
       if (typeof updateCardSortBar === "function") updateCardSortBar();
       if (typeof renderTable === "function") renderTable();
@@ -695,15 +692,26 @@ const bindCardAndTableImageListeners = () => {
   }
 
   // Default sort direction
+  function applyDefaultSortDir(dir) {
+    const btn = getExistingElement("settingsDefaultSortDir");
+    if (btn) {
+      btn.dataset.dir = dir;
+      btn.setAttribute(
+        "aria-label",
+        dir === "asc" ? "Sort ascending — click to reverse" : "Sort descending — click to reverse"
+      );
+    }
+    localStorage.setItem(DEFAULT_SORT_DIR_KEY, dir);
+    sortDirection = dir;
+  }
+
   const defaultSortDirEl = getExistingElement("settingsDefaultSortDir");
   if (defaultSortDirEl) {
     const savedDir = localStorage.getItem(DEFAULT_SORT_DIR_KEY) || "asc";
-    defaultSortDirEl.dataset.dir = savedDir;
+    applyDefaultSortDir(savedDir);
     defaultSortDirEl.addEventListener("click", () => {
       const newDir = defaultSortDirEl.dataset.dir === "asc" ? "desc" : "asc";
-      defaultSortDirEl.dataset.dir = newDir;
-      localStorage.setItem(DEFAULT_SORT_DIR_KEY, newDir);
-      sortDirection = newDir;
+      applyDefaultSortDir(newDir);
       if (typeof updateCardSortBar === "function") updateCardSortBar();
       if (typeof renderTable === "function") renderTable();
     });

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -687,10 +687,7 @@ const bindCardAndTableImageListeners = () => {
         sortDirection = "desc";
         localStorage.setItem(DEFAULT_SORT_DIR_KEY, "desc");
         const dirEl = getExistingElement("settingsDefaultSortDir");
-        if (dirEl)
-          dirEl.querySelectorAll(".chip-sort-btn").forEach((b) => {
-            b.classList.toggle("active", b.dataset.val === "desc");
-          });
+        if (dirEl) dirEl.dataset.dir = "desc";
       }
       if (typeof updateCardSortBar === "function") updateCardSortBar();
       if (typeof renderTable === "function") renderTable();
@@ -701,18 +698,12 @@ const bindCardAndTableImageListeners = () => {
   const defaultSortDirEl = getExistingElement("settingsDefaultSortDir");
   if (defaultSortDirEl) {
     const savedDir = localStorage.getItem(DEFAULT_SORT_DIR_KEY) || "asc";
-    defaultSortDirEl.querySelectorAll(".chip-sort-btn").forEach((btn) => {
-      btn.classList.toggle("active", btn.dataset.val === savedDir);
-    });
-    defaultSortDirEl.addEventListener("click", (e) => {
-      const btn = e.target.closest("[data-val]");
-      if (!btn) return;
-      const val = btn.dataset.val;
-      localStorage.setItem(DEFAULT_SORT_DIR_KEY, val);
-      sortDirection = val;
-      defaultSortDirEl
-        .querySelectorAll(".chip-sort-btn")
-        .forEach((b) => b.classList.toggle("active", b === btn));
+    defaultSortDirEl.dataset.dir = savedDir;
+    defaultSortDirEl.addEventListener("click", () => {
+      const newDir = defaultSortDirEl.dataset.dir === "asc" ? "desc" : "asc";
+      defaultSortDirEl.dataset.dir = newDir;
+      localStorage.setItem(DEFAULT_SORT_DIR_KEY, newDir);
+      sortDirection = newDir;
       if (typeof updateCardSortBar === "function") updateCardSortBar();
       if (typeof renderTable === "function") renderTable();
     });

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.20-b1776812774";
+const CACHE_NAME = "staktrakr-v3.34.20-b1776813267";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.20-b1776811708";
+const CACHE_NAME = "staktrakr-v3.34.20-b1776812774";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/03-settings/03-appearance.spec.js
+++ b/tests/playwright/03-settings/03-appearance.spec.js
@@ -4,9 +4,9 @@ import { injectSeedInventory } from "../helpers/seed.js";
 /**
  * Playwright tests for Settings > Appearance settings
  *
- * STAK-529: Add Sort Direction Toggle to Settings > Appearance
- * STAK-535: Move Metals & Inline Chips settings to Appearance
- * These tests verify the sort direction toggle and moved Metals & Inline Chips settings.
+ * STAK-563: Appearance tab UI cleanup — flat layout, section reorder, sort toggle replacement
+ * Tests verify the icon-button sort direction toggle and Metal Order / Inline Name Chips
+ * relocated as flat groups under Layout.
  *
  * TDD Phase: GREEN — Implementation exists in index.html and settings-listeners.js.
  */
@@ -24,7 +24,7 @@ async function openAppearanceSettings(page) {
   await expect(page.locator("#settingsPanel_site")).toBeVisible();
 }
 
-test.describe("03-settings/03-appearance — Sort Direction Toggle & Metals Settings", () => {
+test.describe("03-settings/03-appearance — Sort Direction Icon Button & Flat Layout", () => {
   test.beforeEach(async ({ page }) => {
     // Seed localStorage to suppress ack modal and What's New popup
     await injectSeedInventory(page);
@@ -39,103 +39,78 @@ test.describe("03-settings/03-appearance — Sort Direction Toggle & Metals Sett
     await expect(toggle).toBeVisible();
   });
 
-  test("3.2 — toggle has two buttons with correct structure", async ({ page }) => {
-    // Verify two buttons exist with correct class and data attributes
-    const buttons = page.locator("#settingsDefaultSortDir .chip-sort-btn");
-    await expect(buttons).toHaveCount(2);
-
-    // Verify data-val attributes
-    const ascBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="asc"]');
-    const descBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="desc"]');
-
-    await expect(ascBtn).toBeVisible();
-    await expect(ascBtn).toHaveText("Asc");
-
-    await expect(descBtn).toBeVisible();
-    await expect(descBtn).toHaveText("Desc");
+  test("3.2 — sort button is an icon button with card-sort-dir-btn class and data-dir", async ({
+    page,
+  }) => {
+    const btn = page.locator("#settingsDefaultSortDir");
+    await expect(btn).toHaveClass(/card-sort-dir-btn/);
+    const dir = await btn.getAttribute("data-dir");
+    expect(["asc", "desc"]).toContain(dir);
   });
 
-  test("3.3 — clicking Asc button sets active class and localStorage", async ({ page }) => {
-    // Click the Asc button
-    const ascBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="asc"]');
-    await ascBtn.click();
+  test("3.3 — clicking button toggles data-dir from asc to desc and saves localStorage", async ({
+    page,
+  }) => {
+    const btn = page.locator("#settingsDefaultSortDir");
+    await expect(btn).toHaveAttribute("data-dir", "asc");
 
-    // Verify active class is set
-    await expect(ascBtn).toHaveClass(/active/);
+    await btn.click();
 
-    // Verify localStorage is set
-    const localStorageValue = await page.evaluate(() => {
-      return localStorage.getItem("defaultSortDir");
-    });
-    expect(localStorageValue).toBe("asc");
+    await expect(btn).toHaveAttribute("data-dir", "desc");
+    const stored = await page.evaluate(() => localStorage.getItem("defaultSortDir"));
+    expect(stored).toBe("desc");
   });
 
-  test("3.4 — clicking Desc button sets active class and localStorage", async ({ page }) => {
-    // Click the Desc button
-    const descBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="desc"]');
-    await descBtn.click();
+  test("3.4 — clicking twice cycles back to asc and saves localStorage", async ({ page }) => {
+    const btn = page.locator("#settingsDefaultSortDir");
 
-    // Verify active class is set
-    await expect(descBtn).toHaveClass(/active/);
+    await btn.click();
+    await expect(btn).toHaveAttribute("data-dir", "desc");
 
-    // Verify localStorage is set
-    const localStorageValue = await page.evaluate(() => {
-      return localStorage.getItem("defaultSortDir");
-    });
-    expect(localStorageValue).toBe("desc");
+    await btn.click();
+    await expect(btn).toHaveAttribute("data-dir", "asc");
+
+    const stored = await page.evaluate(() => localStorage.getItem("defaultSortDir"));
+    expect(stored).toBe("asc");
   });
 
-  test("3.5 — active class toggles between buttons", async ({ page }) => {
-    const ascBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="asc"]');
-    const descBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="desc"]');
+  test("3.5 — each click alternates direction", async ({ page }) => {
+    const btn = page.locator("#settingsDefaultSortDir");
 
-    // Click Asc — verify it's active, Desc is not
-    await ascBtn.click();
-    await expect(ascBtn).toHaveClass(/active/);
-    await expect(descBtn).not.toHaveClass(/active/);
+    await btn.click();
+    await expect(btn).toHaveAttribute("data-dir", "desc");
 
-    // Click Desc — verify it's active, Asc is not
-    await descBtn.click();
-    await expect(descBtn).toHaveClass(/active/);
-    await expect(ascBtn).not.toHaveClass(/active/);
+    await btn.click();
+    await expect(btn).toHaveAttribute("data-dir", "asc");
 
-    // Verify localStorage reflects the final selection
-    const localStorageValue = await page.evaluate(() => {
-      return localStorage.getItem("defaultSortDir");
-    });
-    expect(localStorageValue).toBe("desc");
+    await btn.click();
+    const stored = await page.evaluate(() => localStorage.getItem("defaultSortDir"));
+    expect(stored).toBe("desc");
   });
 
-  test("3.6 — selection persists across page refresh", async ({ page }) => {
-    const descBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="desc"]');
-    await descBtn.click();
-    await expect(descBtn).toHaveClass(/active/);
+  test("3.6 — direction persists across page refresh", async ({ page }) => {
+    const btn = page.locator("#settingsDefaultSortDir");
+    await btn.click();
+    await expect(btn).toHaveAttribute("data-dir", "desc");
 
     await page.reload();
     await openAppearanceSettings(page);
 
-    const descBtnAfter = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="desc"]');
-    await expect(descBtnAfter).toHaveClass(/active/);
-
-    const localStorageValue = await page.evaluate(() => {
-      return localStorage.getItem("defaultSortDir");
-    });
-    expect(localStorageValue).toBe("desc");
+    await expect(page.locator("#settingsDefaultSortDir")).toHaveAttribute("data-dir", "desc");
+    const stored = await page.evaluate(() => localStorage.getItem("defaultSortDir"));
+    expect(stored).toBe("desc");
   });
 
-  test("3.7 — default selection is Asc on first load", async ({ page }) => {
-    await page.evaluate(() => {
-      localStorage.removeItem("defaultSortDir");
-    });
+  test("3.7 — default data-dir is asc on first load with no localStorage", async ({ page }) => {
+    await page.evaluate(() => localStorage.removeItem("defaultSortDir"));
 
     await page.reload();
     await openAppearanceSettings(page);
 
-    const ascBtn = page.locator('#settingsDefaultSortDir .chip-sort-btn[data-val="asc"]');
-    await expect(ascBtn).toHaveClass(/active/);
+    await expect(page.locator("#settingsDefaultSortDir")).toHaveAttribute("data-dir", "asc");
   });
 
-  // STAK-535: Regression tests for Metals & Inline Chips in combined fieldset
+  // STAK-563: Metal Order + Inline Name Chips now flat groups under Layout fieldset
 
   test("3.8 — metals config container exists in Appearance", async ({ page }) => {
     const metalConfig = page.locator("#metalOrderConfigContainer");
@@ -147,11 +122,17 @@ test.describe("03-settings/03-appearance — Sort Direction Toggle & Metals Sett
     await expect(inlineChipConfig).toBeVisible();
   });
 
-  test("3.10 — metals & inline chips share a combined fieldset", async ({ page }) => {
-    const fieldset = page.locator('.settings-fieldset:has-text("Metals & Inline Chips")');
-    await expect(fieldset).toBeVisible();
-    await expect(fieldset.locator("#metalOrderConfigContainer")).toBeVisible();
-    await expect(fieldset.locator("#inlineChipConfigContainer")).toBeVisible();
+  test("3.10 — metal order and inline chips are flat groups inside the Layout fieldset", async ({
+    page,
+  }) => {
+    const layoutFieldset = page.locator('.settings-fieldset:has-text("Layout")');
+    await expect(layoutFieldset).toBeVisible();
+    await expect(layoutFieldset.locator("#metalOrderConfigContainer")).toBeVisible();
+    await expect(layoutFieldset.locator("#inlineChipConfigContainer")).toBeVisible();
+    // Standalone "Metals & Inline Chips" section no longer exists
+    await expect(
+      page.locator('.settings-fieldset-title:text("Metals & Inline Chips")')
+    ).toHaveCount(0);
   });
 
   test("3.11 — metal order config has rows", async ({ page }) => {


### PR DESCRIPTION
## STAK-563 — Appearance Tab UI Cleanup

### Changes
- Add **"Display"** section header to first fieldset (Color scheme + Inventory View)
- Replace `[Asc][Desc]` chip-sort-toggle with icon-button (`card-sort-dir-btn` + `data-dir`) matching the main sort bar; arrow direction driven by existing CSS
- Remove standalone **"Metals & Inline Chips"** nested-card fieldset
- Relocate **Metal Order** + **Inline Name Chips** as flat `settings-group` rows inside the **Layout** fieldset below Visible Sections
- Update `settings-listeners.js` sort-dir handler to use `data-dir` toggle
- Rewrite `03-appearance.spec.js` tests 3.2–3.7 for icon-button pattern; rewrite test 3.10 to verify flat placement in Layout fieldset

### Test results
11/11 Playwright tests pass.

### Notes
- Cosmetic / layout only — no new settings, no behavior changes, no new localStorage keys
- No version bump — rolls into next release