### PR TITLE
v3.34.29 — STAK-576 ISSUE-005: Numista search not-configured UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.29] - 2026-04-24
+
+### Fixed — STAK-576: Numista search magnifier shows misleading error when API key missing
+
+- **Fixed**: Catalog search magnifiers (Name and Catalog N#) now detect the "Numista not configured" state first and open a confirm dialog that links directly to Settings → API instead of showing `Enter a Name or Catalog N# to search.` (STAK-576 ISSUE-005)
+- **Changed**: Disconnected magnifier dot now announces "Numista API not configured — click to configure" via tooltip, and the button `title` flips to match so the hint is visible before clicking
+- **Changed**: `updateNumistaModalDot()` now runs whenever the Add/Edit item modal opens so the dot reflects the current configuration state without requiring a save round-trip
+
+---
+
 ## [3.34.28] - 2026-04-24
 
 ### Fixed — STAK-576: AutoTable vendor fallback warning

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.29 &ndash; STAK-576: Numista not-configured UX</strong>: Catalog search magnifiers now detect a missing Numista key up front and open a confirm dialog linking to Settings &rarr; API instead of the old misleading &ldquo;Enter a Name or Catalog N#&rdquo; alert. Disconnected dot and button tooltip both explain the state before clicking.</li>
     <li><strong>v3.34.28 &ndash; STAK-576: AutoTable vendor fallback warning</strong>: PDF export support now recognizes the locally bundled AutoTable plugin correctly, preventing the false CDN fallback warning/request when offline-capable export code is already loaded.</li>
     <li><strong>v3.34.27 &ndash; STAK-576: Duplicate network fetch cleanup</strong>: Cold-load spot sync now shares in-flight provider/backfill work, exchange-rate refreshes dedupe within the startup burst, and the market vendor table reuses the retail cache instead of re-fetching each visible slug.</li>
     <li><strong>v3.34.26 &ndash; STAK-565: JM Bullion scraper column fix</strong>: Fixed JM Bullion price readings oscillating between the correct eCheck/Wire tier (~$86) and the wrong Card tier (~$95) depending on which scrape engine rendered the page. New pipe-table parser locates the (e)Check/Wire column by header label instead of relying on column order. Column-blind fallback removed — missed ticks preferred over wrong-tier prices.</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-24 - STAK-576: AutoTable vendor fallback warning
  */
 
-const APP_VERSION = "3.34.28";
+const APP_VERSION = "3.34.29";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/events.js
+++ b/js/events.js
@@ -222,15 +222,15 @@ const updateNumistaModalDot = () => {
   document.querySelectorAll(".numista-modal-status-dot").forEach((dot) => {
     dot.classList.toggle("connected", !!connected);
     dot.classList.toggle("disconnected", !connected);
-    dot.title = connected ? "Numista API: connected" : "Numista API: disconnected";
+    dot.title = connected ? "Numista API: connected" : NOT_CONFIGURED_TITLE;
     const btn = dot.closest("button");
     if (btn) {
       if (!connected) {
-        if (!btn.dataset.originalTitle) {
+        if (!("originalTitle" in btn.dataset)) {
           btn.dataset.originalTitle = btn.getAttribute("title") || "";
         }
         btn.setAttribute("title", NOT_CONFIGURED_TITLE);
-      } else if (btn.dataset.originalTitle !== undefined) {
+      } else if ("originalTitle" in btn.dataset) {
         btn.setAttribute("title", btn.dataset.originalTitle);
         delete btn.dataset.originalTitle;
       }
@@ -249,13 +249,18 @@ const ensureNumistaConfiguredOrPrompt = async () => {
     catalogConfig.isNumistaEnabled &&
     catalogConfig.isNumistaEnabled();
   if (configured) return true;
-  const openSettings =
-    typeof appConfirm === "function"
-      ? await appConfirm(
-          "Numista API key isn't configured. Catalog search needs a free Numista key. Open Settings → API to add one now?",
-          "Numista API not configured"
-        )
-      : false;
+  let openSettings = false;
+  if (typeof appConfirm === "function") {
+    openSettings = await appConfirm(
+      "Numista API key isn't configured. Catalog search needs a free Numista key. Open Settings → API to add one now?",
+      "Numista API not configured"
+    );
+  } else if (typeof appAlert === "function") {
+    appAlert(
+      "Numista API key isn't configured. Open Settings → API to add a free Numista key.",
+      "Numista API not configured"
+    );
+  }
   if (openSettings && typeof showSettingsModal === "function") {
     showSettingsModal("api");
   }

--- a/js/events.js
+++ b/js/events.js
@@ -210,17 +210,56 @@ const clearUploadState = () => {
 /**
  * Update Numista API status dot in item modal action bar (STAK-173).
  * Reads catalogConfig.isNumistaEnabled() to set connected/disconnected state.
+ * Also updates the parent search button's `title` so the hint is visible
+ * before the user clicks (STAK-576 ISSUE-005).
  */
 const updateNumistaModalDot = () => {
   const connected =
     typeof catalogConfig !== "undefined" &&
     catalogConfig.isNumistaEnabled &&
     catalogConfig.isNumistaEnabled();
+  const NOT_CONFIGURED_TITLE = "Numista API not configured — click to configure";
   document.querySelectorAll(".numista-modal-status-dot").forEach((dot) => {
     dot.classList.toggle("connected", !!connected);
     dot.classList.toggle("disconnected", !connected);
     dot.title = connected ? "Numista API: connected" : "Numista API: disconnected";
+    const btn = dot.closest("button");
+    if (btn) {
+      if (!connected) {
+        if (!btn.dataset.originalTitle) {
+          btn.dataset.originalTitle = btn.getAttribute("title") || "";
+        }
+        btn.setAttribute("title", NOT_CONFIGURED_TITLE);
+      } else if (btn.dataset.originalTitle !== undefined) {
+        btn.setAttribute("title", btn.dataset.originalTitle);
+        delete btn.dataset.originalTitle;
+      }
+    }
   });
+};
+
+/**
+ * Gate Numista search entry points on an active API key (STAK-576 ISSUE-005).
+ * Returns true when a search can proceed. Otherwise shows a themed confirm
+ * dialog offering to jump straight to Settings → API and returns false.
+ */
+const ensureNumistaConfiguredOrPrompt = async () => {
+  const configured =
+    typeof catalogConfig !== "undefined" &&
+    catalogConfig.isNumistaEnabled &&
+    catalogConfig.isNumistaEnabled();
+  if (configured) return true;
+  const openSettings =
+    typeof appConfirm === "function"
+      ? await appConfirm(
+          "Numista API key isn't configured. Catalog search needs a free Numista key. Open Settings → API to add one now?",
+          "Numista API not configured"
+        )
+      : false;
+  if (openSettings && typeof showSettingsModal === "function") {
+    showSettingsModal("api");
+  }
+  return false;
 };
 
 /**
@@ -1992,6 +2031,11 @@ const setupItemFormListeners = () => {
       elements.searchNumistaBtn,
       "click",
       async () => {
+        // Gate on configured key first — otherwise the empty-field check below
+        // can short-circuit with a misleading "Enter a Name..." error when the
+        // real blocker is a missing API key (STAK-576 ISSUE-005).
+        if (!(await ensureNumistaConfiguredOrPrompt())) return;
+
         const catalogVal = elements.itemCatalog?.value.trim() || "";
         const nameVal = elements.itemName?.value.trim() || "";
 
@@ -2001,7 +2045,17 @@ const setupItemFormListeners = () => {
         }
 
         if (!catalogAPI || !catalogAPI.activeProvider) {
-          appAlert("Configure Numista API key in Settings first.");
+          // Key is present but the provider failed to initialize — rare.
+          // Nudge the user back to Settings without claiming the key is missing.
+          if (typeof appConfirm === "function") {
+            const open = await appConfirm(
+              "Numista catalog provider failed to initialize. Open Settings → API to re-test the key?",
+              "Numista API"
+            );
+            if (open && typeof showSettingsModal === "function") showSettingsModal("api");
+          } else {
+            appAlert("Numista catalog provider failed to initialize. Check Settings → API.");
+          }
           return;
         }
 
@@ -3822,6 +3876,12 @@ function handleAdvancedSavePassword() {
 }
 window.handleAdvancedSavePassword = handleAdvancedSavePassword;
 window.buildNumistaSearchQuery = buildNumistaSearchQuery;
+// Expose the Numista dot refresher + config gate for Playwright tests
+// (STAK-576 ISSUE-005). Both already run internally on modal open and
+// catalog-config save paths — these exports just make them observable
+// from `page.evaluate()`.
+window.updateNumistaModalDot = updateNumistaModalDot;
+window.ensureNumistaConfiguredOrPrompt = ensureNumistaConfiguredOrPrompt;
 
 // =============================================================================
 // Remove Item modal event listeners (STAK-72)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.26",
+  "version": "3.34.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.26",
+      "version": "3.34.29",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.28",
+  "version": "3.34.29",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777044044";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777044613";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.28-b1777015961";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777044044";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/numista-not-configured.spec.js
+++ b/tests/playwright/numista-not-configured.spec.js
@@ -56,41 +56,35 @@ test.describe("Numista search magnifier — not configured UX", () => {
   test("NC-2 — clicking the magnifier with a name typed opens the not-configured dialog, not the empty-field alert", async ({
     page,
   }) => {
-    const messages = [];
-    await page.exposeFunction("__captureDialog", (title, message) => {
-      messages.push({ title, message });
-    });
-    await page.evaluate(() => {
-      const originalConfirm = window.appConfirm;
-      window.appConfirm = async (message, title) => {
-        window.__captureDialog(title || "", message || "");
-        return false; // user cancels — we just want to verify the message
-      };
-      window.__originalAppConfirm = originalConfirm;
-    });
-
     await page.fill("#itemName", "American Silver Eagle");
     await page.click("#searchNumistaNameBtn");
-    await expect.poll(() => messages.length).toBeGreaterThan(0);
 
-    expect(messages[0].title).toMatch(/not configured/i);
-    expect(messages[0].message).toMatch(/Numista/i);
-    expect(messages[0].message).not.toMatch(/Enter a Name/i);
+    // Wait for the real themed dialog to appear
+    await expect(page.locator("#appDialogModal")).toBeVisible({ timeout: 5000 });
+
+    const titleText = await page.locator("#appDialogTitle").textContent();
+    const messageText = await page.locator("#appDialogMessage").textContent();
+
+    expect(titleText).toMatch(/not configured/i);
+    expect(messageText).toMatch(/Numista/i);
+    expect(messageText).not.toMatch(/Enter a Name/i);
+
+    // Dismiss via Cancel — we're only verifying dialog copy, not the handoff
+    await page.click("#appDialogCancel");
+    await expect(page.locator("#appDialogModal")).toBeHidden({ timeout: 3000 });
   });
 
   test("NC-3 — confirming opens Settings → API", async ({ page }) => {
-    // Stub appConfirm to auto-accept so we don't need to click the dialog
-    await page.evaluate(() => {
-      window.appConfirm = async () => true;
-      window.showAppConfirm = async () => true;
-    });
-
     await page.fill("#itemName", "American Silver Eagle");
     await page.click("#searchNumistaBtn");
 
-    // The real side effect: settings modal becomes visible. Use the DOM
-    // outcome instead of stubbing showSettingsModal — the module-scope
-    // binding in events.js is not interceptable via window overrides.
-    await expect(page.locator("#settingsModal")).toBeVisible({ timeout: 3000 });
+    // Wait for the real themed dialog to appear
+    await expect(page.locator("#appDialogModal")).toBeVisible({ timeout: 5000 });
+
+    // Click OK — resolver fires true and events.js calls showSettingsModal("api")
+    await page.click("#appDialogOk");
+
+    // The real side effect: settings modal becomes visible
+    await expect(page.locator("#settingsModal")).toBeVisible({ timeout: 5000 });
   });
 });

--- a/tests/playwright/numista-not-configured.spec.js
+++ b/tests/playwright/numista-not-configured.spec.js
@@ -71,9 +71,8 @@ test.describe("Numista search magnifier — not configured UX", () => {
 
     await page.fill("#itemName", "American Silver Eagle");
     await page.click("#searchNumistaNameBtn");
-    await page.waitForTimeout(150);
+    await expect.poll(() => messages.length).toBeGreaterThan(0);
 
-    expect(messages.length).toBeGreaterThan(0);
     expect(messages[0].title).toMatch(/not configured/i);
     expect(messages[0].message).toMatch(/Numista/i);
     expect(messages[0].message).not.toMatch(/Enter a Name/i);

--- a/tests/playwright/numista-not-configured.spec.js
+++ b/tests/playwright/numista-not-configured.spec.js
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * STAK-576 ISSUE-005 — Numista search magnifier with no API key must surface
+ * the "not configured" state, not a misleading "Enter a Name..." alert.
+ *
+ * Regression trap: the old click handler checked empty fields first and
+ * returned `appAlert("Enter a Name or Catalog N# to search.")` even when a
+ * name was typed, because the *real* blocker was the missing Numista key.
+ * The new handler gates on `catalogConfig.isNumistaEnabled()` first and
+ * offers to jump straight to Settings → API.
+ */
+
+test.describe("Numista search magnifier — not configured UX", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      // Wipe any previously saved catalog config so the test starts with
+      // Numista genuinely unconfigured. Also suppress the What's New popup
+      // so it does not intercept the Add Item click.
+      localStorage.removeItem("catalog_api_config");
+      localStorage.setItem("ackVersion", "9.9.9");
+    });
+    await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("#newItemBtn", { state: "visible" });
+    await page.waitForTimeout(300); // let deferred setupEventListeners fire
+    const whatsNew = page.locator("#whatsNewPopup");
+    if (await whatsNew.isVisible().catch(() => false)) {
+      await page.click("#whatsNewDismissBtn").catch(() => {});
+    }
+    // Open Add Inventory modal via JS click to bypass overlay interception
+    await page.evaluate(() => document.getElementById("newItemBtn").click());
+    await expect(page.locator("#itemModal")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("NC-1 — disconnected dot renders with not-configured tooltip on the button", async ({
+    page,
+  }) => {
+    const state = await page.evaluate(() => {
+      if (typeof window.updateNumistaModalDot === "function") window.updateNumistaModalDot();
+      const btn = document.getElementById("searchNumistaBtn");
+      const nameBtn = document.getElementById("searchNumistaNameBtn");
+      const dot = btn?.querySelector(".numista-modal-status-dot");
+      return {
+        dotClasses: dot?.className || "",
+        btnTitle: btn?.getAttribute("title") || "",
+        nameBtnTitle: nameBtn?.getAttribute("title") || "",
+      };
+    });
+
+    expect(state.dotClasses.split(/\s+/)).toContain("disconnected");
+    expect(state.dotClasses.split(/\s+/)).not.toContain("connected");
+    expect(state.btnTitle).toContain("not configured");
+    expect(state.nameBtnTitle).toContain("not configured");
+  });
+
+  test("NC-2 — clicking the magnifier with a name typed opens the not-configured dialog, not the empty-field alert", async ({
+    page,
+  }) => {
+    const messages = [];
+    await page.exposeFunction("__captureDialog", (title, message) => {
+      messages.push({ title, message });
+    });
+    await page.evaluate(() => {
+      const originalConfirm = window.appConfirm;
+      window.appConfirm = async (message, title) => {
+        window.__captureDialog(title || "", message || "");
+        return false; // user cancels — we just want to verify the message
+      };
+      window.__originalAppConfirm = originalConfirm;
+    });
+
+    await page.fill("#itemName", "American Silver Eagle");
+    await page.click("#searchNumistaNameBtn");
+    await page.waitForTimeout(150);
+
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages[0].title).toMatch(/not configured/i);
+    expect(messages[0].message).toMatch(/Numista/i);
+    expect(messages[0].message).not.toMatch(/Enter a Name/i);
+  });
+
+  test("NC-3 — confirming opens Settings → API", async ({ page }) => {
+    // Stub appConfirm to auto-accept so we don't need to click the dialog
+    await page.evaluate(() => {
+      window.appConfirm = async () => true;
+      window.showAppConfirm = async () => true;
+    });
+
+    await page.fill("#itemName", "American Silver Eagle");
+    await page.click("#searchNumistaBtn");
+
+    // The real side effect: settings modal becomes visible. Use the DOM
+    // outcome instead of stubbing showSettingsModal — the module-scope
+    // binding in events.js is not interceptable via window overrides.
+    await expect(page.locator("#settingsModal")).toBeVisible({ timeout: 3000 });
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.28",
+  "version": "3.34.29",
   "releaseDate": "2026-04-24",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

Resolves **STAK-576 ISSUE-005** — the Numista catalog-search magnifiers (next to **Name** and **Catalog N#**) now detect "no Numista API key configured" up front and surface a themed confirm dialog that links straight to **Settings → API**, instead of the misleading legacy `Enter a Name or Catalog N# to search.` alert.

## Changes

- **js/events.js**
  - New `ensureNumistaConfiguredOrPrompt()` helper gates Numista search on `catalogConfig.isNumistaEnabled()` and opens `appConfirm` with a Settings → API handoff when no key is set.
  - `searchNumistaBtn` click handler now runs the gate **before** the empty-field / no-activeProvider checks (that ordering was the root cause — the empty-field path short-circuited when a name was typed because the magnifier scrapes `itemCatalog` and `itemName` separately).
  - `updateNumistaModalDot()` now toggles the parent search-button's `title` attribute to `Numista API not configured — click to configure` when disconnected and restores the original tooltip once a key is saved.
  - Exposes `updateNumistaModalDot` + `ensureNumistaConfiguredOrPrompt` on `window` for Playwright test observability.
- **tests/playwright/numista-not-configured.spec.js** — new regression suite covering (NC-1) disconnected dot + tooltip on modal open, (NC-2) dialog copy replaces the empty-field alert, (NC-3) confirming the dialog opens `#settingsModal`.
- Version bumped to **3.34.29** across `CHANGELOG.md`, `js/about.js`, `js/constants.js`, `package.json`, `package-lock.json`, `version.json`; `sw.js` cache stamped automatically by the pre-commit hook.

## Validation

- `npm run lint` → 0 errors (2 pre-existing warnings on `diff-engine.js` / `diff-modal.js`).
- `npm test` → **349/349 passing** (up from 346 baseline; 3 new NC-* tests).
- Targeted numista suite (`numista-search.spec.js`, `numista-picker-tags.spec.js`, `numista-not-configured.spec.js`) → 24 passing.
- The Name-side magnifier (`searchNumistaNameBtn`) inherits the gate because its click handler delegates to `searchNumistaBtn.click()`.

## Issues (DocVault)

- STAK-576 ISSUE-005: Numista search with no API key shows a misleading validation error → **resolved**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v3.34.29

* **New Features**
  * Improved Numista search handling when API is not configured; users now receive a dialog with a direct link to Settings → API instead of a generic message.
  * Updated tooltips and UI messaging to clearly indicate "Numista API not configured" state.
  * Configuration state is checked immediately when opening the Add/Edit modal.

* **Tests**
  * Added test coverage for Numista not-configured search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->