### PR TITLE
chore(home-poller): pin byparr to fork image ghcr.io/lbruton/byparr:2.1.0

### DIFF
--- a/devops/pollers/docker-compose.home.yml
+++ b/devops/pollers/docker-compose.home.yml
@@ -54,7 +54,7 @@ services:
         max-file: "3"
 
   byparr:
-    image: ghcr.io/lbruton/byparr:v2.1.0
+    image: ghcr.io/lbruton/byparr:2.1.0
     container_name: staktrakr-byparr
     restart: unless-stopped
     shm_size: "1g"

--- a/devops/pollers/docker-compose.home.yml
+++ b/devops/pollers/docker-compose.home.yml
@@ -54,7 +54,7 @@ services:
         max-file: "3"
 
   byparr:
-    image: ghcr.io/thephaseless/byparr:latest
+    image: ghcr.io/lbruton/byparr:v2.1.0
     container_name: staktrakr-byparr
     restart: unless-stopped
     shm_size: "1g"


### PR DESCRIPTION
## Summary

Swap the `byparr` service in `docker-compose.home.yml` from the upstream `ghcr.io/thephaseless/byparr:latest` (deleted from GHCR — every tag now 404s on pull) to the freshly-published fork image at `ghcr.io/lbruton/byparr:2.1.0`.

## Context

- Upstream maintainer deleted the `thephaseless/byparr` GHCR package. Stack 7 redeploys with `pullImage:true` failed at the compose-pull step (caught during STRK-7 home-poller redeploy attempt).
- Forked repo: `lbruton/Byparr` (public).
- Fork's inherited `docker-publish.yml` workflow ran on tag `v2.1.0` push → published multi-arch (amd64 + arm64) image to `ghcr.io/lbruton/byparr` with tags `:2.1.0`, `:2.1`, `:2`, `:latest`.
- Pinned to `:2.1.0` (immutable semver tag, not `:latest`) so future redeploys are predictable. Version bumps become a deliberate one-line PR.

Note: docker tag is `:2.1.0`, not `:v2.1.0` — the `docker/metadata-action` strips the `v` prefix per semver convention. The branch's first commit had `:v2.1.0`; the second commit corrected to `:2.1.0`.

## Verification

- [x] Anonymous pull works (package now public): `curl https://ghcr.io/v2/lbruton/byparr/manifests/2.1.0` returns 200 with multi-arch manifest list (`amd64` + `arm64`).
- [x] Image source label correctly attributes to fork: `org.opencontainers.image.source = https://github.com/lbruton/Byparr`.
- [ ] Stack 7 redeploy with `pullImage:true` succeeds end-to-end (no `denied: denied` from GHCR).
- [ ] `staktrakr-byparr` container starts cleanly on the new image, port 8191 reachable from Fly.io via Tailscale.

## Follow-up
- This unblocks the STRK-7 home-poller redeploy that was queued after merging PR #1042.