### PR TITLE
chore(STRK-23): auto-convert purchase price mode input

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -66,8 +66,31 @@ const getPurchasePriceToggleButtons = () => {
   return Array.from(toggle.children).filter((child) => child.dataset?.mode);
 };
 
-const setPurchasePriceMode = (mode) => {
-  purchasePriceMode = mode === "lot" ? "lot" : "each";
+const maybeConvertPurchasePriceForMode = (nextMode) => {
+  if (!elements.itemPrice || nextMode === purchasePriceMode) return;
+
+  const rawPrice = elements.itemPrice.value.trim();
+  const price = Number(rawPrice);
+  const qty = Number(elements.itemQty?.value?.trim() ?? "");
+
+  if (rawPrice === "" || !Number.isFinite(price) || price <= 0) return;
+  if (!Number.isFinite(qty) || qty <= 1) return;
+
+  const convertedPrice = nextMode === "each" ? price / qty : price * qty;
+  if (!Number.isFinite(convertedPrice) || convertedPrice <= 0) return;
+
+  elements.itemPrice.value = convertedPrice.toFixed(2);
+};
+
+const setPurchasePriceMode = (mode, options = {}) => {
+  const nextMode = mode === "lot" ? "lot" : "each";
+  const { convertInput = true } = options;
+
+  if (convertInput) {
+    maybeConvertPurchasePriceForMode(nextMode);
+  }
+
+  purchasePriceMode = nextMode;
 
   getPurchasePriceToggleButtons().forEach((button) => {
     const isActive = button.dataset.mode === purchasePriceMode;
@@ -96,13 +119,13 @@ const updatePurchasePriceToggleVisibility = () => {
   toggle.classList.toggle("is-hidden", !showToggle);
 
   if (!showToggle && purchasePriceMode === "lot") {
-    setPurchasePriceMode("each");
+    setPurchasePriceMode("each", { convertInput: false });
   }
   updatePurchasePricePlaceholder();
 };
 
 const resetPurchasePriceToggle = () => {
-  setPurchasePriceMode("each");
+  setPurchasePriceMode("each", { convertInput: false });
   updatePurchasePriceToggleVisibility();
 };
 

--- a/js/events.js
+++ b/js/events.js
@@ -71,7 +71,7 @@ const maybeConvertPurchasePriceForMode = (nextMode) => {
 
   const rawPrice = elements.itemPrice.value.trim();
   const price = Number(rawPrice);
-  const qty = Number(elements.itemQty?.value?.trim() ?? "");
+  const qty = parseInt(elements.itemQty?.value?.trim() ?? "", 10);
 
   if (rawPrice === "" || !Number.isFinite(price) || price <= 0) return;
   if (!Number.isFinite(qty) || qty <= 1) return;
@@ -79,7 +79,7 @@ const maybeConvertPurchasePriceForMode = (nextMode) => {
   const convertedPrice = nextMode === "each" ? price / qty : price * qty;
   if (!Number.isFinite(convertedPrice) || convertedPrice <= 0) return;
 
-  elements.itemPrice.value = convertedPrice.toFixed(2);
+  elements.itemPrice.value = Number(convertedPrice.toFixed(6)).toString();
 };
 
 const setPurchasePriceMode = (mode, options = {}) => {

--- a/js/events.js
+++ b/js/events.js
@@ -80,6 +80,7 @@ const maybeConvertPurchasePriceForMode = (nextMode) => {
   if (!Number.isFinite(convertedPrice) || convertedPrice <= 0) return;
 
   elements.itemPrice.value = Number(convertedPrice.toFixed(6)).toString();
+  elements.itemPrice.dispatchEvent(new Event("input", { bubbles: true }));
 };
 
 const setPurchasePriceMode = (mode, options = {}) => {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.39-b1777602389";
+const CACHE_NAME = "staktrakr-v3.34.39-b1777668503";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.39-b1777668503";
+const CACHE_NAME = "staktrakr-v3.34.39-b1777672172";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.39-b1777672172";
+const CACHE_NAME = "staktrakr-v3.34.39-b1777672580";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/inventory/lot-each-purchase-price.spec.js
+++ b/tests/playwright/inventory/lot-each-purchase-price.spec.js
@@ -236,8 +236,9 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await seedData(page);
     await gotoApp(page);
     await openAddModal(page);
-    await fillInventoryForm(page, { name: itemName, qty: "4", price: "400" });
+    await fillInventoryForm(page, { name: itemName, qty: "4", price: "" });
     await selectPurchaseMode(page, "lot");
+    await page.fill("#itemPrice", "400");
     await submitItemForm(page);
 
     const item = await getInventoryItem(page, itemName);
@@ -256,10 +257,11 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await fillInventoryForm(page, {
       name: itemName,
       qty: "120",
-      price: "120",
+      price: "",
       weight: "0.3617",
     });
     await selectPurchaseMode(page, "lot");
+    await page.fill("#itemPrice", "120");
     await submitItemForm(page);
 
     const item = await getInventoryItem(page, itemName);
@@ -420,13 +422,39 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await seedData(page, { displayCurrency: "EUR", exchangeRates: { EUR: 0.9 } });
     await gotoApp(page);
     await openAddModal(page);
-    await fillInventoryForm(page, { name: itemName, qty: "3", price: "90" });
+    await fillInventoryForm(page, { name: itemName, qty: "3", price: "" });
     await selectPurchaseMode(page, "lot");
+    await page.fill("#itemPrice", "90");
     await submitItemForm(page);
 
     const item = await getInventoryItem(page, itemName);
     expect(item).not.toBeNull();
     expect(item.qty).toBe(3);
     expect(item.price).toBeCloseTo((90 / 3) * (1 / 0.9), 6);
+  });
+
+  test("15. STRK-23 switching Lot to Each converts the visible input", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.fill("#itemQty", "2");
+    await selectPurchaseMode(page, "lot");
+    await page.fill("#itemPrice", "100");
+    await selectPurchaseMode(page, "each");
+
+    await expect(page.locator("#itemPrice")).toHaveValue("50.00");
+  });
+
+  test("16. STRK-23 switching Each to Lot converts the visible input", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.fill("#itemQty", "2");
+    await page.fill("#itemPrice", "50");
+    await selectPurchaseMode(page, "lot");
+
+    await expect(page.locator("#itemPrice")).toHaveValue("100.00");
   });
 });

--- a/tests/playwright/inventory/lot-each-purchase-price.spec.js
+++ b/tests/playwright/inventory/lot-each-purchase-price.spec.js
@@ -457,4 +457,25 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
 
     await expect(page.locator("#itemPrice")).toHaveValue("100");
   });
+
+  test("17. STRK-23 switching modes emits input after auto-conversion", async ({ page }) => {
+    await seedData(page);
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.fill("#itemQty", "2");
+    await selectPurchaseMode(page, "lot");
+    await page.fill("#itemPrice", "100");
+    await page.evaluate(() => {
+      window.__strk23PriceInputEvents = 0;
+      document.getElementById("itemPrice").addEventListener("input", () => {
+        window.__strk23PriceInputEvents += 1;
+      });
+    });
+
+    await selectPurchaseMode(page, "each");
+
+    await expect(page.locator("#itemPrice")).toHaveValue("50");
+    await expect.poll(() => page.evaluate(() => window.__strk23PriceInputEvents)).toBe(1);
+  });
 });

--- a/tests/playwright/inventory/lot-each-purchase-price.spec.js
+++ b/tests/playwright/inventory/lot-each-purchase-price.spec.js
@@ -443,7 +443,7 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await page.fill("#itemPrice", "100");
     await selectPurchaseMode(page, "each");
 
-    await expect(page.locator("#itemPrice")).toHaveValue("50.00");
+    await expect(page.locator("#itemPrice")).toHaveValue("50");
   });
 
   test("16. STRK-23 switching Each to Lot converts the visible input", async ({ page }) => {
@@ -455,6 +455,6 @@ test.describe("STRK-4 Lot/Each Purchase Price toggle", () => {
     await page.fill("#itemPrice", "50");
     await selectPurchaseMode(page, "lot");
 
-    await expect(page.locator("#itemPrice")).toHaveValue("100.00");
+    await expect(page.locator("#itemPrice")).toHaveValue("100");
   });
 });


### PR DESCRIPTION
## Summary
- Auto-convert the Purchase Price input when users switch Lot <-> Each with quantity greater than 1.
- Skip conversion for empty, invalid, zero-price, and programmatic reset paths.
- Add STRK-23 Playwright coverage while preserving STRK-4 save-time behavior.

## Validation
- `npx playwright test tests/playwright/inventory/lot-each-purchase-price.spec.js` - 16 passed
- `npm run lint` - passed with existing warnings in `js/diff-engine.js` and `js/diff-modal.js`

## Notes
- GSD chore for STRK-23; no version bump.
- `sw.js` cache name was stamped by the pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase prices now automatically convert when switching between per-item and lot-total pricing modes based on quantity, with validation safeguards.
  * Manual resets and quantity-driven mode changes no longer trigger automatic price conversion.

* **Tests**
  * Added test coverage validating purchase price conversion behavior when toggling between pricing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->