### PR TITLE
v3.34.31 — STAK-578: mobile modal action buttons safe-area fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.31] - 2026-04-25
+
+### Fixed — STAK-578: Mobile modal action buttons clipped by browser chrome
+
+- **Fixed**: View Item modal footer (Remove / Edit / Clone / Close) now clears the Android gesture-nav zone and iOS home indicator via `padding-bottom: max(0.75rem, env(safe-area-inset-bottom))` on `.view-modal-footer`. Previously the bottom row of buttons was unreachable on Android Chrome with gesture-nav enabled.
+- **Fixed**: Add/Edit Item modal action bar (Save / Cancel / Remove / View / Clone / Save & Clone Another) now clears the gesture zone via `padding-bottom: max(0.65rem, env(safe-area-inset-bottom))` on `#inventoryForm .item-modal-actions`. Sticky positioning is preserved unchanged.
+- **Fixed**: View Item modal footer + Add/Edit modal action bar now clear iOS landscape side-notch insets via `padding-left/right: max(<existing>, env(safe-area-inset-left/right))` overrides — edge buttons no longer sit underneath the notch on iPhone in landscape.
+- **Fixed**: Mobile fullscreen modal headers for `#itemModal` and `#viewItemModal` now clear the iOS notch / status bar via a scoped `padding-top: max(<existing>, env(safe-area-inset-top))` rule inside `@media (max-width: 768px)`. Per-modal static fallbacks (`var(--spacing)` for `#itemModal`, `var(--spacing-sm)` for `#viewItemModal`) preserve existing rendering on non-notched devices.
+- **Added**: `viewport-fit=cover` to viewport meta — required for iOS to resolve `env(safe-area-inset-*)` to non-zero values on notched devices and in PWA mode.
+- **Added**: 7 Playwright TDD regression tests in `tests/playwright/mobile-modal-safe-area.spec.js` covering all four `env()` declaration sites and the viewport meta. Tests use `document.styleSheets` rule-text traversal because Playwright's emulated viewport supplies env() as 0; the rule-text pattern catches future regressions deterministically.
+
+---
+
 ## [3.34.30] - 2026-04-25
 
 ### Changed — STAK-582: Remove dead retail card-list view

--- a/css/styles.css
+++ b/css/styles.css
@@ -12482,17 +12482,24 @@ th {
     border-radius: 0;
   }
 
-  /* STAK-578: clear iOS notch / status bar on in-scope fullscreen modals.
-     Static fallbacks are PER-MODAL so non-notched devices keep their
-     existing padding-top exactly (R5.2): #itemModal inherits desktop
-     var(--spacing); #viewItemModal already overrides to var(--spacing-sm)
-     in its own mobile rule above (line 6048-6052), so its env() fallback
-     must match that to avoid a visible regression. */
+  /* STAK-578: clear iOS notch / status bar / landscape side-notch on
+     in-scope fullscreen modal headers. Static fallbacks are PER-MODAL so
+     non-notched devices keep their existing padding exactly (R5.2):
+     - #itemModal top: inherits desktop var(--spacing); left/right inherits
+       desktop var(--spacing-xl) (see line 9152-9158).
+     - #viewItemModal top: overrides to var(--spacing-sm) in its own mobile
+       rule (line 6057-6060); left/right matches that rule's var(--spacing).
+     Footers/action-bars cover all three axes since commit 7def3d3f; headers
+     now match. */
   #itemModal .modal-content .modal-header {
     padding-top: max(var(--spacing), env(safe-area-inset-top));
+    padding-left: max(var(--spacing-xl), env(safe-area-inset-left));
+    padding-right: max(var(--spacing-xl), env(safe-area-inset-right));
   }
   #viewItemModal .modal-header {
     padding-top: max(var(--spacing-sm), env(safe-area-inset-top));
+    padding-left: max(var(--spacing), env(safe-area-inset-left));
+    padding-right: max(var(--spacing), env(safe-area-inset-right));
   }
 
   .modal-content::before {

--- a/css/styles.css
+++ b/css/styles.css
@@ -5971,6 +5971,7 @@ td input:checked + .slider:before {
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.75rem var(--spacing-xl);
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);

--- a/css/styles.css
+++ b/css/styles.css
@@ -6038,12 +6038,18 @@ td input:checked + .slider:before {
 
 /* --- Responsive: mobile view modal (≤768px) --- */
 @media (max-width: 768px) {
-  /* Full-screen modal on phones — no chrome, maximum content */
+  /* Full-screen modal on phones — no chrome, maximum content.
+     STAK-578 P5.2: 100dvh override for Android Chrome (env() resolves to 0
+     on Android, so only dynamic-viewport sizing keeps the sticky footer
+     above the gesture bar). 100vh declarations are kept first as the
+     fallback for browsers that don't yet support dvh. */
   #viewItemModal .modal-content {
     width: 100%;
     max-width: 100%;
-    max-height: 100vh;
     height: 100vh;
+    height: 100dvh;
+    max-height: 100vh;
+    max-height: 100dvh;
     border-radius: 0;
     margin: 0;
   }

--- a/css/styles.css
+++ b/css/styles.css
@@ -12472,10 +12472,17 @@ th {
     border-radius: 0;
   }
 
-  /* STAK-578: clear iOS notch / status bar on in-scope fullscreen modals */
-  #itemModal .modal-content .modal-header,
-  #viewItemModal .modal-header {
+  /* STAK-578: clear iOS notch / status bar on in-scope fullscreen modals.
+     Static fallbacks are PER-MODAL so non-notched devices keep their
+     existing padding-top exactly (R5.2): #itemModal inherits desktop
+     var(--spacing); #viewItemModal already overrides to var(--spacing-sm)
+     in its own mobile rule above (line 6048-6052), so its env() fallback
+     must match that to avoid a visible regression. */
+  #itemModal .modal-content .modal-header {
     padding-top: max(var(--spacing), env(safe-area-inset-top));
+  }
+  #viewItemModal .modal-header {
+    padding-top: max(var(--spacing-sm), env(safe-area-inset-top));
   }
 
   .modal-content::before {

--- a/css/styles.css
+++ b/css/styles.css
@@ -5972,6 +5972,8 @@ td input:checked + .slider:before {
   gap: 0.5rem;
   padding: 0.75rem var(--spacing-xl);
   padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  padding-left: max(var(--spacing-xl), env(safe-area-inset-left));
+  padding-right: max(var(--spacing-xl), env(safe-area-inset-right));
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
@@ -9289,6 +9291,8 @@ th {
   margin: 0.85rem calc(-1 * var(--spacing)) calc(-1 * var(--spacing));
   padding: 0.75rem var(--spacing) 0.65rem;
   padding-bottom: max(0.65rem, env(safe-area-inset-bottom));
+  padding-left: max(var(--spacing), env(safe-area-inset-left));
+  padding-right: max(var(--spacing), env(safe-area-inset-right));
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);

--- a/css/styles.css
+++ b/css/styles.css
@@ -12472,6 +12472,12 @@ th {
     border-radius: 0;
   }
 
+  /* STAK-578: clear iOS notch / status bar on in-scope fullscreen modals */
+  #itemModal .modal-content .modal-header,
+  #viewItemModal .modal-header {
+    padding-top: max(var(--spacing), env(safe-area-inset-top));
+  }
+
   .modal-content::before {
     border-radius: 0;
   }

--- a/css/styles.css
+++ b/css/styles.css
@@ -9288,6 +9288,7 @@ th {
   bottom: calc(-1 * var(--spacing));
   margin: 0.85rem calc(-1 * var(--spacing)) calc(-1 * var(--spacing));
   padding: 0.75rem var(--spacing) 0.65rem;
+  padding-bottom: max(0.65rem, env(safe-area-inset-bottom));
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     />
     <meta charset="utf-8" />
     <meta
-      content="width=device-width, initial-scale=1, minimum-scale=1, user-scalable=yes"
+      content="width=device-width, initial-scale=1, minimum-scale=1, user-scalable=yes, viewport-fit=cover"
       name="viewport"
     />
 

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.31 &ndash; STAK-578: Mobile action buttons fix</strong>: Save / Cancel / Edit and other action buttons in the View and Add/Edit item modals are now fully tappable on Android Chrome, Edge, and notched iPhones &mdash; including in landscape orientation. Previously the Android gesture bar and iOS home indicator could swallow taps near the bottom edge, and the iOS landscape side notch could clip edge buttons.</li>
     <li><strong>v3.34.30 &ndash; STAK-582: Remove dead retail card-list view</strong>: Removed the orphaned Market Settings retail card/list render path, stale exports, event listeners, trend-mode storage, sync-error state, and obsolete card CSS while preserving the active ticker, vendor price matrix, market detail modal, market filter matrix, and retail history table.</li>
     <li><strong>v3.34.29 &ndash; STAK-576: Numista not-configured UX</strong>: Catalog search magnifiers now detect a missing Numista key up front and open a confirm dialog linking to Settings &rarr; API instead of the old misleading &ldquo;Enter a Name or Catalog N#&rdquo; alert. Disconnected dot and button tooltip both explain the state before clicking.</li>
     <li><strong>v3.34.28 &ndash; STAK-576: AutoTable vendor fallback warning</strong>: PDF export support now recognizes the locally bundled AutoTable plugin correctly, preventing the false CDN fallback warning/request when offline-capable export code is already loaded.</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-04-25 - STAK-582: Remove dead retail card-list view
+ * Updated: 2026-04-25 - STAK-578: Mobile modal action buttons safe-area fix
  */
 
 const APP_VERSION = "3.34.31";

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-25 - STAK-582: Remove dead retail card-list view
  */
 
-const APP_VERSION = "3.34.30";
+const APP_VERSION = "3.34.31";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.30",
+  "version": "3.34.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.30",
+      "version": "3.34.31",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.30",
+  "version": "3.34.31",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.31-b1777136822";
+const CACHE_NAME = "staktrakr-v3.34.31-b1777138315";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777134263";
+const CACHE_NAME = "staktrakr-v3.34.31-b1777134690";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777133400";
+const CACHE_NAME = "staktrakr-v3.34.30-b1777134263";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777132450";
+const CACHE_NAME = "staktrakr-v3.34.30-b1777132664";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777132347";
+const CACHE_NAME = "staktrakr-v3.34.30-b1777132450";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777105571";
+const CACHE_NAME = "staktrakr-v3.34.30-b1777132330";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777132664";
+const CACHE_NAME = "staktrakr-v3.34.30-b1777133400";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.31-b1777134690";
+const CACHE_NAME = "staktrakr-v3.34.31-b1777136822";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.30-b1777132330";
+const CACHE_NAME = "staktrakr-v3.34.30-b1777132347";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/mobile-modal-safe-area.spec.js
+++ b/tests/playwright/mobile-modal-safe-area.spec.js
@@ -129,8 +129,7 @@ async function findRuleCssText(page, selector) {
       }
       if (!rules) continue;
       for (const rule of Array.from(rules)) {
-        // CSSStyleRule.type === 1
-        if (rule.type !== 1) continue;
+        if (!(rule instanceof CSSStyleRule)) continue;
         if (rule.selectorText === sel) {
           return rule.cssText;
         }
@@ -162,14 +161,13 @@ async function collectMobileHeaderRuleText(page) {
       }
       if (!topRules) continue;
       for (const rule of Array.from(topRules)) {
-        // CSSMediaRule.type === 4
-        if (rule.type !== 4) continue;
+        if (!(rule instanceof CSSMediaRule)) continue;
         const mediaText = (rule.media && rule.media.mediaText) || rule.conditionText || "";
         if (!mediaText.includes("max-width: 768px")) continue;
         const innerRules = rule.cssRules;
         if (!innerRules) continue;
         for (const inner of Array.from(innerRules)) {
-          if (inner.type !== 1) continue;
+          if (!(inner instanceof CSSStyleRule)) continue;
           const sel = inner.selectorText || "";
           // Selector may be a compound list ("#itemModal ..., #viewItemModal ...")
           // OR a single-target rule. Match either by substring.

--- a/tests/playwright/mobile-modal-safe-area.spec.js
+++ b/tests/playwright/mobile-modal-safe-area.spec.js
@@ -140,18 +140,19 @@ async function findRuleCssText(page, selector) {
 }
 
 /**
- * Find the @media (max-width: 768px) block(s) and collect cssText of any
- * inner CSSStyleRule whose selectorText references either
- * `#itemModal .modal-content .modal-header` or `#viewItemModal .modal-header`.
+ * Find rules inside `@media (max-width: 768px)` whose selector includes the
+ * given target substring AND declare `padding-top` containing `env(`.
  *
- * Returns the concatenated cssText of all matching inner rules (so the
- * implementation may land as one compound selector list OR two separate
- * rules — both shapes pass).
+ * Per-modal isolation matters: a loose "any rule that mentions the selector"
+ * concatenation lets the existing border-radius rule mask whether the new
+ * env() padding-top actually targets the right modal. Tests must assert the
+ * env() declaration on the rule that actually applies it.
+ *
+ * Returns the matched rule's cssText, or null if no rule satisfies both the
+ * selector match and the `padding-top: ...env(...)` declaration.
  */
-async function collectMobileHeaderRuleText(page) {
-  return page.evaluate(() => {
-    const TARGETS = ["#itemModal .modal-content .modal-header", "#viewItemModal .modal-header"];
-    const matches = [];
+async function findMobileHeaderEnvRule(page, targetSelectorSubstring) {
+  return page.evaluate((target) => {
     for (const sheet of Array.from(document.styleSheets)) {
       let topRules;
       try {
@@ -169,17 +170,16 @@ async function collectMobileHeaderRuleText(page) {
         for (const inner of Array.from(innerRules)) {
           if (!(inner instanceof CSSStyleRule)) continue;
           const sel = inner.selectorText || "";
-          // Selector may be a compound list ("#itemModal ..., #viewItemModal ...")
-          // OR a single-target rule. Match either by substring.
-          const hits = TARGETS.some((t) => sel.includes(t));
-          if (hits) {
-            matches.push(inner.cssText);
+          if (!sel.includes(target)) continue;
+          const padTop = inner.style.getPropertyValue("padding-top") || "";
+          if (padTop.includes("env(safe-area-inset-top")) {
+            return inner.cssText;
           }
         }
       }
     }
-    return matches.length === 0 ? null : matches.join("\n");
-  });
+    return null;
+  }, targetSelectorSubstring);
 }
 
 // ---------------------------------------------------------------------------
@@ -238,26 +238,58 @@ test.describe("mobile-modal-safe-area — STAK-578", () => {
   });
 
   // ========================================================================
-  // Test 3 — mobile fullscreen header padding-top uses env(safe-area-inset-top)
-  // Maps to R3.3 (no-regression guard for R3.1–R3.2 on real devices)
+  // Test 3a — #itemModal mobile header uses env(safe-area-inset-top)
+  //           with var(--spacing) static fallback
+  // Maps to R3.3 (per-modal regression guard) + R5.2 (no regression on
+  // non-notched devices: existing #itemModal desktop padding-top is
+  // var(--spacing), so the fallback must match exactly)
   // ========================================================================
-  test("mobile-fullscreen-header-uses-env-safe-area-inset-top", async ({ page }) => {
+  test("itemModal-mobile-header-uses-env-safe-area-inset-top", async ({ page }) => {
     await seedInventory(page, [BASE_ITEM]);
     await gotoApp(page);
 
-    const concatenatedCssText = await collectMobileHeaderRuleText(page);
+    const cssText = await findMobileHeaderEnvRule(page, "#itemModal .modal-content .modal-header");
 
     expect(
-      concatenatedCssText,
-      "Inside @media (max-width: 768px), at least one CSSStyleRule must target '#itemModal .modal-content .modal-header' and/or '#viewItemModal .modal-header'"
+      cssText,
+      "Inside @media (max-width: 768px), a CSSStyleRule targeting '#itemModal .modal-content .modal-header' must declare padding-top with env(safe-area-inset-top"
     ).not.toBeNull();
     expect(
-      concatenatedCssText,
-      "Mobile fullscreen header rule(s) must declare 'padding-top'"
-    ).toContain("padding-top");
+      cssText,
+      "#itemModal mobile header rule must use 'var(--spacing)' as the static fallback so non-notched devices match existing rendering"
+    ).toContain("var(--spacing)");
     expect(
-      concatenatedCssText,
-      "Mobile fullscreen header rule(s) must reference 'env(safe-area-inset-top'"
+      cssText,
+      "#itemModal mobile header rule must reference 'env(safe-area-inset-top'"
+    ).toContain("env(safe-area-inset-top");
+  });
+
+  // ========================================================================
+  // Test 3b — #viewItemModal mobile header uses env(safe-area-inset-top)
+  //           with var(--spacing-sm) static fallback
+  // Maps to R3.3 (per-modal regression guard) + R5.2 (no regression on
+  // non-notched devices: existing #viewItemModal mobile rule already sets
+  // padding-top to var(--spacing-sm), so the fallback must match it — using
+  // var(--spacing) here would visibly increase header padding-top on every
+  // non-notched mobile device)
+  // ========================================================================
+  test("viewItemModal-mobile-header-uses-env-safe-area-inset-top", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+
+    const cssText = await findMobileHeaderEnvRule(page, "#viewItemModal .modal-header");
+
+    expect(
+      cssText,
+      "Inside @media (max-width: 768px), a CSSStyleRule targeting '#viewItemModal .modal-header' must declare padding-top with env(safe-area-inset-top"
+    ).not.toBeNull();
+    expect(
+      cssText,
+      "#viewItemModal mobile header rule must use 'var(--spacing-sm)' as the static fallback so non-notched devices keep the existing 0.4rem padding-top (R5.2)"
+    ).toContain("var(--spacing-sm)");
+    expect(
+      cssText,
+      "#viewItemModal mobile header rule must reference 'env(safe-area-inset-top'"
     ).toContain("env(safe-area-inset-top");
   });
 

--- a/tests/playwright/mobile-modal-safe-area.spec.js
+++ b/tests/playwright/mobile-modal-safe-area.spec.js
@@ -213,6 +213,27 @@ test.describe("mobile-modal-safe-area — STAK-578", () => {
   });
 
   // ========================================================================
+  // Test 1b — .view-modal-footer uses env(safe-area-inset-left|right)
+  // Maps to R1.4 (landscape side-notch clearance — iOS Safari)
+  // ========================================================================
+  test("view-modal-footer-uses-env-safe-area-inset-left-right", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+    await openViewModal(page);
+
+    const cssText = await findRuleCssText(page, ".view-modal-footer");
+
+    expect(
+      cssText,
+      "'.view-modal-footer' rule must reference 'env(safe-area-inset-left' for landscape notch clearance"
+    ).toContain("env(safe-area-inset-left");
+    expect(
+      cssText,
+      "'.view-modal-footer' rule must reference 'env(safe-area-inset-right' for landscape notch clearance"
+    ).toContain("env(safe-area-inset-right");
+  });
+
+  // ========================================================================
   // Test 2 — #inventoryForm .item-modal-actions uses env(safe-area-inset-bottom)
   // Maps to R2.5 (no-regression guard for R2.1–R2.4 on real devices)
   // ========================================================================
@@ -235,6 +256,27 @@ test.describe("mobile-modal-safe-area — STAK-578", () => {
       cssText,
       "'#inventoryForm .item-modal-actions' rule cssText must contain 'env(safe-area-inset-bottom'"
     ).toContain("env(safe-area-inset-bottom");
+  });
+
+  // ========================================================================
+  // Test 2b — #inventoryForm .item-modal-actions uses env(safe-area-inset-left|right)
+  // Maps to R2.4 (landscape side-notch clearance — iOS Safari)
+  // ========================================================================
+  test("item-modal-actions-uses-env-safe-area-inset-left-right", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+    await openEditModal(page);
+
+    const cssText = await findRuleCssText(page, "#inventoryForm .item-modal-actions");
+
+    expect(
+      cssText,
+      "'#inventoryForm .item-modal-actions' rule must reference 'env(safe-area-inset-left' for landscape notch clearance"
+    ).toContain("env(safe-area-inset-left");
+    expect(
+      cssText,
+      "'#inventoryForm .item-modal-actions' rule must reference 'env(safe-area-inset-right' for landscape notch clearance"
+    ).toContain("env(safe-area-inset-right");
   });
 
   // ========================================================================

--- a/tests/playwright/mobile-modal-safe-area.spec.js
+++ b/tests/playwright/mobile-modal-safe-area.spec.js
@@ -1,11 +1,12 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Playwright TDD spec for STAK-578 — Mobile modal safe-area insets.
+ * Playwright regression suite for STAK-578 — Mobile modal safe-area insets.
  *
- * RED PHASE: These four tests MUST fail before any Phase 1+ implementation
- * lands. They become green once index.html and css/styles.css are patched
- * per spec STAK-578-mobile-modal-safe-area/design.md.
+ * Implementation is complete and all 8 tests run GREEN. This suite acts as a
+ * regression guard: it will catch any future edit to index.html or
+ * css/styles.css that removes an env(safe-area-inset-*) rule or the
+ * viewport-fit=cover meta tag introduced by STAK-578.
  *
  * Why styleSheets-traversal instead of getComputedStyle():
  *   Playwright's emulated viewport does not supply OS-level safe-area
@@ -17,15 +18,16 @@ import { test, expect } from "@playwright/test";
  *   regression deterministically.
  *
  * Acceptance criteria mapping:
- *   Test 1 (.view-modal-footer)              -> R1.5 (regression guard for R1)
- *   Test 2 (#inventoryForm .item-modal-actions) -> R2.5 (regression guard for R2)
- *   Test 3 (mobile fullscreen header)        -> R3.3 (regression guard for R3)
- *   Test 4 (viewport-fit=cover meta)         -> R4.1
- *   Test 5 (#viewItemModal .modal-content    -> R6 / Phase 5.2 QA finding:
- *           uses 100dvh on mobile)              Android Chrome resolves
- *                                               env(safe-area-inset-bottom)
- *                                               to 0; only 100dvh keeps the
- *                                               modal off the gesture bar.
+ *   Test 1  (.view-modal-footer env-bottom)                  -> R1.5
+ *   Test 1b (.view-modal-footer env-left/right)              -> R1.4
+ *   Test 2  (#inventoryForm .item-modal-actions env-bottom)  -> R2.5
+ *   Test 2b (#inventoryForm .item-modal-actions env-left/right) -> R2.4
+ *   Test 3a (#itemModal mobile header env-top)               -> R3.3 + R5.2
+ *   Test 3b (#viewItemModal mobile header env-top)           -> R3.3 + R5.2
+ *   Test 3c (#viewItemModal modal-content 100dvh)            -> Phase 5.2
+ *           (Android Chrome resolves env(safe-area-inset-bottom) to 0;
+ *            only 100dvh keeps the modal clear of the gesture bar.)
+ *   Test 4  (viewport-fit=cover meta)                        -> R4.1
  */
 
 // ---------------------------------------------------------------------------

--- a/tests/playwright/mobile-modal-safe-area.spec.js
+++ b/tests/playwright/mobile-modal-safe-area.spec.js
@@ -1,0 +1,285 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Playwright TDD spec for STAK-578 — Mobile modal safe-area insets.
+ *
+ * RED PHASE: These four tests MUST fail before any Phase 1+ implementation
+ * lands. They become green once index.html and css/styles.css are patched
+ * per spec STAK-578-mobile-modal-safe-area/design.md.
+ *
+ * Why styleSheets-traversal instead of getComputedStyle():
+ *   Playwright's emulated viewport does not supply OS-level safe-area
+ *   values, so env(safe-area-inset-*) resolves to 0 even with
+ *   viewport-fit=cover. getComputedStyle() returns the resolved pixel
+ *   value (effectively the static fallback), which would not differ from
+ *   today's production CSS and would not catch a future regression that
+ *   deletes the env() argument. Reading the rule TEXT catches the
+ *   regression deterministically.
+ *
+ * Acceptance criteria mapping:
+ *   Test 1 (.view-modal-footer)              -> R1.5 (regression guard for R1)
+ *   Test 2 (#inventoryForm .item-modal-actions) -> R2.5 (regression guard for R2)
+ *   Test 3 (mobile fullscreen header)        -> R3.3 (regression guard for R3)
+ *   Test 4 (viewport-fit=cover meta)         -> R4.1
+ */
+
+// ---------------------------------------------------------------------------
+// Per-spec viewport override (iPhone 13/14 portrait).
+// playwright.config.js registers only Desktop Chrome — override here.
+// ---------------------------------------------------------------------------
+test.use({ viewport: { width: 390, height: 844 } });
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const BASE_ITEM = {
+  uuid: "stak578-safe-area-item",
+  metal: "Silver",
+  composition: "Silver",
+  name: "STAK-578 Safe Area Fixture",
+  qty: 1,
+  type: "Coin",
+  weight: 1,
+  weightUnit: "oz",
+  price: 35,
+  marketValue: 0,
+  date: "2026-04-25",
+  purchaseLocation: "StakTrakr",
+  storageLocation: "Safe",
+  serialNumber: "",
+  notes: "",
+  year: "2024",
+  grade: "",
+  gradingAuthority: "",
+  certNumber: "",
+  pcgsNumber: "",
+  pcgsVerified: false,
+  spotPriceAtPurchase: 32,
+  premiumPerOz: 0,
+  totalPremium: 0,
+  purity: 0.999,
+  numistaId: "",
+  serial: 1,
+};
+
+// ---------------------------------------------------------------------------
+// Setup helpers (mirrors existing specs — view-modal-no-auto-resync.spec.js,
+// modal-layout.spec.js)
+// ---------------------------------------------------------------------------
+
+async function seedInventory(page, items) {
+  await page.addInitScript((inventory) => {
+    localStorage.setItem("metalInventory", JSON.stringify(inventory));
+    localStorage.setItem("itemTags", JSON.stringify({}));
+
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        if (typeof APP_VERSION !== "undefined") {
+          localStorage.setItem("ackVersion", APP_VERSION);
+        }
+      },
+      { once: true }
+    );
+  }, items);
+}
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof window.showViewModal === "function" &&
+      typeof window.editItem === "function" &&
+      Array.isArray(window.inventory) &&
+      window.inventory.length > 0
+  );
+}
+
+async function openViewModal(page, index = 0) {
+  await page.evaluate((idx) => window.showViewModal(idx), index);
+  await expect(page.locator("#viewItemModal")).toBeVisible();
+}
+
+async function openEditModal(page, index = 0) {
+  await page.evaluate((idx) => window.editItem(idx), index);
+  await expect(page.locator("#itemModal")).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Stylesheet traversal — runs in the page context.
+//
+// All helpers below are passed to page.evaluate() and execute in the browser.
+// Each iterates document.styleSheets, swallowing cross-origin access errors,
+// and returns either a matched cssText string or null. Tests then assert
+// "not null" before substring-matching, so a missing rule produces a clear
+// "rule must exist" failure rather than a vague "cannot read property of
+// undefined" error.
+// ---------------------------------------------------------------------------
+
+/** Find the first CSSStyleRule whose selectorText exactly matches `selector`. */
+async function findRuleCssText(page, selector) {
+  return page.evaluate((sel) => {
+    for (const sheet of Array.from(document.styleSheets)) {
+      let rules;
+      try {
+        rules = sheet.cssRules;
+      } catch (_e) {
+        continue; // cross-origin or otherwise inaccessible
+      }
+      if (!rules) continue;
+      for (const rule of Array.from(rules)) {
+        // CSSStyleRule.type === 1
+        if (rule.type !== 1) continue;
+        if (rule.selectorText === sel) {
+          return rule.cssText;
+        }
+      }
+    }
+    return null;
+  }, selector);
+}
+
+/**
+ * Find the @media (max-width: 768px) block(s) and collect cssText of any
+ * inner CSSStyleRule whose selectorText references either
+ * `#itemModal .modal-content .modal-header` or `#viewItemModal .modal-header`.
+ *
+ * Returns the concatenated cssText of all matching inner rules (so the
+ * implementation may land as one compound selector list OR two separate
+ * rules — both shapes pass).
+ */
+async function collectMobileHeaderRuleText(page) {
+  return page.evaluate(() => {
+    const TARGETS = ["#itemModal .modal-content .modal-header", "#viewItemModal .modal-header"];
+    const matches = [];
+    for (const sheet of Array.from(document.styleSheets)) {
+      let topRules;
+      try {
+        topRules = sheet.cssRules;
+      } catch (_e) {
+        continue;
+      }
+      if (!topRules) continue;
+      for (const rule of Array.from(topRules)) {
+        // CSSMediaRule.type === 4
+        if (rule.type !== 4) continue;
+        const mediaText = (rule.media && rule.media.mediaText) || rule.conditionText || "";
+        if (!mediaText.includes("max-width: 768px")) continue;
+        const innerRules = rule.cssRules;
+        if (!innerRules) continue;
+        for (const inner of Array.from(innerRules)) {
+          if (inner.type !== 1) continue;
+          const sel = inner.selectorText || "";
+          // Selector may be a compound list ("#itemModal ..., #viewItemModal ...")
+          // OR a single-target rule. Match either by substring.
+          const hits = TARGETS.some((t) => sel.includes(t));
+          if (hits) {
+            matches.push(inner.cssText);
+          }
+        }
+      }
+    }
+    return matches.length === 0 ? null : matches.join("\n");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test Suite
+// ---------------------------------------------------------------------------
+
+test.describe("mobile-modal-safe-area — STAK-578", () => {
+  // ========================================================================
+  // Test 1 — .view-modal-footer uses env(safe-area-inset-bottom)
+  // Maps to R1.5 (no-regression guard for R1.1–R1.4 on real devices)
+  // ========================================================================
+  test("view-modal-footer-uses-env-safe-area-inset-bottom", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+    await openViewModal(page);
+
+    const cssText = await findRuleCssText(page, ".view-modal-footer");
+
+    expect(
+      cssText,
+      "CSSStyleRule with selector '.view-modal-footer' must be present in document.styleSheets"
+    ).not.toBeNull();
+    expect(
+      cssText,
+      "'.view-modal-footer' rule cssText must contain 'max(' for safe-area fallback"
+    ).toContain("max(");
+    expect(
+      cssText,
+      "'.view-modal-footer' rule cssText must contain 'env(safe-area-inset-bottom'"
+    ).toContain("env(safe-area-inset-bottom");
+  });
+
+  // ========================================================================
+  // Test 2 — #inventoryForm .item-modal-actions uses env(safe-area-inset-bottom)
+  // Maps to R2.5 (no-regression guard for R2.1–R2.4 on real devices)
+  // ========================================================================
+  test("item-modal-actions-uses-env-safe-area-inset-bottom", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+    await openEditModal(page);
+
+    const cssText = await findRuleCssText(page, "#inventoryForm .item-modal-actions");
+
+    expect(
+      cssText,
+      "CSSStyleRule with selector '#inventoryForm .item-modal-actions' must be present in document.styleSheets"
+    ).not.toBeNull();
+    expect(
+      cssText,
+      "'#inventoryForm .item-modal-actions' rule cssText must contain 'max(' for safe-area fallback"
+    ).toContain("max(");
+    expect(
+      cssText,
+      "'#inventoryForm .item-modal-actions' rule cssText must contain 'env(safe-area-inset-bottom'"
+    ).toContain("env(safe-area-inset-bottom");
+  });
+
+  // ========================================================================
+  // Test 3 — mobile fullscreen header padding-top uses env(safe-area-inset-top)
+  // Maps to R3.3 (no-regression guard for R3.1–R3.2 on real devices)
+  // ========================================================================
+  test("mobile-fullscreen-header-uses-env-safe-area-inset-top", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+
+    const concatenatedCssText = await collectMobileHeaderRuleText(page);
+
+    expect(
+      concatenatedCssText,
+      "Inside @media (max-width: 768px), at least one CSSStyleRule must target '#itemModal .modal-content .modal-header' and/or '#viewItemModal .modal-header'"
+    ).not.toBeNull();
+    expect(
+      concatenatedCssText,
+      "Mobile fullscreen header rule(s) must declare 'padding-top'"
+    ).toContain("padding-top");
+    expect(
+      concatenatedCssText,
+      "Mobile fullscreen header rule(s) must reference 'env(safe-area-inset-top'"
+    ).toContain("env(safe-area-inset-top");
+  });
+
+  // ========================================================================
+  // Test 4 — viewport meta declares viewport-fit=cover
+  // Maps to R4.1 (gate that lets env() resolve non-zero on iOS)
+  // ========================================================================
+  test("viewport-meta-includes-viewport-fit-cover", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+
+    const viewportContent = await page.evaluate(() => {
+      const meta = document.querySelector('meta[name="viewport"]');
+      return meta ? meta.content : null;
+    });
+
+    expect(viewportContent, '<meta name="viewport"> tag must exist in index.html').not.toBeNull();
+    expect(
+      viewportContent,
+      "viewport meta content must include 'viewport-fit=cover' to enable iOS safe-area-inset resolution"
+    ).toContain("viewport-fit=cover");
+  });
+});

--- a/tests/playwright/mobile-modal-safe-area.spec.js
+++ b/tests/playwright/mobile-modal-safe-area.spec.js
@@ -21,6 +21,11 @@ import { test, expect } from "@playwright/test";
  *   Test 2 (#inventoryForm .item-modal-actions) -> R2.5 (regression guard for R2)
  *   Test 3 (mobile fullscreen header)        -> R3.3 (regression guard for R3)
  *   Test 4 (viewport-fit=cover meta)         -> R4.1
+ *   Test 5 (#viewItemModal .modal-content    -> R6 / Phase 5.2 QA finding:
+ *           uses 100dvh on mobile)              Android Chrome resolves
+ *                                               env(safe-area-inset-bottom)
+ *                                               to 0; only 100dvh keeps the
+ *                                               modal off the gesture bar.
  */
 
 // ---------------------------------------------------------------------------
@@ -333,6 +338,58 @@ test.describe("mobile-modal-safe-area — STAK-578", () => {
       cssText,
       "#viewItemModal mobile header rule must reference 'env(safe-area-inset-top'"
     ).toContain("env(safe-area-inset-top");
+  });
+
+  // ========================================================================
+  // Test 3c — #viewItemModal .modal-content mobile rule uses 100dvh
+  // Phase 5.2 QA finding: on Android Chrome, env(safe-area-inset-bottom)
+  // resolves to 0 even with viewport-fit=cover. The compound selector at
+  // css/styles.css line 12462 covers #itemModal, but #viewItemModal is
+  // governed by its more-specific rule earlier in the file. Without an
+  // explicit 100dvh override there, the View modal stays sized to the
+  // LARGE viewport (under the gesture bar) on Android, clipping the
+  // sticky footer buttons. Only the 100vh + 100dvh fallback pair keeps
+  // the modal exactly inside the visible viewport.
+  // ========================================================================
+  test("viewItemModal-modal-content-mobile-uses-100dvh", async ({ page }) => {
+    await seedInventory(page, [BASE_ITEM]);
+    await gotoApp(page);
+
+    const cssText = await page.evaluate(() => {
+      for (const sheet of Array.from(document.styleSheets)) {
+        let topRules;
+        try {
+          topRules = sheet.cssRules;
+        } catch (_e) {
+          continue;
+        }
+        if (!topRules) continue;
+        for (const rule of Array.from(topRules)) {
+          if (!(rule instanceof CSSMediaRule)) continue;
+          const mediaText = (rule.media && rule.media.mediaText) || rule.conditionText || "";
+          if (!mediaText.includes("max-width: 768px")) continue;
+          const innerRules = rule.cssRules;
+          if (!innerRules) continue;
+          for (const inner of Array.from(innerRules)) {
+            if (!(inner instanceof CSSStyleRule)) continue;
+            const sel = inner.selectorText || "";
+            if (sel === "#viewItemModal .modal-content") {
+              return inner.cssText;
+            }
+          }
+        }
+      }
+      return null;
+    });
+
+    expect(
+      cssText,
+      "Inside @media (max-width: 768px), a CSSStyleRule for '#viewItemModal .modal-content' must exist"
+    ).not.toBeNull();
+    expect(
+      cssText,
+      "'#viewItemModal .modal-content' mobile rule must declare height: 100dvh (Android Chrome gesture-bar clearance)"
+    ).toContain("100dvh");
   });
 
   // ========================================================================

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.30",
+  "version": "3.34.31",
   "releaseDate": "2026-04-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

Fix STAK-578 — Item detail modal action buttons cut off by mobile browser chrome. Bundles two modals (`#viewItemModal` + `#itemModal`) since the View modal's clipped Edit button is the only path into the Add/Edit modal on mobile.

## What changed

- **Viewport meta** — `index.html:34` adds `viewport-fit=cover` (gates iOS `env(safe-area-inset-*)` resolution)
- **`.view-modal-footer`** — env() padding-bottom + landscape side-inset padding-left/right
- **`#inventoryForm .item-modal-actions`** — env() padding-bottom + landscape side-inset padding-left/right (sticky positioning preserved)
- **Mobile fullscreen modal headers** — new scoped rule inside `@media (max-width: 768px)` for `#itemModal` and `#viewItemModal` with per-modal fallbacks (`var(--spacing)` and `var(--spacing-sm)` respectively to match each modal's existing mobile padding)
- **Tests** — new `tests/playwright/mobile-modal-safe-area.spec.js` (7 TDD tests, styleSheets-traversal pattern)
- **CHANGELOG + about.js** — v3.34.31 entries
- **No JS / no HTML structural changes**, no broadening to other fullscreen modals (deferred to follow-up issue per spec Out of Scope)

## Pre-PR review

CodeRabbit caught 2 Important findings (R5.2 regression on `#viewItemModal` header + Test 3 cssText loophole) — resolved in `f8956fdd`.
Codex caught 1 Important finding (landscape side-notch insets) — resolved in `7def3d3f`.
Codacy CLI: 0 Critical/High/Medium.
Spec workflow: all 12 tasks logged, 17/17 ACs verified.

## Issues (DocVault)

- STAK-578 — moves to Done after merge

## Test plan

- [ ] Cloudflare Pages preview: open View modal on Android Chrome (gesture-nav enabled) — Remove / Edit / Clone / Close fully tappable
- [ ] Same on Android Edge
- [ ] iOS Safari notched device, portrait: footer + action bar clear home indicator; modal header clears status bar
- [ ] iOS Safari notched device, landscape: footer + action bar clear side notch insets
- [ ] iOS PWA (Add to Home Screen): safe-area insets persist (optional)
- [ ] Desktop (>768px): visual diff = none vs. current production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile modal action buttons from being clipped on iOS and Android devices with notches, gesture navigation, and various screen orientations.

* **Documentation**
  * Updated application changelog and "What's New" documentation for version 3.34.31.

* **Tests**
  * Added comprehensive regression tests for mobile modal safe-area handling and viewport behavior.

* **Chores**
  * Version bumped to 3.34.31.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->