### PR TITLE
chore: extract JSON-LD from Byparr HTML in cf-clearance path

### DIFF
--- a/devops/pollers/shared/price-extract-cf-helpers.test.mjs
+++ b/devops/pollers/shared/price-extract-cf-helpers.test.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Fixture tests for cf-clearance Byparr HTML helpers — run with:
+//   node devops/pollers/shared/price-extract-cf-helpers.test.mjs
+//
+// Covers the two helpers added for the cf-clearance reliability fix
+// (2026-04-24): looksLikeChallengePage() and extractJsonLdScriptsFromHtml().
+// These are not exported, so we duplicate them here — keep in sync with
+// price-extract.js.
+
+function looksLikeChallengePage(html) {
+  if (!html) return true;
+  if (html.length < 5000) return true;
+  const head = html.slice(0, 4096);
+  if (/<title>\s*(Just a moment|Attention Required|Access denied|Please Wait)/i.test(head))
+    return true;
+  if (/cf-browser-verification|cf-challenge-running|__cf_chl_jschl_tk__/i.test(head)) return true;
+  return false;
+}
+
+function extractJsonLdScriptsFromHtml(html) {
+  if (!html) return [];
+  const scripts = [];
+  const re = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let match;
+  while ((match = re.exec(html)) !== null) {
+    const body = match[1].trim();
+    if (body) scripts.push(body);
+  }
+  return scripts;
+}
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log("  PASS ", name);
+    passed++;
+  } catch (err) {
+    console.log("  FAIL ", name, "-", err.message);
+    failed++;
+  }
+}
+function eq(actual, expected, msg = "") {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`${msg} expected ${e} got ${a}`);
+}
+
+const padding = "x".repeat(6000);
+const realProductHead = `<html><head><title>1 oz Gold Eagle | Bullion Exchanges</title></head><body>${padding}</body></html>`;
+
+console.log("--- looksLikeChallengePage ---");
+
+test("null / empty → challenge", () => {
+  eq(looksLikeChallengePage(null), true);
+  eq(looksLikeChallengePage(""), true);
+});
+
+test("short body (<5KB) → challenge", () => {
+  eq(looksLikeChallengePage("<html><body>short</body></html>"), true);
+});
+
+test("'Just a moment' title → challenge", () => {
+  const html = `<html><head><title>Just a moment...</title></head><body>${padding}</body></html>`;
+  eq(looksLikeChallengePage(html), true);
+});
+
+test("'Attention Required' title → challenge", () => {
+  const html = `<html><head><title>Attention Required! | Cloudflare</title></head><body>${padding}</body></html>`;
+  eq(looksLikeChallengePage(html), true);
+});
+
+test("'Access denied' title → challenge", () => {
+  const html = `<html><head><title>Access denied</title></head><body>${padding}</body></html>`;
+  eq(looksLikeChallengePage(html), true);
+});
+
+test("cf-browser-verification marker in head → challenge", () => {
+  const html = `<html><head><title>Loading</title><script>cf-browser-verification</script></head><body>${padding}</body></html>`;
+  eq(looksLikeChallengePage(html), true);
+});
+
+test("real product page → not challenge", () => {
+  eq(looksLikeChallengePage(realProductHead), false);
+});
+
+test("real product page with 'cloudflare' in body → not challenge", () => {
+  const html = `<html><head><title>1 oz Silver Round</title></head><body>${padding}<footer>Powered by Cloudflare</footer></body></html>`;
+  eq(looksLikeChallengePage(html), false);
+});
+
+console.log("\n--- extractJsonLdScriptsFromHtml ---");
+
+test("empty / null html → []", () => {
+  eq(extractJsonLdScriptsFromHtml(""), []);
+  eq(extractJsonLdScriptsFromHtml(null), []);
+});
+
+test("no JSON-LD → []", () => {
+  eq(extractJsonLdScriptsFromHtml("<html><body>hello</body></html>"), []);
+});
+
+test("single JSON-LD script extracted", () => {
+  const html = `<html><head><script type="application/ld+json">{"@type":"Product","offers":{"price":"100"}}</script></head></html>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 1);
+  const parsed = JSON.parse(out[0]);
+  eq(parsed["@type"], "Product");
+});
+
+test("multiple JSON-LD scripts extracted in order", () => {
+  const html = `<script type="application/ld+json">{"a":1}</script><div>x</div><script type='application/ld+json'>{"b":2}</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 2);
+  eq(JSON.parse(out[0]), { a: 1 });
+  eq(JSON.parse(out[1]), { b: 2 });
+});
+
+test("mixed attributes on script tag still matched", () => {
+  const html = `<script id="meta" type="application/ld+json" data-foo="bar">{"c":3}</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 1);
+  eq(JSON.parse(out[0]), { c: 3 });
+});
+
+test("non-JSON-LD script tags ignored", () => {
+  const html = `<script>var x=1;</script><script type="text/javascript">y=2</script><script type="application/ld+json">{"d":4}</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 1);
+  eq(JSON.parse(out[0]), { d: 4 });
+});
+
+test("empty JSON-LD body is skipped", () => {
+  const html = `<script type="application/ld+json">  </script><script type="application/ld+json">{"e":5}</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 1);
+});
+
+test("body preserves raw text (JSON array root)", () => {
+  const html = `<script type="application/ld+json">[{"@type":"Product","offers":{"price":"50"}}]</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  const parsed = JSON.parse(out[0]);
+  eq(Array.isArray(parsed), true);
+  eq(parsed[0]["@type"], "Product");
+});
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/devops/pollers/shared/price-extract-cf-helpers.test.mjs
+++ b/devops/pollers/shared/price-extract-cf-helpers.test.mjs
@@ -20,7 +20,7 @@ function looksLikeChallengePage(html) {
 function extractJsonLdScriptsFromHtml(html) {
   if (!html) return [];
   const scripts = [];
-  const re = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  const re = /<script\b[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
   let match;
   while ((match = re.exec(html)) !== null) {
     const body = match[1].trim();
@@ -143,6 +143,20 @@ test("body preserves raw text (JSON array root)", () => {
   const parsed = JSON.parse(out[0]);
   eq(Array.isArray(parsed), true);
   eq(parsed[0]["@type"], "Product");
+});
+
+test("whitespace around type attribute still matches", () => {
+  const html = `<script type = "application/ld+json">{"f":6}</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 1);
+  eq(JSON.parse(out[0]), { f: 6 });
+});
+
+test("mixed whitespace and single quotes still matches", () => {
+  const html = `<script  type\t=  'application/ld+json' >{"g":7}</script>`;
+  const out = extractJsonLdScriptsFromHtml(html);
+  eq(out.length, 1);
+  eq(JSON.parse(out[0]), { g: 7 });
 });
 
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -783,7 +783,7 @@ function looksLikeChallengePage(html) {
 function extractJsonLdScriptsFromHtml(html) {
   if (!html) return [];
   const scripts = [];
-  const re = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  const re = /<script\b[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
   let match;
   while ((match = re.exec(html)) !== null) {
     const body = match[1].trim();
@@ -806,7 +806,19 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     );
     const retry = await getCFClearanceCookie(url);
     if (retry && retry.responseHtml && !looksLikeChallengePage(retry.responseHtml)) {
-      cfData = retry;
+      // Merge: take retry's clean HTML but keep whichever cookie/UA is set.
+      // Byparr often returns HTML without a cookie — losing a valid cookie
+      // from the first attempt would silently break the Playwright fallback.
+      cfData = {
+        cfClearance: retry.cfClearance ?? cfData.cfClearance,
+        userAgent: retry.userAgent ?? cfData.userAgent,
+        responseHtml: retry.responseHtml,
+      };
+    } else {
+      // Both attempts returned challenge HTML (or retry failed). Don't try to
+      // extract prices from a challenge page — drop the HTML so we skip to the
+      // Playwright fallback when a cookie is available.
+      cfData = { ...cfData, responseHtml: null };
     }
   }
 
@@ -1499,7 +1511,13 @@ async function main() {
               source = scrapeResult.source;
               inStock = scrapeResult.inStock;
               finalUrl = url;
-              log(`  ✓ ${coinSlug}/${provider.id}: $${price.toFixed(2)} (${source})`);
+              // price may be null when cf-clearance detected OOS via JSON-LD
+              // (zero-price sentinel) — guard before toFixed.
+              if (price !== null) {
+                log(`  ✓ ${coinSlug}/${provider.id}: $${price.toFixed(2)} (${source})`);
+              } else {
+                log(`  ✓ ${coinSlug}/${provider.id}: OOS, no price (${source})`);
+              }
               break;
             }
             markdown = scrapeResult;

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -770,19 +770,62 @@ async function scrapeViaProxy(url, waitFor = 15000, timeout = 40000) {
   }
 }
 
+function looksLikeChallengePage(html) {
+  if (!html) return true;
+  if (html.length < 5000) return true;
+  const head = html.slice(0, 4096);
+  if (/<title>\s*(Just a moment|Attention Required|Access denied|Please Wait)/i.test(head))
+    return true;
+  if (/cf-browser-verification|cf-challenge-running|__cf_chl_jschl_tk__/i.test(head)) return true;
+  return false;
+}
+
+function extractJsonLdScriptsFromHtml(html) {
+  if (!html) return [];
+  const scripts = [];
+  const re = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let match;
+  while ((match = re.exec(html)) !== null) {
+    const body = match[1].trim();
+    if (body) scripts.push(body);
+  }
+  return scripts;
+}
+
 async function scrapeViaCFClearance(url, providerId, coin) {
   log(`[cf-clearance] attempt: ${providerId} ${url}`);
-  const cfData = await getCFClearanceCookie(url);
+  let cfData = await getCFClearanceCookie(url);
   if (!cfData) {
     warn(`[cf-clearance] sidecar unavailable for ${providerId}`);
     return null;
   }
 
-  // Byparr already fetched the page — try its response HTML first (fast path).
-  // For server-rendered pages this avoids a second Playwright request. For SPAs
-  // (e.g. Bullion Exchanges Magento PWA) the HTML is just the app shell with no
-  // prices — fall through to Playwright with the cookie so the SPA can hydrate.
+  if (cfData.responseHtml && looksLikeChallengePage(cfData.responseHtml)) {
+    warn(
+      `[cf-clearance] challenge-looking HTML from Byparr for ${providerId} (len=${cfData.responseHtml.length}) — retrying once`
+    );
+    const retry = await getCFClearanceCookie(url);
+    if (retry && retry.responseHtml && !looksLikeChallengePage(retry.responseHtml)) {
+      cfData = retry;
+    }
+  }
+
+  // Byparr already fetched the page. Try JSON-LD first (authoritative —
+  // matches the Playwright fallback's extractor), then fall back to
+  // regex-on-stripped-text. For SPAs where both fail, fall through to
+  // Playwright with the cookie so the pricing grid can hydrate.
   if (cfData.responseHtml) {
+    const jsonLdScripts = extractJsonLdScriptsFromHtml(cfData.responseHtml);
+    const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
+    if (jsonLdPrice === JSONLD_ZERO_PRICE) {
+      log(`[cf-clearance] ${providerId}: JSON-LD price=0 in Byparr HTML -> OOS`);
+      return { price: null, inStock: false, source: "cf-clearance:jsonLd" };
+    }
+    if (jsonLdPrice !== null) {
+      log(`[cf-clearance] success (html jsonLd): ${providerId} price=${jsonLdPrice}`);
+      return { price: jsonLdPrice, inStock: true, source: "cf-clearance:jsonLd" };
+    }
+
     const rawText = cfData.responseHtml
       .replace(/<(script|style|head)[^>]*>[\s\S]*?<\/(script|style|head)>/gi, " ")
       .replace(/<[^>]+>/g, " ")
@@ -799,17 +842,14 @@ async function scrapeViaCFClearance(url, providerId, coin) {
       };
     }
     warn(
-      `[cf-clearance] no price from Byparr HTML for ${providerId} — falling through to Playwright`
+      `[cf-clearance] no price from Byparr HTML for ${providerId} (len=${cfData.responseHtml.length}, jsonLd=${jsonLdScripts.length}) -- falling through to Playwright`
     );
-    // Don't return null — fall through to Playwright with the cookie.
-    // SPA pages need a real browser to hydrate their pricing grids.
   }
 
-  // Fallback: launch Playwright with the cf_clearance cookie.
-  // Reached when (a) Byparr had no response HTML, or (b) HTML was present but
-  // extraction failed (SPA app shell). Requires a valid cookie.
   if (!cfData.cfClearance) {
-    warn(`[cf-clearance] no cookie and no usable HTML for ${providerId}`);
+    warn(
+      `[cf-clearance] ${providerId}: Byparr had no cookie and HTML yielded no price -- cannot fall back to Playwright`
+    );
     return null;
   }
   let browser;


### PR DESCRIPTION
## Problem

The cf-clearance fast path (Byparr sidecar) succeeded at fetching HTML but intermittently failed to extract a price from it, causing recurring `price_not_found` failures. Observed 2026-04-24:

- **BullionExchanges**: ~65% success baseline for 3+ weeks (should be 95%+)
- **JMBullion**: slipped to 91.2% today from 98% baseline
- 17:30 UTC run: all 5 target URLs failed at `[cf-clearance] no price from Byparr HTML`
- Same-run other BE items (kookaburra, krugerrand, goldback) extracted cleanly — not a universal regex failure

## Root cause

1. **JMBullion** — Byparr returns ~527KB of full product HTML but **no cf_clearance cookie**. The fast path stripped HTML to text and ran regex on it. When regex missed (e.g. when nav/footer markup pushed the product price past the first in-range match), the code hit `if (!cfData.cfClearance) return null` and bailed — never trying JSON-LD, even though JSON-LD with the authoritative wire/eCheck price is embedded in the page.
2. **Intermittent Byparr challenge responses** — no retry, so any transient solver hiccup produced a permanent-for-this-hour failure.

## Fix

1. **`extractJsonLdScriptsFromHtml(html)`** — pull `<script type="application/ld+json">` blocks out of raw Byparr HTML.
2. In `scrapeViaCFClearance`, try `extractJsonLdPrice()` (existing, authoritative) on those scripts **before** falling back to the regex-on-stripped-text path.
3. **`looksLikeChallengePage(html)`** — heuristic detection (short body, CF challenge markers in `<head>`). Retry Byparr once if the first response looks like a challenge page.
4. Improved failure diagnostics: warn logs now include HTML length and JSON-LD script count so future failures can be triaged from logs alone.

## Verified live on home poller

Replayed the 5 URLs that failed at 17:30 UTC through the new path:

| URL | Result |
|---|---|
| BE 10oz generic silver bar | **$767.80** (jsonLd) |
| JM 1oz Canadian gold maple | **$4886.82** (jsonLd) |
| BE 1oz American gold eagle | **$4774.40** (jsonLd) |
| BE 1oz silver generic rounds | **$76.78** (jsonLd) |
| JM 1oz Australian silver kangaroo | Byparr timeout (unchanged — retry path activates here) |

## Test plan

- [x] 16 new fixture tests for the two helpers (`price-extract-cf-helpers.test.mjs`)
- [x] 19 existing `extractJsonLdPrice` tests still pass
- [x] 8 existing pipe-table tests still pass
- [x] Live verification against 5 production URLs on home poller
- [ ] Deploy to home poller and watch next 3 hourly cron runs for BE/JM success-rate improvement
- [ ] 24h rolling success-rate check — expect BE to jump from ~65% toward ~90%+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare challenge detection with automatic retry logic
  * Enhanced price extraction with JSON-LD parsing when available
  * Better fallback handling for missing data

* **Tests**
  * Added comprehensive test coverage for price extraction helper functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->