### PR TITLE
fix(STRK-30): BullionExchanges OOS detection regression

### DIFF
--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1054,25 +1054,38 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     }
   }
 
-  // Byparr already fetched the page. Try JSON-LD first (authoritative —
-  // matches the Playwright fallback's extractor), then fall back to
-  // scanner-stripped text. For SPAs where both fail, fall through to
-  // Playwright with the cookie so the pricing grid can hydrate.
+  // Byparr already fetched the page. Check stock status from both JSON-LD
+  // availability and page text, then try JSON-LD price (authoritative).
+  // For SPAs where both fail, fall through to Playwright with the cookie.
   if (cfData.responseHtml) {
     const jsonLdScripts = extractJsonLdScriptsFromHtml(cfData.responseHtml);
+
+    // JSON-LD availability is the fastest OOS signal (STRK-30: BullionExchanges
+    // keeps JSON-LD price populated on OOS pages but sets availability=OutOfStock).
+    const availability = extractJsonLdAvailability(jsonLdScripts);
+    if (availability && JSONLD_OOS_VALUES.has(availability)) {
+      log(`[cf-clearance] ${providerId}: JSON-LD availability=${availability} -> OOS`);
+      return { price: null, inStock: false, source: "cf-clearance:jsonLd" };
+    }
+
+    // Text-based OOS detection before JSON-LD price short-circuit — catches
+    // visible "Out Of Stock" text even when JSON-LD availability is stale/missing.
+    const rawText = htmlToPlainText(cfData.responseHtml);
+    const cleaned = preprocessMarkdown(rawText, providerId);
+    const inStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
+
     const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
     if (jsonLdPrice === JSONLD_ZERO_PRICE) {
       log(`[cf-clearance] ${providerId}: JSON-LD price=0 in Byparr HTML -> OOS`);
       return { price: null, inStock: false, source: "cf-clearance:jsonLd" };
     }
     if (jsonLdPrice !== null) {
-      log(`[cf-clearance] success (html jsonLd): ${providerId} price=${jsonLdPrice}`);
-      return { price: jsonLdPrice, inStock: true, source: "cf-clearance:jsonLd" };
+      log(
+        `[cf-clearance] success (html jsonLd): ${providerId} price=${jsonLdPrice} inStock=${inStock.inStock}`
+      );
+      return { price: jsonLdPrice, inStock: inStock.inStock, source: "cf-clearance:jsonLd" };
     }
 
-    const rawText = htmlToPlainText(cfData.responseHtml);
-    const cleaned = preprocessMarkdown(rawText, providerId);
-    const inStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
     const price = extractPrice(cleaned, coin.metal, coin.weight_oz || 1, providerId);
     if (price !== null) {
       log(`[cf-clearance] success (html): ${providerId} price=${price.price}`);


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

- Fix false in-stock results for BullionExchanges (and any cf-clearance provider) where JSON-LD `offers.price` is populated on out-of-stock product pages
- The Byparr HTML extraction path returned `inStock: true` whenever JSON-LD had a valid price, skipping both `extractJsonLdAvailability()` and `detectStockStatus()`
- Two-layer fix matching the Playwright fallback pattern already used 20 lines below:
  1. Check JSON-LD `availability` field first (catches explicit `OutOfStock` signal)
  2. Hoist text-based `detectStockStatus()` above JSON-LD price short-circuit (catches visible "Out Of Stock" text)

## Root Cause

Regression seeded in `6216d8fa` (extract JSON-LD from Byparr HTML in cf-clearance path) which added `return { price: jsonLdPrice, inStock: true }` without any stock check. The Hero Bullion fix (`9d68d495`, STAK-566) added `extractJsonLdAvailability()` but only to the Firecrawl path — the Byparr path was missed.

## Issues

- [STRK-30](https://plane.lbruton.cc/lbruton/browse/STRK-30/) — BullionExchanges OOS detection regression

## Test Plan

- [ ] Verify BullionExchanges OOS items no longer report stale prices as in-stock
- [ ] Verify in-stock BullionExchanges items continue to extract correct prices
- [ ] Verify other cf-clearance providers (JM Bullion) unaffected
- [ ] Run full `npm test` suite