### PR TITLE
chore: wrap filter summary and restore gain/loss column on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8355,6 +8355,11 @@ input:disabled + .slider {
    Column hides removed — .portal-scroll handles horizontal overflow so users
    can scroll to gain/loss and source columns on narrow viewports. */
 
+/* Dense baseline: slightly smaller font for compact inventory view (>1024px) */
+#inventoryTable {
+  font-size: 0.86rem;
+}
+
 @media (max-width: 1024px) {
   #inventoryTable {
     font-size: 0.8rem;
@@ -8445,11 +8450,7 @@ th {
   height: 0.95rem;
 }
 
-/* Dense table mode: reduce paddings, font-size and icon sizes for a compact view */
-#inventoryTable {
-  font-size: 0.86rem; /* slightly smaller overall */
-}
-
+/* Dense table mode: reduce paddings and icon sizes for a compact view */
 #inventoryTable th,
 #inventoryTable td {
   padding: 0.18rem 0.28rem; /* tighter padding */

--- a/css/styles.css
+++ b/css/styles.css
@@ -8351,20 +8351,11 @@ input:disabled + .slider {
 
 /* CANONICAL RESPONSIVE TABLE RULES — Progressive disclosure + portfolio layout
    Single source of truth for all inventory table responsive behavior.
-   Card view (≤768px) lives at end of file.  See STACK-38 / STACK-31. */
-
-@media (max-width: 1200px) {
-  #inventoryTable th[data-column="gainLoss"],
-  #inventoryTable td[data-column="gainLoss"] {
-    display: none;
-  }
-}
+   Card view (≤768px) lives at end of file.  See STACK-38 / STACK-31.
+   Column hides removed — .portal-scroll handles horizontal overflow so users
+   can scroll to gain/loss and source columns on narrow viewports. */
 
 @media (max-width: 1024px) {
-  #inventoryTable th[data-column="purchaseLocation"],
-  #inventoryTable td[data-column="purchaseLocation"] {
-    display: none;
-  }
   #inventoryTable {
     font-size: 0.8rem;
   }

--- a/index.html
+++ b/index.html
@@ -183,14 +183,14 @@
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        row-gap: 0.25rem;
         justify-content: center;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         font-size: 0.75rem;
         width: 100%;
         padding: 0.35rem 0 0;
         border-top: 1px solid var(--border-color, var(--border));
         margin-top: 0.25rem;
-        overflow: hidden;
       }
       .card-sort-summary .summary-item {
         display: inline-flex;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777400532";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777404659";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777404659";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777432254";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Two related mobile UX fixes triggered by a Reddit user report (PumpkinCrouton on r/Silverbugs) that gain/loss values were missing from his phone view.

### 1. Filter summary footer wraps instead of clipping

`.card-sort-summary` (the `ITEMS · WEIGHT · BUY · MELT · MARKET · G/L` row beneath the chip cloud) had `flex-wrap: nowrap` + `overflow: hidden`, which clipped `ITEMS` on the left and `G/L` on the right at narrow widths.

- Switched to `flex-wrap: wrap` with a small `row-gap` so the line breaks gracefully on phones instead of losing data.
- Removed `overflow: hidden` so wrapped lines aren't clipped.

### 2. Inventory table no longer hides Gain/Loss + Source columns

Two media queries silently removed columns from view:

- `@media (max-width: 1200px)` hid `gainLoss`
- `@media (max-width: 1024px)` hid `purchaseLocation` (Source)

Both removed. The `.portal-scroll` wrapper already handles horizontal overflow, so the table now scrolls to reveal those columns on mobile rather than dropping the data.

Kept the density tweaks (font-size + padding) at ≤1024px — those still help on small viewports without hiding information.

## Why

> "The gains and losses on individual inventory listings don't show on the phone, either accidentally or by design... I wouldn't mind trading the retail for the gain/loss back."  
> — PumpkinCrouton, r/Silverbugs, 2026-04-28

The original column-hide was over-aggressive desktop polish — silent data loss is a worse UX than horizontal scroll, especially with no settings toggle to discover.

## Scope

- 2 CSS files, 6 insertions / 15 deletions
- No JS, no HTML structure changes, no settings
- Card view at ≤768px is a separate code path and unaffected (already shows gain/loss)
- Service worker cache auto-stamped by pre-commit hook

## Test plan

- [ ] Beta deploys on merge to `dev`; verify on phone-width viewport that the filter summary row wraps cleanly and shows all 6 items
- [ ] Verify inventory table on phone-width viewport scrolls horizontally and Gain/Loss + Source columns become visible by scrolling
- [ ] Verify desktop view (≥1200px) is visually unchanged
- [ ] Card view at ≤768px still works as before

## Notes

- Full mobile rework is still on the roadmap; this is the interim polish to address the immediate Reddit feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout on narrow viewports by enabling horizontal scrolling instead of hiding certain columns.
  * Enhanced summary card display to support multi-line text wrapping with proper spacing, preventing content from being clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->