### PR TITLE
chore(STAK-575): clean up price-extract.js LSP diagnostics

### DIFF
--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -23,7 +23,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  openTursoDb,
+  openSqldDb,
   writeSnapshot,
   windowFloor,
   startRunLog,
@@ -689,11 +689,6 @@ function resolveProxy(providerId) {
 
 // Compatibility shims — used in code that still references the old Sets.
 // TODO: Remove these after all callsites are refactored to use providerCfg().
-const SLOW_PROVIDERS = new Set(
-  Object.entries(PROVIDER_CONFIG)
-    .filter(([, c]) => c.waitFor > 0)
-    .map(([id]) => id)
-);
 const FIRECRAWL_PREFERRED_PROVIDERS = new Set(
   Object.entries(PROVIDER_CONFIG)
     .filter(([, c]) => c.phase === "firecrawl")
@@ -1086,7 +1081,6 @@ async function main() {
     tursoClient = (await import("./sqld-client.js")).createSqldClient();
   } catch {}
   const providersJson = await loadProviders(tursoClient, DATA_DIR);
-  const dateStr = new Date().toISOString().slice(0, 10);
 
   // Build scrape targets — shuffled to avoid rate-limit fingerprinting
   const targets = [];
@@ -1120,7 +1114,7 @@ async function main() {
   if (DRY_RUN) log("DRY RUN — no SQLite writes");
 
   // Open SQLite for this run — closed in finally block to ensure cleanup on fatal errors
-  const db = DRY_RUN ? null : await openTursoDb();
+  const db = DRY_RUN ? null : await openSqldDb();
   const scrapedAt = new Date().toISOString();
   const winStart = windowFloor();
 


### PR DESCRIPTION
Closes [STAK-575](../../DocVault/Projects/StakTrakr/Issues/STAK-575.md).

## Summary

Clears four long-standing LSP diagnostics in `devops/pollers/shared/price-extract.js` that surfaced during STAK-574 PR review.

| Line | Before | After |
|---|---|---|
| `:26` | `openTursoDb` (deprecated alias) | `openSqldDb` (real export) |
| `:692-696` | `SLOW_PROVIDERS` compat Set (dead) | removed |
| `:1089` | unused `dateStr` declaration | removed |
| `:1123` | `openTursoDb()` call | `openSqldDb()` call |

## Why narrow scope

`openTursoDb` is still imported in 4 other files (`api-export.js`, `api-export-v2.js`, `goldback-scraper.js`, `extract-vision.js`). The `@deprecated` alias at `db.js:74` stays in place for them — a cross-poller sweep + alias removal can be a follow-up issue.

The other 4 compat Sets next to `SLOW_PROVIDERS` (`FIRECRAWL_PREFERRED_PROVIDERS`, `FIRECRAWL_TABLE_PARSE_PROVIDERS`, `PLAYWRIGHT_ONLY_PROVIDERS`, `FRACTIONAL_EXEMPT_PROVIDERS`) are still referenced elsewhere in the file — only `SLOW_PROVIDERS` is truly dead.

## Zero runtime change

`openSqldDb === openTursoDb` by definition (alias at `db.js:74`). Deleted symbols had no readers.

## Test plan

- [x] `node -c price-extract.js` passes
- [x] `grep openTursoDb devops/pollers/shared/price-extract.js` returns 0 matches
- [x] `grep SLOW_PROVIDERS devops/pollers/shared/price-extract.js` returns only a historical comment at `:582`
- [ ] Post-merge: next home-poller retail cycle runs clean (spot-check JM + BEx fresh counts)
- [ ] Post-merge: LSP diagnostic count on `price-extract.js` drops from 4 → 0

## Out of scope

- Cross-poller `openTursoDb` rename + removal of the `db.js:74` deprecation alias (follow-up)
- Refactoring remaining compat Sets to use `providerCfg()` fully (follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database initialization mechanism

* **Chores**
  * Removed legacy compatibility code that is no longer required
  * Cleaned up unused variable declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->