### PR TITLE
docs: CLAUDE.md session learnings — skill authoring rules + worktree pull-first flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,11 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 | `/start-patch`                    | Pick a DocVault issue, claim version lock, create worktree                                                        |
 | `/ui-mockup`                      | New multi-element UI — Playground prototype before production code                                                |
 
+**Skill authoring rules (when creating a new skill):**
+
+- Filename must be `SKILL.md` exactly — `.gitignore` only tracks `!.claude/skills/*/SKILL.md`. Other `.md` names are silently gitignored.
+- All `SKILL.md` files need YAML frontmatter: `---\nname: <slug>\ndescription: <one line>\n---`. Pattern: see `.claude/skills/sw-cache/SKILL.md`.
+
 ---
 
 ## Always-Load Context
@@ -106,7 +111,7 @@ Always read catalog keys via `catalogConfig.getNumistaConfig()` / `getPcgsConfig
 ### Known Reviewer False Positives
 
 - **`ALLOWED_STORAGE_KEYS` "undefined guard"** — constant exists at `constants.js`; the `typeof` guard is intentional defensive coding.
-- **CodeRabbit re-review duplicates** — after pushing fixes, CodeRabbit regenerates threads on the same file/line. Auto-resolve without user approval.
+- **Automated re-review duplicates** — after pushing fixes, CodeRabbit, Gemini, and Copilot regenerate threads on the same file/line. Gemini duplicates have `"line": null` in the API (reliable stale signal). Auto-resolve without user approval.
 - **CodeRabbit "simplify code" PRs** — auto-generated refactor PRs. Triage individually.
 - **`gb-*` CSS classes** — goldback-scoped. Don't copy to other panels; rename to neutral prefixes (`source-group`, `source-btn`, `input-shell`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 - **Branch model:** `feature/* → dev → main`. All commits go through worktree branch → PR → dev. Both `dev` and `main` are protected — no direct pushes.
 - **Version format:** `MAJOR.MINOR.PATCH` in `js/constants.js` (code comment calls these `BRANCH.RELEASE.PATCH`). Use `/release` to bump (touches 7 files).
 - **Version lock:** `devops/version.lock` is gitignored — local coordination only.
-- **Worktrees:** `.worktrees/<issue>-<slug>/`. After `git worktree add`: `cp CLAUDE.md .worktrees/<issue>-<slug>/CLAUDE.md` then `npm install --no-audit --no-fund`.
+- **Worktrees:** `.worktrees/<issue>-<slug>/`. Before creating: `git checkout dev && git pull origin dev` to sync local dev first. Then: `git worktree add .worktrees/<issue>-<slug>/ -b <branch-name>`. After: `cp CLAUDE.md .worktrees/<issue>-<slug>/CLAUDE.md` then `npm install --no-audit --no-fund`.
 - **Squash merge only** — rebase merge is blocked (GitHub can't sign rebase commits). Use squash merge or local merge with SSH signing.
 - **`stamp-sw-cache` hook** — auto-stages `sw.js` when JS/CSS/image files are committed. No need to add it manually.
 - **`data/` and `vendor/` excluded from prettier** — lint-staged formats `js/` and `css/` only. Avoid manually formatting excluded paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 
 **Skill authoring rules (when creating a new skill):**
 
-- Filename must be `SKILL.md` exactly — `.gitignore` only tracks `!.claude/skills/*/SKILL.md`. Other `.md` names are silently gitignored.
+- Filename must be `SKILL.md` exactly — `.gitignore` only tracks `!.claude/skills/*/SKILL.md`. Other `.md` names are silently gitignored. **Exception:** If a genuinely different structure is required, stop and ask the user to confirm, update `.gitignore` to allow the new pattern, and include that change in the same PR so the deviation is reviewed and tracked.
 - All `SKILL.md` files need YAML frontmatter (pattern: see `.claude/skills/sw-cache/SKILL.md`):
 
   ```yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 
 **Skill authoring rules (when creating a new skill):**
 
-- Filename must be `SKILL.md` exactly — `.gitignore` only tracks `!.claude/skills/*/SKILL.md`. Other `.md` names are silently gitignored.
+Add an exception path (e.g., 'unless the user explicitly requests it') or escalation ('ask the user for confirmation').
 - All `SKILL.md` files need YAML frontmatter: `---\nname: <slug>\ndescription: <one line>\n---`. Pattern: see `.claude/skills/sw-cache/SKILL.md`.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 - **Branch model:** `feature/* → dev → main`. All commits go through worktree branch → PR → dev. Both `dev` and `main` are protected — no direct pushes.
 - **Version format:** `MAJOR.MINOR.PATCH` in `js/constants.js` (code comment calls these `BRANCH.RELEASE.PATCH`). Use `/release` to bump (touches 7 files).
 - **Version lock:** `devops/version.lock` is gitignored — local coordination only.
-- **Worktrees:** `.worktrees/<issue>-<slug>/`. Before creating: `git checkout dev && git pull origin dev` to sync local dev first. Then: `git worktree add .worktrees/<issue>-<slug>/ -b <branch-name>`. After: `cp CLAUDE.md .worktrees/<issue>-<slug>/CLAUDE.md` then `npm install --no-audit --no-fund`.
+- **Worktrees:** `.worktrees/<issue>-<slug>/`. Before creating: `git fetch origin dev` to sync remote dev (works from any worktree — no branch checkout needed). Then: `git worktree add .worktrees/<issue>-<slug>/ -b <branch-name> origin/dev`. After: `cp CLAUDE.md .worktrees/<issue>-<slug>/CLAUDE.md` then `npm install --no-audit --no-fund`.
 - **Squash merge only** — rebase merge is blocked (GitHub can't sign rebase commits). Use squash merge or local merge with SSH signing.
 - **`stamp-sw-cache` hook** — auto-stages `sw.js` when JS/CSS/image files are committed. No need to add it manually.
 - **`data/` and `vendor/` excluded from prettier** — lint-staged formats `js/` and `css/` only. Avoid manually formatting excluded paths.
@@ -87,8 +87,15 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 
 **Skill authoring rules (when creating a new skill):**
 
-Add an exception path (e.g., 'unless the user explicitly requests it') or escalation ('ask the user for confirmation').
-- All `SKILL.md` files need YAML frontmatter: `---\nname: <slug>\ndescription: <one line>\n---`. Pattern: see `.claude/skills/sw-cache/SKILL.md`.
+- Filename must be `SKILL.md` exactly — `.gitignore` only tracks `!.claude/skills/*/SKILL.md`. Other `.md` names are silently gitignored.
+- All `SKILL.md` files need YAML frontmatter (pattern: see `.claude/skills/sw-cache/SKILL.md`):
+
+  ```yaml
+  ---
+  name: <slug>
+  description: <one line>
+  ---
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary

- **Skill authoring rules** — documents the exact-filename (`SKILL.md`) and required YAML frontmatter requirements for new skills; both caused fix commits in the previous session
- **Reviewer duplicate note** — expands the CodeRabbit-only entry to cover Gemini and Copilot, which also regenerate threads after pushes; notes that Gemini duplicates have `"line": null` in the API as a reliable stale signal
- **Worktree pull-first flow** — restores the lost instruction to sync local `dev` with `origin/dev` before creating a worktree, preventing commits from being stranded on post-merge branches

## Test plan

- [ ] Review CLAUDE.md diff for accuracy