### PR TITLE
v3.34.23 — STAK-446: Activity Log tab redesign and undo audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.23] - 2026-04-22
+
+### Changed — STAK-446: Activity Log tab redesign and undo audit
+
+- **Changed**: Activity Log sub-tabs renamed — "Metals" → "Spot Price", "Price History" → "Item History" (STAK-446)
+- **Changed**: Activity Log sub-tabs reordered — Changelog, Catalogs, Cloud, Spot Price, Market, Item History, LBMA History (STAK-446)
+- **Added**: Undo/redo support for "Added" changelog entries — undo removes the item, redo restores it from snapshot (STAK-446)
+- **Fixed**: JSON.parse on redo path now guarded with try/catch for corrupted localStorage resilience (STAK-446)
+- **Added**: 7 Playwright TDD tests covering tab rename, tab order, undo-add, and redo-add (STAK-446)
+
+---
+
 ## [3.34.22] - 2026-04-22
 
 ### Changed — STAK-570: Currency tab Goldback pricing redesign

--- a/css/styles.css
+++ b/css/styles.css
@@ -11058,6 +11058,26 @@ th {
   margin-bottom: var(--spacing);
 }
 
+.settings-changelog-actions .btn,
+.settings-pricehistory-controls .btn,
+.settings-log-panel .btn.secondary {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-primary);
+  padding: 0.4rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  min-height: auto;
+}
+
+.settings-changelog-actions .btn:hover,
+.settings-pricehistory-controls .btn:hover,
+.settings-log-panel .btn.secondary:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+}
+
 .settings-changelog-wrap {
   overflow-y: auto;
   max-height: 55vh;
@@ -11178,7 +11198,9 @@ th {
 /* Shared table styles for all log sub-tab tables */
 #settingsSpotHistoryTable,
 #settingsCatalogHistoryTable,
-#settingsPriceHistoryTable {
+#settingsPriceHistoryTable,
+#settingsLbmaHistoryTable,
+#settingsCloudActivityTable {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.75rem;
@@ -11186,7 +11208,9 @@ th {
 
 #settingsSpotHistoryTable thead,
 #settingsCatalogHistoryTable thead,
-#settingsPriceHistoryTable thead {
+#settingsPriceHistoryTable thead,
+#settingsLbmaHistoryTable thead,
+#settingsCloudActivityTable thead {
   position: sticky;
   top: 0;
   z-index: 1;
@@ -11195,7 +11219,9 @@ th {
 
 #settingsSpotHistoryTable th,
 #settingsCatalogHistoryTable th,
-#settingsPriceHistoryTable th {
+#settingsPriceHistoryTable th,
+#settingsLbmaHistoryTable th,
+#settingsCloudActivityTable th {
   padding: 0.35rem 0.5rem;
   text-align: left;
   font-weight: 600;
@@ -11209,7 +11235,9 @@ th {
 
 #settingsSpotHistoryTable td,
 #settingsCatalogHistoryTable td,
-#settingsPriceHistoryTable td {
+#settingsPriceHistoryTable td,
+#settingsLbmaHistoryTable td,
+#settingsCloudActivityTable td {
   padding: 0.3rem 0.5rem;
   border-bottom: 1px solid var(--border);
   white-space: nowrap;

--- a/index.html
+++ b/index.html
@@ -6684,18 +6684,20 @@
                 <button class="settings-log-tab active" data-log-tab="changelog" type="button">
                   Changelog
                 </button>
-                <button class="settings-log-tab" data-log-tab="metals" type="button">Metals</button>
-                <button class="settings-log-tab" data-log-tab="lbma" type="button">
-                  LBMA History
-                </button>
                 <button class="settings-log-tab" data-log-tab="catalogs" type="button">
                   Catalogs
                 </button>
-                <button class="settings-log-tab" data-log-tab="pricehistory" type="button">
-                  Price History
-                </button>
                 <button class="settings-log-tab" data-log-tab="cloud" type="button">Cloud</button>
+                <button class="settings-log-tab" data-log-tab="metals" type="button">
+                  Spot Price
+                </button>
                 <button class="settings-log-tab" data-log-tab="market" type="button">Market</button>
+                <button class="settings-log-tab" data-log-tab="pricehistory" type="button">
+                  Item History
+                </button>
+                <button class="settings-log-tab" data-log-tab="lbma" type="button">
+                  LBMA History
+                </button>
               </div>
 
               <!-- Changelog panel (existing) -->

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.23 &ndash; STAK-446: Activity Log tab redesign</strong>: Activity Log sub-tabs renamed (Metals &rarr; Spot Price, Price History &rarr; Item History) and reordered by usage priority. Undo/redo now works for added items in the changelog.</li>
     <li><strong>v3.34.22 &ndash; STAK-570: Currency tab Goldback pricing redesign</strong>: Goldback pricing moved into Settings &gt; Currency with a single Off / API / Spot / Manual source selector, contextual inputs, a read-only denomination table, and the old Goldback settings tab removed.</li>
     <li><strong>v3.34.21 &ndash; STAK-439: Images tab redesign</strong>: Settings &gt; Images tab fully redesigned &mdash; Storage fieldset removed, Add Rule form collapses behind a &ldquo;+ New Rule&rdquo; pill button, styled upload buttons with image preview replace native file inputs, Edit form restyled to match Add form, flat Image Display grid, and solid pill buttons for proper dark mode contrast.</li>
     <li><strong>v3.34.20 &ndash; STAK-569: Fix Numista search metal prepend</strong>: Numista search no longer auto-prepends the metal dropdown value to the name query. Searches use exactly what you typed. Custom pattern rules still fire normally.</li>

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -264,6 +264,38 @@ const toggleChange = (logIdx) => {
       }
       entry.undone = true;
     }
+    // Added undo/redo (STAK-446)
+  } else if (entry.field === "Added") {
+    if (entry.undone) {
+      // Redo: re-add the item
+      let restored;
+      try {
+        restored = JSON.parse(entry.newValue || "{}");
+      } catch {
+        return;
+      }
+      inventory.splice(entry.idx, 0, restored);
+      if (restored.serial) {
+        catalogMap[restored.serial] = restored.numistaId || "";
+      }
+      entry.undone = false;
+    } else {
+      // Undo: remove the item — snapshot it into newValue for redo
+      const removed = inventory.splice(entry.idx, 1)[0];
+      if (removed) entry.newValue = JSON.stringify(removed);
+      if (removed && removed.serial) {
+        delete catalogMap[removed.serial];
+      }
+      entry.undone = true;
+    }
+    saveInventory();
+    renderTable();
+    if (typeof renderActiveFilters === "function") renderActiveFilters();
+    if (typeof updateSummary === "function") updateSummary();
+    if (typeof window.invalidateSearchCache === "function") window.invalidateSearchCache(null);
+    renderChangeLog();
+    saveDataSync("changeLog", changeLog);
+    return;
     // Disposition undo/redo (STAK-388)
   } else if (entry.field === "Disposed") {
     const item = inventory[entry.idx];

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -251,27 +251,53 @@ const toggleChange = (logIdx) => {
 
   if (entry.field === "Deleted") {
     if (entry.undone) {
-      const removed = inventory.splice(entry.idx, 1)[0];
-      if (removed && removed.serial) {
+      const realIdx = entry.itemKey
+        ? inventory.findIndex((i) => computeItemKey(i) === entry.itemKey)
+        : entry.idx;
+      if (realIdx === -1 || realIdx >= inventory.length) return;
+      const removed = inventory.splice(realIdx, 1)[0];
+      if (removed.serial) {
         delete catalogMap[removed.serial];
       }
       entry.undone = false;
     } else {
-      const restored = JSON.parse(entry.oldValue || "{}");
+      if (!entry.oldValue) {
+        if (typeof showToast === "function") showToast("Redo failed — snapshot missing.");
+        return;
+      }
+      let restored;
+      try {
+        restored = JSON.parse(entry.oldValue);
+      } catch {
+        if (typeof showToast === "function") showToast("Redo failed — corrupt snapshot.");
+        return;
+      }
       inventory.splice(entry.idx, 0, restored);
       if (restored.serial) {
         catalogMap[restored.serial] = restored.numistaId || "";
       }
       entry.undone = true;
     }
-    // Added undo/redo (STAK-446)
+    saveInventory();
+    renderTable();
+    if (typeof renderActiveFilters === "function") renderActiveFilters();
+    if (typeof updateSummary === "function") updateSummary();
+    if (typeof window.invalidateSearchCache === "function") window.invalidateSearchCache(null);
+    renderChangeLog();
+    saveDataSync("changeLog", changeLog);
+    return;
   } else if (entry.field === "Added") {
     if (entry.undone) {
       // Redo: re-add the item
+      if (!entry.newValue) {
+        if (typeof showToast === "function") showToast("Redo failed — snapshot missing.");
+        return;
+      }
       let restored;
       try {
-        restored = JSON.parse(entry.newValue || "{}");
+        restored = JSON.parse(entry.newValue);
       } catch {
+        if (typeof showToast === "function") showToast("Redo failed — corrupt snapshot.");
         return;
       }
       inventory.splice(entry.idx, 0, restored);
@@ -281,9 +307,13 @@ const toggleChange = (logIdx) => {
       entry.undone = false;
     } else {
       // Undo: remove the item — snapshot it into newValue for redo
-      const removed = inventory.splice(entry.idx, 1)[0];
-      if (removed) entry.newValue = JSON.stringify(removed);
-      if (removed && removed.serial) {
+      const realIdx = entry.itemKey
+        ? inventory.findIndex((i) => computeItemKey(i) === entry.itemKey)
+        : entry.idx;
+      if (realIdx === -1 || realIdx >= inventory.length) return;
+      const removed = inventory.splice(realIdx, 1)[0];
+      entry.newValue = JSON.stringify(removed);
+      if (removed.serial) {
         delete catalogMap[removed.serial];
       }
       entry.undone = true;

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-02-12 - STACK-38/STACK-31: Responsive card view + mobile layout
  */
 
-const APP_VERSION = "3.34.22";
+const APP_VERSION = "3.34.23";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/settings.js
+++ b/js/settings.js
@@ -225,12 +225,12 @@ const switchLogTab = (key) => {
 /** Dispatch map: log sub-tab key → window function name */
 const LOG_TAB_RENDERERS = {
   changelog: "renderChangeLog",
-  metals: "renderSpotHistoryTable",
-  lbma: "renderLbmaHistoryTable",
   catalogs: "renderCatalogHistoryForSettings",
-  pricehistory: "renderItemPriceHistoryTable",
   cloud: "renderCloudActivityTable",
+  metals: "renderSpotHistoryTable",
   market: "renderRetailHistoryTable",
+  pricehistory: "renderItemPriceHistoryTable",
+  lbma: "renderLbmaHistoryTable",
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.21",
+  "version": "3.34.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.21",
+      "version": "3.34.23",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.22",
+  "version": "3.34.23",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.23-b1776896258";
+const CACHE_NAME = "staktrakr-v3.34.23-b1776897665";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.23-b1776895415";
+const CACHE_NAME = "staktrakr-v3.34.23-b1776896258";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.22-b1776885201";
+const CACHE_NAME = "staktrakr-v3.34.23-b1776895415";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/changelog-redesign.spec.js
+++ b/tests/playwright/changelog-redesign.spec.js
@@ -1,0 +1,220 @@
+import { test, expect } from "@playwright/test";
+import { injectSeedInventory } from "./helpers/seed.js";
+
+/**
+ * STAK-446: Log / Changelog Redesign — TDD failing tests
+ *
+ * These tests assert the NEW requirements (tab rename, tab order,
+ * undo/redo for "Added" items, CRUD audit). All should fail against
+ * the current implementation and pass once the spec is implemented.
+ */
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#newItemBtn", { state: "visible" });
+  await page.waitForFunction(
+    () => typeof window.editItem === "function" && Array.isArray(window.inventory)
+  );
+  await page.waitForTimeout(500);
+}
+
+async function dismissWhatsNew(page) {
+  const whatsNew = page.locator("#whatsNewPopup");
+  if (await whatsNew.isVisible()) {
+    await page.click("#whatsNewDismissBtn");
+  }
+}
+
+async function openSettings(page) {
+  await dismissWhatsNew(page);
+  await page.click("#settingsBtn");
+  await expect(page.locator("#settingsModal")).toBeVisible({ timeout: 10000 });
+}
+
+async function navigateToActivityLog(page) {
+  await openSettings(page);
+  await page.click('[data-section="changelog"]');
+  // Wait for the log tab bar to be visible
+  await expect(page.locator(".settings-log-tabs")).toBeVisible();
+}
+
+async function openAddModal(page) {
+  await dismissWhatsNew(page);
+  await page.evaluate(() => document.getElementById("newItemBtn").click());
+  await expect(page.locator("#itemModal")).toBeVisible({ timeout: 10000 });
+}
+
+async function addSilverCoin(page, name = "CL-TEST-COIN") {
+  await openAddModal(page);
+  await page.selectOption("#itemMetal", "Silver");
+  await page.selectOption("#itemType", "Coin");
+  await page.fill("#itemName", name);
+  await page.fill("#itemWeight", "1");
+  await page.fill("#itemPrice", "30");
+  await page.click("#itemModalSubmit");
+  await expect(page.locator("#itemModal")).toBeHidden();
+}
+
+test.describe("STAK-446: Log/Changelog Redesign", () => {
+  // ── REQ-1: Tab Rename ───────────────────────────────────────────────────
+
+  test.describe("REQ-1: Tab Rename", () => {
+    test("REQ-1a — 'Metals' tab is renamed to 'Spot Price'", async ({ page }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+      await navigateToActivityLog(page);
+
+      const metalsTab = page.locator('[data-log-tab="metals"]');
+      await expect(metalsTab).toBeVisible();
+      const text = await metalsTab.textContent();
+      expect(text.trim()).toBe("Spot Price");
+    });
+
+    test("REQ-1b — 'Price History' tab is renamed to 'Item History'", async ({ page }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+      await navigateToActivityLog(page);
+
+      const priceHistoryTab = page.locator('[data-log-tab="pricehistory"]');
+      await expect(priceHistoryTab).toBeVisible();
+      const text = await priceHistoryTab.textContent();
+      expect(text.trim()).toBe("Item History");
+    });
+  });
+
+  // ── REQ-2: Tab Order ──────────────────────────────────────────────────
+
+  test.describe("REQ-2: Tab Order", () => {
+    test("REQ-2 — sub-tab DOM order matches spec", async ({ page }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+      await navigateToActivityLog(page);
+
+      const tabs = page.locator(".settings-log-tab");
+      const tabValues = await tabs.evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-log-tab"))
+      );
+
+      // Expected order per STAK-446 spec
+      const expectedOrder = [
+        "changelog",
+        "catalogs",
+        "cloud",
+        "metals",
+        "market",
+        "pricehistory",
+        "lbma",
+      ];
+
+      expect(tabValues).toEqual(expectedOrder);
+    });
+  });
+
+  // ── REQ-3: Undo/Redo for Added Items ──────────────────────────────────
+
+  test.describe("REQ-3: Undo/Redo for Added Items", () => {
+    test("REQ-3a — adding an item creates a changelog entry with field 'Added'", async ({
+      page,
+    }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+
+      const beforeCount = await page.evaluate(() => inventory.length);
+      await addSilverCoin(page, "CL-UNDO-TEST");
+
+      const afterCount = await page.evaluate(() => inventory.length);
+      expect(afterCount).toBe(beforeCount + 1);
+
+      const addedEntries = await page.evaluate(() =>
+        changeLog.filter((e) => e.field === "Added" && e.itemName === "CL-UNDO-TEST")
+      );
+      expect(addedEntries.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("REQ-3b — undo on 'Added' entry removes item from inventory", async ({ page }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+      await addSilverCoin(page, "CL-UNDO-ITEM");
+
+      const countAfterAdd = await page.evaluate(() => inventory.length);
+
+      // Find the "Added" entry index in changeLog
+      const addedIdx = await page.evaluate(() =>
+        changeLog.findIndex((e) => e.field === "Added" && e.itemName === "CL-UNDO-ITEM")
+      );
+      expect(addedIdx).toBeGreaterThanOrEqual(0);
+
+      // Click undo via the changelog modal
+      // Open the changelog modal (not settings — the floating button)
+      await dismissWhatsNew(page);
+      await page.evaluate(() => {
+        if (typeof renderChangeLog === "function") renderChangeLog();
+      });
+
+      // Use toggleChange directly to undo the "Added" entry
+      await page.evaluate((idx) => {
+        if (typeof toggleChange === "function") toggleChange(idx);
+      }, addedIdx);
+
+      const countAfterUndo = await page.evaluate(() => inventory.length);
+      // Undo of "Added" should remove the item, decreasing count by 1
+      expect(countAfterUndo).toBe(countAfterAdd - 1);
+    });
+
+    test("REQ-3c — redo after undo restores the item to inventory", async ({ page }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+      await addSilverCoin(page, "CL-REDO-ITEM");
+
+      const countAfterAdd = await page.evaluate(() => inventory.length);
+
+      // Find and undo the "Added" entry
+      const addedIdx = await page.evaluate(() =>
+        changeLog.findIndex((e) => e.field === "Added" && e.itemName === "CL-REDO-ITEM")
+      );
+      expect(addedIdx).toBeGreaterThanOrEqual(0);
+
+      // Undo (remove the item)
+      await page.evaluate((idx) => {
+        if (typeof toggleChange === "function") toggleChange(idx);
+      }, addedIdx);
+
+      const countAfterUndo = await page.evaluate(() => inventory.length);
+      expect(countAfterUndo).toBe(countAfterAdd - 1);
+
+      // Redo (restore the item)
+      await page.evaluate((idx) => {
+        if (typeof toggleChange === "function") toggleChange(idx);
+      }, addedIdx);
+
+      const countAfterRedo = await page.evaluate(() => inventory.length);
+      expect(countAfterRedo).toBe(countAfterAdd);
+    });
+  });
+
+  // ── REQ-4: CRUD Audit ────────────────────────────────────────────────
+
+  test.describe("REQ-4: CRUD Audit", () => {
+    test("REQ-4 — adding an item produces a changelog entry with field 'Added'", async ({
+      page,
+    }) => {
+      await injectSeedInventory(page);
+      await gotoApp(page);
+
+      // Clear changelog first
+      await page.evaluate(() => {
+        if (typeof changeLog !== "undefined") {
+          changeLog.length = 0;
+        }
+      });
+
+      await addSilverCoin(page, "CL-AUDIT-ITEM");
+
+      const entries = await page.evaluate(() => changeLog.filter((e) => e.field === "Added"));
+      expect(entries.length).toBe(1);
+      expect(entries[0].itemName).toBe("CL-AUDIT-ITEM");
+    });
+  });
+});

--- a/tests/playwright/changelog-redesign.spec.js
+++ b/tests/playwright/changelog-redesign.spec.js
@@ -2,11 +2,7 @@ import { test, expect } from "@playwright/test";
 import { injectSeedInventory } from "./helpers/seed.js";
 
 /**
- * STAK-446: Log / Changelog Redesign — TDD failing tests
- *
- * These tests assert the NEW requirements (tab rename, tab order,
- * undo/redo for "Added" items, CRUD audit). All should fail against
- * the current implementation and pass once the spec is implemented.
+ * STAK-446: Log / Changelog Redesign — tab rename, tab order, undo/redo for Added items, CRUD audit.
  */
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -146,17 +142,17 @@ test.describe("STAK-446: Log/Changelog Redesign", () => {
       );
       expect(addedIdx).toBeGreaterThanOrEqual(0);
 
-      // Click undo via the changelog modal
-      // Open the changelog modal (not settings — the floating button)
-      await dismissWhatsNew(page);
-      await page.evaluate(() => {
-        if (typeof renderChangeLog === "function") renderChangeLog();
-      });
+      // Navigate to Activity Log → Changelog tab and click the undo button
+      await navigateToActivityLog(page);
+      await page.click('[data-log-tab="changelog"]');
+      await page.waitForSelector("#settingsChangeLogTable tbody tr", { state: "visible" });
 
-      // Use toggleChange directly to undo the "Added" entry
-      await page.evaluate((idx) => {
-        if (typeof toggleChange === "function") toggleChange(idx);
-      }, addedIdx);
+      // Click the undo button for the entry matching CL-UNDO-ITEM
+      const undoBtn = page
+        .locator("#settingsChangeLogTable tbody tr")
+        .filter({ hasText: "CL-UNDO-ITEM" })
+        .locator(".action-cell button");
+      await undoBtn.click();
 
       const countAfterUndo = await page.evaluate(() => inventory.length);
       // Undo of "Added" should remove the item, decreasing count by 1
@@ -176,18 +172,20 @@ test.describe("STAK-446: Log/Changelog Redesign", () => {
       );
       expect(addedIdx).toBeGreaterThanOrEqual(0);
 
-      // Undo (remove the item)
-      await page.evaluate((idx) => {
-        if (typeof toggleChange === "function") toggleChange(idx);
-      }, addedIdx);
+      // Navigate to Activity Log → Changelog tab and click Undo
+      await navigateToActivityLog(page);
+      await page.click('[data-log-tab="changelog"]');
+      await page.waitForSelector("#settingsChangeLogTable tbody tr", { state: "visible" });
+      const redoItemRow = page
+        .locator("#settingsChangeLogTable tbody tr")
+        .filter({ hasText: "CL-REDO-ITEM" });
+      await redoItemRow.locator(".action-cell button").click();
 
       const countAfterUndo = await page.evaluate(() => inventory.length);
       expect(countAfterUndo).toBe(countAfterAdd - 1);
 
-      // Redo (restore the item)
-      await page.evaluate((idx) => {
-        if (typeof toggleChange === "function") toggleChange(idx);
-      }, addedIdx);
+      // Click Redo (button label flips to "Redo" after undo)
+      await redoItemRow.locator(".action-cell button").click();
 
       const countAfterRedo = await page.evaluate(() => inventory.length);
       expect(countAfterRedo).toBe(countAfterAdd);
@@ -203,10 +201,11 @@ test.describe("STAK-446: Log/Changelog Redesign", () => {
       await injectSeedInventory(page);
       await gotoApp(page);
 
-      // Clear changelog first
+      // Clear changelog first and persist to localStorage for consistency
       await page.evaluate(() => {
         if (typeof changeLog !== "undefined") {
           changeLog.length = 0;
+          if (typeof saveDataSync === "function") saveDataSync("changeLog", changeLog);
         }
       });
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.22",
+  "version": "3.34.23",
   "releaseDate": "2026-04-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Changes

- **Renamed** Activity Log sub-tabs: Metals → Spot Price, Price History → Item History
- **Reordered** sub-tabs by usage priority: Changelog, Catalogs, Cloud, Spot Price, Market, Item History, LBMA History
- **Added** undo/redo support for "Added" changelog entries — undo removes item, redo restores from JSON snapshot
- **Fixed** JSON.parse on redo path guarded with try/catch for localStorage corruption resilience
- **Added** 7 Playwright TDD tests covering tab rename, order, undo-add, redo-add, and CRUD audit

## Issues (DocVault)

- STAK-446: Settings Redesign: LOG/Changelog — audit CRUD logging, rename and reorder tabs → Done

## Test Results

- 312/312 Playwright tests passed (305 baseline + 7 new)
- Zero regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added undo/redo capability for items in the Activity Log
  * Renamed Activity Log tabs for improved clarity: "Metals" → "Spot Price", "Price History" → "Item History"

* **Bug Fixes**
  * Improved error handling to prevent crashes from corrupted local storage data

* **Style**
  * Enhanced visual consistency across Activity Log interface elements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->