### PR TITLE
fix(STRK-31): clean up remaining border-left state indicators

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5852,8 +5852,6 @@ td input:checked + .slider:before {
   color: var(--primary);
   margin: 0 0 var(--spacing-sm) 0;
   padding-bottom: 2px;
-  padding-left: 8px;
-  border-left: 2px solid var(--primary);
 }
 
 .view-detail-grid {
@@ -12305,7 +12303,28 @@ th {
 }
 
 .bulk-edit-pinned {
-  border-left: 3px solid var(--primary);
+  background: rgba(59, 130, 246, 0.04);
+}
+
+[data-theme="dark"] .bulk-edit-pinned {
+  background: rgba(59, 130, 246, 0.07);
+}
+
+[data-theme="sepia"] .bulk-edit-pinned {
+  background: rgba(139, 92, 42, 0.05);
+}
+
+.bulk-pin-icon {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+  color: var(--text-muted);
+  vertical-align: middle;
+}
+
+.bulk-pin-icon svg {
+  width: 10px;
+  height: 10px;
 }
 
 .bulk-edit-pinned.bulk-edit-selected {

--- a/css/styles.css
+++ b/css/styles.css
@@ -12303,15 +12303,15 @@ th {
 }
 
 .bulk-edit-pinned {
-  background: rgba(59, 130, 246, 0.04);
+  background: color-mix(in srgb, var(--primary) 4%, transparent);
 }
 
 [data-theme="dark"] .bulk-edit-pinned {
-  background: rgba(59, 130, 246, 0.07);
+  background: color-mix(in srgb, var(--primary) 7%, transparent);
 }
 
 [data-theme="sepia"] .bulk-edit-pinned {
-  background: rgba(139, 92, 42, 0.05);
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
 }
 
 .bulk-pin-icon {

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -443,6 +443,23 @@ const buildBulkItemRow = (item, isPinned, dataColumns) => {
   cb.checked = isSelected;
   cb.addEventListener("change", () => toggleItemSelection(serial));
   cbTd.appendChild(cb);
+  if (isPinned) {
+    const pin = document.createElement("span");
+    pin.className = "bulk-pin-icon";
+    pin.title = "Pinned selection";
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("fill", "currentColor");
+    svg.setAttribute("aria-hidden", "true");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute(
+      "d",
+      "M14 4v5c0 1.12.37 2.16 1 3H9c.63-.84 1-1.88 1-3V4h4m3-2H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3V4h1c.55 0 1-.45 1-1s-.45-1-1-1z"
+    );
+    svg.appendChild(path);
+    pin.appendChild(svg);
+    cbTd.appendChild(pin);
+  }
   tr.appendChild(cbTd);
 
   // Image thumbnail cell — resolved async from IDB after row is appended

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -447,6 +447,8 @@ const buildBulkItemRow = (item, isPinned, dataColumns) => {
     const pin = document.createElement("span");
     pin.className = "bulk-pin-icon";
     pin.title = "Pinned selection";
+    pin.setAttribute("role", "img");
+    pin.setAttribute("aria-label", "Pinned");
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     svg.setAttribute("viewBox", "0 0 24 24");
     svg.setAttribute("fill", "currentColor");

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.42-b1777883709";
+const CACHE_NAME = "staktrakr-v3.34.42-b1777902350";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.42-b1777877956";
+const CACHE_NAME = "staktrakr-v3.34.42-b1777883709";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Follow-up to STRK-26. Evaluates the 5 remaining `border-left` instances and takes per-instance action:

- **Remove** `.view-section-title` border-left — purely decorative typography accent; heading hierarchy already conveyed by uppercase + bold 700 + letter-spacing + primary color
- **Replace** `.bulk-edit-pinned` border-left with a pin icon (SVG thumbtack) + subtle background tint per theme — resolves WCAG 1.4.1 concern (was color-only state indicator)
- **Keep** `.settings-nav-item.active` — classic sidebar active-tab pattern, deliberately designed with mobile override
- **Keep** `.about-alert` — universally recognized alert/callout pattern
- **Keep** `.faq-limitations-section` — blockquote-style content grouping

## Test plan

- [ ] Open any item's View modal → section titles (Valuation, Price History, etc.) render as clean uppercase text without left-border accent
- [ ] Open Bulk Edit → select items → search to filter → pinned rows show pin icon next to checkbox + subtle background tint (no left-border stripe)
- [ ] Verify across all 3 themes (light, dark, sepia)
- [ ] Settings sidebar active tab still has left-border indicator
- [ ] About page alert box still has left-border accent
- [ ] FAQ "Honest Limitations" section still has left-border accent

Closes STRK-31