### PR TITLE
v3.34.42 — STRK-26: Remove side-stripe accents from cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.42] - 2026-05-04
+
+### Changed — STRK-26: Remove side-stripe accents from cards
+
+- **Removed**: 3px metal-color `border-left` accents from `.card-a`, `.card-b`, and `.card-c` — flagged by the Impeccable design critique as the strongest AI-dashboard tell.
+- **Removed**: Card C's `.cv-image-col::before` radial-gradient halo, which was anchored to the now-removed stripe and would have become visually orphaned.
+- **Removed**: Dormant `.cv-sparkline-strip` element from Card C — hidden via `display: none` since the card view engine first shipped (STAK-118), no longer needed.
+- **Note**: 4 remaining `border-left` indicators (`--danger`, `--warning`, `--primary`) encode functional state and are preserved; evaluation tracked separately in STRK-31.
+
+---
+
 ## [3.34.41] - 2026-05-03
 
 ### Changed — STRK-29: Monospace font consolidation and font-size-base review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Removed**: 3px metal-color `border-left` accents from `.card-a`, `.card-b`, and `.card-c` — flagged by the Impeccable design critique as the strongest AI-dashboard tell.
 - **Removed**: Card C's `.cv-image-col::before` radial-gradient halo, which was anchored to the now-removed stripe and would have become visually orphaned.
 - **Removed**: Dormant `.cv-sparkline-strip` element from Card C — hidden via `display: none` since the card view engine first shipped (STAK-118), no longer needed.
-- **Note**: 4 remaining `border-left` indicators (`--danger`, `--warning`, `--primary`) encode functional state and are preserved; evaluation tracked separately in STRK-31.
+- **Note**: 4 remaining `border-left` indicators using 3 variables (`--danger`, `--warning`, `--primary` × 2) encode functional state and are preserved; evaluation tracked separately in STRK-31.
 
 ---
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -13195,9 +13195,6 @@ th {
   width: 56px;
   height: 56px;
 }
-.card-c .cv-sparkline-strip {
-  display: none;
-}
 .card-c .cv-data-col {
   flex: 1;
   padding: 0.6rem 0.75rem;

--- a/css/styles.css
+++ b/css/styles.css
@@ -13022,7 +13022,6 @@ th {
 .card-a {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-left: 3px solid var(--metal-color);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
@@ -13095,7 +13094,6 @@ th {
 .card-b {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-left: 3px solid var(--metal-color, var(--border));
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
@@ -13159,7 +13157,6 @@ th {
 .card-c {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-left: 3px solid var(--metal-color, var(--border));
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
@@ -13186,20 +13183,7 @@ th {
   justify-content: center;
   gap: 0.35rem;
   padding: 0.5rem;
-  position: relative;
   box-shadow: inset -1px 0 3px rgba(0, 0, 0, 0.08);
-}
-.card-c .cv-image-col::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    ellipse at 0% 50%,
-    var(--metal-color, transparent) 0%,
-    transparent 70%
-  );
-  opacity: 0.18;
-  pointer-events: none;
 }
 /* Rect items in split card — constrained height */
 .card-c .coin-img.bar-shape {

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.42 &ndash; STRK-26: Cleaner card visuals</strong>: Removed decorative metal-color stripes from inventory cards in all three card layouts. Card C also lost a soft tinted glow on its image column. The cards now feel less &ldquo;templated&rdquo; and put more focus on your actual coin photos (STRK-26).</li>
     <li><strong>v3.34.41 &ndash; STRK-29: Monospace font consolidation</strong>: Added Geist Mono as the unified monospace font, replacing 6 inconsistent font stacks across CSS and JS. All monospace text now flows through a single <code>--font-mono</code> variable. Inline JS styles migrated to CSS classes (STRK-29).</li>
     <li><strong>v3.34.40 &ndash; Distinctive typography</strong>: Replaced the generic Inter font with Geist (body) and Instrument Serif (headings) &mdash; locally bundled, offline-ready, and tuned for dense data at 13px. The interface now feels like a precision instrument, not a template (STRK-24).</li>
     <li><strong>v3.34.39 &ndash; Market matrix alphabetical sorting</strong>: Vendor columns and item rows in the market price matrix now appear in alphabetical order by display name, eliminating layout drift between page loads (STRK-21).</li>

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -707,7 +707,6 @@ const renderCardC = (item, idx, computed) => {
     `<div class="cv-image-col">` +
     `${_cardImageHTML(item, "", "obverse")}` +
     `${_cardImageHTML(item, "", "reverse")}` +
-    `<div class="cv-sparkline-strip"><svg viewBox="0 0 4 120" preserveAspectRatio="none"><rect width="4" height="120" rx="2" fill="var(--metal-color)" opacity="0.3"/></svg></div>` +
     `</div>` +
     `<div class="cv-data-col">` +
     `<div class="cv-item-name">${sanitizeHtml(item.name || "")}${isDisposed(item) ? ` <span class="disposition-badge disposition-badge--${item.disposition.type}">${DISPOSITION_TYPES[item.disposition.type]?.label || item.disposition.type}</span>` : ""}</div>` +

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.41";
+const APP_VERSION = "3.34.42";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.41",
+  "version": "3.34.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.41",
+      "version": "3.34.42",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.41",
+  "version": "3.34.42",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.41-b1777877535";
+const CACHE_NAME = "staktrakr-v3.34.42-b1777877956";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.41-b1777864141";
+const CACHE_NAME = "staktrakr-v3.34.41-b1777877243";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.41-b1777877243";
+const CACHE_NAME = "staktrakr-v3.34.41-b1777877535";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.41",
-  "releaseDate": "2026-05-03",
+  "version": "3.34.42",
+  "releaseDate": "2026-05-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Codacy + Copilot review, then mark ready and merge to `dev` for the beta group.

## v3.34.42 — STRK-26: Remove side-stripe accents from cards

Drops the 3px metal-color `border-left` stripes from `.card-a`, `.card-b`, and `.card-c` — flagged by the Impeccable design critique as the strongest AI-dashboard tell. Card C additionally loses its anchored radial-gradient halo on `.cv-image-col::before` (which only "worked" because it bled off the now-removed stripe) and a long-dormant `.cv-sparkline-strip` element that has been `display: none` since the card view engine first shipped (STAK-118, ~17 months ago).

The metal cue on Card C is preserved through (a) the actual coin photo and (b) the `.cv-no-image` placeholder orb's metal-tinted `linear-gradient(145deg, var(--metal-color), var(--bg-tertiary))` at 65% opacity.

## Changes

- **chore(STRK-26)**: Remove side-stripe accents and metal glow from cards (`a5209bf1`)
- **chore(STRK-26)**: Remove dormant cv-sparkline-strip from card-c (`aebf6993`)
- **v3.34.42**: STRK-26 release bump (`c59e7c03`)

## Issues (Plane)

- [STRK-26](https://plane.lbruton.cc/lbruton/browse/STRK-26/) — Remove side-stripe border-left accents from cards (In Progress → mark Done after merge)
- [STRK-31](https://plane.lbruton.cc/lbruton/browse/STRK-31/) — Evaluate remaining border-left state indicators (`--danger`, `--warning`, `--primary`) — created as a follow-up; out of scope for this PR

## Out of Scope

The 4 remaining `border-left` state indicators (`.field--error`/`--danger`, warning notices/`--warning`, `.settings-nav-item.active`/`--primary`, `.bulk-edit-pinned`/`--primary`) encode functional state and were intentionally preserved. The Impeccable critique itself recommended evaluating them per-instance — that work is tracked in STRK-31.

## Beta Test Plan

- [ ] Confirm card grid views A, B, C render without left-edge stripes in **light**, **dark**, and **sepia** themes
- [ ] Confirm Card C image column reads cleanly without the metal-tinted glow at the left edge
- [ ] Confirm metal identity is still legible via the coin photo / no-image placeholder orb
- [ ] Confirm form validation, warning banners, settings nav active state, and bulk-edit pinned rows still show their state indicators (those stripes were preserved by design)
- [ ] Service worker cache rotates to `staktrakr-v3.34.42-*` — hard refresh once per browser to pick up new CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed decorative left-border accent stripes from cards while preserving functional state indicators for warning and error states.
  * Refined Card C layout and styling, removing extraneous visual elements for a cleaner design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->