### PR TITLE
fix(STRK-13): inventory seed guard prevents data loss on storage failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.35] - 2026-04-29
+
+### Fixed — STRK-13: Inventory seed guard prevents data loss on storage failure
+
+- **Fixed**: Startup no longer overwrites user inventory with sample data when localStorage is missing or corrupt. A new `classifyBootState()` function distinguishes first-run (no prior evidence) from storage failure (orphaned keys like `inventorySerial` exist without `metalInventory`).
+- **Added**: Seed sentinel (`inventorySeedApplied`) — sample data is only persisted once per origin; returning users with existing data are never re-seeded.
+- **Added**: Recovery banner — when storage damage is detected, a non-dismissable warning surfaces above the inventory table instead of silently replacing data with samples. Users can restore from cloud backup or dismiss.
+- **Added**: Boot diagnostics ring buffer (`staktrakr.bootDiagnostics`) — records the last 10 boot classifications for post-mortem analysis without storing PII.
+- **Fixed**: `classifyBootState()` now decompresses CMP1-prefixed inventory before parsing, preventing large inventories from being misclassified as corrupt.
+- **Added**: `migrateSentinelIfMissing()` — one-shot migration writes the seed sentinel for existing users so they are never re-seeded on future boots.
+
+---
+
 ## [3.34.34] - 2026-04-27
 
 ### Added — STRK-4: Lot ⇄ Each toggle for Purchase Price

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed**: Startup no longer overwrites user inventory with sample data when localStorage is missing or corrupt. A new `classifyBootState()` function distinguishes first-run (no prior evidence) from storage failure (orphaned keys like `inventorySerial` exist without `metalInventory`).
 - **Added**: Seed sentinel (`inventorySeedApplied`) — sample data is only persisted once per origin; returning users with existing data are never re-seeded.
-- **Added**: Recovery banner — when storage damage is detected, a non-dismissable warning surfaces above the inventory table instead of silently replacing data with samples. Users can restore from cloud backup or dismiss.
+- **Added**: Recovery banner — when storage damage is detected, a persistent warning surfaces above the inventory table instead of silently replacing data with samples. Users can restore from cloud backup or dismiss the banner.
 - **Added**: Boot diagnostics ring buffer (`staktrakr.bootDiagnostics`) — records the last 10 boot classifications for post-mortem analysis without storing PII.
 - **Fixed**: `classifyBootState()` now decompresses CMP1-prefixed inventory before parsing, preventing large inventories from being misclassified as corrupt.
 - **Added**: `migrateSentinelIfMissing()` — one-shot migration writes the seed sentinel for existing users so they are never re-seeded on future boots.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed**: Startup no longer overwrites user inventory with sample data when localStorage is missing or corrupt. A new `classifyBootState()` function distinguishes first-run (no prior evidence) from storage failure (orphaned keys like `inventorySerial` exist without `metalInventory`).
 - **Added**: Seed sentinel (`inventorySeedApplied`) — sample data is only persisted once per origin; returning users with existing data are never re-seeded.
-- **Added**: Recovery banner — when storage damage is detected, a persistent warning surfaces above the inventory table instead of silently replacing data with samples. Users can restore from cloud backup or dismiss the banner.
+- **Added**: Recovery banner — when storage damage is detected, a dismissible warning surfaces above the inventory table instead of silently replacing data with samples. Users can restore from cloud backup or dismiss the banner.
 - **Added**: Boot diagnostics ring buffer (`staktrakr.bootDiagnostics`) — records the last 10 boot classifications for post-mortem analysis without storing PII.
 - **Fixed**: `classifyBootState()` now decompresses CMP1-prefixed inventory before parsing, preventing large inventories from being misclassified as corrupt.
 - **Added**: `migrateSentinelIfMissing()` — one-shot migration writes the seed sentinel for existing users so they are never re-seeded on future boots.

--- a/css/styles.css
+++ b/css/styles.css
@@ -3632,6 +3632,78 @@ input[type="submit"] {
   border-bottom: 1px solid var(--border, #dee2e6);
 }
 
+/* STRK-13: Sticky inventory recovery banner — shown when boot detected
+   damaged or unparseable inventory storage. Themes via existing custom
+   properties; no new colors introduced. */
+.inventory-recovery-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin: 0 0 0.75rem 0;
+  border-radius: var(--radius-lg, 12px);
+  background: color-mix(in srgb, var(--warning) 10%, var(--bg-secondary));
+  color: var(--text);
+  border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--border));
+  box-shadow: var(--shadow-sm);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.inventory-recovery-banner__icon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+  color: var(--warning);
+}
+
+.inventory-recovery-banner__copy {
+  flex: 1 1 auto;
+  margin: 0;
+  color: var(--text);
+}
+
+.inventory-recovery-banner__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.inventory-recovery-banner__btn {
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius, 8px);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.inventory-recovery-banner__btn:hover {
+  background: var(--bg-secondary);
+  border-color: var(--border-hover);
+}
+
+.inventory-recovery-banner__btn--primary {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.inventory-recovery-banner__btn--primary:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+}
+
+@media (max-width: 640px) {
+  .inventory-recovery-banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .inventory-recovery-banner__actions {
+    flex-wrap: wrap;
+  }
+}
+
 /* Cloud beta banner & provider cards */
 .cloud-beta-banner {
   position: relative;

--- a/css/styles.css
+++ b/css/styles.css
@@ -3643,7 +3643,7 @@ input[type="submit"] {
   margin: 0 0 0.75rem 0;
   border-radius: var(--radius-lg, 12px);
   background: color-mix(in srgb, var(--warning) 10%, var(--bg-secondary));
-  color: var(--text);
+  color: var(--text-primary, var(--text));
   border: 1px solid color-mix(in srgb, var(--warning) 35%, var(--border));
   box-shadow: var(--shadow-sm);
   font-size: 0.9rem;
@@ -3659,7 +3659,7 @@ input[type="submit"] {
 .inventory-recovery-banner__copy {
   flex: 1 1 auto;
   margin: 0;
-  color: var(--text);
+  color: var(--text-primary, var(--text));
 }
 
 .inventory-recovery-banner__actions {
@@ -3673,7 +3673,7 @@ input[type="submit"] {
   border-radius: var(--radius, 8px);
   border: 1px solid var(--border);
   background: var(--bg-card);
-  color: var(--text);
+  color: var(--text-primary, var(--text));
   font-size: 0.85rem;
   cursor: pointer;
 }
@@ -3685,7 +3685,7 @@ input[type="submit"] {
 
 .inventory-recovery-banner__btn--primary {
   background: var(--primary);
-  color: #fff;
+  color: #f8fafc;
   border-color: var(--primary);
 }
 

--- a/index.html
+++ b/index.html
@@ -8193,6 +8193,7 @@
        ============================================================================= -->
 
     <script defer src="js/debug-log.js"></script>
+    <script defer src="./js/boot-diagnostics.js"></script>
     <script defer src="./js/constants.js"></script>
     <script defer src="./js/field-meta.js"></script>
     <script defer src="./js/state.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -144,7 +144,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.33 &ndash; STAK-581: Retail currency conversion phase 1</strong>: Retail and market price surfaces now honor the selected display currency through a shared currencychange event bus. Non-USD market tables also show a convenience-conversion note because vendor checkout remains US-based.</li>
     <li><strong>v3.34.32 &ndash; STAK-571: Spot provider switch confirmation</strong>: Settings &rarr; API now asks before switching spot price providers, names the provider being selected, and explains that the change affects spot prices, charts, ticker, and portfolio values. Cancel leaves the previous provider unchanged.</li>
     <li><strong>v3.34.31 &ndash; STAK-578: Mobile action buttons fix</strong>: Save / Cancel / Edit and other action buttons in the View and Add/Edit item modals are now fully tappable on Android Chrome, Edge, and notched iPhones &mdash; including in landscape orientation. Previously the Android gesture bar and iOS home indicator could swallow taps near the bottom edge, and the iOS landscape side notch could clip edge buttons.</li>
-    <li><strong>v3.34.30 &ndash; STAK-582: Remove dead retail card-list view</strong>: Removed the orphaned Market Settings retail card/list render path, stale exports, event listeners, trend-mode storage, sync-error state, and obsolete card CSS while preserving the active ticker, vendor price matrix, market detail modal, market filter matrix, and retail history table.</li>
   `;
 };
 

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.35 &ndash; STRK-13: Inventory seed guard</strong>: Startup no longer overwrites your inventory with sample data when localStorage is missing or corrupt. A recovery banner now appears instead of silently replacing your data, and a boot diagnostics buffer records classifications for post-mortem analysis.</li>
     <li><strong>v3.34.34 &ndash; STRK-4: Lot &harr; Each toggle for Purchase Price</strong>: Enter a lot total when buying multiples &mdash; the app divides by quantity to store a per-unit price automatically. The Purchase column now shows the qty-multiplied total instead of the per-unit price.</li>
     <li><strong>v3.34.33 &ndash; STAK-581: Retail currency conversion phase 1</strong>: Retail and market price surfaces now honor the selected display currency through a shared currencychange event bus. Non-USD market tables also show a convenience-conversion note because vendor checkout remains US-based.</li>
     <li><strong>v3.34.32 &ndash; STAK-571: Spot provider switch confirmation</strong>: Settings &rarr; API now asks before switching spot price providers, names the provider being selected, and explains that the change affects spot prices, charts, ticker, and portfolio values. Cancel leaves the previous provider unchanged.</li>

--- a/js/boot-diagnostics.js
+++ b/js/boot-diagnostics.js
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Boot diagnostics ring buffer for the seed-guard pipeline (STRK-13).
+ *
+ * Records lightweight, privacy-safe boot events so we can diagnose first-run
+ * failures (parse errors, missing seeds, quota issues) without inspecting the
+ * user's inventory contents. The ring buffer is capped at 10 entries —
+ * newest-first — and persisted to localStorage under
+ * `staktrakr.bootDiagnostics`.
+ *
+ * Persisted entry shape:
+ *   {
+ *     ts: ISO string,
+ *     version: APP_VERSION,
+ *     classification: string,
+ *     keyPresence: { [key]: boolean },
+ *     errorName?: string   // JS error class name only — never the message
+ *   }
+ *
+ * Privacy contract: callers MUST pass booleans for `keyPresence` values and
+ * the JS error class name (e.g. "SyntaxError") for `errorName`. No inventory
+ * contents, serials, prices, tokens, or user-identifying data.
+ *
+ * Both functions are exposed on `window` so init.js, error handlers, and
+ * console debugging can reach them. All globals (`APP_VERSION`, `debugLog`,
+ * `loadDataSync`, `saveDataSync`) are looked up at call time, not at parse
+ * time, so script load order does not matter.
+ */
+
+(function (global) {
+  "use strict";
+
+  var STORAGE_KEY = "staktrakr.bootDiagnostics";
+  var MAX_ENTRIES = 10;
+
+  /**
+   * Record a single boot diagnostic event.
+   *
+   * Failures (storage quota, disabled storage, JSON errors) are swallowed —
+   * boot diagnostics must never break boot. Errors are logged via debugLog
+   * when available.
+   *
+   * @param {Object} entry
+   * @param {string} entry.classification - short event label (e.g. "first-run-empty", "parse-error")
+   * @param {Object} entry.keyPresence - map of localStorage key name to boolean
+   * @param {string} [entry.errorName] - JS error class name (optional)
+   */
+  function recordBootDiagnostic(entry) {
+    try {
+      if (!entry || typeof entry !== "object") return;
+
+      var version = typeof APP_VERSION === "string" ? APP_VERSION : "unknown";
+
+      var record = {
+        ts: new Date().toISOString(),
+        version: version,
+        classification: entry.classification,
+        keyPresence: entry.keyPresence,
+      };
+
+      if (entry.errorName) {
+        record.errorName = entry.errorName;
+      }
+
+      var existing = [];
+      if (typeof loadDataSync === "function") {
+        existing = loadDataSync(STORAGE_KEY, []);
+      }
+      if (!Array.isArray(existing)) existing = [];
+
+      existing.unshift(record);
+      existing = existing.slice(0, MAX_ENTRIES);
+
+      if (typeof saveDataSync === "function") {
+        saveDataSync(STORAGE_KEY, existing, { quietQuotaToast: true });
+      }
+    } catch (err) {
+      try {
+        if (typeof debugLog === "function") {
+          debugLog("recordBootDiagnostic failed:", err && err.name);
+        }
+      } catch (_) {
+        /* swallow — must not propagate */
+      }
+    }
+  }
+
+  /**
+   * Retrieve the current boot diagnostics ring buffer.
+   *
+   * @returns {Array<Object>} newest-first array of entries (empty on failure)
+   */
+  function getBootDiagnostics() {
+    try {
+      if (typeof loadDataSync !== "function") return [];
+      var arr = loadDataSync(STORAGE_KEY, []);
+      return Array.isArray(arr) ? arr : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  global.recordBootDiagnostic = recordBootDiagnostic;
+  global.getBootDiagnostics = getBootDiagnostics;
+})(typeof window !== "undefined" ? window : this);

--- a/js/boot-diagnostics.js
+++ b/js/boot-diagnostics.js
@@ -29,8 +29,8 @@
 (function (global) {
   "use strict";
 
-  var STORAGE_KEY = "staktrakr.bootDiagnostics";
-  var MAX_ENTRIES = 10;
+  const STORAGE_KEY = "staktrakr.bootDiagnostics";
+  const MAX_ENTRIES = 10;
 
   /**
    * Record a single boot diagnostic event.
@@ -48,9 +48,9 @@
     try {
       if (!entry || typeof entry !== "object") return;
 
-      var version = typeof APP_VERSION === "string" ? APP_VERSION : "unknown";
+      const version = typeof APP_VERSION === "string" ? APP_VERSION : "unknown";
 
-      var record = {
+      const record = {
         ts: new Date().toISOString(),
         version: version,
         classification: entry.classification,
@@ -61,7 +61,7 @@
         record.errorName = entry.errorName;
       }
 
-      var existing = [];
+      let existing = [];
       if (typeof loadDataSync === "function") {
         existing = loadDataSync(STORAGE_KEY, []);
       }
@@ -92,7 +92,7 @@
   function getBootDiagnostics() {
     try {
       if (typeof loadDataSync !== "function") return [];
-      var arr = loadDataSync(STORAGE_KEY, []);
+      const arr = loadDataSync(STORAGE_KEY, []);
       return Array.isArray(arr) ? arr : [];
     } catch (_) {
       return [];

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -773,8 +773,14 @@ const renderCardView = (sortedItems, container, itemIndexMap) => {
   }
   _cvBlobUrls = [];
 
+  // STRK-13: Skip the "Add Item" empty-state placeholder during recovery — the
+  // recovery banner already owns the screen real estate, and showing Add Item
+  // would let the user defeat the saveInventory recovery hold.
+  const recoveryActive =
+    typeof isInventoryRecoveryActive === "function" && isInventoryRecoveryActive();
+
   // Handle empty state: no items or no search results
-  if (html.length === 0) {
+  if (html.length === 0 && !recoveryActive) {
     const isFiltered = typeof inventory !== "undefined" && inventory.length > 0;
     const message = isFiltered ? "No matching items found." : "Your stack is empty.";
     const subtext = isFiltered

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,10 +281,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-04-27 - STRK-4: Lot ⇄ Each toggle for Purchase Price
+ * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.34";
+const APP_VERSION = "3.34.35";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -1019,6 +1019,8 @@ const ALLOWED_STORAGE_KEYS = [
   "vendorPricesActiveTab", // string: active metal tab in vendor prices section
   "v2SpotHistoryTs", // string: ISO timestamp of cached v2 spot history
   "itemRemovedTags", // JSON object: per-item removed Numista tags keyed by UUID (STAK-556)
+  "inventorySeedApplied", // STRK-13: ISO timestamp string, sentinel proving seed has been applied (or migration ran)
+  "staktrakr.bootDiagnostics", // STRK-13: JSON array, 10-entry ring buffer of boot classifications
 ];
 
 /**

--- a/js/events.js
+++ b/js/events.js
@@ -1493,6 +1493,8 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       catalogManager.setCatalogId(serial, f.catalog);
     }
 
+    if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+    if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by addItem");
     saveInventory();
 
     // Log the add action to the changelog (BUG-004)

--- a/js/init.js
+++ b/js/init.js
@@ -491,6 +491,16 @@ document.addEventListener("DOMContentLoaded", async () => {
       elements.itemDate.value = todayStr();
     }
 
+    // STRK-13: Snapshot boot state BEFORE loadInventory() runs. loadInventory
+    // unconditionally writes inventorySerial (inventory.js:291), which would
+    // trip classifyBootState's "damaged-key" branch on a first-run boot. Design.md
+    // documented classify-after-load, but empirically that ordering breaks the
+    // first-run path — see STRK-13 task 9 notes for the design follow-up.
+    let bootState = null;
+    if (typeof classifyBootState === "function") {
+      bootState = classifyBootState();
+    }
+
     // Load data
     await loadInventory();
 
@@ -507,9 +517,41 @@ document.addEventListener("DOMContentLoaded", async () => {
       NumistaLookup.loadEnabledSeedRules();
     }
 
-    // Seed sample inventory for first-time users
-    if (typeof loadSeedInventory === "function") {
-      loadSeedInventory();
+    if (bootState) {
+      if (bootState.classification === "first-run") {
+        if (typeof loadSeedInventory === "function") {
+          loadSeedInventory(bootState);
+        }
+      } else if (bootState.classification === "returning-with-data") {
+        if (typeof migrateSentinelIfMissing === "function") {
+          migrateSentinelIfMissing(bootState);
+        }
+      } else if (
+        bootState.classification === "damaged-key" ||
+        bootState.classification === "parse-error"
+      ) {
+        var cloudConnected = false;
+        if (typeof syncIsEnabled === "function" && typeof cloudIsConnected === "function") {
+          cloudConnected = !!(syncIsEnabled() && cloudIsConnected("dropbox"));
+        }
+        if (typeof showInventoryRecoveryBanner === "function") {
+          showInventoryRecoveryBanner({ cloudConnected: cloudConnected });
+        }
+        if (typeof setInventoryRecoveryActive === "function") {
+          setInventoryRecoveryActive(true);
+        }
+      }
+
+      if (typeof recordBootDiagnostic === "function") {
+        var diag = {
+          classification: bootState.classification,
+          keyPresence: bootState.keyPresence,
+        };
+        if (bootState.errorName) {
+          diag.errorName = bootState.errorName;
+        }
+        recordBootDiagnostic(diag);
+      }
     }
     if (typeof sanitizeTablesOnLoad === "function") {
       sanitizeTablesOnLoad();

--- a/js/init.js
+++ b/js/init.js
@@ -532,7 +532,16 @@ document.addEventListener("DOMContentLoaded", async () => {
       ) {
         var cloudConnected = false;
         if (typeof syncIsEnabled === "function" && typeof cloudIsConnected === "function") {
-          cloudConnected = !!(syncIsEnabled() && cloudIsConnected("dropbox"));
+          var providers =
+            typeof CLOUD_PROVIDERS === "object"
+              ? Object.keys(CLOUD_PROVIDERS)
+              : ["dropbox", "pcloud", "box"];
+          cloudConnected = !!(
+            syncIsEnabled() &&
+            providers.some(function (p) {
+              return cloudIsConnected(p);
+            })
+          );
         }
         if (typeof showInventoryRecoveryBanner === "function") {
           showInventoryRecoveryBanner({ cloudConnected: cloudConnected });

--- a/js/inventory-import.js
+++ b/js/inventory-import.js
@@ -59,6 +59,8 @@
     if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
       inventory = catalogManager.syncInventory(inventory);
     }
+    if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+    if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by import");
     saveInventory();
     renderTable();
     if (typeof renderActiveFilters === "function") renderActiveFilters();
@@ -497,6 +499,8 @@
               }
             }
 
+            if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+            if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by csvImport");
             saveInventory();
             // STAK-424: Apply deferred tags after override confirmation
             if (pendingTagsByUuid.size > 0 && typeof addItemTag === "function") {
@@ -832,6 +836,9 @@
             if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
               inventory = catalogManager.syncInventory(inventory);
             }
+            if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+            if (typeof debugLog === "function")
+              debugLog("inventoryRecovery: cleared by numistaImport");
             saveInventory();
             // STAK-421: Cancel debounced sync push after override import
             if (
@@ -1332,6 +1339,8 @@
           if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
             inventory = catalogManager.syncInventory(inventory);
           }
+          if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+          if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by jsonImport");
           saveInventory();
           // Restore itemRemovedTags from import payload (STAK-556)
           if (parsedRemovedTags && typeof saveDataSync === "function") {

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -650,7 +650,12 @@
       }
       _thumbBlobUrls = [];
 
-      if (sortedInventory.length === 0) {
+      // STRK-13: When inventory recovery is active, the banner takes over the
+      // empty-state messaging. Skip the "Your stack is empty / Add Item" placeholder
+      // so a panicked user can't click Add Item and defeat the recovery hold.
+      const recoveryActive =
+        typeof isInventoryRecoveryActive === "function" && isInventoryRecoveryActive();
+      if (sortedInventory.length === 0 && !recoveryActive) {
         const isFiltered = inventory.length > 0;
         const message = isFiltered ? "No matching items found." : "Your stack is empty.";
         const subtext = isFiltered

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -36,6 +36,86 @@ window.isInventoryRecoveryActive = isInventoryRecoveryActive;
 window.clearInventoryRecovery = clearInventoryRecovery;
 
 /**
+ * STRK-13: Show the sticky inventory recovery banner above the inventory
+ * table section. Idempotent — re-invocation is a no-op when the banner
+ * already exists. Banner is built with createElement / textContent (no
+ * innerHTML) and stays visible until the user clicks Dismiss or Open Cloud
+ * Settings.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.cloudConnected] - When true, copy directs the user
+ *   toward cloud restore; when false/undefined, copy directs toward refresh
+ *   or local backup import.
+ */
+const showInventoryRecoveryBanner = ({ cloudConnected } = {}) => {
+  if (typeof document === "undefined") return;
+  if (safeGetElement("inventoryRecoveryBanner")) return;
+  const tableSection = safeGetElement("tableSectionEl");
+  if (!tableSection || !tableSection.parentNode) return;
+
+  const copyConnected =
+    "Your inventory could not be loaded from this device. Restore from your cloud backup, or refresh and try again. Your local data was not modified.";
+  const copyDisconnected =
+    "Your inventory could not be loaded from this device. Refresh and try again, or import a backup file. Your local data was not modified.";
+
+  const banner = document.createElement("div");
+  banner.id = "inventoryRecoveryBanner";
+  banner.className = "inventory-recovery-banner";
+  banner.setAttribute("role", "alert");
+
+  const icon = document.createElement("span");
+  icon.className = "inventory-recovery-banner__icon";
+  icon.setAttribute("aria-hidden", "true");
+  icon.textContent = "⚠";
+
+  const copy = document.createElement("p");
+  copy.className = "inventory-recovery-banner__copy";
+  copy.textContent = cloudConnected ? copyConnected : copyDisconnected;
+
+  const actions = document.createElement("div");
+  actions.className = "inventory-recovery-banner__actions";
+
+  const primaryBtn = document.createElement("button");
+  primaryBtn.type = "button";
+  primaryBtn.className = "inventory-recovery-banner__btn inventory-recovery-banner__btn--primary";
+  primaryBtn.textContent = "Open Cloud Settings";
+  primaryBtn.addEventListener("click", () => {
+    if (typeof showSettingsModal === "function") {
+      showSettingsModal("cloud");
+    }
+    clearInventoryRecovery();
+  });
+
+  const secondaryBtn = document.createElement("button");
+  secondaryBtn.type = "button";
+  secondaryBtn.className =
+    "inventory-recovery-banner__btn inventory-recovery-banner__btn--secondary";
+  secondaryBtn.textContent = "Dismiss";
+  secondaryBtn.addEventListener("click", () => {
+    clearInventoryRecovery();
+  });
+
+  actions.appendChild(primaryBtn);
+  actions.appendChild(secondaryBtn);
+  banner.appendChild(icon);
+  banner.appendChild(copy);
+  banner.appendChild(actions);
+
+  tableSection.parentNode.insertBefore(banner, tableSection);
+};
+
+const dismissInventoryRecoveryBanner = () => {
+  if (typeof document === "undefined") return;
+  const banner = safeGetElement("inventoryRecoveryBanner");
+  if (banner && banner.parentNode) {
+    banner.parentNode.removeChild(banner);
+  }
+};
+
+window.showInventoryRecoveryBanner = showInventoryRecoveryBanner;
+window.dismissInventoryRecoveryBanner = dismissInventoryRecoveryBanner;
+
+/**
  * Invalidates the cached item index map.
  * Should be called whenever the inventory array is mutated (add/remove/reorder).
  */

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -108,7 +108,9 @@ const showInventoryRecoveryBanner = ({ cloudConnected } = {}) => {
 
 const dismissInventoryRecoveryBanner = () => {
   if (typeof document === "undefined") return;
-  const banner = safeGetElement("inventoryRecoveryBanner");
+  // safeGetElement returns a truthy dummy on miss; use document.getElementById so
+  // banner.parentNode is null when absent and the removeChild guard works correctly.
+  const banner = document.getElementById("inventoryRecoveryBanner");
   if (banner && banner.parentNode) {
     banner.parentNode.removeChild(banner);
   }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -49,8 +49,10 @@ window.clearInventoryRecovery = clearInventoryRecovery;
  */
 const showInventoryRecoveryBanner = ({ cloudConnected } = {}) => {
   if (typeof document === "undefined") return;
-  if (safeGetElement("inventoryRecoveryBanner")) return;
-  const tableSection = safeGetElement("tableSectionEl");
+  // safeGetElement returns a truthy dummy on miss, so use document.getElementById
+  // for these existence checks where null matters.
+  if (document.getElementById("inventoryRecoveryBanner")) return;
+  const tableSection = document.getElementById("tableSectionEl");
   if (!tableSection || !tableSection.parentNode) return;
 
   const copyConnected =

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -9,6 +9,33 @@
 let _cachedItemIndexMap = null;
 
 /**
+ * STRK-13: Inventory recovery flag.
+ * Set true when boot detected damaged or unparseable metalInventory; gated
+ * `saveInventory()` calls become no-ops until cleared by an explicit user
+ * action (add / import / restore — wired in task 8). Prevents the auto-write
+ * of `[]` that would overwrite the corrupt key with an empty array, destroying
+ * forensic evidence and preventing cloud-restore.
+ */
+let inventoryRecoveryActive = false;
+const setInventoryRecoveryActive = (val) => {
+  inventoryRecoveryActive = !!val;
+};
+const isInventoryRecoveryActive = () => inventoryRecoveryActive;
+const clearInventoryRecovery = () => {
+  if (!inventoryRecoveryActive) return;
+  inventoryRecoveryActive = false;
+  if (typeof dismissInventoryRecoveryBanner === "function") {
+    dismissInventoryRecoveryBanner();
+  }
+  if (typeof debugLog === "function") {
+    debugLog("inventoryRecovery: cleared");
+  }
+};
+window.setInventoryRecoveryActive = setInventoryRecoveryActive;
+window.isInventoryRecoveryActive = isInventoryRecoveryActive;
+window.clearInventoryRecovery = clearInventoryRecovery;
+
+/**
  * Invalidates the cached item index map.
  * Should be called whenever the inventory array is mutated (add/remove/reorder).
  */
@@ -49,6 +76,16 @@ window.getNextSerial = getNextSerial;
  * Saves current inventory to localStorage
  */
 const saveInventory = async () => {
+  // STRK-13: Suppress automatic writes during recovery mode. Cleared by the
+  // recovery banner's actions or by the first explicit user-driven mutation
+  // (add/import/restore — see task 8 wiring).
+  if (inventoryRecoveryActive) {
+    if (typeof debugLog === "function") {
+      debugLog("saveInventory: suppressed (recovery mode active — explicit user action required)");
+    }
+    return;
+  }
+
   // Invalidate cached index map as inventory has likely changed
   invalidateItemIndexMap();
 

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8377,7 +8377,7 @@ function loadSeedInventory(stateResult) {
   // Replaces the old `inventory.length > 0` heuristic which silently overwrote
   // damaged storage with sample data.
   if (typeof shouldSeedInventory === "function" && !shouldSeedInventory(stateResult)) {
-    var cls = stateResult && stateResult.classification ? stateResult.classification : "unknown";
+    const cls = stateResult && stateResult.classification ? stateResult.classification : "unknown";
     debugLog("Seed inventory: skipped — classification=" + cls);
     return;
   }
@@ -8398,8 +8398,12 @@ function loadSeedInventory(stateResult) {
 
   // STRK-13: Write the seed sentinel atomically with the seed save so subsequent
   // boots take the "returning user" branch even if the user empties their inventory.
-  if (typeof saveDataSync === "function") {
-    saveDataSync("inventorySeedApplied", new Date().toISOString());
+  try {
+    if (typeof saveDataSync === "function") {
+      saveDataSync("inventorySeedApplied", new Date().toISOString());
+    }
+  } catch (e) {
+    if (typeof debugLog === "function") debugLog("Seed sentinel write failed:", e && e.name);
   }
 
   debugLog("Seed inventory: loaded " + SEED_INVENTORY_ITEMS.length + " sample items");
@@ -8419,7 +8423,13 @@ function migrateSentinelIfMissing(stateResult) {
   if (!stateResult || stateResult.classification !== "returning-with-data") return;
   if (stateResult.keyPresence && stateResult.keyPresence.inventorySeedApplied) return;
   if (typeof saveDataSync !== "function") return;
-  saveDataSync("inventorySeedApplied", new Date().toISOString());
+  try {
+    saveDataSync("inventorySeedApplied", new Date().toISOString());
+  } catch (e) {
+    if (typeof debugLog === "function")
+      debugLog("Seed sentinel migration write failed:", e && e.name);
+    return;
+  }
   if (typeof debugLog === "function") {
     debugLog("Seed sentinel migration: sentinel set for existing user");
   }

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8306,6 +8306,58 @@ const SEED_INVENTORY_ITEMS = [
   },
 ];
 
+function classifyBootState() {
+  const PRIOR_KEYS = [
+    "metalInventory",
+    "inventorySerial",
+    "cloud_sync_local_modified",
+    "cloud_sync_device_id",
+    "inventorySeedApplied",
+  ];
+  const keyPresence = {};
+  PRIOR_KEYS.forEach((k) => {
+    keyPresence[k] = localStorage.getItem(k) !== null;
+  });
+
+  if (keyPresence.metalInventory) {
+    const raw = localStorage.getItem(LS_KEY);
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      return {
+        classification: "parse-error",
+        keyPresence,
+        errorName: err && err.name ? err.name : "ParseError",
+      };
+    }
+    if (!Array.isArray(parsed)) {
+      return { classification: "parse-error", keyPresence, errorName: "ShapeError" };
+    }
+    if (parsed.length > 0) {
+      return { classification: "returning-with-data", keyPresence };
+    }
+    // Empty array — fall through to evidence check
+  }
+
+  if (
+    keyPresence.inventorySerial ||
+    keyPresence.cloud_sync_local_modified ||
+    keyPresence.cloud_sync_device_id ||
+    keyPresence.inventorySeedApplied
+  ) {
+    return { classification: "damaged-key", keyPresence };
+  }
+
+  return { classification: "first-run", keyPresence };
+}
+
+function shouldSeedInventory(stateResult) {
+  if (!stateResult || stateResult.classification !== "first-run") return false;
+  if (stateResult.keyPresence && stateResult.keyPresence.inventorySeedApplied) return false;
+  return true;
+}
+
 /**
  * Loads sample inventory items for first-time users.
  *
@@ -8340,3 +8392,5 @@ function loadSeedInventory() {
 // Export for global access
 window.loadSeedSpotHistory = loadSeedSpotHistory;
 window.loadSeedInventory = loadSeedInventory;
+window.classifyBootState = classifyBootState;
+window.shouldSeedInventory = shouldSeedInventory;

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8399,8 +8399,29 @@ function loadSeedInventory(stateResult) {
   debugLog("Seed inventory: loaded " + SEED_INVENTORY_ITEMS.length + " sample items");
 }
 
+/**
+ * STRK-13: Idempotent migration that back-fills the seed sentinel for users
+ * who pre-date this fix. Runs on every boot; only writes when classification
+ * is "returning-with-data" AND the sentinel is missing.
+ *
+ * Does NOT seed inventory — that's loadSeedInventory's job. Does NOT touch
+ * APP_VERSION_KEY (per requirements REQ-4 AC 3).
+ *
+ * @param {{classification: string, keyPresence: object}} stateResult
+ */
+function migrateSentinelIfMissing(stateResult) {
+  if (!stateResult || stateResult.classification !== "returning-with-data") return;
+  if (stateResult.keyPresence && stateResult.keyPresence.inventorySeedApplied) return;
+  if (typeof saveDataSync !== "function") return;
+  saveDataSync("inventorySeedApplied", new Date().toISOString());
+  if (typeof debugLog === "function") {
+    debugLog("Seed sentinel migration: sentinel set for existing user");
+  }
+}
+
 // Export for global access
 window.loadSeedSpotHistory = loadSeedSpotHistory;
 window.loadSeedInventory = loadSeedInventory;
 window.classifyBootState = classifyBootState;
 window.shouldSeedInventory = shouldSeedInventory;
+window.migrateSentinelIfMissing = migrateSentinelIfMissing;

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8323,7 +8323,13 @@ function classifyBootState() {
     const raw = localStorage.getItem(LS_KEY);
     let parsed;
     try {
-      parsed = JSON.parse(raw);
+      // STRK-13: Decompress before parsing — large inventories are stored with
+      // a CMP1: prefix by __compressIfNeeded (utils.js:3163). Raw JSON.parse on
+      // a compressed payload throws SyntaxError, which would misclassify real
+      // users with valid large inventory as parse-error. Fall back to raw on
+      // missing wrapper (file load order, no-op for uncompressed payloads).
+      const decoded = typeof __decompressIfNeeded === "function" ? __decompressIfNeeded(raw) : raw;
+      parsed = JSON.parse(decoded);
     } catch (err) {
       return {
         classification: "parse-error",

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8334,10 +8334,10 @@ function classifyBootState() {
     if (!Array.isArray(parsed)) {
       return { classification: "parse-error", keyPresence, errorName: "ShapeError" };
     }
-    if (parsed.length > 0) {
-      return { classification: "returning-with-data", keyPresence };
-    }
-    // Empty array — fall through to evidence check
+    // STRK-13: Any valid array — including empty — is "returning-with-data".
+    // An empty array is a legitimate state (user deleted everything); falling
+    // through to the evidence check would misclassify them as damaged-key.
+    return { classification: "returning-with-data", keyPresence };
   }
 
   if (

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8320,7 +8320,16 @@ function classifyBootState() {
   });
 
   if (keyPresence.metalInventory) {
-    const raw = localStorage.getItem(LS_KEY);
+    let raw;
+    try {
+      raw = localStorage.getItem("metalInventory");
+    } catch (storageErr) {
+      return {
+        classification: "parse-error",
+        keyPresence,
+        errorName: storageErr && storageErr.name ? storageErr.name : "StorageError",
+      };
+    }
     let parsed;
     try {
       // STRK-13: Decompress before parsing — large inventories are stored with
@@ -8372,7 +8381,7 @@ function shouldSeedInventory(stateResult) {
  * pushes them into the inventory array, and persists with a single
  * saveInventory() call.
  */
-function loadSeedInventory(stateResult) {
+async function loadSeedInventory(stateResult) {
   // STRK-13: Gate on classification — only seed when shouldSeedInventory() agrees.
   // Replaces the old `inventory.length > 0` heuristic which silently overwrote
   // damaged storage with sample data.
@@ -8394,10 +8403,11 @@ function loadSeedInventory(stateResult) {
     inventory.push(item);
   }
 
-  saveInventory();
+  await saveInventory();
 
-  // STRK-13: Write the seed sentinel atomically with the seed save so subsequent
-  // boots take the "returning user" branch even if the user empties their inventory.
+  // STRK-13: Write the seed sentinel only after saveInventory() resolves so a
+  // quota-exceeded or other storage failure doesn't leave the user permanently
+  // stuck with an empty inventory on all subsequent boots.
   try {
     if (typeof saveDataSync === "function") {
       saveDataSync("inventorySeedApplied", new Date().toISOString());

--- a/js/seed-data.js
+++ b/js/seed-data.js
@@ -8366,10 +8366,13 @@ function shouldSeedInventory(stateResult) {
  * pushes them into the inventory array, and persists with a single
  * saveInventory() call.
  */
-function loadSeedInventory() {
-  // Guard: existing users already have inventory
-  if (typeof inventory !== "undefined" && inventory.length > 0) {
-    debugLog("Seed inventory: skipped — inventory already has " + inventory.length + " items");
+function loadSeedInventory(stateResult) {
+  // STRK-13: Gate on classification — only seed when shouldSeedInventory() agrees.
+  // Replaces the old `inventory.length > 0` heuristic which silently overwrote
+  // damaged storage with sample data.
+  if (typeof shouldSeedInventory === "function" && !shouldSeedInventory(stateResult)) {
+    var cls = stateResult && stateResult.classification ? stateResult.classification : "unknown";
+    debugLog("Seed inventory: skipped — classification=" + cls);
     return;
   }
 
@@ -8386,6 +8389,13 @@ function loadSeedInventory() {
   }
 
   saveInventory();
+
+  // STRK-13: Write the seed sentinel atomically with the seed save so subsequent
+  // boots take the "returning user" branch even if the user empties their inventory.
+  if (typeof saveDataSync === "function") {
+    saveDataSync("inventorySeedApplied", new Date().toISOString());
+  }
+
   debugLog("Seed inventory: loaded " + SEED_INVENTORY_ITEMS.length + " sample items");
 }
 

--- a/js/vault.js
+++ b/js/vault.js
@@ -685,6 +685,8 @@ async function vaultRestoreWithPreview(fileBytes, password) {
         }
 
         // Save & render
+        if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+        if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by cloudRestore");
         if (typeof saveInventory === "function") saveInventory();
         if (typeof renderTable === "function") renderTable();
         if (typeof renderActiveFilters === "function") renderActiveFilters();

--- a/js/vault.js
+++ b/js/vault.js
@@ -686,7 +686,7 @@ async function vaultRestoreWithPreview(fileBytes, password) {
 
         // Save & render
         if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
-        if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by cloudRestore");
+        if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by vaultRestore");
         if (typeof saveInventory === "function") saveInventory();
         if (typeof renderTable === "function") renderTable();
         if (typeof renderActiveFilters === "function") renderActiveFilters();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.34",
+  "version": "3.34.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.34",
+      "version": "3.34.35",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.34",
+  "version": "3.34.35",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777433275";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777433444";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777433102";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777433275";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777468518";
+const CACHE_NAME = "staktrakr-v3.34.35-b1777471441";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777434268";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777434404";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777439859";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777468518";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.35-b1777471718";
+const CACHE_NAME = "staktrakr-v3.34.35-b1777472736";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777433444";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777433823";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777434404";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777436248";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777432798";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777432968";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.35-b1777472736";
+const CACHE_NAME = "staktrakr-v3.34.35-b1777473409";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777400532";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777432650";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777436248";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777439859";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777433823";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777434268";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777432968";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777433102";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.34-b1777432650";
+const CACHE_NAME = "staktrakr-v3.34.34-b1777432798";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =
@@ -23,6 +23,7 @@ const CORE_ASSETS = [
   "./css/styles.css",
   "./js/file-protocol-fix.js",
   "./js/debug-log.js",
+  "./js/boot-diagnostics.js",
   "./js/constants.js",
   "./js/field-meta.js",
   "./js/state.js",

--- a/tests/playwright/inventory/seed-guard.spec.js
+++ b/tests/playwright/inventory/seed-guard.spec.js
@@ -1,0 +1,160 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_ITEM = {
+  uuid: "strk13-base-item",
+  metal: "Silver",
+  composition: "Silver",
+  name: "STRK-13 Base Silver Eagle",
+  qty: 4,
+  type: "Coin",
+  weight: 1,
+  weightUnit: "oz",
+  price: 100,
+  marketValue: 0,
+  date: "2026-04-01",
+  purchaseLocation: "StakTrakr",
+  storageLocation: "Safe",
+  serialNumber: "",
+  notes: "",
+  year: "2026",
+  grade: "",
+  gradingAuthority: "",
+  certNumber: "",
+  pcgsNumber: "",
+  pcgsVerified: false,
+  spotPriceAtPurchase: 30,
+  premiumPerOz: 0,
+  totalPremium: 0,
+  purity: 0.999,
+  numistaId: "",
+  serial: 1,
+};
+
+async function suppressWhatsNewPopup(page) {
+  await page.addInitScript(() => {
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        if (typeof APP_VERSION !== "undefined") {
+          localStorage.setItem("ackVersion", APP_VERSION);
+        }
+      },
+      { once: true }
+    );
+  });
+}
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => Array.isArray(window.inventory));
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("STRK-13 Inventory Seed Guard", () => {
+  test("1. first-run-seeds: empty localStorage seeds 8 sample items and sets sentinel — REQ-1.4, REQ-1.5", async ({
+    page,
+  }) => {
+    await suppressWhatsNewPopup(page);
+    await gotoApp(page);
+
+    const inventoryLength = await page.evaluate(() => window.inventory && window.inventory.length);
+    expect(inventoryLength).toBe(8);
+
+    const sentinel = await page.evaluate(() => localStorage.getItem("inventorySeedApplied"));
+    expect(sentinel).not.toBeNull();
+
+    const banner = page.locator("#inventoryRecoveryBanner");
+    await expect(banner).toHaveCount(0);
+  });
+
+  test("2. returning-with-data-no-seed: pre-set inventory with sentinel does not merge sample data — REQ-1.1", async ({
+    page,
+  }) => {
+    await suppressWhatsNewPopup(page);
+    await page.addInitScript((item) => {
+      localStorage.setItem("metalInventory", JSON.stringify([item]));
+      localStorage.setItem("inventorySeedApplied", "2026-04-01T00:00:00.000Z");
+    }, BASE_ITEM);
+
+    await gotoApp(page);
+
+    const inventoryLength = await page.evaluate(() => window.inventory && window.inventory.length);
+    expect(inventoryLength).toBe(1);
+
+    const firstName = await page.evaluate(() => window.inventory[0] && window.inventory[0].name);
+    expect(firstName).toBe(BASE_ITEM.name);
+
+    const sentinel = await page.evaluate(() => localStorage.getItem("inventorySeedApplied"));
+    expect(sentinel).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  test("3. damaged-key-shows-banner: missing inventory + present serial shows recovery banner, no seed — REQ-1.2, REQ-2.1", async ({
+    page,
+  }) => {
+    await suppressWhatsNewPopup(page);
+    await page.addInitScript(() => {
+      localStorage.setItem("inventorySerial", "5");
+      localStorage.setItem("cloud_sync_local_modified", "2026-04-20T00:00:00.000Z");
+    });
+
+    await gotoApp(page);
+
+    const banner = page.locator("#inventoryRecoveryBanner");
+    await expect(banner).toBeVisible();
+
+    const metalInventoryRaw = await page.evaluate(() => localStorage.getItem("metalInventory"));
+    expect(metalInventoryRaw).toBeNull();
+
+    const inventoryLength = await page.evaluate(() => window.inventory && window.inventory.length);
+    expect(inventoryLength).toBe(0);
+
+    const tableRows = await page.locator("#inventoryTable tbody tr").count();
+    expect(tableRows).toBe(0);
+  });
+
+  test("4. parse-error-shows-banner: corrupt JSON shows recovery banner, leaves storage untouched, records SyntaxError — REQ-1.3, REQ-2.1, REQ-3.2", async ({
+    page,
+  }) => {
+    await suppressWhatsNewPopup(page);
+    await page.addInitScript(() => {
+      localStorage.setItem("metalInventory", "{not valid json");
+    });
+
+    await gotoApp(page);
+
+    const banner = page.locator("#inventoryRecoveryBanner");
+    await expect(banner).toBeVisible();
+
+    const metalInventoryRaw = await page.evaluate(() => localStorage.getItem("metalInventory"));
+    expect(metalInventoryRaw).toBe("{not valid json");
+
+    const diagnosticsRaw = await page.evaluate(() =>
+      localStorage.getItem("staktrakr.bootDiagnostics")
+    );
+    expect(diagnosticsRaw).not.toBeNull();
+    const diagnostics = JSON.parse(diagnosticsRaw);
+    expect(Array.isArray(diagnostics)).toBe(true);
+    const hasSyntaxError = diagnostics.some((entry) => entry && entry.errorName === "SyntaxError");
+    expect(hasSyntaxError).toBe(true);
+  });
+
+  test("5. migration-sets-sentinel: returning user without sentinel gets sentinel set without seeding — REQ-4.1", async ({
+    page,
+  }) => {
+    await suppressWhatsNewPopup(page);
+    await page.addInitScript((item) => {
+      localStorage.setItem("metalInventory", JSON.stringify([item]));
+    }, BASE_ITEM);
+
+    await gotoApp(page);
+
+    const inventoryLength = await page.evaluate(() => window.inventory && window.inventory.length);
+    expect(inventoryLength).toBe(1);
+
+    const firstName = await page.evaluate(() => window.inventory[0] && window.inventory[0].name);
+    expect(firstName).toBe(BASE_ITEM.name);
+
+    const sentinel = await page.evaluate(() => localStorage.getItem("inventorySeedApplied"));
+    expect(sentinel).not.toBeNull();
+  });
+});

--- a/tests/playwright/inventory/seed-guard.spec.js
+++ b/tests/playwright/inventory/seed-guard.spec.js
@@ -157,4 +157,42 @@ test.describe("STRK-13 Inventory Seed Guard", () => {
     const sentinel = await page.evaluate(() => localStorage.getItem("inventorySeedApplied"));
     expect(sentinel).not.toBeNull();
   });
+
+  test("6. compressed-inventory-loads: large CMP1-prefixed inventory must NOT be misclassified as parse-error — REQ-1.1, regression for Codex finding", async ({
+    page,
+  }) => {
+    // Pre-seed a CMP1:-prefixed metalInventory value to exercise the
+    // compression-wrapper code path in classifyBootState. The current
+    // LZString implementation in js/utils.js is a no-op (compressToUTF16
+    // returns input unchanged), so the on-disk shape for large payloads is
+    // simply "CMP1:" + JSON_STRING. Raw JSON.parse on that prefix throws
+    // SyntaxError, which without the decompression-aware classifier would
+    // misclassify a real returning user as parse-error.
+    await suppressWhatsNewPopup(page);
+    await page.addInitScript((item) => {
+      const items = [];
+      for (let i = 0; i < 60; i++) {
+        items.push(Object.assign({}, item, { uuid: `cmp-test-${i}`, serial: i + 1 }));
+      }
+      const json = JSON.stringify(items);
+      // Sanity: confirm the fixture is large enough to actually trip the
+      // production compression threshold (4096 chars).
+      if (json.length < 4096) {
+        throw new Error("test fixture too small to trigger compression wrapper");
+      }
+      localStorage.setItem("metalInventory", "CMP1:" + json);
+      localStorage.setItem("inventorySerial", String(items.length));
+      localStorage.setItem("inventorySeedApplied", "2026-04-01T00:00:00.000Z");
+    }, BASE_ITEM);
+
+    await gotoApp(page);
+
+    // Recovery banner MUST NOT be visible — this is the regression we're guarding.
+    const banner = page.locator("#inventoryRecoveryBanner");
+    await expect(banner).toHaveCount(0);
+
+    // Inventory loaded from the CMP1:-prefixed payload, not seeded over.
+    const inventoryLength = await page.evaluate(() => window.inventory && window.inventory.length);
+    expect(inventoryLength).toBe(60);
+  });
 });

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.34",
-  "releaseDate": "2026-04-27",
+  "version": "3.34.35",
+  "releaseDate": "2026-04-29",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Seed guard**: `classifyBootState()` now distinguishes first-run (no prior localStorage evidence) from storage failure (orphaned keys exist without `metalInventory`). Sample data is only seeded on genuine first-run, never on storage corruption.
- **Recovery banner**: When storage damage is detected, a sticky warning banner surfaces above the inventory table instead of silently overwriting data with samples. Users can restore from cloud backup or dismiss.
- **Boot diagnostics**: 10-entry ring buffer records boot classifications (`staktrakr.bootDiagnostics`) for post-mortem analysis without storing PII.
- **Sentinel migration**: `migrateSentinelIfMissing()` writes the seed sentinel for existing users on first upgrade so they are never re-seeded.
- **CMP1 fix**: `classifyBootState()` decompresses CMP1-prefixed inventory before parsing, preventing large inventories (≥4096 chars) from being misclassified as corrupt.

Closes [STRK-13](https://plane.lbruton.cc/lbruton/browse/STRK-13/)

## Files changed

| Action | Files | Scope |
|--------|-------|-------|
| CREATE | `js/boot-diagnostics.js` | 10-entry ring buffer: `recordBootDiagnostic()` + `getBootDiagnostics()` |
| MODIFY | `js/seed-data.js` | `classifyBootState()`, `shouldSeedInventory()`, `migrateSentinelIfMissing()`, gated `loadSeedInventory()` |
| MODIFY | `js/inventory.js` | `inventoryRecoveryActive` flag, `saveInventory()` gate, recovery banner UI |
| MODIFY | `js/init.js` | Boot dispatch replaces unconditional `loadSeedInventory()` call |
| MODIFY | `js/constants.js` | `inventorySeedApplied` and `staktrakr.bootDiagnostics` in `ALLOWED_STORAGE_KEYS` |
| MODIFY | `css/styles.css` | `.inventory-recovery-banner` rule + 4-theme tokens |
| MODIFY | `index.html` | `<script defer>` for boot-diagnostics.js |
| MODIFY | `js/inventory-import.js`, `js/vault.js`, `js/events.js`, `js/card-view.js`, `js/inventory-table.js` | Wire `clearInventoryRecovery()` into user-mutation paths |
| TEST   | `tests/playwright/inventory/seed-guard.spec.js` | 6 scenarios: first-run, returning, damaged-key, parse-error, migration, CMP1-compressed |

## Test plan

- [x] Playwright seed-guard suite: 6/6 green
- [x] Full Playwright suite: 400 pass / 2 fail (pre-existing STRK-4 + STAK-437 flakes)
- [x] Codacy CLI: zero unaddressed findings
- [x] CodeRabbit: 2 critical findings found and fixed (commit `5f774d7c`)
- [x] Codex peer review: CMP1 decompression bug found and fixed (commit `214b3ece`)
- [ ] QA on Cloudflare Pages preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes v3.34.35

* **New Features**
  * Added recovery warning banner that appears when storage damage is detected during startup
  * Implemented boot diagnostics logging (last 10 startup classifications)

* **Bug Fixes**
  * Fixed startup inventory behavior to prevent sample data overwrites when local storage is missing or corrupted
  * Corrected boot classification to properly decompress and parse compressed inventory data

* **Tests**
  * Added comprehensive test suite validating inventory seeding behavior across storage scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->