### PR TITLE
fix(STRK-21): sort vendor columns and item rows alphabetically in market price matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.39] - 2026-05-01
+
+### Fixed — STRK-21: Market price matrix alphabetical sorting
+
+- **Fixed**: Vendor columns in the market price matrix now appear in alphabetical order by display name (APMEX, BullionX, Gville, Hero, JM, Monument, Provident, SD, Summit) instead of reflecting unpredictable data load order.
+- **Fixed**: Item rows in the market price matrix now appear in alphabetical order by item name instead of JSON key enumeration order.
+
+---
+
 ## [3.34.38] - 2026-04-29
 
 ### Fixed — STRK-20: Backup conflict modal context-aware messaging

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.39 &ndash; Market matrix alphabetical sorting</strong>: Vendor columns and item rows in the market price matrix now appear in alphabetical order by display name, eliminating layout drift between page loads (STRK-21).</li>
     <li><strong>v3.34.38 &ndash; Silverback as a first-class metal type</strong>: Silverbacks now have their own 0.001 troy ounce weight unit, separate from Goldback retail pricing. Existing records migrate automatically on load, import, and cloud restore. Denomination selector, purity default, and aria labels are all corrected (STRK-4, STRK-12, STRK-15, STRK-17).</li>
     <li><strong>v3.34.36 &ndash; Inventory data safety</strong>: Startup no longer overwrites your inventory with sample data when localStorage is missing or corrupt &mdash; a recovery banner appears instead. Re-importing your own encrypted backup no longer produces duplicates; items match by serial, Numista ID, or name+date before comparison (STRK-13, STRK-14).</li>
     <li><strong>v3.34.34 &ndash; Lot &harr; Each purchase price toggle</strong>: Enter a lot total when buying multiples &mdash; the app divides by quantity and stores a per-unit price. The Purchase column now shows the qty-multiplied total in the inventory table (STRK-4).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.38";
+const APP_VERSION = "3.34.39";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -914,6 +914,9 @@ const _renderVendorTable = async (metalCode) => {
       metalSlugs.push({ slug, meta });
     }
   }
+  metalSlugs.sort((a, b) =>
+    String(a.meta.name || a.slug).localeCompare(String(b.meta.name || b.slug))
+  );
 
   if (metalSlugs.length === 0) {
     tableWrap.textContent = "";
@@ -971,7 +974,9 @@ const _renderVendorTable = async (metalCode) => {
     }
   }
 
-  const vendorIds = Array.from(allVendorIds);
+  const vendorIds = Array.from(allVendorIds).sort((a, b) =>
+    _shortVendor(a).localeCompare(_shortVendor(b))
+  );
 
   if (vendorIds.length === 0) {
     tableWrap.textContent = "";

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -914,8 +914,11 @@ const _renderVendorTable = async (metalCode) => {
       metalSlugs.push({ slug, meta });
     }
   }
-  metalSlugs.sort((a, b) =>
-    String(a.meta.name || a.slug).localeCompare(String(b.meta.name || b.slug))
+  metalSlugs.sort(
+    (a, b) =>
+      String(a.meta.name || a.slug).localeCompare(String(b.meta.name || b.slug), undefined, {
+        numeric: true,
+      }) || a.slug.localeCompare(b.slug)
   );
 
   if (metalSlugs.length === 0) {
@@ -974,8 +977,8 @@ const _renderVendorTable = async (metalCode) => {
     }
   }
 
-  const vendorIds = Array.from(allVendorIds).sort((a, b) =>
-    _shortVendor(a).localeCompare(_shortVendor(b))
+  const vendorIds = Array.from(allVendorIds).sort(
+    (a, b) => String(_shortVendor(a)).localeCompare(String(_shortVendor(b))) || a.localeCompare(b)
   );
 
   if (vendorIds.length === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.36",
+  "version": "3.34.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.36",
+      "version": "3.34.39",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.38",
+  "version": "3.34.39",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.38-b1777517142";
+const CACHE_NAME = "staktrakr-v3.34.39-b1777597766";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.39-b1777597766";
+const CACHE_NAME = "staktrakr-v3.34.39-b1777602389";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/market-sorting.spec.js
+++ b/tests/playwright/market-sorting.spec.js
@@ -195,7 +195,6 @@ const setupSortingFixture = async (page) => {
       typeof window.renderVendorPrices === "function" &&
       typeof window.refreshMarketData === "function"
   );
-  await page.waitForTimeout(350);
   await page.evaluate(() => window.refreshMarketData());
   // Wait for the vendor table to render
   await page.waitForSelector(".vendor-prices-table", { timeout: 10000 });

--- a/tests/playwright/market-sorting.spec.js
+++ b/tests/playwright/market-sorting.spec.js
@@ -1,0 +1,238 @@
+import { test, expect } from "@playwright/test";
+import { injectSeedInventory } from "./helpers/seed.js";
+
+/**
+ * STRK-21 — Market Price Matrix Sorting
+ *
+ * TDD tests (red phase): vendor columns and item rows must appear in alphabetical
+ * order by display name. These tests FAIL before the fix in js/market-data.js and
+ * PASS after it.
+ *
+ * REQ-1: Vendor columns sorted alphabetically by _shortVendor() display name
+ * REQ-2: Item rows sorted alphabetically by meta.name
+ */
+
+// Three vendor IDs injected in REVERSE-alphabetical display order:
+//   herobullion → "Hero", apmex → "APMEX", bullionexchanges → "BullionX"
+// After fix, column order must be: APMEX, BullionX, Hero
+const VENDORS = [
+  { id: "herobullion", name: "Hero Bullion", color: "#10b981", url: "https://herobullion.com" },
+  { id: "apmex", name: "APMEX", color: "#60a5fa", url: "https://www.apmex.com" },
+  {
+    id: "bullionexchanges",
+    name: "Bullion Exchanges",
+    color: "#f59e0b",
+    url: "https://www.bullionexchanges.com",
+  },
+];
+
+// Three slugs with names in REVERSE-alphabetical order so insertion order ≠ sorted order.
+// Each slug is assigned a unique vendor so Set insertion order tracks slug order exactly.
+const SLUG_Z = "strk21-zebra"; // Zebra Silver Round — last alphabetically
+const SLUG_A = "strk21-alpha"; // Alpha Silver Bar   — first alphabetically
+const SLUG_M = "strk21-middle"; // Middle Silver Coin — second alphabetically
+
+const generatedAt = new Date().toISOString();
+
+const coinMeta = {
+  [SLUG_Z]: { name: "Zebra Silver Round", weight: 1, metal: "silver" },
+  [SLUG_A]: { name: "Alpha Silver Bar", weight: 1, metal: "silver" },
+  [SLUG_M]: { name: "Middle Silver Coin", weight: 1, metal: "silver" },
+};
+
+const vendorMeta = Object.fromEntries(
+  VENDORS.map((v) => [v.id, { name: v.name, color: v.color, url: v.url }])
+);
+
+// Prices keyed so Zebra is first, Alpha second, Middle third — non-alphabetical.
+// Each slug gets a single unique vendor to make Set insertion order predictable.
+const prices = {
+  lastSync: generatedAt,
+  window_start: generatedAt,
+  prices: {
+    [SLUG_Z]: {
+      median_price: 42.0,
+      lowest_price: 41.5,
+      highest_price: 43.0,
+      vendors: {
+        herobullion: { price: 42.0, inStock: true, in_stock: true },
+      },
+    },
+    [SLUG_A]: {
+      median_price: 38.0,
+      lowest_price: 37.5,
+      highest_price: 39.0,
+      vendors: {
+        apmex: { price: 38.0, inStock: true, in_stock: true },
+      },
+    },
+    [SLUG_M]: {
+      median_price: 40.0,
+      lowest_price: 39.5,
+      highest_price: 41.0,
+      vendors: {
+        bullionexchanges: { price: 40.0, inStock: true, in_stock: true },
+      },
+    },
+  },
+};
+
+// Per-slug detail served by the mocked API route
+const detailBySlug = {
+  [SLUG_Z]: {
+    weight_oz: 1,
+    median: 42.0,
+    median_price: 42.0,
+    low: 41.5,
+    lowest_price: 41.5,
+    high: 43.0,
+    highest_price: 43.0,
+    window_start: generatedAt,
+    vendors: {
+      herobullion: { price: 42.0, in_stock: true, inStock: true, url: "https://herobullion.com" },
+    },
+  },
+  [SLUG_A]: {
+    weight_oz: 1,
+    median: 38.0,
+    median_price: 38.0,
+    low: 37.5,
+    lowest_price: 37.5,
+    high: 39.0,
+    highest_price: 39.0,
+    window_start: generatedAt,
+    vendors: {
+      apmex: { price: 38.0, in_stock: true, inStock: true, url: "https://www.apmex.com" },
+    },
+  },
+  [SLUG_M]: {
+    weight_oz: 1,
+    median: 40.0,
+    median_price: 40.0,
+    low: 39.5,
+    lowest_price: 39.5,
+    high: 41.0,
+    highest_price: 41.0,
+    window_start: generatedAt,
+    vendors: {
+      bullionexchanges: {
+        price: 40.0,
+        in_stock: true,
+        inStock: true,
+        url: "https://www.bullionexchanges.com",
+      },
+    },
+  },
+};
+
+const setupSortingFixture = async (page) => {
+  await injectSeedInventory(page);
+
+  await page.addInitScript(
+    ({ pricesData, slugs, meta, vendors, generatedAtValue }) => {
+      const writeJson = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+      writeJson("v2RetailPrices", pricesData);
+      writeJson("retailPrices", pricesData);
+      writeJson("retailManifestSlugs", slugs);
+      writeJson("retailManifestCoinMeta", meta);
+      writeJson("retailManifestVendorMeta", vendors);
+      localStorage.setItem("retailManifestGeneratedAt", generatedAtValue);
+      localStorage.setItem("spotSilver", JSON.stringify(36));
+      // Stub LightweightCharts so market detail modal works without the CDN
+      window.LightweightCharts = {
+        CrosshairMode: { Normal: 0 },
+        createChart(container) {
+          const root = document.createElement("div");
+          root.className = "tv-lightweight-charts";
+          container.appendChild(root);
+          return {
+            addLineSeries() {
+              return { setData() {} };
+            },
+            timeScale() {
+              return { fitContent() {} };
+            },
+            remove() {
+              root.remove();
+            },
+          };
+        },
+      };
+    },
+    {
+      pricesData: prices,
+      slugs: [SLUG_Z, SLUG_A, SLUG_M],
+      meta: coinMeta,
+      vendors: vendorMeta,
+      generatedAtValue: generatedAt,
+    }
+  );
+
+  // Serve per-slug detail from the mocked API so _renderVendorTable can fetch it
+  await page.route("https://api.staktrakr.com/data/v2/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.replace(/^\/data\/v2\//, "");
+    const match = path.match(/^retail\/([^/]+)\/latest\.json$/);
+    if (match && detailBySlug[match[1]]) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ v: 2, generated_at: generatedAt, data: detailBySlug[match[1]] }),
+      });
+    } else {
+      await route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+    }
+  });
+
+  await page.route("https://api2.staktrakr.com/data/v2/**", async (route) => {
+    await route.fulfill({ status: 503, contentType: "application/json", body: "{}" });
+  });
+
+  await page.goto("/index.html");
+  await page.waitForFunction(
+    () =>
+      typeof window.showSettingsModal === "function" &&
+      typeof window.renderVendorPrices === "function" &&
+      typeof window.refreshMarketData === "function"
+  );
+  await page.waitForTimeout(350);
+  await page.evaluate(() => window.refreshMarketData());
+  // Wait for the vendor table to render
+  await page.waitForSelector(".vendor-prices-table", { timeout: 10000 });
+};
+
+test.describe("STRK-21 — Market price matrix sorting", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupSortingFixture(page);
+  });
+
+  // REQ-1: Vendor column headers are sorted alphabetically by display name.
+  // Input order in localStorage: Hero, APMEX, BullionX (non-alphabetical).
+  // Expected rendered order: APMEX, BullionX, Hero.
+  test("REQ-1 — vendor columns appear in alphabetical order by display name", async ({ page }) => {
+    const table = page.locator(".vendor-prices-table");
+    await expect(table).toBeVisible();
+
+    // Collect all header text, strip the fixed "ITEM", "MEDIAN", "SPREAD" columns
+    const headers = await table.locator("thead tr th").allTextContents();
+    const vendorHeaders = headers.filter((h) => !["ITEM", "MEDIAN", "SPREAD"].includes(h.trim()));
+
+    // Exact expected order: the 3 fixture vendors sorted alphabetically by _shortVendor() label
+    expect(vendorHeaders).toEqual(["APMEX", "BullionX", "Hero"]);
+  });
+
+  // REQ-2: Item rows are sorted alphabetically by display name (meta.name).
+  // Input order in localStorage: Zebra Silver Round, Alpha Silver Bar, Middle Silver Coin.
+  // Expected rendered order: Alpha Silver Bar, Middle Silver Coin, Zebra Silver Round.
+  test("REQ-2 — item rows appear in alphabetical order by display name", async ({ page }) => {
+    const table = page.locator(".vendor-prices-table");
+    await expect(table).toBeVisible();
+
+    // Collect item names from the first cell of each body row (the .vp-coin-link span)
+    const rowNames = await table.locator("tbody tr td:first-child").allTextContents();
+    const trimmed = rowNames.map((n) => n.trim()).filter(Boolean);
+
+    // Exact expected order: the 3 fixture slugs sorted alphabetically by meta.name
+    expect(trimmed).toEqual(["Alpha Silver Bar", "Middle Silver Coin", "Zebra Silver Round"]);
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.38",
-  "releaseDate": "2026-04-29",
+  "version": "3.34.39",
+  "releaseDate": "2026-05-01",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to \`dev\` after review.

## Summary

- **Fixed**: Vendor columns in the market price matrix (`_renderVendorTable`) now appear in alphabetical order by display name (APMEX, BullionX, Gville, Hero, JM, Monument, Provident, SD, Summit), instead of reflecting `Set` insertion order which varied by data load sequence.
- **Fixed**: Item rows now appear in alphabetical order by `meta.name` (falling back to slug), instead of following JSON key enumeration order from the API response.
- Both sort calls use `localeCompare` with a `String(... || fallback)` null-safety guard, matching the pattern already used elsewhere in the renderer.

## Implementation

Two `.sort()` calls added to `_renderVendorTable()` in `js/market-data.js`:

- **Line ~917**: `metalSlugs.sort((a, b) => String(a.meta.name || a.slug).localeCompare(String(b.meta.name || b.slug)))`
- **Line ~974**: `Array.from(allVendorIds).sort((a, b) => _shortVendor(a).localeCompare(_shortVendor(b)))`

New TDD test file: `tests/playwright/market-sorting.spec.js` — injects vendors and slugs in reverse-alphabetical order to confirm sorting is applied, not coincidental.

## Test Results

- **REQ-1** (vendor columns alphabetical): ✅ Pass
- **REQ-2** (item rows alphabetical): ✅ Pass
- **Full offline suite**: 415/416 pass (1 pre-existing STAK-437 timeout, unrelated)

## Version

3.34.38 → **3.34.39**

## Issues

- [STRK-21: Market price matrix items and vendors not sorted alphabetically](https://plane.lbruton.cc/lbruton/browse/STRK-21/) — Done ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market price matrix vendor columns now consistently sort alphabetically by vendor display name
  * Market price matrix item rows now consistently sort alphabetically by item name

* **Tests**
  * Added comprehensive test suite for market price matrix sorting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->