### PR TITLE
fix(STRK-19): view modal eBay search overlaps close button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5498,13 +5498,13 @@ td input:checked + .slider:before {
   white-space: nowrap;
 }
 
-/* Title row — title left, eBay right */
+/* Title row — title left, padded so text can't run under the absolute-pos close (X) */
 .view-header-title-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--spacing-sm);
   min-width: 0;
+  padding-right: 28px;
 }
 
 /* Badges row — catalog ID + count chip */
@@ -5516,12 +5516,13 @@ td input:checked + .slider:before {
   min-height: 1.4rem;
 }
 
-/* --- Header action buttons (eBay) --- */
+/* --- Header action buttons (eBay) — pushed right inside badges row --- */
 .view-header-actions {
   display: flex;
   gap: 6px;
   flex-shrink: 0;
   align-items: center;
+  margin-left: auto;
 }
 
 .view-header-actions button {

--- a/css/styles.css
+++ b/css/styles.css
@@ -5504,7 +5504,7 @@ td input:checked + .slider:before {
   align-items: center;
   gap: var(--spacing-sm);
   min-width: 0;
-  padding-right: 28px;
+  padding-right: 32px;
 }
 
 /* Badges row — catalog ID + count chip */

--- a/index.html
+++ b/index.html
@@ -7785,11 +7785,11 @@
           </button>
           <div class="view-header-title-row">
             <h2 id="viewModalTitle"></h2>
-            <div class="view-header-actions" id="viewHeaderActions"></div>
           </div>
           <div class="view-header-badges">
             <span class="view-modal-catalog-id" id="viewModalCatalogId"></span>
             <span class="view-modal-count-chip" id="viewModalCountChip"></span>
+            <div class="view-header-actions" id="viewHeaderActions"></div>
           </div>
         </div>
         <div class="modal-body" id="viewModalBody"></div>

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.37-b1777501709";
+const CACHE_NAME = "staktrakr-v3.34.37-b1777506823";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.37-b1777506823";
+const CACHE_NAME = "staktrakr-v3.34.37-b1777508271";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- Move `viewHeaderActions` (eBay search button) from `.view-header-title-row` to `.view-header-badges` so it sits on the badges row below the title instead of colliding with the absolute-positioned close (X) button
- Add `padding-right: 28px` to `.view-header-title-row` to prevent long titles from running under the X
- Add `margin-left: auto` to `.view-header-actions` to push it right within the badges row

Fixes https://plane.lbruton.cc/lbruton/browse/STRK-19/

## Test plan

- [ ] Open the item view modal for an item with a long name — verify the title is truncated before the X, not overlapping
- [ ] Verify the eBay search button appears on the second row alongside the catalog ID and count chips
- [ ] Verify the close (X) button is fully visible and clickable
- [ ] Test on mobile viewport (≤768px) to confirm layout doesn't break

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed View Item modal header layout to prevent title overlap with the close button and improved alignment of action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->