### PR TITLE
chore(STAK-574): flip jmbullion phase to phase0, Byparr as fallback

### DIFF
--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -616,7 +616,10 @@ const PROVIDER_CONFIG = {
     retryOn408: false, // page either renders in time or doesn't
   },
   jmbullion: {
-    phase: "cf-clearance-first", // Byparr first (100% success), Firecrawl fallback
+    phase: "phase0", // Playwright-direct first (JSON-LD extracts reliably in ~6s on
+    // residential IP). Byparr reserved as fallback via cf_clearance_fallback.
+    // JM's CF tier upgraded beyond Byparr's 45s window ~2026-04-23; fresh-session
+    // Byparr gets harder challenge than long-lived poller browser (STAK-565 follow-up).
     waitFor: 10_000,
     timeout: 40_000,
     onlyMainContent: false, // React pages return empty with onlyMainContent

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -619,7 +619,7 @@ const PROVIDER_CONFIG = {
     phase: "phase0", // Playwright-direct first (JSON-LD extracts reliably in ~6s on
     // residential IP). Byparr reserved as fallback via cf_clearance_fallback.
     // JM's CF tier upgraded beyond Byparr's 45s window ~2026-04-23; fresh-session
-    // Byparr gets harder challenge than long-lived poller browser (STAK-565 follow-up).
+    // Byparr gets harder challenge than long-lived poller browser (STAK-574; follow-up to STAK-565).
     waitFor: 10_000,
     timeout: 40_000,
     onlyMainContent: false, // React pages return empty with onlyMainContent
@@ -1223,8 +1223,8 @@ async function main() {
       const _retriedUrls = new Set();
 
       // ── Phase CF-First: Byparr/CF-clearance first (for cf-clearance-first vendors) ─
-      // For vendors where Byparr has 100% success rate (BE, JM), skip the 70s Firecrawl
-      // timeout entirely. If Byparr fails, fall through to Phase 0/1 as safety net.
+      // For CF-gated vendors (BEx), skip the 70s Firecrawl timeout and solve via Byparr
+      // first. If Byparr fails, fall through to Phase 0/1 as safety net.
       const cfg = providerCfg(provider.id);
       if (cfg.phase === "cf-clearance-first" && CF_CLEARANCE_ENABLED_FLAG) {
         log(`  [cf-first] ${provider.id}: trying Byparr first`);


### PR DESCRIPTION
## Summary

JM Bullion's Cloudflare challenge tier upgraded past Byparr's 45s window. Byparr times out on every JM attempt, then Phase 0 Playwright-direct extracts the price via JSON-LD in ~6s. Net ~51s/coin instead of 6s — adding ~10 min per retail run.

This PR flips `jmbullion.phase` from `cf-clearance-first` to `phase0`. Byparr remains available as a fallback via the existing `cf_clearance_fallback: true` flag, so if CF later tightens on direct requests we fall back automatically. No change to Bullion Exchanges or other providers.

## Issue

- [[STAK-574]] — `DocVault/Projects/StakTrakr/Issues/STAK-574.md`

## Root cause

Fresh-browser Byparr sessions receive harder CF challenges than the long-lived poller browser on the residential Tailscale IP — CF recognizes the poller's browser as lived-in and lets it through easily. BEx still needs Byparr (verified at ~5s/coin after this morning's container restart).

## Expected impact

| Metric | Before | After |
|---|---|---|
| JM time/coin | 51s | 6s |
| JM success rate | ~60% | ~95%+ |
| Overall retail run duration | 30+ min | ~21 min baseline |
| cf-clearance attempts for JM | ~22/run | 0 (fallback only) |

Zero change to BEx, APMEX, SD Bullion, goldback flows.

## Test plan

- [ ] Merge PR
- [ ] Redeploy home poller between scrape runs
- [ ] Verify env: `docker exec staktrakr-home-poller env | grep CF_CLEARANCE` shows 45000
- [ ] Watch next hourly run — JM `cf-clearance` attempts should be 0
- [ ] Confirm `v2/retail/vendors/jmbullion.json` → `fresh:22, stale:0` within 2 runs
- [ ] Confirm run end-log `cf-clearance: NN attempts X ok Y failed` → ok% ≥80% (BEx is now the sole cf-clearance consumer)
- [ ] Total retail duration trending to 21-23 min range
- [ ] No regression on other vendors (APMEX, SD Bullion, goldback)

## Rollback

If JM success rate drops after deploy, revert this commit — Byparr will reactivate as the first phase.

## Follow-ups (not in this PR)

- Refresh stale `Byparr first (100% success)` comment on BEx (line 628 equivalent) once we have fresh run data
- Consider healthcheck + weekly restart on Byparr container (separate issue) to prevent wedge drift