### PR TITLE
fix(STRK-33): drop carry-forward prices — mark missing vendors as OOS (#1073)

### DIFF
--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -514,7 +514,7 @@ async function exportRetail(client) {
 
       // Aggregate fresh in-stock prices only
       const allPrices = Object.values(vendors)
-        .filter((v) => v.price !== null && v.in_stock !== false)
+        .filter((v) => v.price !== null && v.in_stock === true)
         .map((v) => v.price);
 
       const median = medianOf(allPrices);
@@ -601,8 +601,6 @@ async function exportRetail(client) {
         vendorCoinMap[vid][slug] = {
           price: vdata.price,
           in_stock: vdata.in_stock,
-          carried: vdata.carried || false,
-          ...(vdata.carried_from ? { carried_from: vdata.carried_from } : {}),
           product_url: providerEntry?.url || null,
         };
       }

--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -327,22 +327,6 @@ async function queryLatestPerVendor(client, coinSlug, lookbackHours = 2) {
   return result.rows;
 }
 
-async function queryCarryForwardPrice(client, coinSlug, vendorId) {
-  const cutoff = new Date(Date.now() - MS_PER_DAY).toISOString().replace(".000Z", "Z");
-  const result = await client.execute({
-    sql: `
-      SELECT price, scraped_at, in_stock, confidence
-      FROM price_snapshots
-      WHERE coin_slug = ? AND vendor = ? AND is_failed = 0 AND price IS NOT NULL
-        AND scraped_at >= ?
-      ORDER BY scraped_at DESC
-      LIMIT 1
-    `,
-    args: [coinSlug, vendorId, cutoff],
-  });
-  return result.rows.length ? result.rows[0] : null;
-}
-
 async function queryRetailRange(client, coinSlug, startIso, endIso) {
   const result = await client.execute({
     sql: `
@@ -455,31 +439,15 @@ function buildRetailIntradayEntries(rows) {
   return entries;
 }
 
-async function applyCarryForward(currentVendors, slug, client, configuredVendorIds) {
+function fillMissingVendors(currentVendors, configuredVendorIds) {
   for (const vendorId of configuredVendorIds) {
     if (currentVendors[vendorId]) continue;
-
-    try {
-      const carried = await queryCarryForwardPrice(client, slug, vendorId);
-      if (carried) {
-        currentVendors[vendorId] = {
-          price: parseFloat(Number(carried.price).toFixed(2)),
-          in_stock: carried.in_stock === 1,
-          confidence: carried.confidence != null ? Number(carried.confidence) : null,
-          carried: true,
-          carried_from: String(carried.scraped_at),
-        };
-      } else {
-        currentVendors[vendorId] = {
-          price: null,
-          in_stock: false,
-          confidence: null,
-          carried: false,
-        };
-      }
-    } catch (err) {
-      warn(`carry-forward ${slug}/${vendorId}: ${err.message}`);
-    }
+    currentVendors[vendorId] = {
+      price: null,
+      in_stock: false,
+      confidence: null,
+      carried: false,
+    };
   }
 }
 
@@ -542,9 +510,9 @@ async function exportRetail(client) {
         };
       }
 
-      await applyCarryForward(vendors, slug, client, configuredVendorIds);
+      fillMissingVendors(vendors, configuredVendorIds);
 
-      // Aggregate including carried prices
+      // Aggregate fresh in-stock prices only
       const allPrices = Object.values(vendors)
         .filter((v) => v.price !== null && v.in_stock !== false)
         .map((v) => v.price);

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -782,9 +782,6 @@ const openMarketDetailModal = async (slug) => {
         if (entry.in_stock) {
           tdStock.style.color = "var(--success)";
           tdStock.textContent = "In Stock";
-        } else if (entry.carried) {
-          tdStock.style.color = "var(--warning, #eab308)";
-          tdStock.textContent = "Carried";
         } else {
           tdStock.style.color = "var(--danger)";
           tdStock.textContent = "Out of Stock";

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -797,7 +797,7 @@ const openMarketDetailModal = async (slug) => {
           entry.url ||
           (vMeta && vMeta.url) ||
           null;
-        if (_isSafeUrl(url) && entry.price > 0) {
+        if (_isSafeUrl(url)) {
           const buyBtn = document.createElement("a");
           buyBtn.textContent = "Buy";
           buyBtn.href = "#";
@@ -1067,7 +1067,7 @@ const _renderVendorTable = async (metalCode) => {
       const td = document.createElement("td");
       const vInfo = vData[vid];
 
-      if (!vInfo || vInfo.price == null || vInfo.price <= 0) {
+      if (!vInfo) {
         td.textContent = "\u2014";
         td.style.color = "var(--text-muted)";
         tr.appendChild(td);

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.42-b1777918063";
+const CACHE_NAME = "staktrakr-v3.34.42-b1777919145";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.42-b1777902350";
+const CACHE_NAME = "staktrakr-v3.34.42-b1777918063";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- Remove carry-forward price logic from `api-export-v2.js` — when a vendor scrape fails, the export now emits `{price: null, in_stock: false}` instead of pulling stale prices from prior runs
- Remove dead "Carried" display branch from the frontend detail modal (`market-data.js`)
- Missing vendors show "OOS" in the market matrix with the buy link intact

## Context

Carry-forward was surfacing stale in-stock prices in the matrix (e.g. BullionExchanges maple-silver showing $99.10 from a crashed run) — polluting median/low/high aggregations and showing false availability. The current UI just shows "OOS" for unavailable items; carried prices added noise, not value. Chart historical data comes from `price_snapshots` directly and is unaffected.

## Test plan

- [ ] Verify market matrix shows "OOS" (not stale price) for vendors with no fresh data
- [ ] Verify detail modal vendor table shows "Out of Stock" instead of "Carried"
- [ ] Verify median/low/high excludes missing-vendor entries
- [ ] Verify buy links still work for OOS vendors
- [ ] Deploy to home-poller and confirm next export cycle produces clean data

Closes STRK-33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed carry-forward pricing mechanism to ensure price aggregations reflect only current vendor data
  * Simplified stock status display in vendor comparison to show "In Stock" or "Out of Stock" states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->