### PR TITLE
fix: reproducible Docker builds — copy lockfile, use npm ci

### DIFF
--- a/devops/pollers/home-poller/Dockerfile
+++ b/devops/pollers/home-poller/Dockerfile
@@ -80,9 +80,9 @@ RUN printf '%s\n' \
 WORKDIR /app
 
 # ── Shared poller code (single source of truth) ──────────
-COPY shared/package.json ./
+COPY shared/package.json shared/package-lock.json ./
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 # Cache-bust: change this value to force rebuild of JS layer
 ARG CACHE_BUST=2026-03-19a

--- a/devops/pollers/shared/package-lock.json
+++ b/devops/pollers/shared/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "staktrakr-retail-poller",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr-retail-poller",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@libsql/client": "^0.14.0",
         "better-sqlite3": "^11.0.0",
         "dotenv": "^16.4.0",
+        "playwright": "^1.49.0",
         "playwright-core": "^1.49.0"
       }
     },
@@ -382,6 +383,20 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -547,10 +562,28 @@
         "wrappy": "1"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/devops/pollers/shared/package-lock.json
+++ b/devops/pollers/shared/package-lock.json
@@ -11,8 +11,8 @@
         "@libsql/client": "^0.14.0",
         "better-sqlite3": "^11.0.0",
         "dotenv": "^16.4.0",
-        "playwright": "^1.49.0",
-        "playwright-core": "^1.49.0"
+        "playwright": "1.49.0",
+        "playwright-core": "1.49.0"
       }
     },
     "node_modules/@libsql/client": {
@@ -563,12 +563,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/devops/pollers/shared/package.json
+++ b/devops/pollers/shared/package.json
@@ -8,7 +8,7 @@
     "@libsql/client": "^0.14.0",
     "better-sqlite3": "^11.0.0",
     "dotenv": "^16.4.0",
-    "playwright": "^1.49.0",
-    "playwright-core": "^1.49.0"
+    "playwright": "1.49.0",
+    "playwright-core": "1.49.0"
   }
 }


### PR DESCRIPTION
## Summary
- Dockerfile only copied `package.json` — `npm install` resolved `^` ranges from registry on every uncached build
- `playwright` was in `package.json` but missing from `package-lock.json` — resolved to latest (1.59.x) which fails `install-deps` on `node:20-slim`
- Adds `COPY package-lock.json`, switches `npm install` → `npm ci`, regenerates lockfile to include `playwright`

## Test plan
- [ ] Merge and trigger Portainer GitOps deploy — Docker build should succeed
- [ ] Verify home poller container starts and completes a scraping run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build reliability and reproducibility for the home-poller service through optimized Node dependency installation, ensuring consistent builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->