### PR TITLE
feat(STRK-7): add Fly.io→sqld reachability health probe

### DIFF
--- a/devops/pollers/home-poller/check-flyio.sh
+++ b/devops/pollers/home-poller/check-flyio.sh
@@ -64,6 +64,7 @@ if [ -n "$sqld_response" ]; then
   sqld_error_class=$(json_str "$sqld_response" "error_class")
   [ -z "$sqld_ok" ] && sqld_ok="false"
 fi
+[ -z "$sqld_error_class" ] && sqld_error_class="no_response"
 if [ "$sqld_ok" = "true" ]; then
   log "sqld-reachable OK (${sqld_latency_ms:-?}ms)"
 else

--- a/devops/pollers/home-poller/check-flyio.sh
+++ b/devops/pollers/home-poller/check-flyio.sh
@@ -13,10 +13,18 @@
 
 FLYIO_TAILSCALE_IP="${FLYIO_TAILSCALE_IP:-100.90.171.110}"
 FLYIO_HTTP_URL="${FLYIO_HTTP_URL:-https://api2.staktrakr.com/data/retail/providers.json}"
+SQLD_HEALTH_URL="${SQLD_HEALTH_URL:-https://api2.staktrakr.com/health/sqld-reachable}"
 STATUS_FILE="/tmp/flyio-health.json"
 TIMEOUT=10
+SQLD_HEALTH_TIMEOUT=8
 
 log() { echo "[$(date -u +%H:%M:%S)] [flyio-check] $*"; }
+
+# Extract a JSON field from a single-line response. Shape is fixed by
+# serve.js (no nesting), so grep is sufficient — no jq dependency.
+json_bool() { echo "$1" | grep -oE "\"$2\"[[:space:]]*:[[:space:]]*(true|false)" | grep -oE "(true|false)$"; }
+json_num()  { echo "$1" | grep -oE "\"$2\"[[:space:]]*:[[:space:]]*[0-9]+" | grep -oE "[0-9]+$"; }
+json_str()  { echo "$1" | grep -oE "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | sed -E 's/.*"([^"]*)"$/\1/'; }
 
 # ── Tailscale ping (best-effort from Docker bridge) ──────────────────────────
 ts_ok=false
@@ -42,6 +50,37 @@ else
   log "WARN: HTTP check FAILED ($FLYIO_HTTP_URL → ${http_code:-no response})"
 fi
 
+# ── sqld reachability via Fly.io (catches Tailscale subnet route loss) ────────
+# Fly.io's serve.js runs SELECT 1 against home sqld via the Tailscale subnet
+# route. The probe completing at all signals Fly.io is up; the `ok` field
+# signals whether sqld is reachable.
+sqld_response=$(curl -s --max-time "$SQLD_HEALTH_TIMEOUT" "$SQLD_HEALTH_URL" 2>/dev/null)
+sqld_ok="false"
+sqld_latency_ms=""
+sqld_error_class=""
+if [ -n "$sqld_response" ]; then
+  sqld_ok=$(json_bool "$sqld_response" "ok")
+  sqld_latency_ms=$(json_num "$sqld_response" "latency_ms")
+  sqld_error_class=$(json_str "$sqld_response" "error_class")
+  [ -z "$sqld_ok" ] && sqld_ok="false"
+fi
+if [ "$sqld_ok" = "true" ]; then
+  log "sqld-reachable OK (${sqld_latency_ms:-?}ms)"
+else
+  log "WARN: sqld-reachable FAIL (${sqld_error_class:-no_response} ${sqld_latency_ms:-?}ms)"
+fi
+
+# Preserve sqld_reachable_last_success across runs — set to now on OK,
+# carry forward the previous timestamp on FAIL so the dashboard can render
+# "Xm ago" elapsed-time.
+sqld_last_success=""
+if [ -f "$STATUS_FILE" ]; then
+  sqld_last_success=$(json_str "$(cat "$STATUS_FILE" 2>/dev/null | tr -d '\n')" "sqld_reachable_last_success")
+fi
+if [ "$sqld_ok" = "true" ]; then
+  sqld_last_success=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+fi
+
 # ── Write status JSON (dashboard reads this) ─────────────────────────────────
 cat > "$STATUS_FILE" << EOF
 {
@@ -51,6 +90,11 @@ cat > "$STATUS_FILE" << EOF
   "tailscale_latency": "${ts_ms}",
   "http_url": "${FLYIO_HTTP_URL}",
   "http_ok": ${http_ok},
-  "http_code": "${http_code}"
+  "http_code": "${http_code}",
+  "sqld_reachable_url": "${SQLD_HEALTH_URL}",
+  "sqld_reachable_ok": ${sqld_ok},
+  "sqld_reachable_latency_ms": ${sqld_latency_ms:-null},
+  "sqld_reachable_error_class": "${sqld_error_class}",
+  "sqld_reachable_last_success": "${sqld_last_success}"
 }
 EOF

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -344,6 +344,17 @@ function fmtDuration(startedAt, finishedAt) {
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
+function fmtAgo(iso) {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  const m = Math.floor(ms / 60000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
 function logLineClass(line) {
   if (line.includes("\u2713")) return "log-ok";
   if (line.includes("\u26A0")) return "log-warn";
@@ -622,6 +633,19 @@ function renderStatusBar(data) {
       `Fly.io: ${flyOk ? "OK" : flyOk === false ? "DOWN" : "?"}`
   );
 
+  // Fly→sqld (Tailscale subnet route to home sqld; STRK-6 + STRK-7)
+  const sqldOk = flyioHealth?.sqld_reachable_ok;
+  let sqldLabel;
+  if (sqldOk === true) {
+    sqldLabel = "OK";
+  } else if (sqldOk === false) {
+    const ago = fmtAgo(flyioHealth?.sqld_reachable_last_success);
+    sqldLabel = ago ? `FAIL (${ago})` : "FAIL";
+  } else {
+    sqldLabel = "?";
+  }
+  items.push(dot(sqldOk ? "green" : sqldOk === false ? "red" : "amber") + `Fly→sqld: ${sqldLabel}`);
+
   // Lock
   const anyLocked = (lockStatus || []).some((l) => l.locked);
   items.push(dot(anyLocked ? "amber" : "green") + `Lock: ${anyLocked ? "BUSY" : "free"}`);
@@ -639,6 +663,19 @@ function renderInfraRow(data) {
     data;
   const netRx = net ? fmtBytes(net.rx_bytes) : "?";
   const flyOk = flyioHealth?.http_ok;
+  const sqldOk = flyioHealth?.sqld_reachable_ok;
+  const sqldAgo = sqldOk === false ? fmtAgo(flyioHealth?.sqld_reachable_last_success) : "";
+  let sqldLabel, sqldColor;
+  if (sqldOk === true) {
+    sqldLabel = "OK";
+    sqldColor = "var(--green)";
+  } else if (sqldOk === false) {
+    sqldLabel = sqldAgo ? `FAIL (${sqldAgo})` : "FAIL";
+    sqldColor = "var(--red)";
+  } else {
+    sqldLabel = "?";
+    sqldColor = "var(--amber)";
+  }
   const anyLocked = (lockStatus || []).some((l) => l.locked);
   const containerCount = (dockerContainers || []).filter((c) => c.state === "running").length;
   const serviceCount = (supervisord || []).filter((s) => s.state === "RUNNING").length;
@@ -662,6 +699,7 @@ function renderInfraRow(data) {
         : item("Lock", "Free", "var(--green)")
     }
     ${item("Fly API", flyOk ? "OK" : flyOk === false ? "DOWN" : "?", flyOk ? "var(--green)" : "var(--red)")}
+    ${item("Fly→sqld", sqldLabel, sqldColor)}
     ${item("Turso", tursoUp ? "OK" : "DOWN", tursoUp ? "var(--green)" : "var(--red)")}
     ${item("Containers", `${containerCount} up`, "var(--green)")}
     ${item("Services", `${serviceCount} up`, "var(--green)")}

--- a/devops/pollers/shared/serve.js
+++ b/devops/pollers/shared/serve.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 /**
  * Simple HTTP server for StakTrakrApi data (redundancy endpoint)
- * Serves static files from /tmp/staktrakr-api-export
+ * Serves static files from /tmp/staktrakr-api-export.
+ *
+ * Also exposes GET /health/sqld-reachable — runs `SELECT 1` against sqld
+ * via the same libSQL client the publisher uses. Detects when the
+ * Tailscale subnet route to home sqld is broken even though Fly.io
+ * itself is up (STRK-6 + STRK-7).
  */
 
 import { createServer } from "http";
@@ -10,6 +15,7 @@ import { join, resolve, extname } from "path";
 
 const PORT = process.env.PORT || 8080;
 const DATA_DIR = resolve(process.env.API_EXPORT_DIR || "/tmp/staktrakr-api-export");
+const SQLD_PROBE_TIMEOUT_MS = 5000;
 
 const MIME_TYPES = {
   ".json": "application/json",
@@ -17,6 +23,48 @@ const MIME_TYPES = {
   ".html": "text/html",
   ".txt": "text/plain",
 };
+
+let sqldClient = null;
+
+async function probeSqldReachable() {
+  const startedAt = Date.now();
+  const checkedAt = new Date().toISOString();
+
+  let timeoutId;
+  try {
+    if (!sqldClient) {
+      const { createSqldClient } = await import("./sqld-client.js");
+      sqldClient = createSqldClient();
+    }
+
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error("sqld probe timeout")), SQLD_PROBE_TIMEOUT_MS);
+    });
+
+    await Promise.race([sqldClient.execute("SELECT 1 AS ok"), timeoutPromise]);
+    return { ok: true, latency_ms: Date.now() - startedAt, checked_at: checkedAt };
+  } catch (err) {
+    // Drop the cached client so the next probe attempts a fresh connection,
+    // recovering from a stuck pool after a Tailscale-route flap.
+    sqldClient = null;
+    const msg = String(err?.message || err);
+    let errorClass = "query_error";
+    if (msg.includes("timeout")) errorClass = "timeout";
+    else if (msg.includes("ECONNREFUSED")) errorClass = "connection_refused";
+    else if (msg.includes("EHOSTUNREACH") || msg.includes("ENETUNREACH"))
+      errorClass = "host_unreachable";
+    else if (msg.includes("ENOTFOUND")) errorClass = "dns_error";
+    return {
+      ok: false,
+      error_class: errorClass,
+      error: msg.slice(0, 200),
+      latency_ms: Date.now() - startedAt,
+      checked_at: checkedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 const server = createServer(async (req, res) => {
   // CORS headers for API access
@@ -43,6 +91,21 @@ const server = createServer(async (req, res) => {
   } catch {
     res.writeHead(400);
     res.end("Bad Request");
+    return;
+  }
+
+  // Active sqld reachability probe — runs SELECT 1 against the libSQL
+  // client. Always returns 200; the boolean result lives in `ok`. The
+  // probe completing at all signals Fly.io itself is up.
+  if (url === "/health/sqld-reachable") {
+    const result = await probeSqldReachable();
+    const body = JSON.stringify(result);
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+      "Cache-Control": "no-store",
+    });
+    res.end(body);
     return;
   }
 

--- a/devops/pollers/shared/serve.js
+++ b/devops/pollers/shared/serve.js
@@ -46,7 +46,9 @@ async function probeSqldReachable() {
   } catch (err) {
     // Drop the cached client so the next probe attempts a fresh connection,
     // recovering from a stuck pool after a Tailscale-route flap.
+    const clientToClose = sqldClient;
     sqldClient = null;
+    clientToClose?.close().catch(() => {});
     const msg = String(err?.message || err);
     let errorClass = "query_error";
     if (msg.includes("timeout")) errorClass = "timeout";
@@ -57,7 +59,6 @@ async function probeSqldReachable() {
     return {
       ok: false,
       error_class: errorClass,
-      error: msg.slice(0, 200),
       latency_ms: Date.now() - startedAt,
       checked_at: checkedAt,
     };


### PR DESCRIPTION
## Summary

Adds an active health probe that catches the Fly.io→sqld failure mode silently — i.e. when Fly.io is up, the home dashboard is up, but the Tailscale subnet route to home sqld is broken. Pairs with STRK-6 (route persistence): even if STRK-6 covers the common case, this is the defense-in-depth alarm for any future regression.

### `devops/pollers/shared/serve.js` (Fly.io publisher)
- New `GET /health/sqld-reachable`. Lazy-imports `createSqldClient` (cached singleton; reset on failure so a stuck pool recovers on next probe). Runs `SELECT 1` raced against a 5s timeout.
- Always returns HTTP 200 — the **request completing** signals Fly.io is up; the `ok` field signals sqld reachability. Cleanly separates the two failure modes for the caller.
- Error classification: `timeout` / `connection_refused` / `host_unreachable` / `dns_error` / `query_error`.

### `devops/pollers/home-poller/check-flyio.sh` (cron, every 5min per `infrastructure.md:192`)
- Adds a second curl to `/health/sqld-reachable` (8s timeout). Parses `ok` / `latency_ms` / `error_class` via tiny `json_bool`/`json_num`/`json_str` grep helpers — no jq dependency since `node:20-slim` doesn't ship one.
- Tracks `sqld_reachable_last_success` across runs by reading the prior `/tmp/flyio-health.json`. Preserves on FAIL so the dashboard can render "Xm ago"; resets to now on OK.

### `devops/pollers/home-poller/dashboard.js`
- New `fmtAgo()` helper next to `fmtDuration` (`Nm` / `Nh` / `Nd ago`).
- Slim status row: `Fly→sqld: OK | FAIL (12m ago)` — green/red/amber.
- Infra grid row: matching tile, same colors.

## Failure-mode distinction (AC bullet 3)

| Existing `Retail: %` | New `Fly→sqld` | Diagnosis |
|---|---|---|
| green | green | Healthy |
| green | **red** | **Tailscale route broken** (the STRK-6 failure mode) |
| red | red | sqld itself is down |
| red | green | Data pipeline issue, not connectivity |

No extra indicators needed — the two tiles together discriminate.

## Test plan — two redeploy targets

This PR ships code only. Verification requires both the Fly.io publisher and the home poller to be redeployed.

**Fly.io publisher (serve.js)** — local deploy from this repo per `DocVault/Projects/StakTrakr/Foundation/infrastructure.md:144-152`:
- [ ] ```bash
      cd /Volumes/DATA/GitHub/StakTrakr/devops/pollers
      fly deploy --config remote-poller/fly.toml --dockerfile remote-poller/Dockerfile
      ```
- [ ] `curl https://api2.staktrakr.com/health/sqld-reachable | jq` returns `{ "ok": true, "latency_ms": <small>, ... }`

**Home poller** (check-flyio.sh + dashboard.js) — Portainer stack containing `staktrakr-home-poller`:
- [ ] Redeploy via Portainer with `pullImage: true` and the full env array (env not persisted across git redeploys; see `infrastructure.md:254`)
- [ ] After next 5min cron tick: `cat /tmp/flyio-health.json | jq '.sqld_reachable_*'` shows the new fields
- [ ] Dashboard slim row + infra grid both show "Fly→sqld: OK" tile

**Failure-mode simulation:**
- [ ] Stop the `tailscale-staktrakr` container on the home VM (the combined Tailscale+tinyproxy stack from `docker-compose.tinyproxy.yml` — exact stack ID needs Portainer API verification per the [2026-04-27 drift audit](https://github.com/lbruton/DocVault/blob/main/Projects/StakTrakr/drift-reports/2026-04-27.md), since the Foundation table at `infrastructure.md:164-170` is stale on this point)
- [ ] Within 5min: dashboard tile flips to red `FAIL (Xm ago)`
- [ ] `curl /health/sqld-reachable` from outside returns `{ "ok": false, "error_class": "host_unreachable" or "timeout", ... }`
- [ ] Restart `tailscale-staktrakr` (with STRK-6 wrapper) — tile recovers to green within 5min

## CI

- [x] Pre-commit hooks pass (prettier, secret scan, signing key)
- [ ] Codacy Static Code Analysis (uses Codacy infra)

Plane: <https://plane.lbruton.cc/lbruton/browse/STRK-7/>