### PR TITLE
fix(STRK-30): preserve price on OOS items in Byparr HTML path

### DIFF
--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1096,6 +1096,10 @@ async function scrapeViaCFClearance(url, providerId, coin) {
         source: `cf-clearance:${price.matchedBy}`,
       };
     }
+    if (!isInStock) {
+      log(`[cf-clearance] ${providerId}: OOS detected but no price extractable`);
+      return { price: null, inStock: false, source: "cf-clearance:oos" };
+    }
     warn(
       `[cf-clearance] no price from Byparr HTML for ${providerId} (len=${cfData.responseHtml.length}, jsonLd=${jsonLdScripts.length}) -- falling through to Playwright`
     );

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1060,19 +1060,20 @@ async function scrapeViaCFClearance(url, providerId, coin) {
   if (cfData.responseHtml) {
     const jsonLdScripts = extractJsonLdScriptsFromHtml(cfData.responseHtml);
 
-    // JSON-LD availability is the fastest OOS signal (STRK-30: BullionExchanges
-    // keeps JSON-LD price populated on OOS pages but sets availability=OutOfStock).
+    // JSON-LD availability — BullionExchanges keeps JSON-LD price populated on
+    // OOS pages but sets availability=OutOfStock (STRK-30).
     const availability = extractJsonLdAvailability(jsonLdScripts);
-    if (availability && JSONLD_OOS_VALUES.has(availability)) {
+    const jsonLdOos = !!(availability && JSONLD_OOS_VALUES.has(availability));
+    if (jsonLdOos) {
       log(`[cf-clearance] ${providerId}: JSON-LD availability=${availability} -> OOS`);
-      return { price: null, inStock: false, source: "cf-clearance:jsonLd" };
     }
 
-    // Text-based OOS detection before JSON-LD price short-circuit — catches
-    // visible "Out Of Stock" text even when JSON-LD availability is stale/missing.
+    // Text-based OOS detection — catches visible "Out Of Stock" text even when
+    // JSON-LD availability is stale/missing.
     const rawText = htmlToPlainText(cfData.responseHtml);
     const cleaned = preprocessMarkdown(rawText, providerId);
-    const inStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
+    const textStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
+    const isInStock = !jsonLdOos && textStock.inStock;
 
     const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
     if (jsonLdPrice === JSONLD_ZERO_PRICE) {
@@ -1081,9 +1082,9 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     }
     if (jsonLdPrice !== null) {
       log(
-        `[cf-clearance] success (html jsonLd): ${providerId} price=${jsonLdPrice} inStock=${inStock.inStock}`
+        `[cf-clearance] success (html jsonLd): ${providerId} price=${jsonLdPrice} inStock=${isInStock}`
       );
-      return { price: jsonLdPrice, inStock: inStock.inStock, source: "cf-clearance:jsonLd" };
+      return { price: jsonLdPrice, inStock: isInStock, source: "cf-clearance:jsonLd" };
     }
 
     const price = extractPrice(cleaned, coin.metal, coin.weight_oz || 1, providerId);
@@ -1091,7 +1092,7 @@ async function scrapeViaCFClearance(url, providerId, coin) {
       log(`[cf-clearance] success (html): ${providerId} price=${price.price}`);
       return {
         price: price.price,
-        inStock: inStock.inStock,
+        inStock: isInStock,
         source: `cf-clearance:${price.matchedBy}`,
       };
     }


### PR DESCRIPTION
## Summary
- The STRK-30 early-return in the Byparr HTML path discarded the JSON-LD price when `availability=OutOfStock`, writing `price=null` to the DB
- Export queries filter `price IS NOT NULL`, so OOS rows were invisible — stale in-stock data from the previous poll surfaced instead (e.g. American Silver Eagle showing in-stock on BullionExchanges when it's OOS)
- Records the OOS flag without early-returning, continues to `extractJsonLdPrice()`, and returns `{price, inStock: false}` — matching the Playwright fallback which was already correct

## Test plan
- [ ] Deploy to home poller and verify `ase/bullionexchanges` logs show `inStock=false` with a real price (not `price=null`)
- [ ] Confirm `retail/latest.json` export shows BullionExchanges ASE as `in_stock: false` with the JSON-LD price
- [ ] Verify other BEx in-stock items still report correctly with prices