### PR TITLE
v3.34.34 — STRK-4: Lot ⇄ Each toggle for Purchase Price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.34] - 2026-04-27
+
+### Added — STRK-4: Lot ⇄ Each toggle for Purchase Price
+
+- **Added**: Purchase Price field in the Add/Edit modal now has a segmented Lot / Each toggle. In Lot mode, enter the total paid for the whole lot — the app divides by quantity and stores a per-unit price automatically.
+- **Added**: Toggle visibility is tied to quantity: at qty ≤ 1 the control is hidden and mode resets to Each (Lot and Each are equivalent at that point).
+- **Changed**: Purchase column in the inventory table now shows the qty-multiplied total (price × qty) instead of the per-unit price, matching the column header tooltip.
+- **Fixed**: `parseInt` replaced with `Number()` for quantity parsing so fractional inputs like "2.5" are properly rejected by downstream integer validation instead of being silently truncated.
+
+---
+
 ## [3.34.33] - 2026-04-25
 
 ### Changed — STAK-581: Retail currency conversion phase 1

--- a/js/about.js
+++ b/js/about.js
@@ -139,17 +139,16 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.34 &ndash; STRK-4: Lot &harr; Each toggle for Purchase Price</strong>: Enter a lot total when buying multiples &mdash; the app divides by quantity to store a per-unit price automatically. The Purchase column now shows the qty-multiplied total instead of the per-unit price.</li>
     <li><strong>v3.34.33 &ndash; STAK-581: Retail currency conversion phase 1</strong>: Retail and market price surfaces now honor the selected display currency through a shared currencychange event bus. Non-USD market tables also show a convenience-conversion note because vendor checkout remains US-based.</li>
     <li><strong>v3.34.32 &ndash; STAK-571: Spot provider switch confirmation</strong>: Settings &rarr; API now asks before switching spot price providers, names the provider being selected, and explains that the change affects spot prices, charts, ticker, and portfolio values. Cancel leaves the previous provider unchanged.</li>
     <li><strong>v3.34.31 &ndash; STAK-578: Mobile action buttons fix</strong>: Save / Cancel / Edit and other action buttons in the View and Add/Edit item modals are now fully tappable on Android Chrome, Edge, and notched iPhones &mdash; including in landscape orientation. Previously the Android gesture bar and iOS home indicator could swallow taps near the bottom edge, and the iOS landscape side notch could clip edge buttons.</li>
     <li><strong>v3.34.30 &ndash; STAK-582: Remove dead retail card-list view</strong>: Removed the orphaned Market Settings retail card/list render path, stale exports, event listeners, trend-mode storage, sync-error state, and obsolete card CSS while preserving the active ticker, vendor price matrix, market detail modal, market filter matrix, and retail history table.</li>
-    <li><strong>v3.34.29 &ndash; STAK-576: Numista not-configured UX</strong>: Catalog search magnifiers now detect a missing Numista key up front and open a confirm dialog linking to Settings &rarr; API instead of the old misleading &ldquo;Enter a Name or Catalog N#&rdquo; alert. Disconnected dot and button tooltip both explain the state before clicking.</li>
   `;
 };
 
 const getEmbeddedRoadmap = () => {
   return `
-    <li><strong>Settings Redesign (STAK-436&ndash;447)</strong>: 12-issue suite covering Appearance, Filters, and API settings tabs</li>
     <li><strong>Market Page Phase 3</strong>: Inventory-to-market linking with auto-update retail prices</li>
     <li><strong>Cloud Backup Conflict Detection (STAK-150)</strong>: Smarter conflict resolution using item count direction, not just timestamps</li>
   `;

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,10 +281,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-04-25 - STAK-581: Retail currency conversion phase 1
+ * Updated: 2026-04-27 - STRK-4: Lot Each toggle for purchase price
  */
 
-const APP_VERSION = "3.34.33";
+const APP_VERSION = "3.34.34";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-04-27 - STRK-4: Lot Each toggle for purchase price
+ * Updated: 2026-04-27 - STRK-4: Lot ⇄ Each toggle for Purchase Price
  */
 
 const APP_VERSION = "3.34.34";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.33",
+  "version": "3.34.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.33",
+      "version": "3.34.34",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.33",
+  "version": "3.34.34",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.33-b1777322707";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777323319";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777323319";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777323632";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.33",
-  "releaseDate": "2026-04-25",
+  "version": "3.34.34",
+  "releaseDate": "2026-04-27",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after review.

## Changes

- Bump \`APP_VERSION\` to 3.34.34 across \`constants.js\`, \`version.json\`, \`package.json\`
- CHANGELOG: add \`[3.34.34]\` entry documenting Lot ⇄ Each toggle feature (STRK-4)
- \`about.js\`: add v3.34.34 What's New entry; roll off oldest entry (v3.34.29)
- \`about.js\`: remove shipped **Settings Redesign (STAK-436–447)** from roadmap — feature landed last week
- \`sw.js\`: cache stamp auto-updated by pre-commit hook

## Issues

- [STRK-4](https://plane.lbruton.cc/lbruton/browse/STRK-4/): Lot ⇄ Each toggle for Purchase Price (done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)