### PR TITLE
feat(STRK-4): Lot ⇄ Each toggle for Purchase Price + table totals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7438,6 +7438,34 @@ a.about-badge:hover {
   color: #fff;
 }
 
+/* STRK-4: Purchase Price label row — label on the left, compact Lot/Each
+   toggle on the right. Sized so the toggle aligns with the small uppercase
+   label and the right column matches the left (Purchase Date) column height,
+   keeping inputs vertically aligned across the .grid.grid-2 row. */
+.label-with-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.2rem;
+}
+.label-with-toggle > label {
+  margin-bottom: 0;
+}
+
+#purchasePriceModeToggle .chip-sort-btn {
+  padding: 0.1rem 0.45rem;
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+#purchasePriceModeToggle.is-hidden {
+  display: none;
+}
+
 /* Chip context menu (right-click on name/dynamic chips) */
 .chip-context-menu {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -1686,7 +1686,11 @@
                   </svg>
                   <span class="header-text">Weight</span>
                 </th>
-                <th class="shrink" data-column="purchasePrice" title="USD">
+                <th
+                  class="shrink"
+                  data-column="purchasePrice"
+                  title="Total purchase value (qty × per-unit) · Click to search eBay active listings"
+                >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
                     <line x1="12" y1="1" x2="12" y2="23" />
                     <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
@@ -2145,7 +2149,21 @@
                 </div>
               </div>
               <div>
-                <label for="itemPrice">Purchase Price</label>
+                <div class="label-with-toggle">
+                  <label for="itemPrice">Purchase Price</label>
+                  <div
+                    class="chip-sort-toggle"
+                    id="purchasePriceModeToggle"
+                    role="group"
+                    aria-label="Purchase price mode"
+                    title="Choose how you entered this purchase"
+                  >
+                    <button type="button" class="chip-sort-btn active" data-mode="each">
+                      Each
+                    </button>
+                    <button type="button" class="chip-sort-btn" data-mode="lot">Lot</button>
+                  </div>
+                </div>
                 <div class="currency-input input-with-action">
                   <input id="itemPrice" min="0" step="0.01" type="number" />
                   <button
@@ -2170,6 +2188,9 @@
                       <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
                     </svg>
                   </button>
+                </div>
+                <div class="helper-text" id="purchasePriceHelper" aria-live="polite">
+                  Each — price per single item.
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -1689,7 +1689,7 @@
                 <th
                   class="shrink"
                   data-column="purchasePrice"
-                  title="Total purchase value (qty × per-unit) · Click to search eBay active listings"
+                  title="Total purchase value (qty × per-unit) · Click to sort"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
                     <line x1="12" y1="1" x2="12" y2="23" />

--- a/index.html
+++ b/index.html
@@ -2165,7 +2165,7 @@
                   </div>
                 </div>
                 <div class="currency-input input-with-action">
-                  <input id="itemPrice" min="0" step="0.01" type="number" />
+                  <input id="itemPrice" min="0" step="0.01" type="number" placeholder="Each" />
                   <button
                     class="inline-search-btn"
                     id="spotLookupBtn"
@@ -2188,9 +2188,6 @@
                       <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
                     </svg>
                   </button>
-                </div>
-                <div class="helper-text" id="purchasePriceHelper" aria-live="polite">
-                  Each — price per single item.
                 </div>
               </div>
             </div>

--- a/js/events.js
+++ b/js/events.js
@@ -60,7 +60,7 @@ const optionalListener = (el, event, handler, label) => {
 let purchasePriceMode = "each";
 
 const getPurchasePriceToggleButtons = () => {
-  const toggle = safeGetElement("purchasePriceModeToggle");
+  const toggle = document.getElementById("purchasePriceModeToggle");
   if (!toggle) return [];
 
   return Array.from(toggle.children).filter((child) => child.dataset?.mode);
@@ -1127,13 +1127,12 @@ const parseItemFormFields = (isEditing, existingItem) => {
 
   const nameInput = elements.itemName.value.trim();
   const qtyInput = elements.itemQty.value.trim();
-  const parsedQty =
-    qtyInput === "" ? (isEditing ? existingItem.qty || 1 : 1) : parseInt(qtyInput, 10);
+  const parsedQty = qtyInput === "" ? (isEditing ? existingItem.qty || 1 : 1) : Number(qtyInput);
   let priceInput = elements.itemPrice.value.trim();
 
   if (purchasePriceMode === "lot" && priceInput !== "") {
     const rawInput = parseFloat(priceInput) || 0;
-    priceInput = parsedQty > 0 ? String(rawInput / parsedQty) : "0";
+    priceInput = parsedQty > 0 ? String(parseFloat((rawInput / parsedQty).toFixed(6))) : "0";
   }
 
   const weightUnit = elements.itemWeightUnit.value;
@@ -1267,8 +1266,8 @@ const validateItemFields = (f) => {
   }
   if (purchasePriceMode === "lot") {
     const rawQty = f._rawQty?.trim() ?? "";
-    const lotQty = rawQty === "" ? NaN : parseInt(rawQty, 10);
-    if (rawQty === "" || isNaN(lotQty) || lotQty <= 0) {
+    const lotQty = rawQty === "" ? NaN : Number(rawQty);
+    if (rawQty === "" || isNaN(lotQty) || !Number.isInteger(lotQty) || lotQty <= 0) {
       return "Lot mode requires a quantity of at least 1.";
     }
   }

--- a/js/events.js
+++ b/js/events.js
@@ -74,43 +74,35 @@ const setPurchasePriceMode = (mode) => {
     button.classList.toggle("active", isActive);
     button.setAttribute("aria-pressed", String(isActive));
   });
+
+  updatePurchasePricePlaceholder();
 };
 
-const updatePurchaseHelper = () => {
-  const helper = safeGetElement("purchasePriceHelper");
-  if (!helper) return;
+const updatePurchasePricePlaceholder = () => {
+  if (!elements.itemPrice) return;
+  elements.itemPrice.placeholder = purchasePriceMode === "lot" ? "Lot total" : "Each";
+};
 
-  const qtyInput = elements.itemQty?.value?.trim() ?? "";
-  const priceInput = elements.itemPrice?.value?.trim() ?? "";
-  const qty = parseInt(qtyInput, 10);
-  const price = parseFloat(priceInput) || 0;
-  let helperText;
+// Toggle is only meaningful when qty > 1; at qty <= 1 Lot/Each are equivalent
+// so the segmented control is hidden and mode is forced to Each.
+const updatePurchasePriceToggleVisibility = () => {
+  const toggle = safeGetElement("purchasePriceModeToggle");
+  if (!toggle) return;
 
-  if (purchasePriceMode === "lot") {
-    if (!Number.isFinite(qty) || qty <= 0) {
-      helperText = "Lot mode requires a quantity of at least 1.";
-    } else {
-      helperText = `Lot \u2014 total paid for all ${qty} items. Saved as ${formatCurrency(
-        price / qty
-      )} each.`;
-    }
-  } else if (Number.isFinite(qty) && qty > 1) {
-    helperText = `Each \u2014 price per single item. Total for ${qty}: ${formatCurrency(
-      qty * price
-    )}.`;
-  } else {
-    helperText = "Each \u2014 price per single item.";
+  const qtyRaw = elements.itemQty?.value?.trim() ?? "";
+  const qty = parseInt(qtyRaw, 10);
+  const showToggle = Number.isFinite(qty) && qty > 1;
+
+  toggle.classList.toggle("is-hidden", !showToggle);
+
+  if (!showToggle && purchasePriceMode === "lot") {
+    setPurchasePriceMode("each");
   }
-
-  const textNode = document.createElement("span");
-  textNode.textContent = helperText;
-  helper.textContent = "";
-  helper.appendChild(textNode);
 };
 
 const resetPurchasePriceToggle = () => {
   setPurchasePriceMode("each");
-  updatePurchaseHelper();
+  updatePurchasePriceToggleVisibility();
 };
 
 window.resetPurchasePriceToggle = resetPurchasePriceToggle;
@@ -1845,18 +1837,16 @@ const setupItemFormListeners = () => {
       "click",
       () => {
         setPurchasePriceMode(button.dataset.mode);
-        updatePurchaseHelper();
       },
       `Purchase price ${button.dataset.mode} toggle`
     );
   });
 
-  optionalListener(elements.itemQty, "input", updatePurchaseHelper, "Purchase price qty helper");
   optionalListener(
-    elements.itemPrice,
+    elements.itemQty,
     "input",
-    updatePurchaseHelper,
-    "Purchase price input helper"
+    updatePurchasePriceToggleVisibility,
+    "Purchase price toggle visibility"
   );
   resetPurchasePriceToggle();
 

--- a/js/events.js
+++ b/js/events.js
@@ -54,6 +54,68 @@ const optionalListener = (el, event, handler, label) => {
 };
 
 // =============================================================================
+// PURCHASE PRICE MODE STATE
+// =============================================================================
+
+let purchasePriceMode = "each";
+
+const getPurchasePriceToggleButtons = () => {
+  const toggle = safeGetElement("purchasePriceModeToggle");
+  if (!toggle) return [];
+
+  return Array.from(toggle.children).filter((child) => child.dataset?.mode);
+};
+
+const setPurchasePriceMode = (mode) => {
+  purchasePriceMode = mode === "lot" ? "lot" : "each";
+
+  getPurchasePriceToggleButtons().forEach((button) => {
+    const isActive = button.dataset.mode === purchasePriceMode;
+    button.classList.toggle("active", isActive);
+    button.setAttribute("aria-pressed", String(isActive));
+  });
+};
+
+const updatePurchaseHelper = () => {
+  const helper = safeGetElement("purchasePriceHelper");
+  if (!helper) return;
+
+  const qtyInput = elements.itemQty?.value?.trim() ?? "";
+  const priceInput = elements.itemPrice?.value?.trim() ?? "";
+  const qty = parseInt(qtyInput, 10);
+  const price = parseFloat(priceInput) || 0;
+  let helperText;
+
+  if (purchasePriceMode === "lot") {
+    if (!Number.isFinite(qty) || qty <= 0) {
+      helperText = "Lot mode requires a quantity of at least 1.";
+    } else {
+      helperText = `Lot \u2014 total paid for all ${qty} items. Saved as ${formatCurrency(
+        price / qty
+      )} each.`;
+    }
+  } else if (Number.isFinite(qty) && qty > 1) {
+    helperText = `Each \u2014 price per single item. Total for ${qty}: ${formatCurrency(
+      qty * price
+    )}.`;
+  } else {
+    helperText = "Each \u2014 price per single item.";
+  }
+
+  const textNode = document.createElement("span");
+  textNode.textContent = helperText;
+  helper.textContent = "";
+  helper.appendChild(textNode);
+};
+
+const resetPurchasePriceToggle = () => {
+  setPurchasePriceMode("each");
+  updatePurchaseHelper();
+};
+
+window.resetPurchasePriceToggle = resetPurchasePriceToggle;
+
+// =============================================================================
 // IMAGE UPLOAD STATE (STACK-32) — Dual obverse/reverse support
 // =============================================================================
 
@@ -1073,6 +1135,14 @@ const parseItemFormFields = (isEditing, existingItem) => {
 
   const nameInput = elements.itemName.value.trim();
   const qtyInput = elements.itemQty.value.trim();
+  const parsedQty =
+    qtyInput === "" ? (isEditing ? existingItem.qty || 1 : 1) : parseInt(qtyInput, 10);
+  let priceInput = elements.itemPrice.value.trim();
+
+  if (purchasePriceMode === "lot" && priceInput !== "") {
+    const rawInput = parseFloat(priceInput) || 0;
+    priceInput = parsedQty > 0 ? String(rawInput / parsedQty) : "0";
+  }
 
   const weightUnit = elements.itemWeightUnit.value;
   const weightRaw =
@@ -1096,13 +1166,14 @@ const parseItemFormFields = (isEditing, existingItem) => {
     // before parseNumistaMetal's "Alloy" coercion masks them as truthy.
     _rawMetal: rawMetal,
     _rawType: rawType,
+    _rawQty: qtyInput,
     _isEditing: isEditing,
     name: isEditing ? nameInput || existingItem.name || "" : nameInput,
-    qty: qtyInput === "" ? (isEditing ? existingItem.qty || 1 : 1) : parseInt(qtyInput, 10),
+    qty: parsedQty,
     type: elements.itemType.value || (isEditing ? existingItem.type : ""),
     weight: parseWeight(weightRaw, weightUnit, isEditing, existingItem),
     weightUnit,
-    price: parsePriceToUSD(elements.itemPrice.value.trim(), fxRate, isEditing, existingItem.price),
+    price: parsePriceToUSD(priceInput, fxRate, isEditing, existingItem.price),
     purchaseLocation: elements.purchaseLocation.value.trim(),
     storageLocation: elements.storageLocation.value.trim(),
     serialNumber: elements.itemSerialNumber?.value?.trim() ?? "",
@@ -1201,6 +1272,13 @@ const validateItemFields = (f) => {
   // selects from existing data so this should never trigger there.
   if (!f._isEditing && (!f._rawMetal || !f._rawType)) {
     return "Please select a Metal and Type before saving.";
+  }
+  if (purchasePriceMode === "lot") {
+    const rawQty = f._rawQty?.trim() ?? "";
+    const lotQty = rawQty === "" ? NaN : parseInt(rawQty, 10);
+    if (rawQty === "" || isNaN(lotQty) || lotQty <= 0) {
+      return "Lot mode requires a quantity of at least 1.";
+    }
   }
   if (
     !f.name ||
@@ -1760,6 +1838,27 @@ const setupItemFormListeners = () => {
   } else {
     console.error("Main inventory form not found!");
   }
+
+  getPurchasePriceToggleButtons().forEach((button) => {
+    safeAttachListener(
+      button,
+      "click",
+      () => {
+        setPurchasePriceMode(button.dataset.mode);
+        updatePurchaseHelper();
+      },
+      `Purchase price ${button.dataset.mode} toggle`
+    );
+  });
+
+  optionalListener(elements.itemQty, "input", updatePurchaseHelper, "Purchase price qty helper");
+  optionalListener(
+    elements.itemPrice,
+    "input",
+    updatePurchaseHelper,
+    "Purchase price input helper"
+  );
+  resetPurchasePriceToggle();
 
   // UNDO CHANGE BUTTON
   if (elements.undoChangeBtn) {
@@ -3341,6 +3440,7 @@ const setupSearch = () => {
             elements.inventoryForm.reset();
             elements.itemWeightUnit.value = "oz";
             elements.itemDate.value = todayStr();
+            resetPurchasePriceToggle();
           }
           // STAK-580: form.reset() honors `selected` on the placeholder, but be
           // explicit so this stays correct if the HTML ever changes.

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -413,11 +413,9 @@
           typeof computeItemValuation === "function"
             ? computeItemValuation(item, currentSpot)
             : null;
-        const purchasePrice = valuation
-          ? valuation.purchasePrice
-          : typeof item.price === "number"
-            ? item.price
-            : parseFloat(item.price) || 0;
+        const purchaseTotal = valuation
+          ? valuation.purchaseTotal
+          : (parseFloat(item.price) || 0) * (Number(item.qty) || 1);
         const meltValue = valuation ? valuation.meltValue : computeMeltValue(item, currentSpot);
         const gbDenomPrice = valuation ? valuation.gbDenomPrice : null;
         const isManualRetail = valuation ? valuation.isManualRetail : false;
@@ -596,7 +594,7 @@
       <td class="shrink" data-column="weight" data-label="Weight">${filterLink("weight", item.weight, "var(--text-primary)", formatWeight(item.weight, item.weightUnit), WEIGHT_UNIT_TOOLTIPS[item.weightUnit] || "Troy ounces (ozt)")}</td>
       <td class="shrink" data-column="purchasePrice" data-label="Purchase" title="Purchase Price (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
         <a href="#" class="ebay-buy-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? " " + item.year : "") + " " + item.name)}" title="Search eBay active listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
-          ${formatCurrency(purchasePrice)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+          ${formatCurrency(purchaseTotal)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>
       </td>
       <td class="shrink" data-column="meltValue" data-label="Melt" title="Melt Value (${displayCurrency})" style="color: var(--text-primary);">${meltDisplay}</td>

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -415,7 +415,7 @@
             : null;
         const purchaseTotal = valuation
           ? valuation.purchaseTotal
-          : (parseFloat(item.price) || 0) * (Number(item.qty) || 1);
+          : (parseFloat(item.price) || 0) * (Number(item.qty) || 0);
         const meltValue = valuation ? valuation.meltValue : computeMeltValue(item, currentSpot);
         const gbDenomPrice = valuation ? valuation.gbDenomPrice : null;
         const isManualRetail = valuation ? valuation.isManualRetail : false;
@@ -592,7 +592,7 @@
       </td>
       <td class="shrink" data-column="qty" data-label="Qty">${filterLink("qty", item.qty, "var(--text-primary)")}</td>
       <td class="shrink" data-column="weight" data-label="Weight">${filterLink("weight", item.weight, "var(--text-primary)", formatWeight(item.weight, item.weightUnit), WEIGHT_UNIT_TOOLTIPS[item.weightUnit] || "Troy ounces (ozt)")}</td>
-      <td class="shrink" data-column="purchasePrice" data-label="Purchase" title="Purchase Price (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
+      <td class="shrink" data-column="purchasePrice" data-label="Purchase" title="Purchase Total (${displayCurrency}) - Click to search eBay active listings" style="color: var(--text-primary);">
         <a href="#" class="ebay-buy-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? " " + item.year : "") + " " + item.name)}" title="Search eBay active listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${formatCurrency(purchaseTotal)} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -988,6 +988,10 @@ const editItem = (idx, logIdx = null) => {
     window.toggleDimensionFields(shapeEl.value);
   }
 
+  if (typeof window.resetPurchasePriceToggle === "function") {
+    window.resetPurchasePriceToggle();
+  }
+
   // STAK-343: Populate tags in edit modal
   if (item.uuid && typeof getItemTags === "function") {
     const itemTagsChips = safeGetElement("itemModalTagsChips", true);
@@ -1168,6 +1172,10 @@ const duplicateItem = (idx) => {
 
   // Update currency symbols in modal (STACK-50)
   if (typeof updateModalCurrencyUI === "function") updateModalCurrencyUI();
+
+  if (typeof window.resetPurchasePriceToggle === "function") {
+    window.resetPurchasePriceToggle();
+  }
 
   // Open unified modal
   if (window.openModalById) openModalById("itemModal");

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -59,7 +59,7 @@ const sortInventory = (data = inventory) => {
         val = parseFloat(item.weight) || 0;
         break; // Weight
       case 7:
-        val = parseFloat(item.price) || 0;
+        val = (parseFloat(item.price) || 0) * (Number(item.qty) || 1);
         break; // Purchase Price
       case 8: // Melt Value (computed)
         val = computeMeltValue(item, spot);

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -59,8 +59,8 @@ const sortInventory = (data = inventory) => {
         val = parseFloat(item.weight) || 0;
         break; // Weight
       case 7:
-        val = (parseFloat(item.price) || 0) * (Number(item.qty) || 1);
-        break; // Purchase Price
+        val = (parseFloat(item.price) || 0) * (Number(item.qty) || 0);
+        break; // Purchase Total (price × qty)
       case 8: // Melt Value (computed)
         val = computeMeltValue(item, spot);
         break;

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -546,6 +546,9 @@ const useSpotPrice = (spotPrice, timestamp) => {
 
     if (elements.itemPrice) {
       elements.itemPrice.value = displayPrice;
+      if (typeof window.resetPurchasePriceToggle === "function") {
+        window.resetPurchasePriceToggle();
+      }
       flashSpotLookupTarget(elements.itemPrice);
     }
   }

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -478,7 +478,8 @@ function _buildValuationSection(item, metrics) {
     metrics.currentSpot > 0
       ? metrics.weightOz * metrics.qty * metrics.currentSpot * metrics.purity
       : 0;
-  const purchaseTotal = metrics.qty * (parseFloat(item.price) || 0);
+  const purchasePrice = parseFloat(item.price) || 0;
+  const purchaseTotal = metrics.qty * purchasePrice;
   const marketVal = parseFloat(item.marketValue) || 0;
   const retailTotal = marketVal > 0 ? metrics.qty * marketVal : meltValue;
   const gainLoss = retailTotal > 0 ? retailTotal - purchaseTotal : null;
@@ -490,9 +491,11 @@ function _buildValuationSection(item, metrics) {
       ? formatDisplayDate(item.date)
       : item.date
     : "";
-  const purchaseLabel = purchaseDateStr
-    ? `${formatCurrency(purchaseTotal)} (${purchaseDateStr})`
-    : formatCurrency(purchaseTotal);
+  const purchaseBody =
+    metrics.qty > 1
+      ? `${formatCurrency(purchaseTotal)} total \u00b7 ${formatCurrency(purchasePrice)} each`
+      : formatCurrency(purchasePrice);
+  const purchaseLabel = purchaseDateStr ? `${purchaseBody} (${purchaseDateStr})` : purchaseBody;
   _addDetail(valGrid, "Purchase", purchaseLabel);
   _addDetail(valGrid, "Melt Value", metrics.currentSpot > 0 ? formatCurrency(meltValue) : "—");
   _addDetail(valGrid, "Retail", retailTotal > 0 ? formatCurrency(retailTotal) : "—");

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.33-b1777316590";
+const CACHE_NAME = "staktrakr-v3.34.33-b1777317022";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.33-b1777317022";
+const CACHE_NAME = "staktrakr-v3.34.33-b1777322707";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.33-b1777198138";
+const CACHE_NAME = "staktrakr-v3.34.33-b1777316590";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/inventory/lot-each-purchase-price.spec.js
+++ b/tests/playwright/inventory/lot-each-purchase-price.spec.js
@@ -236,8 +236,8 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await seedData(page);
     await gotoApp(page);
     await openAddModal(page);
-    await selectPurchaseMode(page, "lot");
     await fillInventoryForm(page, { name: itemName, qty: "4", price: "400" });
+    await selectPurchaseMode(page, "lot");
     await submitItemForm(page);
 
     const item = await getInventoryItem(page, itemName);
@@ -253,13 +253,13 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await seedData(page);
     await gotoApp(page);
     await openAddModal(page);
-    await selectPurchaseMode(page, "lot");
     await fillInventoryForm(page, {
       name: itemName,
       qty: "120",
       price: "120",
       weight: "0.3617",
     });
+    await selectPurchaseMode(page, "lot");
     await submitItemForm(page);
 
     const item = await getInventoryItem(page, itemName);
@@ -269,47 +269,57 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await expectPurchaseCellText(page, itemName, "$120.00");
   });
 
-  test("7. Qty-zero + Lot blocks submission with appAlert — REQ-1.5", async ({ page }) => {
-    const itemName = "STRK-4 Lot Qty Zero";
-    await seedData(page);
-    await gotoApp(page);
-    await openAddModal(page);
-    await selectPurchaseMode(page, "lot");
-    await fillInventoryForm(page, { name: itemName, qty: "0", price: "120" });
-    await page.click("#itemModalSubmit");
-
-    await expect(page.locator("#itemModal")).toBeVisible();
-    await expect(
-      page.locator(".app-dialog, .dialog, [role='dialog']").filter({
-        hasText: /Lot mode requires a quantity of at least 1/i,
-      })
-    ).toBeVisible();
-    await expect.poll(() => getInventoryItem(page, itemName)).toBeNull();
-  });
-
-  test("8. Helper text live-updates as toggle/qty/price change — REQ-2.1, REQ-2.2, REQ-2.3", async ({
+  test("7. Toggle hides at qty <= 1 and auto-coerces Lot back to Each — STRK-4 QA refinement", async ({
     page,
   }) => {
     await seedData(page);
     await gotoApp(page);
     await openAddModal(page);
-    await expectPurchaseModeTogglePresent(page);
 
-    const helper = page.locator("#purchasePriceHelper");
-    await expect(helper).toHaveAttribute("aria-live", "polite");
+    const toggle = page.locator("#purchasePriceModeToggle");
+
+    // Empty qty → toggle hidden (no mode decision to make)
+    await expect(toggle).toHaveClass(/is-hidden/);
+
+    // qty=1 → still hidden (Lot/Each are equivalent)
     await page.fill("#itemQty", "1");
-    await page.fill("#itemPrice", "100");
-    await expect(helper).toHaveText(/Each.*price per single item/i);
+    await expect(toggle).toHaveClass(/is-hidden/);
 
-    await page.fill("#itemQty", "5");
-    await expect(helper).toContainText("Total for 5: $500.00");
-
-    await selectPurchaseMode(page, "lot");
-    await expect(helper).toContainText("Lot — total paid for all 5 items");
-    await expect(helper).toContainText("Saved as $20.00 each");
-
+    // qty>1 → toggle becomes visible
     await page.fill("#itemQty", "4");
-    await expect(helper).toContainText("Saved as $25.00 each");
+    await expect(toggle).not.toHaveClass(/is-hidden/);
+
+    // Switch to Lot mode while qty>1 is valid
+    await selectPurchaseMode(page, "lot");
+    await expect(purchaseModeButton(page, "lot")).toHaveClass(/active/);
+
+    // Drop qty back to 1 → toggle hides AND mode auto-coerces to Each
+    await page.fill("#itemQty", "1");
+    await expect(toggle).toHaveClass(/is-hidden/);
+    await expect(purchaseModeButton(page, "each")).toHaveClass(/active/);
+    await expect(purchaseModeButton(page, "lot")).not.toHaveClass(/active/);
+  });
+
+  test("8. Mode hint renders inline as input placeholder — STRK-4 QA refinement", async ({
+    page,
+  }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    const priceInput = page.locator("#itemPrice");
+
+    // Each is the default mode — placeholder reflects it
+    await expect(priceInput).toHaveAttribute("placeholder", "Each");
+
+    // qty>1 reveals the toggle; switching to Lot updates the placeholder inline
+    await page.fill("#itemQty", "5");
+    await selectPurchaseMode(page, "lot");
+    await expect(priceInput).toHaveAttribute("placeholder", "Lot total");
+
+    // Switch back to Each — placeholder restores
+    await selectPurchaseMode(page, "each");
+    await expect(priceInput).toHaveAttribute("placeholder", "Each");
   });
 
   test("9. Spot-lookup auto-selects Each — REQ-1.7", async ({ page }) => {
@@ -410,8 +420,8 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await seedData(page, { displayCurrency: "EUR", exchangeRates: { EUR: 0.9 } });
     await gotoApp(page);
     await openAddModal(page);
-    await selectPurchaseMode(page, "lot");
     await fillInventoryForm(page, { name: itemName, qty: "3", price: "90" });
+    await selectPurchaseMode(page, "lot");
     await submitItemForm(page);
 
     const item = await getInventoryItem(page, itemName);

--- a/tests/playwright/inventory/lot-each-purchase-price.spec.js
+++ b/tests/playwright/inventory/lot-each-purchase-price.spec.js
@@ -1,0 +1,422 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_ITEM = {
+  uuid: "strk4-base-item",
+  metal: "Silver",
+  composition: "Silver",
+  name: "STRK-4 Base Silver Eagle",
+  qty: 4,
+  type: "Coin",
+  weight: 1,
+  weightUnit: "oz",
+  price: 100,
+  marketValue: 0,
+  date: "2026-04-01",
+  purchaseLocation: "StakTrakr",
+  storageLocation: "Safe",
+  serialNumber: "",
+  notes: "",
+  year: "2026",
+  grade: "",
+  gradingAuthority: "",
+  certNumber: "",
+  pcgsNumber: "",
+  pcgsVerified: false,
+  spotPriceAtPurchase: 30,
+  premiumPerOz: 0,
+  totalPremium: 0,
+  purity: 0.999,
+  numistaId: "",
+  serial: 1,
+};
+
+const EXACT_SPOT_ENTRY = {
+  timestamp: "2026-04-01T12:00:00.000Z",
+  metal: "Silver",
+  spot: 33.25,
+  source: "seed",
+  provider: "Playwright",
+};
+
+async function seedData(page, options = {}) {
+  const {
+    inventory = [],
+    displayCurrency = "USD",
+    exchangeRates = { EUR: 0.9 },
+    spotHistory = [EXACT_SPOT_ENTRY],
+  } = options;
+
+  await page.route("https://open.er-api.com/v6/latest/USD", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ result: "success", base_code: "USD", rates: exchangeRates }),
+    });
+  });
+
+  await page.addInitScript(
+    ({ seededInventory, currency, rates, history }) => {
+      localStorage.setItem("metalInventory", JSON.stringify(seededInventory));
+      localStorage.setItem("itemTags", JSON.stringify({}));
+      localStorage.setItem("cardViewStyle", "D");
+      localStorage.setItem("displayCurrency", JSON.stringify(currency));
+      localStorage.setItem("exchangeRates", JSON.stringify(rates));
+      localStorage.setItem("metalSpotHistory", JSON.stringify(history));
+      localStorage.setItem("sortColumn", "4");
+      localStorage.setItem("sortDirection", "asc");
+
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          if (typeof APP_VERSION !== "undefined") {
+            localStorage.setItem("ackVersion", APP_VERSION);
+          }
+        },
+        { once: true }
+      );
+    },
+    {
+      seededInventory: inventory,
+      currency: displayCurrency,
+      rates: exchangeRates,
+      history: spotHistory,
+    }
+  );
+}
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#newItemBtn", { state: "visible" });
+  await page.waitForFunction(
+    () =>
+      typeof window.editItem === "function" &&
+      typeof window.showViewModal === "function" &&
+      Array.isArray(window.inventory)
+  );
+  await page.waitForTimeout(500);
+}
+
+async function openAddModal(page) {
+  const modal = page.locator("#itemModal");
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await page.evaluate(() => document.getElementById("newItemBtn").click());
+    if (await modal.isVisible()) return;
+    await page.waitForTimeout(250);
+  }
+  await expect(modal).toBeVisible();
+}
+
+async function openEditModal(page, index = 0) {
+  await page.evaluate((idx) => window.editItem(idx), index);
+  await expect(page.locator("#itemModal")).toBeVisible();
+}
+
+async function openCloneModal(page, index = 0) {
+  await page.evaluate((idx) => window.duplicateItem(idx), index);
+  await expect(page.locator("#itemModal")).toBeVisible();
+}
+
+async function openViewModal(page, index = 0) {
+  await page.evaluate((idx) => window.showViewModal(idx), index);
+  await expect(page.locator("#viewItemModal")).toBeVisible();
+}
+
+async function closeItemModal(page) {
+  await page.evaluate(() => {
+    if (typeof window.closeModalById === "function") {
+      window.closeModalById("itemModal");
+    } else {
+      const modal = document.getElementById("itemModal");
+      if (modal) modal.style.display = "none";
+    }
+  });
+  await expect(page.locator("#itemModal")).toBeHidden();
+}
+
+function purchaseModeButton(page, mode) {
+  return page.locator(`#purchasePriceModeToggle [data-mode="${mode}"]`);
+}
+
+async function expectPurchaseModeTogglePresent(page) {
+  await expect(page.locator("#purchasePriceModeToggle")).toHaveCount(1, { timeout: 1000 });
+  await expect(purchaseModeButton(page, "each")).toHaveCount(1, { timeout: 1000 });
+  await expect(purchaseModeButton(page, "lot")).toHaveCount(1, { timeout: 1000 });
+}
+
+async function expectEachModeActive(page) {
+  await expectPurchaseModeTogglePresent(page);
+  await expect(purchaseModeButton(page, "each")).toHaveClass(/active/);
+  await expect(purchaseModeButton(page, "lot")).not.toHaveClass(/active/);
+}
+
+async function selectPurchaseMode(page, mode) {
+  await expectPurchaseModeTogglePresent(page);
+  await purchaseModeButton(page, mode).click();
+  await expect(purchaseModeButton(page, mode)).toHaveClass(/active/);
+}
+
+async function fillInventoryForm(
+  page,
+  { name, qty = "1", price = "100", weight = "1", date = "2026-04-01" }
+) {
+  await page.selectOption("#itemMetal", "Silver");
+  await page.selectOption("#itemType", "Coin");
+  await page.fill("#itemName", name);
+  await page.fill("#itemQty", String(qty));
+  await page.fill("#itemWeight", String(weight));
+  await page.fill("#itemDate", date);
+  await page.fill("#itemPrice", String(price));
+}
+
+async function submitItemForm(page) {
+  await page.click("#itemModalSubmit");
+  await expect(page.locator("#itemModal")).toBeHidden();
+}
+
+async function getInventoryItem(page, name) {
+  return page.evaluate(
+    (targetName) => window.inventory.find((item) => item.name === targetName) || null,
+    name
+  );
+}
+
+function tableRowByName(page, name) {
+  return page.locator("#inventoryTable tbody tr").filter({ hasText: name });
+}
+
+async function expectPurchaseCellText(page, name, expectedText) {
+  const row = tableRowByName(page, name);
+  await expect(row).toHaveCount(1);
+  await expect(row.locator('[data-column="purchasePrice"]')).toContainText(expectedText);
+}
+
+test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
+  test("1. Toggle defaults to Each on add — REQ-1.1, REQ-1.2", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await expectEachModeActive(page);
+  });
+
+  test("2. Toggle defaults to Each on edit — REQ-1.2", async ({ page }) => {
+    await seedData(page, { inventory: [BASE_ITEM] });
+    await gotoApp(page);
+    await openEditModal(page);
+
+    await expectEachModeActive(page);
+    await expect(page.locator("#itemPrice")).toHaveValue("100");
+  });
+
+  test("3. Toggle defaults to Each on clone — REQ-1.2", async ({ page }) => {
+    await seedData(page, { inventory: [BASE_ITEM] });
+    await gotoApp(page);
+    await openCloneModal(page);
+
+    await expectEachModeActive(page);
+  });
+
+  test("4. Each mode stores input as-is — REQ-1.4", async ({ page }) => {
+    const itemName = "STRK-4 Each Stores Input";
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+    await expectEachModeActive(page);
+    await fillInventoryForm(page, { name: itemName, qty: "4", price: "100" });
+    await submitItemForm(page);
+
+    const item = await getInventoryItem(page, itemName);
+    expect(item).not.toBeNull();
+    expect(item.qty).toBe(4);
+    expect(item.price).toBeCloseTo(100, 6);
+  });
+
+  test("5. Lot mode divides on save (4x at $400 -> $100 each) — REQ-1.3", async ({ page }) => {
+    const itemName = "STRK-4 Lot Divides";
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+    await selectPurchaseMode(page, "lot");
+    await fillInventoryForm(page, { name: itemName, qty: "4", price: "400" });
+    await submitItemForm(page);
+
+    const item = await getInventoryItem(page, itemName);
+    expect(item).not.toBeNull();
+    expect(item.qty).toBe(4);
+    expect(item.price).toBeCloseTo(100, 6);
+  });
+
+  test("6. Reddit reporter scenario (120x at $120 lot -> $1.00 each, $120 total in table) — REQ-1.3, REQ-4.1", async ({
+    page,
+  }) => {
+    const itemName = "STRK-4 Reddit Half Dollars";
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+    await selectPurchaseMode(page, "lot");
+    await fillInventoryForm(page, {
+      name: itemName,
+      qty: "120",
+      price: "120",
+      weight: "0.3617",
+    });
+    await submitItemForm(page);
+
+    const item = await getInventoryItem(page, itemName);
+    expect(item).not.toBeNull();
+    expect(item.qty).toBe(120);
+    expect(item.price).toBeCloseTo(1, 6);
+    await expectPurchaseCellText(page, itemName, "$120.00");
+  });
+
+  test("7. Qty-zero + Lot blocks submission with appAlert — REQ-1.5", async ({ page }) => {
+    const itemName = "STRK-4 Lot Qty Zero";
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+    await selectPurchaseMode(page, "lot");
+    await fillInventoryForm(page, { name: itemName, qty: "0", price: "120" });
+    await page.click("#itemModalSubmit");
+
+    await expect(page.locator("#itemModal")).toBeVisible();
+    await expect(
+      page.locator(".app-dialog, .dialog, [role='dialog']").filter({
+        hasText: /Lot mode requires a quantity of at least 1/i,
+      })
+    ).toBeVisible();
+    await expect.poll(() => getInventoryItem(page, itemName)).toBeNull();
+  });
+
+  test("8. Helper text live-updates as toggle/qty/price change — REQ-2.1, REQ-2.2, REQ-2.3", async ({
+    page,
+  }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+    await expectPurchaseModeTogglePresent(page);
+
+    const helper = page.locator("#purchasePriceHelper");
+    await expect(helper).toHaveAttribute("aria-live", "polite");
+    await page.fill("#itemQty", "1");
+    await page.fill("#itemPrice", "100");
+    await expect(helper).toHaveText(/Each.*price per single item/i);
+
+    await page.fill("#itemQty", "5");
+    await expect(helper).toContainText("Total for 5: $500.00");
+
+    await selectPurchaseMode(page, "lot");
+    await expect(helper).toContainText("Lot — total paid for all 5 items");
+    await expect(helper).toContainText("Saved as $20.00 each");
+
+    await page.fill("#itemQty", "4");
+    await expect(helper).toContainText("Saved as $25.00 each");
+  });
+
+  test("9. Spot-lookup auto-selects Each — REQ-1.7", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+    await fillInventoryForm(page, {
+      name: "STRK-4 Spot Lookup",
+      qty: "3",
+      price: "90",
+      date: "2026-04-01",
+    });
+    await selectPurchaseMode(page, "lot");
+
+    await page.click("#spotLookupBtn");
+    await expect(page.locator("#spotLookupModal")).toBeVisible();
+    await page.locator(".spot-lookup-use-btn").first().click();
+
+    await expectEachModeActive(page);
+    await expect(page.locator("#itemPrice")).toHaveValue("33.25");
+  });
+
+  test("10. View modal dual display when qty greater than one — REQ-3.1", async ({ page }) => {
+    await seedData(page, { inventory: [BASE_ITEM] });
+    await gotoApp(page);
+    await openViewModal(page);
+
+    const purchaseRow = page.locator("#viewItemModal").filter({ hasText: "Purchase" });
+    await expect(purchaseRow).toContainText("$400.00 total");
+    await expect(purchaseRow).toContainText("$100.00 each");
+    await expect(purchaseRow).toContainText("(4/1/26)");
+  });
+
+  test("11. View modal single value when qty equals one — REQ-3.2", async ({ page }) => {
+    await seedData(page, {
+      inventory: [{ ...BASE_ITEM, uuid: "strk4-single-item", name: "STRK-4 Single", qty: 1 }],
+    });
+    await gotoApp(page);
+    await openAddModal(page);
+    await expectPurchaseModeTogglePresent(page);
+    await closeItemModal(page);
+    await openViewModal(page);
+
+    const purchaseRow = page.locator("#viewItemModal").filter({ hasText: "Purchase" });
+    await expect(purchaseRow).toContainText("$100.00 (4/1/26)");
+    await expect(purchaseRow).not.toContainText("total");
+    await expect(purchaseRow).not.toContainText("each");
+  });
+
+  test("12. Table Purchase column shows qty-total — REQ-4.1", async ({ page }) => {
+    await seedData(page, { inventory: [BASE_ITEM] });
+    await gotoApp(page);
+
+    await expectPurchaseCellText(page, BASE_ITEM.name, "$400.00");
+    await expect(
+      tableRowByName(page, BASE_ITEM.name).locator('[data-column="purchasePrice"]')
+    ).not.toContainText("$100.00");
+  });
+
+  test("13. Sort by Purchase column sorts by total — REQ-4.2", async ({ page }) => {
+    const lowerTotal = {
+      ...BASE_ITEM,
+      uuid: "strk4-sort-lower-total",
+      name: "STRK-4 Sort Lower Total",
+      qty: 1,
+      price: 200,
+    };
+    const higherTotal = {
+      ...BASE_ITEM,
+      uuid: "strk4-sort-higher-total",
+      name: "STRK-4 Sort Higher Total",
+      qty: 5,
+      price: 50,
+    };
+    await seedData(page, { inventory: [higherTotal, lowerTotal] });
+    await gotoApp(page);
+
+    await page.locator('#inventoryTable thead th[data-column="purchasePrice"]').click();
+    await expect(
+      tableRowByName(page, lowerTotal.name).locator('[data-column="purchasePrice"]')
+    ).toContainText("$200.00");
+    await expect(
+      tableRowByName(page, higherTotal.name).locator('[data-column="purchasePrice"]')
+    ).toContainText("$250.00");
+
+    const orderedNames = await page
+      .locator("#inventoryTable tbody tr [data-column='name']")
+      .allTextContents();
+    const lowerIndex = orderedNames.findIndex((text) => text.includes(lowerTotal.name));
+    const higherIndex = orderedNames.findIndex((text) => text.includes(higherTotal.name));
+    expect(lowerIndex).toBeGreaterThanOrEqual(0);
+    expect(higherIndex).toBeGreaterThanOrEqual(0);
+    expect(lowerIndex).toBeLessThan(higherIndex);
+  });
+
+  test("14. FX path (USD->EUR with known rate) — REQ-1.3 + Reliability NFR", async ({ page }) => {
+    const itemName = "STRK-4 EUR Lot";
+    await seedData(page, { displayCurrency: "EUR", exchangeRates: { EUR: 0.9 } });
+    await gotoApp(page);
+    await openAddModal(page);
+    await selectPurchaseMode(page, "lot");
+    await fillInventoryForm(page, { name: itemName, qty: "3", price: "90" });
+    await submitItemForm(page);
+
+    const item = await getInventoryItem(page, itemName);
+    expect(item).not.toBeNull();
+    expect(item.qty).toBe(3);
+    expect(item.price).toBeCloseTo((90 / 3) * (1 / 0.9), 6);
+  });
+});

--- a/tests/playwright/inventory/lot-each-purchase-price.spec.js
+++ b/tests/playwright/inventory/lot-each-purchase-price.spec.js
@@ -62,8 +62,8 @@ async function seedData(page, options = {}) {
       localStorage.setItem("displayCurrency", JSON.stringify(currency));
       localStorage.setItem("exchangeRates", JSON.stringify(rates));
       localStorage.setItem("metalSpotHistory", JSON.stringify(history));
-      localStorage.setItem("sortColumn", "4");
-      localStorage.setItem("sortDirection", "asc");
+      localStorage.setItem("defaultSortColumn", "4");
+      localStorage.setItem("defaultSortDir", "asc");
 
       document.addEventListener(
         "DOMContentLoaded",


### PR DESCRIPTION
## Summary

Implements [STRK-4](https://plane.lbruton.cc/lbruton/browse/STRK-4/) — adds a per-item Lot ⇄ Each toggle to the Purchase Price field in the Add/Edit Inventory Item modal so users can declare whether their entered value is the lot total or the per-unit price. Lot mode divides by qty before save; the stored `item.price` contract (per-unit) is unchanged. Inventory table Purchase column switches to qty-totals to match Melt/Retail.

Triggered by a Reddit report (r/staktrakr · u/dddqqq69, 2026-04-27) where 120 half-dollars at a $120 lot price were silently inflated to $14,400 cost basis.

## Commits

- **`feat(STRK-4)`** — primary implementation per the approved spec at `DocVault/specflow/StakTrakr/specs/STRK-4-lot-each-toggle-purchase-price/`
- **`chore(STRK-4)`** — visual QA pass: toggle hides at qty ≤ 1, mode hint moves inline as placeholder, toggle buttons sized to match the label, columns vertically aligned

## Visual QA refinements (deviations from approved spec)

Discovered while reviewing the live UI; recorded here so the spec/implementation mismatch is traceable:

- **Req 1.1** said "always display the toggle" — the live UI showed it as visual noise at qty=1 where Lot/Each are equivalent. Toggle now hides at qty ≤ 1 and auto-coerces Lot back to Each if the user drops qty.
- **Req 2** specified a sentence-style helper text below the input. Replaced with a compact "Each" / "Lot total" placeholder inside the input, after the currency indicator. Keeps Purchase Date and Purchase Price columns vertically aligned regardless of toggle visibility.
- **Design line 100** specified `.chip-sort-btn` verbatim. Scoped overrides only inside `#purchasePriceModeToggle` shrink the buttons to roughly match the small uppercase Purchase Price label; global `.chip-sort-btn` dimensions used by Smart Grouping/Settings are unchanged.

## Test plan

- [ ] Open Add Inventory modal with empty form — toggle is hidden, placeholder reads "Each"
- [ ] Type qty=1 — toggle stays hidden
- [ ] Type qty=2 — toggle appears
- [ ] Click "Lot" — placeholder updates to "Lot total"
- [ ] Type a lot price (e.g. \$400 with qty=4) and submit — verify item stored with price=\$100 per-unit
- [ ] Drop qty back to 1 with Lot active — toggle hides AND mode auto-resets to Each
- [ ] Open existing item with qty>1 — toggle visible, defaults to Each
- [ ] Inventory table Purchase column displays qty × price (matches Melt/Retail)
- [ ] Sort by Purchase column — sorts by qty × price total
- [ ] View Item modal Purchase row shows `\$total · \$each` when qty > 1
- [ ] Spot lookup with toggle in Lot mode auto-resets to Each
- [ ] `npm run test:e2e` against `tests/playwright/inventory/lot-each-purchase-price.spec.js`

## Codacy

Local CLI scan skipped — tool config has a missing semgrep plugin file in this worktree (environment issue, not PR). Required `Codacy Static Code Analysis` GitHub check will run on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase price entry now supports "Each/Lot" toggle mode. In "Lot" mode, enter a total cost and it automatically divides by quantity.
  * Purchase column displays total purchase cost instead of per-unit price.
  * Item details view shows both total and per-unit costs for multi-quantity items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->