### PR TITLE
chore(STAK-576): default purity to .9999 — Four Nines (ISSUE-007)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2055,16 +2055,16 @@
                   >Purity <span style="font-weight: normal; opacity: 0.6">(fineness)</span></label
                 >
                 <select id="itemPuritySelect">
-                  <option value="1.0">100% — Pure</option>
                   <option value="0.9999">.9999 — Four Nines</option>
+                  <option value="1.0">100% — Pure</option>
                   <option value="0.9995">.9995 — Pure Platinum</option>
                   <option value="0.999">.999 — Fine</option>
                   <option value="0.925">.925 — Sterling</option>
-                  <option value="0.500">.500 — 12K</option>
                   <option value="0.9167">.9167 — 22K (Krugerrand)</option>
                   <option value="0.900">.900 — 90% Silver</option>
                   <option value="0.800">.800 — 80% (European)</option>
                   <option value="0.600">.600 — 60%</option>
+                  <option value="0.500">.500 — 12K</option>
                   <option value="0.400">.400 — 40% Silver</option>
                   <option value="0.350">.350 — War Nickels</option>
                   <option value="custom">Custom…</option>

--- a/index.html
+++ b/index.html
@@ -2055,16 +2055,16 @@
                   >Purity <span style="font-weight: normal; opacity: 0.6">(fineness)</span></label
                 >
                 <select id="itemPuritySelect">
-                  <option value="0.9999">.9999 — Four Nines</option>
                   <option value="1.0">100% — Pure</option>
+                  <option value="0.9999" selected>.9999 — Four Nines</option>
                   <option value="0.9995">.9995 — Pure Platinum</option>
                   <option value="0.999">.999 — Fine</option>
                   <option value="0.925">.925 — Sterling</option>
+                  <option value="0.500">.500 — 12K</option>
                   <option value="0.9167">.9167 — 22K (Krugerrand)</option>
                   <option value="0.900">.900 — 90% Silver</option>
                   <option value="0.800">.800 — 80% (European)</option>
                   <option value="0.600">.600 — 60%</option>
-                  <option value="0.500">.500 — 12K</option>
                   <option value="0.400">.400 — 40% Silver</option>
                   <option value="0.350">.350 — War Nickels</option>
                   <option value="custom">Custom…</option>

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777087828";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777090618";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.29-b1777053203";
+const CACHE_NAME = "staktrakr-v3.34.29-b1777087828";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

STAK-576 ISSUE-007 — change the default purity for new inventory items from `1.0 — 100% Pure` to `.9999 — Four Nines`.

Pure (1.0) metal does not exist in commercial bullion. Accepting the old default biased every new item's melt-value math high. `.9999` is exact for modern gold (Maples, Buffalos, Britannias) and overstates `.999` silver/bars by 0.01% (negligible).

## Change

One-line block reorder in `index.html` — `.9999 — Four Nines` is now slot 1 (the de-facto default), `1.0 — 100% Pure` stays in slot 2 for users who genuinely want it. Also tidied the .500 / 12K position into the descending-purity sort. No JS touched — `parsePurity()` reads `puritySelect.value`, browsers default `<select>` to the first `<option>`.

## Goldback impact: zero

`getGoldbackRetailPrice()` returns the per-Goldback denomination price and never consults purity. Goldback retail rendering is unchanged. Only side effect is in the academic "if melted down" `computeMeltValue()` path, where the new default overstates by 0.01% — invisible in practice since Goldbacks trade at 3-4× melt.

## Test plan

- [ ] On preview build, open Add Inventory Item modal — verify the Purity dropdown opens with `.9999 — Four Nines` selected
- [ ] Add a new item without changing purity → verify the saved item carries `purity: 0.9999` and the table shows the `.9999` purity tag
- [ ] Edit an existing item with `purity: 1.0` → verify the dropdown still pre-selects `100% — Pure` correctly (the option still exists, just no longer first)
- [ ] Switch to Custom purity → verify custom input appears and accepts a value
- [ ] Add a Goldback item → verify retail still uses denomination price, melt math unchanged for end-user view

## Refs

- Parent issue: STAK-576 (dogfood pass)
- Sub-finding: ISSUE-007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reordered purity selection options in the Add/Edit Inventory Item modal for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->