### PR TITLE
fix(STRK-15): remove stale aria-label from Silverback denomination select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed — STRK-15: Silverback denomination aria-label
 
-- **Fixed**: Silverback denomination selector now renders correct `aria-label` attributes for screen reader accessibility.
+- **Fixed**: Silverback denomination selector no longer carries a stale `aria-label="Goldback denomination"` attribute. The dynamically managed `<label for>` association in `toggleGbDenomPicker` now provides the only accessible name, eliminating the misleading screen-reader announcement.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.38] - 2026-04-29
+
+### Fixed — STRK-15: Silverback denomination aria-label
+
+- **Fixed**: Silverback denomination selector now renders correct `aria-label` attributes for screen reader accessibility.
+
+---
+
 ## [3.34.37] - 2026-04-29
 
 ### Fixed — STRK-17: Silverback weight unit wrong retail pricing

--- a/index.html
+++ b/index.html
@@ -2092,7 +2092,7 @@
                   type="text"
                   value="1"
                 />
-                <select id="itemGbDenom" style="display: none" aria-label="Goldback denomination">
+                <select id="itemGbDenom" style="display: none">
                   <option value="0.5">½ Goldback</option>
                   <option value="1" selected>1 Goldback</option>
                   <option value="2">2 Goldback</option>

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.38 &ndash; STRK-15: Silverback denomination aria-label</strong>: Silverback denomination selector now renders correct aria-label attributes for screen reader accessibility.</li>
     <li><strong>v3.34.37 &ndash; STRK-17: Silverback weight unit</strong>: Silverbacks now use their own 0.001 troy ounce unit instead of sharing Goldback retail pricing semantics. Existing Silverback records saved with the old unit are migrated automatically during load, import, backup preview, and cloud restore flows.</li>
     <li><strong>v3.34.36 &ndash; STRK-14: Vault round-trip fix</strong>: Re-importing your own encrypted backup no longer produces duplicates. Items are now matched by serial, numistaId, or name+date before comparison, and volatile cache keys no longer trigger false settings diffs.</li>
     <li><strong>v3.34.35 &ndash; STRK-13: Inventory seed guard</strong>: Startup no longer overwrites your inventory with sample data when localStorage is missing or corrupt. A recovery banner now appears instead of silently replacing your data, and a boot diagnostics buffer records classifications for post-mortem analysis.</li>

--- a/js/about.js
+++ b/js/about.js
@@ -139,7 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.34.38 &ndash; STRK-15: Silverback denomination aria-label</strong>: Silverback denomination selector now renders correct aria-label attributes for screen reader accessibility.</li>
+    <li><strong>v3.34.38 &ndash; STRK-15: Silverback denomination aria-label</strong>: Silverback denomination selector no longer carries a stale aria-label referencing Goldback. The dynamic field label provides the accessible name.</li>
     <li><strong>v3.34.37 &ndash; STRK-17: Silverback weight unit</strong>: Silverbacks now use their own 0.001 troy ounce unit instead of sharing Goldback retail pricing semantics. Existing Silverback records saved with the old unit are migrated automatically during load, import, backup preview, and cloud restore flows.</li>
     <li><strong>v3.34.36 &ndash; STRK-14: Vault round-trip fix</strong>: Re-importing your own encrypted backup no longer produces duplicates. Items are now matched by serial, numistaId, or name+date before comparison, and volatile cache keys no longer trigger false settings diffs.</li>
     <li><strong>v3.34.35 &ndash; STRK-13: Inventory seed guard</strong>: Startup no longer overwrites your inventory with sample data when localStorage is missing or corrupt. A recovery banner now appears instead of silently replacing your data, and a boot diagnostics buffer records classifications for post-mortem analysis.</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.37";
+const APP_VERSION = "3.34.38";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.37",
+  "version": "3.34.38",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.38-b1777507297";
+const CACHE_NAME = "staktrakr-v3.34.38-b1777508455";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.37-b1777501709";
+const CACHE_NAME = "staktrakr-v3.34.37-b1777505343";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.37-b1777505343";
+const CACHE_NAME = "staktrakr-v3.34.38-b1777507297";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/silverback.spec.js
+++ b/tests/playwright/silverback.spec.js
@@ -260,12 +260,6 @@ test.describe("STRK-17 Silverback weight unit and pricing", () => {
     await page.selectOption("#itemMetal", "Silver");
     await page.selectOption("#itemType", "Silverback");
 
-    await expect(page.locator("#itemGbDenom"))
-      .toBeVisible({ timeout: 5000 })
-      .catch(() => {
-        // #itemGbDenom may be hidden for Silverback — but aria-label must not say Goldback
-      });
-
     await expect(page.locator("#itemGbDenom")).not.toHaveAttribute("aria-label", /Goldback/i);
   });
 

--- a/tests/playwright/silverback.spec.js
+++ b/tests/playwright/silverback.spec.js
@@ -250,6 +250,25 @@ test.describe("STRK-17 Silverback weight unit and pricing", () => {
     expect(imported.weightUnit).toBe("sb");
   });
 
+  test("STRK-15 — #itemGbDenom has no stale Goldback aria-label when Type=Silverback", async ({
+    page,
+  }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.selectOption("#itemMetal", "Silver");
+    await page.selectOption("#itemType", "Silverback");
+
+    await expect(page.locator("#itemGbDenom"))
+      .toBeVisible({ timeout: 5000 })
+      .catch(() => {
+        // #itemGbDenom may be hidden for Silverback — but aria-label must not say Goldback
+      });
+
+    await expect(page.locator("#itemGbDenom")).not.toHaveAttribute("aria-label", /Goldback/i);
+  });
+
   test("REQ-5 AC-2 — encrypted backup preview migrates legacy Silverback gb items to sb", async ({
     page,
   }) => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.37",
+  "version": "3.34.38",
   "releaseDate": "2026-04-29",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Removed hardcoded `aria-label="Goldback denomination"` from `<select id="itemGbDenom">` (`index.html:2095`)
- The attribute always read "Goldback denomination" regardless of selected type (e.g. Silverback), making screen readers announce incorrect context
- Fix uses attribute removal — the `<label for="itemGbDenom">` already provides the correct accessible name via the HTML labelling algorithm; `toggleGbDenomPicker()` in `js/events.js:1036` handles dynamic label text at runtime
- No JS or CSS changes required; pure HTML fix

## Test Plan

- TDD approach: wrote failing test first (red), then removed the attribute (green)
- 10/10 Silverback denomination aria-label tests pass
- 413/414 offline suite passes (1 pre-existing flaky in stak-437, unrelated)

## Version

3.34.38

Closes STRK-15