### PR TITLE
fix(STRK-20): backup conflict modal says "newer" for stale remote

### DIFF
--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -942,9 +942,7 @@ async function cloudUploadVault(provider, fileBytes, opts) {
     appVersion: cloudSafeAppVersion(),
     itemCount: safeCount,
   };
-  if (!(opts && opts.skipLatestUpdate)) {
-    localStorage.setItem("cloud_last_backup", JSON.stringify(backupMeta));
-  }
+  localStorage.setItem("cloud_last_backup", JSON.stringify(backupMeta));
 
   recordCloudActivity({
     action: "backup",

--- a/js/cloud-storage.js
+++ b/js/cloud-storage.js
@@ -942,7 +942,11 @@ async function cloudUploadVault(provider, fileBytes, opts) {
     appVersion: cloudSafeAppVersion(),
     itemCount: safeCount,
   };
-  localStorage.setItem("cloud_last_backup", JSON.stringify(backupMeta));
+  try {
+    localStorage.setItem("cloud_last_backup", JSON.stringify(backupMeta));
+  } catch (err) {
+    console.warn("[CloudStorage] Failed to update cloud_last_backup cache", err);
+  }
 
   recordCloudActivity({
     action: "backup",

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1105,8 +1105,13 @@ const bindCloudStorageListeners = () => {
             var remoteLine =
               "Remote: " + remoteItems.toLocaleString() + " items (" + remoteInfo + ")";
             var localLine = "Local: " + localInfo;
+            var conflictMsg =
+              conflict.reason === "remote_newer"
+                ? "A more recent remote backup exists."
+                : "An existing remote backup was found.";
             const shouldOverwrite = await appConfirm(
-              "A newer remote backup exists.\n\n" +
+              conflictMsg +
+                "\n\n" +
                 remoteLine +
                 "\n" +
                 localLine +

--- a/js/settings-listeners.js
+++ b/js/settings-listeners.js
@@ -1105,7 +1105,7 @@ const bindCloudStorageListeners = () => {
             var remoteLine =
               "Remote: " + remoteItems.toLocaleString() + " items (" + remoteInfo + ")";
             var localLine = "Local: " + localInfo;
-            var conflictMsg =
+            const conflictMsg =
               conflict.reason === "remote_newer"
                 ? "A more recent remote backup exists."
                 : "An existing remote backup was found.";

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.37-b1777507107";
+const CACHE_NAME = "staktrakr-v3.34.37-b1777508458";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.37-b1777501709";
+const CACHE_NAME = "staktrakr-v3.34.37-b1777507107";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- **Context-aware conflict message**: Modal now checks `conflict.reason` — shows "A more recent remote backup exists" when the remote is genuinely newer, and "An existing remote backup was found" when there's simply no local backup record (the common case after manual backups).
- **Always track local backups**: `cloud_last_backup` localStorage is now written unconditionally after a successful upload. Previously, `skipLatestUpdate` gated both the Dropbox `latest.json` pointer AND the local tracking — conflating two independent concerns. Manual backups should skip the sync pointer but still record that the device backed up.

Fixes https://plane.lbruton.cc/lbruton/browse/STRK-20/

## Test plan

- [ ] Connect to Dropbox, ensure a remote backup exists (from any prior session)
- [ ] Click "Backup" — if `cloud_last_backup` is absent from localStorage, modal should say "An existing remote backup was found" (not "newer")
- [ ] Complete the backup, then click "Backup" again — modal should now say "A more recent remote backup exists" (since remote timestamp matches the one we just uploaded, and local record is current)
- [ ] Verify the backup completes successfully and `cloud_last_backup` in localStorage has the correct timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud backup synchronization now reliably records your "last backup" metadata after successful uploads.
  * Cloud conflict confirmation messages now provide dynamic, reason-specific information to help you better understand sync conflicts and available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->