### PR TITLE
chore(STAK-576): hide Remove btn in Add-mode item modal (ISSUE-006)

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -3352,9 +3352,11 @@ const setupSearch = () => {
           });
           // Update Numista API status dot (STAK-173)
           if (typeof updateNumistaModalDot === "function") updateNumistaModalDot();
-          // Hide clone/view buttons in add mode (STAK-173)
+          // Hide clone/view/remove buttons in add mode (STAK-173, STAK-576 ISSUE-006)
           if (elements.cloneItemBtn) elements.cloneItemBtn.style.display = "none";
           if (elements.viewItemFromEditBtn) elements.viewItemFromEditBtn.style.display = "none";
+          const deleteFromEditBtnAddReset = document.getElementById("deleteFromEditBtn");
+          if (deleteFromEditBtnAddReset) deleteFromEditBtnAddReset.style.display = "none";
           // Reset date N/A toggle button
           if (elements.itemDateNABtn) {
             elements.itemDateNABtn.classList.remove("active");

--- a/js/events.js
+++ b/js/events.js
@@ -3355,7 +3355,7 @@ const setupSearch = () => {
           // Hide clone/view/remove buttons in add mode (STAK-173, STAK-576 ISSUE-006)
           if (elements.cloneItemBtn) elements.cloneItemBtn.style.display = "none";
           if (elements.viewItemFromEditBtn) elements.viewItemFromEditBtn.style.display = "none";
-          const deleteFromEditBtnAddReset = document.getElementById("deleteFromEditBtn");
+          const deleteFromEditBtnAddReset = safeGetElement("deleteFromEditBtn");
           if (deleteFromEditBtnAddReset) deleteFromEditBtnAddReset.style.display = "none";
           // Reset date N/A toggle button
           if (elements.itemDateNABtn) {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777051945";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777052582";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777052582";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777053203";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Closes ISSUE-006 from [[STAK-576]] dogfood pass.

`#deleteFromEditBtn` defaults to `display:none` in `index.html:2719`, and `inventory.js:953` flips it to `""` when entering Edit mode. The Add-mode open handler at `events.js:3355` reset `cloneItemBtn` and `viewItemFromEditBtn` but **not** `deleteFromEditBtn`, so the red Remove button leaked across **Edit → Cancel → open Add Inventory** sequences.

## Context

Fresh-page Add-modal opens were already correct (button hidden by markup default) — the dogfood tool flagged on DOM presence, not rendered state. Confirmed visually by repo owner: no Remove button appears in Add mode on fresh load.

The leak path is the latent edge case this PR addresses.

## Fix

One-liner defensive reset at `events.js:3357` alongside the sibling `cloneItemBtn` / `viewItemFromEditBtn` resets — makes the Add-mode state path self-consistent.

```js
const deleteFromEditBtnAddReset = document.getElementById("deleteFromEditBtn");
if (deleteFromEditBtnAddReset) deleteFromEditBtnAddReset.style.display = "none";
```

## Test plan

- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated)
- [ ] Visual check post-merge: fresh Add modal → no Remove button (baseline, already correct)
- [ ] Edit item → Cancel → open Add Inventory → no Remove button (previously leaked, now fixed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the delete button visibility in the item modal to properly hide when adding a new item, consistent with other action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->