### PR TITLE
fix: catalog API key toggle and legacy format normalization

### DIFF
--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -26,11 +26,17 @@ class CatalogConfig {
             // Key wasn't base64 encoded (legacy or plain text) — keep as-is
           }
         }
-        if (parsed.pcgs && parsed.pcgs.bearerToken) {
-          try {
-            parsed.pcgs.bearerToken = atob(parsed.pcgs.bearerToken);
-          } catch (e) {
-            // Token wasn't base64 encoded — keep as-is
+        if (parsed.pcgs) {
+          if (!parsed.pcgs.bearerToken && parsed.pcgs.apiKey) {
+            parsed.pcgs.bearerToken = parsed.pcgs.apiKey;
+            delete parsed.pcgs.apiKey;
+          }
+          if (parsed.pcgs.bearerToken) {
+            try {
+              parsed.pcgs.bearerToken = atob(parsed.pcgs.bearerToken);
+            } catch (e) {
+              // Token wasn't base64 encoded (legacy or plain text) — keep as-is
+            }
           }
         }
         this.config = parsed;

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1829,6 +1829,8 @@ const handleCatalogTest = async (btn) => {
     saveCatalogProviderConfig(provider, value);
   }
 
+  if (window.catalogConfig) window.catalogConfig.load();
+
   if (provider === "numista" && typeof window.testNumistaAPI === "function") {
     try {
       const result = await window.testNumistaAPI();
@@ -1855,6 +1857,23 @@ const handleCatalogTogglePassword = (btn) => {
   const input = expand.querySelector(".js-api-key-input");
   if (!input) return;
   const isVisible = input.type === "text";
+
+  if (input.dataset.masked === "true" && input.dataset.dirty !== "true" && window.catalogConfig) {
+    const row = expand.closest(".catalog-row");
+    const provider = row ? row.dataset.provider : "";
+    if (isVisible) {
+      input.value = CATALOG_KEY_MASK;
+    } else {
+      let realKey = "";
+      if (provider === "numista") {
+        realKey = window.catalogConfig.getNumistaConfig().apiKey || "";
+      } else if (provider === "pcgs") {
+        realKey = window.catalogConfig.getPcgsConfig().bearerToken || "";
+      }
+      input.value = realKey;
+    }
+  }
+
   input.type = isVisible ? "password" : "text";
   btn.setAttribute("aria-label", isVisible ? "Show API key" : "Hide API key");
 };

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1864,13 +1864,14 @@ const handleCatalogTogglePassword = (btn) => {
     if (isVisible) {
       input.value = CATALOG_KEY_MASK;
     } else {
-      let realKey = "";
+      window.catalogConfig.load();
       if (provider === "numista") {
-        realKey = window.catalogConfig.getNumistaConfig().apiKey || "";
+        const cfg = window.catalogConfig.getNumistaConfig();
+        input.value = cfg.apiKey || "";
       } else if (provider === "pcgs") {
-        realKey = window.catalogConfig.getPcgsConfig().bearerToken || "";
+        const cfg = window.catalogConfig.getPcgsConfig();
+        input.value = cfg.bearerToken || "";
       }
-      input.value = realKey;
     }
   }
 

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1738,8 +1738,6 @@ const wireCatalogConfigureChevrons = () => {
   });
 };
 
-const CATALOG_KEY_MASK = "••••••••";
-
 const reinitializeCatalogProviders = () => {
   if (
     typeof window.catalogAPI !== "undefined" &&

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,8 @@
 // SETTINGS MODAL
 // =============================================================================
 
+const CATALOG_KEY_MASK = "••••••••";
+
 /**
  * Opens the unified Settings modal, optionally navigating to a section.
  * @param {string} [section='about'] - Section to display: 'about', 'site', 'system', 'table', 'grouping', 'api', 'cloud', 'images', 'storage', 'changelog', 'market', 'currency'
@@ -408,11 +410,12 @@ const _buildApiKeyField = (opts) => {
     window.catalogConfig
   ) {
     const cc = window.catalogConfig;
+    cc.load();
     if (provider === "numista" && cc.isNumistaEnabled()) {
-      input.value = "••••••••";
+      input.value = CATALOG_KEY_MASK;
       input.dataset.masked = "true";
     } else if (provider === "pcgs" && cc.isPcgsEnabled()) {
-      input.value = "••••••••";
+      input.value = CATALOG_KEY_MASK;
       input.dataset.masked = "true";
     }
   } else if (typeof loadApiConfig === "function") {

--- a/js/settings.js
+++ b/js/settings.js
@@ -411,15 +411,9 @@ const _buildApiKeyField = (opts) => {
     if (provider === "numista" && cc.isNumistaEnabled()) {
       input.value = "••••••••";
       input.dataset.masked = "true";
-    } else if (provider === "pcgs") {
-      const storedCfg =
-        typeof loadDataSync === "function" ? loadDataSync("catalog_api_config", null) : null;
-      const hasPcgsToken =
-        cc.isPcgsEnabled() || !!storedCfg?.pcgs?.bearerToken || !!storedCfg?.pcgs?.apiKey;
-      if (hasPcgsToken) {
-        input.value = "••••••••";
-        input.dataset.masked = "true";
-      }
+    } else if (provider === "pcgs" && cc.isPcgsEnabled()) {
+      input.value = "••••••••";
+      input.dataset.masked = "true";
     }
   } else if (typeof loadApiConfig === "function") {
     try {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777349777";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777388166";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777388166";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777392115";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777323632";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777349777";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/03-settings/catalog-api-key.spec.js
+++ b/tests/playwright/03-settings/catalog-api-key.spec.js
@@ -1,0 +1,248 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * fix/catalog-api-settings — Catalog API key toggle and legacy format migration.
+ *
+ * Covers:
+ *   CA-1  CatalogConfig.load maps legacy pcgs.apiKey → pcgs.bearerToken
+ *   CA-2  Numista key is decrypted and shown when toggling visibility on
+ *   CA-3  PCGS token is decrypted and shown when toggling visibility on
+ *   CA-4  Toggling visibility off re-masks the input
+ *   CA-5  handleCatalogTest reloads config from localStorage before execution
+ *   CA-6  Visibility toggle preserves value when field is dirty
+ */
+
+const NUMISTA_KEY = "my-numista-key-2026"; // gitleaks:allow
+const PCGS_TOKEN = "my-pcgs-token-2026"; // gitleaks:allow
+const MASK = "••••••••";
+
+function seedCatalogConfig(page) {
+  return page.addInitScript(
+    ({ numistaKey, pcgsToken }) => {
+      localStorage.setItem(
+        "catalog_api_config",
+        JSON.stringify({
+          numista: { apiKey: btoa(numistaKey), quota: 2000 },
+          numistaUsage: { used: 0, month: "2026-04" },
+          pcgs: { bearerToken: btoa(pcgsToken) },
+          pcgsUsage: { used: 0, date: "2026-04-28" },
+          local: { enabled: true },
+        })
+      );
+      localStorage.setItem("ackVersion", "9.9.9");
+    },
+    { numistaKey: NUMISTA_KEY, pcgsToken: PCGS_TOKEN }
+  );
+}
+
+async function openApiCatalog(page) {
+  await page.waitForFunction(() => typeof window.showSettingsModal === "function");
+  await page.evaluate(() => window.showSettingsModal("api"));
+  await expect(page.locator("#settingsModal")).toBeVisible();
+  // Wait for catalog rows (populated by populateApiSection inside showSettingsModal)
+  await page.waitForSelector('.catalog-row[data-provider="numista"]', { timeout: 5000 });
+  // wireCatalogActions() is called in a 200ms setTimeout (init.js Phase 14).
+  // Explicitly re-run wiring after the modal is open so the delegated listeners
+  // are guaranteed to be bound to the real #apiSection_catalog element, whether
+  // or not the init setTimeout has already fired.
+  await page.evaluate(() => {
+    if (typeof window.setupSettingsEventListeners === "function") {
+      window.setupSettingsEventListeners();
+    }
+  });
+}
+
+async function expandCatalogRow(page, provider) {
+  // The expand panel is CSS-controlled via max-height (not display:none).
+  // Add the `open` class and also override the inline styles so Playwright
+  // sees a non-zero bounding box without waiting for the CSS transition.
+  await page.evaluate((p) => {
+    const row = document.querySelector(`.catalog-row[data-provider="${p}"]`);
+    if (!row) return;
+    row.classList.add("open");
+    const expand = row.querySelector(".catalog-row-expand");
+    if (expand) {
+      // _buildCatalogRow initialises expand.style.display = "none" inline.
+      // Clearing it lets the CSS `max-height` approach take over; also
+      // override max-height/overflow directly so Playwright sees a non-zero
+      // bounding box without waiting for the 0.2s CSS transition.
+      expand.style.display = "";
+      expand.style.maxHeight = "none";
+      expand.style.overflow = "visible";
+    }
+  }, provider);
+  await expect(
+    page.locator(`.catalog-row[data-provider="${provider}"] .catalog-row-expand`)
+  ).toBeVisible({ timeout: 3000 });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-1: Legacy key migration
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("CA-1 — CatalogConfig.load maps legacy pcgs.apiKey to pcgs.bearerToken and deletes the old key", async ({
+  page,
+}) => {
+  // Use a complete valid config at page-load time so initialization succeeds,
+  // then replace localStorage with the legacy format and call load() explicitly.
+  await seedCatalogConfig(page);
+  await page.goto("/index.html", { waitUntil: "load" });
+  await page.waitForFunction(() => typeof window.catalogConfig !== "undefined");
+
+  const result = await page.evaluate(() => {
+    // Overwrite with legacy format that uses apiKey instead of bearerToken
+    localStorage.setItem(
+      "catalog_api_config",
+      JSON.stringify({ pcgs: { apiKey: btoa("legacy-pcgs-token") } })
+    );
+    window.catalogConfig.load();
+    const pcgs = window.catalogConfig.config.pcgs;
+    return {
+      bearerToken: pcgs.bearerToken,
+      hasApiKey: "apiKey" in pcgs,
+    };
+  });
+
+  expect(result.bearerToken).toBe("legacy-pcgs-token");
+  expect(result.hasApiKey).toBe(false);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-2 / CA-3: Toggle-on reveals decrypted key
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("CA-2 — Numista API key decrypts and displays when toggling visibility on", async ({
+  page,
+}) => {
+  await seedCatalogConfig(page);
+  await page.goto("/index.html", { waitUntil: "load" });
+  await openApiCatalog(page);
+  await expandCatalogRow(page, "numista");
+
+  const input = page.locator('.catalog-row[data-provider="numista"] .js-api-key-input');
+  const toggle = page.locator(
+    '.catalog-row[data-provider="numista"] .catalog-row-expand .js-toggle-password'
+  );
+
+  await expect(input).toHaveValue(MASK);
+  await expect(input).toHaveAttribute("type", "password");
+
+  await toggle.click();
+
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveValue(NUMISTA_KEY);
+});
+
+test("CA-3 — PCGS bearer token decrypts and displays when toggling visibility on", async ({
+  page,
+}) => {
+  await seedCatalogConfig(page);
+  await page.goto("/index.html", { waitUntil: "load" });
+  await openApiCatalog(page);
+  await expandCatalogRow(page, "pcgs");
+
+  const input = page.locator('.catalog-row[data-provider="pcgs"] .js-api-key-input');
+  const toggle = page.locator(
+    '.catalog-row[data-provider="pcgs"] .catalog-row-expand .js-toggle-password'
+  );
+
+  await expect(input).toHaveValue(MASK);
+  await expect(input).toHaveAttribute("type", "password");
+
+  await toggle.click();
+
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveValue(PCGS_TOKEN);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-4: Toggle-off re-masks
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("CA-4 — toggling visibility off replaces the visible key with the mask string", async ({
+  page,
+}) => {
+  await seedCatalogConfig(page);
+  await page.goto("/index.html", { waitUntil: "load" });
+  await openApiCatalog(page);
+  await expandCatalogRow(page, "numista");
+
+  const input = page.locator('.catalog-row[data-provider="numista"] .js-api-key-input');
+  const toggle = page.locator(
+    '.catalog-row[data-provider="numista"] .catalog-row-expand .js-toggle-password'
+  );
+
+  await toggle.click();
+  await expect(input).toHaveValue(NUMISTA_KEY);
+
+  await toggle.click();
+  await expect(input).toHaveValue(MASK);
+  await expect(input).toHaveAttribute("type", "password");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-5: handleCatalogTest reloads config before execution
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("CA-5 — handleCatalogTest reloads config from localStorage before execution", async ({
+  page,
+}) => {
+  await seedCatalogConfig(page);
+  await page.goto("/index.html", { waitUntil: "load" });
+  await openApiCatalog(page);
+  await expandCatalogRow(page, "numista");
+
+  const freshKey = "fresh-key-injected-after-load";
+  await page.evaluate((key) => {
+    // Overwrite localStorage with a key different from what was seeded at load time
+    const parsed = JSON.parse(localStorage.getItem("catalog_api_config"));
+    parsed.numista.apiKey = btoa(key);
+    localStorage.setItem("catalog_api_config", JSON.stringify(parsed));
+
+    // Stub testNumistaAPI to capture what catalogConfig holds at call time
+    window.__testCapturedKey = undefined;
+    window.testNumistaAPI = async () => {
+      window.__testCapturedKey = window.catalogConfig.getNumistaConfig().apiKey;
+      return true;
+    };
+  }, freshKey);
+
+  await page.locator('.catalog-row[data-provider="numista"] .js-catalog-test').click();
+  await page.waitForFunction(() => window.__testCapturedKey !== undefined, { timeout: 5000 });
+
+  const capturedKey = await page.evaluate(() => window.__testCapturedKey);
+  expect(capturedKey).toBe(freshKey);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CA-6: Dirty field value preserved through toggle
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("CA-6 — visibility toggle preserves the input value when the field is marked as dirty", async ({
+  page,
+}) => {
+  await seedCatalogConfig(page);
+  await page.goto("/index.html", { waitUntil: "load" });
+  await openApiCatalog(page);
+  await expandCatalogRow(page, "numista");
+
+  const input = page.locator('.catalog-row[data-provider="numista"] .js-api-key-input');
+  const toggle = page.locator(
+    '.catalog-row[data-provider="numista"] .catalog-row-expand .js-toggle-password'
+  );
+
+  // Typing into the masked field triggers the input handler which clears
+  // `data-masked` and sets `data-dirty=true`, protecting the value from toggle logic.
+  await input.click();
+  await input.fill("new-user-typed-key");
+
+  // Toggle on: value must survive (not replaced by mask or decrypted key)
+  await toggle.click();
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveValue("new-user-typed-key");
+
+  // Toggle off: value must still survive
+  await toggle.click();
+  await expect(input).toHaveAttribute("type", "password");
+  await expect(input).toHaveValue("new-user-typed-key");
+});


### PR DESCRIPTION
## Summary
- **Toggle reveal**: eye button now shows the real decrypted key from `catalogConfig` instead of literal mask dots ("••••••••") — fixes both Numista and PCGS cards
- **Legacy normalization**: `CatalogConfig.load()` maps `pcgs.apiKey` → `pcgs.bearerToken` for backwards compatibility with the main build's storage format
- **Stale config guard**: `handleCatalogTest` calls `catalogConfig.load()` before testing, preventing false failures after cloud sync
- **Dirty-input guard**: toggling visibility skips the stored-key overwrite when the user has typed a new key over the mask

## Test plan
- [ ] Open Settings → API → expand Numista Configure → click eye toggle → real key appears
- [ ] Click eye toggle again → mask dots restored
- [ ] Repeat for PCGS card
- [ ] Store legacy format (`pcgs.apiKey` instead of `bearerToken`) in localStorage → reload → PCGS shows "Configured" and Test passes
- [ ] Type a new key over mask dots → click eye toggle → typed key is preserved (not overwritten by stored key)
- [ ] After cloud sync pull, click Test → uses fresh config, not stale in-memory values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved PCGS credential handling with support for legacy field migration
* Fixed password visibility toggle to properly restore masked credential values from stored settings
* Catalog configuration now reloads after entering a new provider key to ensure accurate testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->