### PR TITLE
fix(STRK-12): correct Silverback denominations, unit label, and purity default

### DIFF
--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -605,14 +605,16 @@ const renderBulkFieldPanel = () => {
       const label = isSilverback ? "Silverback" : "Goldback";
 
       while (denomSelect.firstChild) denomSelect.removeChild(denomSelect.firstChild);
-      denominations.forEach((d, i) => {
+      denominations.forEach((d) => {
         const opt = document.createElement("option");
         opt.value = String(d.weight);
         const prefix = d.weight === 0.5 ? "½" : String(d.weight);
         opt.textContent = `${prefix} ${label}`;
-        if (i === (isSilverback ? 0 : 1)) opt.selected = true;
+        if (d.weight === 1) opt.selected = true;
         denomSelect.appendChild(opt);
       });
+      const bulkUnitOpt = bwUnitSelect ? bwUnitSelect.querySelector('option[value="gb"]') : null;
+      if (bulkUnitOpt) bulkUnitOpt.textContent = isSilverback ? "silverback" : "goldback";
     };
 
     const bulkTypeSelect = document.getElementById("bulkFieldVal_type");

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -597,12 +597,21 @@ const renderBulkFieldPanel = () => {
     };
 
     const updateBulkDenomLabels = (typeValue = "") => {
-      const denominationLabel = typeValue === "Silverback" ? "Silverback" : "Goldback";
-      GOLDBACK_DENOMINATIONS.forEach((denomination, index) => {
-        const option = denomSelect.options[index];
-        if (!option) return;
-        const prefix = denomination.weight === 0.5 ? "½" : String(denomination.weight);
-        option.textContent = `${prefix} ${denominationLabel}`;
+      const isSilverback = typeValue === "Silverback";
+      const denominations =
+        isSilverback && typeof SILVERBACK_DENOMINATIONS !== "undefined"
+          ? SILVERBACK_DENOMINATIONS
+          : GOLDBACK_DENOMINATIONS;
+      const label = isSilverback ? "Silverback" : "Goldback";
+
+      while (denomSelect.firstChild) denomSelect.removeChild(denomSelect.firstChild);
+      denominations.forEach((d, i) => {
+        const opt = document.createElement("option");
+        opt.value = String(d.weight);
+        const prefix = d.weight === 0.5 ? "½" : String(d.weight);
+        opt.textContent = `${prefix} ${label}`;
+        if (i === (isSilverback ? 0 : 1)) opt.selected = true;
+        denomSelect.appendChild(opt);
       });
     };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -593,6 +593,8 @@ const GOLDBACK_DENOMINATIONS = [
   { weight: 100, label: "100 Goldback", goldOz: 0.1 },
 ];
 
+const SILVERBACK_DENOMINATIONS = [{ weight: 1, label: "1 Silverback", silverOz: 0.001 }];
+
 /** @constant {Object<string, string[]>} TYPE_METAL_FILTER - Type visibility constraints by selected metal */
 const TYPE_METAL_FILTER = {
   Goldback: ["Gold"],

--- a/js/events.js
+++ b/js/events.js
@@ -1559,7 +1559,12 @@ const buildNumistaSearchQuery = (nameVal, metalVal) => {
  */
 const updateDenomLabels = (typeValue = "") => {
   const denomSelect = document.getElementById("itemGbDenom");
-  if (!denomSelect || typeof GOLDBACK_DENOMINATIONS === "undefined") return;
+  if (
+    !denomSelect ||
+    typeof GOLDBACK_DENOMINATIONS === "undefined" ||
+    typeof SILVERBACK_DENOMINATIONS === "undefined"
+  )
+    return;
 
   const isSilverback = typeValue === "Silverback";
   const denominations =
@@ -1569,12 +1574,12 @@ const updateDenomLabels = (typeValue = "") => {
   const label = isSilverback ? "Silverback" : "Goldback";
 
   while (denomSelect.firstChild) denomSelect.removeChild(denomSelect.firstChild);
-  denominations.forEach((d, i) => {
+  denominations.forEach((d) => {
     const opt = document.createElement("option");
     opt.value = String(d.weight);
     const prefix = d.weight === 0.5 ? "½" : String(d.weight);
     opt.textContent = `${prefix} ${label}`;
-    if (i === (isSilverback ? 0 : 1)) opt.selected = true;
+    if (d.weight === 1) opt.selected = true;
     denomSelect.appendChild(opt);
   });
 

--- a/js/events.js
+++ b/js/events.js
@@ -1554,20 +1554,32 @@ const buildNumistaSearchQuery = (nameVal, metalVal) => {
 };
 
 /**
- * Updates denomination option labels based on selected type.
+ * Rebuilds denomination select options for the given type.
  * @param {string} [typeValue=""]
  */
 const updateDenomLabels = (typeValue = "") => {
   const denomSelect = document.getElementById("itemGbDenom");
   if (!denomSelect || typeof GOLDBACK_DENOMINATIONS === "undefined") return;
 
-  const denominationLabel = typeValue === "Silverback" ? "Silverback" : "Goldback";
-  GOLDBACK_DENOMINATIONS.forEach((denomination, index) => {
-    const option = denomSelect.options[index];
-    if (!option) return;
-    const prefix = denomination.weight === 0.5 ? "½" : String(denomination.weight);
-    option.textContent = `${prefix} ${denominationLabel}`;
+  const isSilverback = typeValue === "Silverback";
+  const denominations =
+    isSilverback && typeof SILVERBACK_DENOMINATIONS !== "undefined"
+      ? SILVERBACK_DENOMINATIONS
+      : GOLDBACK_DENOMINATIONS;
+  const label = isSilverback ? "Silverback" : "Goldback";
+
+  while (denomSelect.firstChild) denomSelect.removeChild(denomSelect.firstChild);
+  denominations.forEach((d, i) => {
+    const opt = document.createElement("option");
+    opt.value = String(d.weight);
+    const prefix = d.weight === 0.5 ? "½" : String(d.weight);
+    opt.textContent = `${prefix} ${label}`;
+    if (i === (isSilverback ? 0 : 1)) opt.selected = true;
+    denomSelect.appendChild(opt);
   });
+
+  const unitOption = document.querySelector('#itemWeightUnit option[value="gb"]');
+  if (unitOption) unitOption.textContent = isSilverback ? "silverback" : "goldback";
 };
 
 /**
@@ -1585,6 +1597,10 @@ const handleTypeChange = () => {
     unitSelect.value = "gb";
     if (unitGroup) unitGroup.classList.add("hidden");
     updateDenomLabels(selectedType);
+    const puritySelect = document.getElementById("itemPuritySelect");
+    if (puritySelect && puritySelect.value !== "custom") {
+      puritySelect.value = "0.999";
+    }
   } else {
     if (unitSelect.value === "gb") {
       unitSelect.value = "oz";

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777397170";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777400532";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777395234";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777397170";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/goldback-type.spec.js
+++ b/tests/playwright/goldback-type.spec.js
@@ -243,4 +243,119 @@ test.describe("goldback-type — STAK-562 first-class type behavior", () => {
     await expect(page.locator("#bulkFieldVal_weightDenom")).toBeVisible();
     await expect(page.locator("#bulkFieldVal_weight")).toBeHidden();
   });
+
+  test("8. Silverback type shows only 1 Silverback denomination", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Silver");
+    await page.selectOption("#itemType", "Silverback");
+
+    const options = await page.evaluate(() => {
+      const sel = document.getElementById("itemGbDenom");
+      return Array.from(sel.options).map((o) => ({ value: o.value, text: o.textContent }));
+    });
+    expect(options).toHaveLength(1);
+    expect(options[0].value).toBe("1");
+    expect(options[0].text).toBe("1 Silverback");
+  });
+
+  test("9. Goldback type shows all 8 standard denominations", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+
+    const options = await page.evaluate(() => {
+      const sel = document.getElementById("itemGbDenom");
+      return Array.from(sel.options).map((o) => ({ value: o.value, text: o.textContent }));
+    });
+    expect(options).toHaveLength(8);
+    expect(options[0].text).toBe("½ Goldback");
+    expect(options[7].text).toBe("100 Goldback");
+  });
+
+  test("10. Unit label updates to silverback for Silverback type", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Silver");
+    await page.selectOption("#itemType", "Silverback");
+
+    const unitText = await page.evaluate(() => {
+      const opt = document.querySelector('#itemWeightUnit option[value="gb"]');
+      return opt ? opt.textContent : null;
+    });
+    expect(unitText).toBe("silverback");
+  });
+
+  test("11. Purity defaults to .999 when switching to Goldback or Silverback", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await expect(page.locator("#itemPuritySelect")).toHaveValue("0.9999");
+
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+    await expect(page.locator("#itemPuritySelect")).toHaveValue("0.999");
+
+    await page.selectOption("#itemType", "Coin");
+    await page.selectOption("#itemPuritySelect", "0.925");
+
+    await page.selectOption("#itemMetal", "Silver");
+    await page.selectOption("#itemType", "Silverback");
+    await expect(page.locator("#itemPuritySelect")).toHaveValue("0.999");
+  });
+
+  test("12. Custom purity is not overwritten when switching to Goldback/Silverback", async ({
+    page,
+  }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemPuritySelect", "custom");
+    await page.fill("#itemPurity", "0.9995");
+
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+
+    await expect(page.locator("#itemPuritySelect")).toHaveValue("custom");
+  });
+
+  test("13. Bulk edit Silverback shows only 1 denomination", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openBulkEditModal(page);
+
+    await page.click("#bulkField_metal");
+    await page.click("#bulkField_type");
+    await page.click("#bulkField_weight");
+    await page.click("#bulkField_weightUnit");
+
+    await page.selectOption("#bulkFieldVal_metal", "Silver");
+    await page.selectOption("#bulkFieldVal_type", "Silverback");
+
+    const options = await page.evaluate(() => {
+      const sel = document.getElementById("bulkFieldVal_weightDenom");
+      return Array.from(sel.options).map((o) => ({ value: o.value, text: o.textContent }));
+    });
+    expect(options).toHaveLength(1);
+    expect(options[0].text).toBe("1 Silverback");
+
+    await page.selectOption("#bulkFieldVal_metal", "Gold");
+    await page.selectOption("#bulkFieldVal_type", "Goldback");
+
+    const goldOptions = await page.evaluate(() => {
+      const sel = document.getElementById("bulkFieldVal_weightDenom");
+      return Array.from(sel.options).map((o) => ({ value: o.value, text: o.textContent }));
+    });
+    expect(goldOptions).toHaveLength(8);
+    expect(goldOptions[0].text).toBe("½ Goldback");
+  });
 });


### PR DESCRIPTION
## Summary

- Add `SILVERBACK_DENOMINATIONS` constant with single "1 Silverback" entry (1/1000 ozt .999 silver)
- Rebuild denomination `<select>` dynamically when switching types — Silverback shows only "1 Silverback", Goldback restores full 8 options
- Update unit label from "goldback" to "silverback" when Silverback type is active
- Auto-default purity to .999 when type changes to Goldback or Silverback (both are .999 fine); respects custom purity if user has set one
- Mirror all denomination fixes in bulk edit

Closes [STRK-12](https://plane.lbruton.cc/lbruton/browse/STRK-12/)

## Test plan

- [ ] Add Item → Silver → Silverback: denomination shows only "1 Silverback", unit label shows "silverback", purity defaults to .999
- [ ] Add Item → Gold → Goldback: denomination shows all 8 (½ through 100), unit label shows "goldback", purity defaults to .999
- [ ] Switch between Goldback and Silverback: denominations and labels update correctly
- [ ] Switch from Goldback/Silverback to Coin: weight/unit input restores, unit dropdown visible
- [ ] Set custom purity, then switch to Goldback: custom purity preserved (not overwritten)
- [ ] Bulk edit: same denomination and label behavior as add modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Silverback item type support.
  * Denomination dropdown now dynamically updates per selected item type (Silverback shows its single denomination; Goldback shows full set).
  * Weight unit label updates to “silverback” or “goldback”.
  * Purity defaults to 0.999 when switching types, while custom purity selections are preserved.

* **Tests**
  * Added UI tests covering denomination, unit label, and purity behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->