### PR TITLE
chore(STAK-530): Phase 0 — Mintage and Rarity sort options

### DIFF
--- a/index.html
+++ b/index.html
@@ -1559,6 +1559,8 @@
               <option value="10">Gain/Loss</option>
               <option value="11">Source</option>
               <option value="99">Last Modified</option>
+              <option value="100">Mintage</option>
+              <option value="101">Rarity</option>
             </select>
             <button
               type="button"
@@ -3899,6 +3901,8 @@
                         <option value="10">Gain/Loss</option>
                         <option value="11">Source</option>
                         <option value="99">Last Modified</option>
+                        <option value="100">Mintage</option>
+                        <option value="101">Rarity</option>
                       </select>
                       <button
                         type="button"

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -21,7 +21,7 @@ const sortInventory = (data = inventory) => {
   // Pre-calculate sort values (Schwartzian transform) to avoid repeated computation
   // Map column index to data property — must match <th> order in index.html
   // 0:Date 1:Metal 2:Type 3:Image 4:Name 5:Qty 6:Weight 7:Purchase 8:Melt 9:Retail 10:Gain/Loss 11:Source 12:Actions
-  // Virtual (no <th>): 99:Last Modified
+  // Virtual (no <th>): 99:Last Modified 100:Mintage 101:Rarity
   const mapped = data.map((item) => {
     let val;
     let secondaryVal = 0; // secondary sort key; only populated for column 4 (Name)
@@ -101,7 +101,7 @@ const sortInventory = (data = inventory) => {
       }
       case SORT_COL_MINTAGE: {
         // Mintage — manual or Numista-derived; tolerates "1,000,000" or numeric
-        const raw = item.mintage;
+        const raw = item.numistaData?.mintage;
         if (raw === undefined || raw === null || raw === "") {
           val = Infinity;
         } else {
@@ -112,8 +112,8 @@ const sortInventory = (data = inventory) => {
       }
       case SORT_COL_RARITY: {
         // Rarity Index (Numista 1-100; 0/missing → end)
-        const r = parseFloat(item.rarityIndex);
-        val = !isFinite(r) || r <= 0 ? Infinity : r;
+        const r = parseFloat(String(item.numistaData?.rarityIndex ?? "").replace(/[, ]/g, ""));
+        val = !Number.isFinite(r) || r <= 0 ? Infinity : r;
         break;
       }
       default:

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -2,6 +2,8 @@
 // =============================================================================
 
 const SORT_COL_LAST_MODIFIED = 99;
+const SORT_COL_MINTAGE = 100;
+const SORT_COL_RARITY = 101;
 
 /**
  * Sorts inventory based on the current sort column and direction.
@@ -97,6 +99,23 @@ const sortInventory = (data = inventory) => {
         if (Number.isNaN(val)) val = 0;
         break;
       }
+      case SORT_COL_MINTAGE: {
+        // Mintage — manual or Numista-derived; tolerates "1,000,000" or numeric
+        const raw = item.mintage;
+        if (raw === undefined || raw === null || raw === "") {
+          val = Infinity;
+        } else {
+          const parsed = parseFloat(String(raw).replace(/[, ]/g, ""));
+          val = !isFinite(parsed) || parsed <= 0 ? Infinity : parsed;
+        }
+        break;
+      }
+      case SORT_COL_RARITY: {
+        // Rarity Index (Numista 1-100; 0/missing → end)
+        const r = parseFloat(item.rarityIndex);
+        val = !isFinite(r) || r <= 0 ? Infinity : r;
+        break;
+      }
       default:
         val = 0;
     }
@@ -117,6 +136,16 @@ const sortInventory = (data = inventory) => {
       if (aIsEmpty) return sortDirection === "asc" ? -1 : 1;
       if (bIsEmpty) return sortDirection === "asc" ? 1 : -1;
 
+      return sortDirection === "asc" ? valA - valB : valB - valA;
+    }
+
+    // Mintage / Rarity: missing values bucket to the end regardless of direction
+    if (sortColumn === SORT_COL_MINTAGE || sortColumn === SORT_COL_RARITY) {
+      const aIsEmpty = valA === Infinity;
+      const bIsEmpty = valB === Infinity;
+      if (aIsEmpty && bIsEmpty) return 0;
+      if (aIsEmpty) return 1;
+      if (bIsEmpty) return -1;
       return sortDirection === "asc" ? valA - valB : valB - valA;
     }
 
@@ -145,5 +174,7 @@ const sortInventory = (data = inventory) => {
 };
 
 window.SORT_COL_LAST_MODIFIED = SORT_COL_LAST_MODIFIED;
+window.SORT_COL_MINTAGE = SORT_COL_MINTAGE;
+window.SORT_COL_RARITY = SORT_COL_RARITY;
 
 // =============================================================================

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.33-b1777157373";
+const CACHE_NAME = "staktrakr-v3.34.33-b1777172875";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.33-b1777172875";
+const CACHE_NAME = "staktrakr-v3.34.33-b1777198138";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Phase 0 stop-gap for STAK-530 (Rarity & mintage as table columns). Surfaces both fields as sort options in the existing dropdowns so the two power users who requested this get value from data they've already entered, without touching the table column layout.

## Changes

- `js/sorting.js`
  - New constants `SORT_COL_MINTAGE` (100) and `SORT_COL_RARITY` (101)
  - `sortInventory()` switch cases parse `item.mintage` (tolerates `"1,000,000"` strings and numeric values) and `item.rarityIndex`
  - Missing or zero values bucket to the end regardless of sort direction (separate from date null-handling, which inverts with direction)
- `index.html`
  - Added **Mintage** and **Rarity** options to `cardSortColumn` (table/card sort bar)
  - Added the same options to `settingsDefaultSortColumn` (default sort dropdown in Settings)
- `sw.js` cache stamp updated by pre-commit hook

## Out of scope (Phase 1 / 2)

- Table column changes (Actions shrink, Mintage column)
- Settings widget for user-controlled column show/hide and reorder
- Both deferred until Phase 0 ships and sort usage is observed

## Test plan

- [ ] Sort table view by Mintage asc/desc — items with no mintage stay at the end either way
- [ ] Sort table view by Rarity asc/desc — items with `rarityIndex === 0` stay at the end
- [ ] Pick Mintage / Rarity in Settings → Default Sort, reload, confirm persists
- [ ] No regression on existing sort options (Date, Name, Qty, etc.)
- [ ] Manual-mintage user data ("1,000,000" string) sorts numerically, not lexicographically

Refs: STAK-530