### PR TITLE
fix: Monument Metals false OOS from ShopperApproved reviews

### DIFF
--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -187,6 +187,14 @@ const MARKDOWN_CUTOFF_PATTERNS = {
     /^Similar Products You May Like/im, // Firecrawl markdown section heading
     /<[^>]*>\s*Similar Products You May Like/i, // Playwright HTML heading
   ],
+  // Monument Metals embeds ShopperApproved customer reviews on every product
+  // page. Review prose can contain OOS keywords ("Out Of Stock") that trigger
+  // false positives in detectStockStatus(). Cut before the review block.
+  monumentmetals: [
+    /[\d,]+\s+Reviews\]\(https:\/\/www\.shopperapproved/i, // Firecrawl markdown link
+    /[\d,]+\s+Reviews\s*https:\/\/www\.shopperapproved/i, // Playwright plain-text
+    /\bSuggested Products\b/i, // "Suggested Products" section after reviews
+  ],
 };
 
 // Patterns that match the START of the actual product content, used to strip

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -191,8 +191,8 @@ const MARKDOWN_CUTOFF_PATTERNS = {
   // page. Review prose can contain OOS keywords ("Out Of Stock") that trigger
   // false positives in detectStockStatus(). Cut before the review block.
   monumentmetals: [
-    /[\d,]+\s+Reviews\]\(https:\/\/www\.shopperapproved/i, // Firecrawl markdown link
-    /[\d,]+\s+Reviews\s*https:\/\/www\.shopperapproved/i, // Playwright plain-text
+    /[\d,]+\s+Reviews\]\(https:\/\/www\.shopperapproved/i, // Firecrawl markdown (includes href)
+    /[\d,]+\s+Reviews\b/i, // Playwright plain-text (innerText has no href)
     /\bSuggested Products\b/i, // "Suggested Products" section after reviews
   ],
 };

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -191,8 +191,8 @@ const MARKDOWN_CUTOFF_PATTERNS = {
   // page. Review prose can contain OOS keywords ("Out Of Stock") that trigger
   // false positives in detectStockStatus(). Cut before the review block.
   monumentmetals: [
-    /[\d,]+\s+Reviews\]\(https:\/\/www\.shopperapproved/i, // Firecrawl markdown (includes href)
-    /[\d,]+\s+Reviews\b/i, // Playwright plain-text (innerText has no href)
+    /[\d,]+\s+Reviews?\]\(https:\/\/www\.shopperapproved/i, // Firecrawl markdown (includes href)
+    /[\d,]+\s+Reviews?\b/i, // Playwright plain-text (innerText has no href)
     /\bSuggested Products\b/i, // "Suggested Products" section after reviews
   ],
 };


### PR DESCRIPTION
## Summary
- All 17 Monument Metals items showing "OOS" on the market price matrix despite valid prices being captured (162/165 successful)
- Root cause: a ShopperApproved customer review posted 2026-05-01 contains "Out Of Stock" in prose, triggering `/out of stock/i` pattern in `detectStockStatus()`
- Reviews are shared site-wide — one review broke all Monument items simultaneously
- Fix: add `monumentmetals` to `MARKDOWN_CUTOFF_PATTERNS` to trim content at the ShopperApproved review block before stock detection runs
- Pricing table is well before the review section — price extraction is unaffected
- Verified by simulating `preprocessMarkdown()` with the new cutoff against two live Monument product pages (ASE silver, gold eagle)

## Test plan
- [ ] Deploy updated home poller image
- [ ] Wait for next poll cycle (~30 min)
- [ ] Verify Monument column on market page shows prices instead of OOS
- [ ] Spot-check a Monument product URL in the dashboard to confirm `in_stock: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of price and stock information extraction by refining data preprocessing filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->