### PR TITLE
fix(STRK-6): re-apply Tailscale subnet route on every container start

### DIFF
--- a/devops/pollers/docker-compose.tinyproxy.yml
+++ b/devops/pollers/docker-compose.tinyproxy.yml
@@ -17,7 +17,8 @@
 
 services:
   tailscale:
-    image: tailscale/tailscale:latest
+    build:
+      context: tailscale
     container_name: tailscale-staktrakr
     hostname: stacktrckr-home
     restart: unless-stopped

--- a/devops/pollers/tailscale/Dockerfile
+++ b/devops/pollers/tailscale/Dockerfile
@@ -1,0 +1,13 @@
+# StakTrakr Tailscale sidecar — wraps the upstream tailscale/tailscale image
+# to re-apply the 192.168.1.0/24 subnet route after containerboot starts.
+#
+# Why: containerboot drops TS_ROUTES from prefs on restart when the persistent
+# state volume is present. Without re-applying, Fly.io silently loses its route
+# to home sqld (192.168.1.81:8080). See STRK-6 / Foundation/infrastructure.md.
+
+FROM tailscale/tailscale:latest
+
+COPY docker-entrypoint.sh /usr/local/bin/strk-tailscale-entrypoint.sh
+RUN chmod +x /usr/local/bin/strk-tailscale-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/strk-tailscale-entrypoint.sh"]

--- a/devops/pollers/tailscale/docker-entrypoint.sh
+++ b/devops/pollers/tailscale/docker-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# StakTrakr Tailscale wrapper — backgrounds containerboot, re-applies the
+# 192.168.1.0/24 subnet route via `tailscale set`, then foregrounds.
+#
+# Works around containerboot dropping TS_ROUTES from prefs on restart when
+# the persistent state volume already contains a prefs file. The wrapper is
+# idempotent: `tailscale set` with current prefs is a no-op.
+
+ROUTE="192.168.1.0/24"
+TIMEOUT=120
+
+/usr/local/bin/containerboot &
+BOOT_PID=$!
+
+# Forward SIGTERM/SIGINT so `docker stop` and `compose down` terminate
+# tailscaled cleanly instead of waiting out the 10s grace period.
+forward() {
+  kill -TERM "$BOOT_PID" 2>/dev/null
+  wait "$BOOT_PID" 2>/dev/null
+  exit $?
+}
+trap forward TERM INT
+
+# Wait for tailscaled to be ready, using the same probe as the compose
+# healthcheck. 120s covers cold-start auth refresh after long downtime.
+echo "[tailscale-wrapper] waiting up to ${TIMEOUT}s for tailscaled..."
+ELAPSED=0
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  if tailscale status --peers=false 2>/dev/null | grep -q '100\.'; then
+    echo "[tailscale-wrapper] ready after ${ELAPSED}s"
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+
+if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+  echo "[tailscale-wrapper] WARN: tailscaled not ready after ${TIMEOUT}s; skipping route apply"
+else
+  echo "[tailscale-wrapper] applying --advertise-routes=${ROUTE} --advertise-exit-node"
+  tailscale set --advertise-routes="$ROUTE" --advertise-exit-node \
+    || echo "[tailscale-wrapper] WARN: tailscale set failed; route may be missing"
+fi
+
+wait "$BOOT_PID"
+exit $?

--- a/devops/pollers/tailscale/docker-entrypoint.sh
+++ b/devops/pollers/tailscale/docker-entrypoint.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
 # StakTrakr Tailscale wrapper — backgrounds containerboot, re-applies the
-# 192.168.1.0/24 subnet route via `tailscale set`, then foregrounds.
+# configured subnet route via `tailscale set`, then foregrounds.
 #
 # Works around containerboot dropping TS_ROUTES from prefs on restart when
 # the persistent state volume already contains a prefs file. The wrapper is
 # idempotent: `tailscale set` with current prefs is a no-op.
 
-ROUTE="192.168.1.0/24"
+ROUTE="${TS_ROUTES:-192.168.1.0/24}"
+EXIT_NODE="${TS_ADVERTISE_EXIT_NODE:-1}"
 TIMEOUT=120
 
-/usr/local/bin/containerboot &
+/usr/local/bin/containerboot "$@" &
 BOOT_PID=$!
 
 # Forward SIGTERM/SIGINT so `docker stop` and `compose down` terminate
@@ -26,7 +27,11 @@ trap forward TERM INT
 echo "[tailscale-wrapper] waiting up to ${TIMEOUT}s for tailscaled..."
 ELAPSED=0
 while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
-  if tailscale status --peers=false 2>/dev/null | grep -q '100\.'; then
+  if ! kill -0 "$BOOT_PID" 2>/dev/null; then
+    echo "[tailscale-wrapper] ERROR: containerboot exited unexpectedly; aborting"
+    exit 1
+  fi
+  if tailscale ip -4 2>/dev/null | grep -q '^100\.'; then
     echo "[tailscale-wrapper] ready after ${ELAPSED}s"
     break
   fi
@@ -38,8 +43,13 @@ if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
   echo "[tailscale-wrapper] WARN: tailscaled not ready after ${TIMEOUT}s; skipping route apply"
 else
   echo "[tailscale-wrapper] applying --advertise-routes=${ROUTE} --advertise-exit-node"
-  tailscale set --advertise-routes="$ROUTE" --advertise-exit-node \
-    || echo "[tailscale-wrapper] WARN: tailscale set failed; route may be missing"
+  if [ "${EXIT_NODE}" = "1" ]; then
+    tailscale set --advertise-routes="$ROUTE" --advertise-exit-node \
+      || echo "[tailscale-wrapper] WARN: tailscale set failed; route may be missing"
+  else
+    tailscale set --advertise-routes="$ROUTE" \
+      || echo "[tailscale-wrapper] WARN: tailscale set failed; route may be missing"
+  fi
 fi
 
 wait "$BOOT_PID"


### PR DESCRIPTION
## Summary

Wraps the upstream `tailscale/tailscale:latest` image in a thin sidecar build at `devops/pollers/tailscale/` that re-applies the `192.168.1.0/24` subnet route via `tailscale set` after `containerboot` starts. Fixes the recurring API outage where Fly.io silently loses the route to home sqld whenever the Tailscale container restarts.

- New `devops/pollers/tailscale/Dockerfile` — `FROM tailscale/tailscale:latest` + custom entrypoint.
- New `devops/pollers/tailscale/docker-entrypoint.sh` — backgrounds containerboot, waits ≤120s for tailscaled, runs `tailscale set --advertise-routes=192.168.1.0/24 --advertise-exit-node`, foregrounds with SIGTERM/SIGINT trap so `docker stop` is graceful.
- `docker-compose.tinyproxy.yml` — `tailscale` service now uses `build: context: tailscale` instead of the upstream image. tinyproxy unchanged.
- `DocVault/Projects/StakTrakr/Foundation/infrastructure.md:265` — gotcha note rewritten to reflect the mitigation.

## Why this design

Three approaches were considered:

1. **Inline `command:` override in compose** — rejected: shell escaping + signal handling get ugly fast.
2. **Sidecar init container** — rejected: `tailscaled.sock` lives at `/tmp/tailscaled.sock`, not on a shared volume; sharing it requires extra mount acrobatics.
3. **Dockerfile wrapper** (chosen) — mirrors the existing `tinyproxy/Dockerfile` sibling pattern that Portainer already builds successfully. Idempotent. No socket-sharing.

`TS_EXTRA_ARGS=--reset` was left untouched. The wrapper works regardless of why containerboot drops the route, which is the design's point.

## Test plan — deploy + verify required (cannot merge-and-forget)

This PR ships only the code. Verification requires home VM + Fly.io access. After merge to `dev`:

- [ ] Redeploy stack 7 via Portainer with `pullImage: true` (rebuilds the new wrapper image)
- [ ] Restart the `tailscale-staktrakr` container — confirm `[tailscale-wrapper]` lines appear in `docker logs tailscale-staktrakr`
- [ ] `docker exec tailscale-staktrakr tailscale debug prefs | grep -A4 AdvertiseRoutes` includes `192.168.1.0/24`
- [ ] From Fly.io: `fly ssh console -a staktrakr -C 'curl -m 5 http://192.168.1.81:8080'` returns a response (404 is fine — connection accepted)
- [ ] Stack survives a Docker daemon restart (e.g., `sudo systemctl restart snap.docker.dockerd`) without losing the route — this is the original failure mode

## CI

- [x] Pre-commit hooks pass (prettier, secret scan, signing key)
- [ ] Codacy Static Code Analysis (uses Codacy infra; expected green — only added a sh script + Dockerfile)

Plane: <https://plane.lbruton.cc/lbruton/browse/STRK-6/>