### PR TITLE
chore(STAK-576): fix branding map for subdomain hosts (ISSUE-003)

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -441,17 +441,19 @@ const BRANDING_DOMAIN_OPTIONS = {
 const BRANDING_DOMAIN_OVERRIDE =
   typeof window !== "undefined" && window.location && window.location.hostname
     ? (() => {
-        let host = window.location.hostname.toLowerCase();
-        if (BRANDING_DOMAIN_OPTIONS.removeExtension) {
-          const parts = host.split(".");
-          // Strip www prefix and TLD to get the core domain name
-          // "www.stackrtrackr.com" → ["www","stackrtrackr","com"] → "stackrtrackr"
-          // "stackrtrackr.com" → ["stackrtrackr","com"] → "stackrtrackr"
-          // "staktrakr.pages.dev" → ["staktrakr","pages","dev"] → "staktrakr"
-          const filtered = parts.filter((p) => p !== "www");
-          host = filtered.length > 1 ? filtered[0] : parts[0];
+        const host = window.location.hostname.toLowerCase();
+        const { domainMap, removeExtension } = BRANDING_DOMAIN_OPTIONS;
+        if (removeExtension) {
+          // Scan hostname parts for the first branded label. Handles plain
+          // domains ("stackrtrackr.com"), www ("www.stackrtrackr.com"),
+          // subdomains ("beta.staktrakr.com", "dev.staktrakr.com"), and
+          // multi-level hosts ("staktrakr.pages.dev") uniformly.
+          for (const part of host.split(".")) {
+            if (part && part !== "www" && domainMap[part]) return domainMap[part];
+          }
+          return null;
         }
-        return BRANDING_DOMAIN_OPTIONS.domainMap[host] || null;
+        return domainMap[host] || null;
       })()
     : null;
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -448,12 +448,16 @@ const BRANDING_DOMAIN_OVERRIDE =
           // domains ("stackrtrackr.com"), www ("www.stackrtrackr.com"),
           // subdomains ("beta.staktrakr.com", "dev.staktrakr.com"), and
           // multi-level hosts ("staktrakr.pages.dev") uniformly.
+          // typeof guard prevents inherited Object.prototype keys
+          // (constructor, toString, etc.) from returning a function.
           for (const part of host.split(".")) {
-            if (part && part !== "www" && domainMap[part]) return domainMap[part];
+            if (part && part !== "www" && typeof domainMap[part] === "string") {
+              return domainMap[part];
+            }
           }
           return null;
         }
-        return domainMap[host] || null;
+        return typeof domainMap[host] === "string" ? domainMap[host] : null;
       })()
     : null;
 

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777051402";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777051945";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777044613";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777051402";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Closes ISSUE-003 from [[STAK-576]] dogfood pass.

`beta.staktrakr.com` (and any other subdomain) was logging `No branding mapping found for domain: beta.staktrakr.com` on load. Root cause: `BRANDING_DOMAIN_OVERRIDE` stripped `www` from hostname parts and then picked `filtered[0]`, which for subdomains is the subdomain label itself — not the registrable domain.

### Fix

`js/constants.js:441` — iterate every hostname label and return the first one present in `domainMap`. One change fixes the whole class of bug: `beta.*`, `dev.*`, `preview.*`, and any future subdomain, with no per-subdomain enumeration.

### Preserves all existing cases

| Host | Resolves to |
|---|---|
| `staktrakr.com` | `StakTrakr` |
| `www.stackrtrackr.com` | `StackrTrackr` |
| `staktrakr.pages.dev` | `StakTrakr` |
| `stackertrackr.com` | `Stacker Tracker` |
| `beta.staktrakr.com` | `StakTrakr` ← newly fixed |
| unmapped host | `null` (falls back to `BRANDING_TITLE`) |

## Test plan

- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated to this change)
- [ ] Visual check on beta.staktrakr.com post-merge: no "No branding mapping found" console warn
- [ ] Title still reads "StakTrakr" on beta deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain branding identification to correctly recognize branded domains across different hostname structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->