### PR TITLE
v3.34.44 — STRK-27: CSS polish pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.44] - 2026-05-04
+
+### Changed — STRK-27: CSS polish pass
+
+- **Normalized**: Border-radius token usage — reclassified 12 of 13 `--radius-xl` usages to semantic tokens (`--radius-lg` for cards/panels, `--radius-pill` for pills/sliders/buttons). Only the decorative about-logo retains `--radius-xl`.
+- **Refactored**: Eliminated 21 `!important` declarations (99 → 78) by converting `.img-btn` pill block to compound selectors (`.btn.img-btn`) that naturally beat `.btn` specificity.
+
+---
+
 ## [3.34.42] - 2026-05-04
 
 ### Changed — STRK-26: Remove side-stripe accents from cards

--- a/css/styles.css
+++ b/css/styles.css
@@ -2969,58 +2969,70 @@ input[type="submit"] {
   flex-shrink: 0;
 }
 
-/* Pill buttons with color coding */
-.img-btn {
-  border-radius: var(--radius-pill) !important;
-  padding: 0.3rem 0.7rem !important;
-  font-size: var(--font-size-sm) !important;
-  font-weight: 600 !important;
-  min-height: 0 !important;
+/* Pill buttons with color coding — compound selector beats .btn specificity */
+.btn.img-btn {
+  border-radius: var(--radius-pill);
+  padding: 0.3rem 0.7rem;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  min-height: 0;
   white-space: nowrap;
-  border: 1px solid transparent !important;
+  border: 1px solid transparent;
+  transform: none;
+  box-shadow: none;
   transition:
     opacity 0.15s ease,
     background 0.15s ease;
 }
 
-.img-btn-upload {
-  background: var(--primary) !important;
-  color: #fff !important;
-  border-color: var(--primary) !important;
+.btn.img-btn:hover {
+  transform: none;
+  box-shadow: none;
 }
 
-.img-btn-upload:hover {
+.btn.img-btn::before {
+  display: none;
+}
+
+.btn.img-btn-upload {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.btn.img-btn-upload:hover {
   opacity: 0.85;
+  background: var(--primary);
 }
 
-.img-btn-url {
-  background: rgba(16, 185, 129, 0.15) !important;
-  color: #10b981 !important;
-  border-color: rgba(16, 185, 129, 0.3) !important;
+.btn.img-btn-url {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+  border-color: rgba(16, 185, 129, 0.3);
 }
 
-.img-btn-url:hover {
-  background: rgba(16, 185, 129, 0.25) !important;
+.btn.img-btn-url:hover {
+  background: rgba(16, 185, 129, 0.25);
 }
 
-.img-btn-camera {
-  background: rgba(139, 92, 246, 0.15) !important;
-  color: #8b5cf6 !important;
-  border-color: rgba(139, 92, 246, 0.3) !important;
+.btn.img-btn-camera {
+  background: rgba(139, 92, 246, 0.15);
+  color: #8b5cf6;
+  border-color: rgba(139, 92, 246, 0.3);
 }
 
-.img-btn-camera:hover {
-  background: rgba(139, 92, 246, 0.25) !important;
+.btn.img-btn-camera:hover {
+  background: rgba(139, 92, 246, 0.25);
 }
 
-.img-btn-remove {
-  background: rgba(239, 68, 68, 0.12) !important;
-  color: #ef4444 !important;
-  border-color: rgba(239, 68, 68, 0.25) !important;
+.btn.img-btn-remove {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.25);
 }
 
-.img-btn-remove:hover {
-  background: rgba(239, 68, 68, 0.22) !important;
+.btn.img-btn-remove:hover {
+  background: rgba(239, 68, 68, 0.22);
 }
 
 .image-size-info {
@@ -5338,7 +5350,7 @@ td .switch {
 }
 
 td .slider {
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-pill);
 }
 
 td .slider:before {
@@ -6407,7 +6419,7 @@ td input:checked + .slider:before {
   color: var(--text-secondary);
   background: var(--bg-primary);
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-pill);
   text-decoration: none;
   transition:
     color 0.15s ease,
@@ -7805,7 +7817,7 @@ a.about-badge:hover {
   bottom: 0;
   background-color: var(--border);
   transition: var(--transition);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-pill);
 }
 
 .slider:before {
@@ -11040,7 +11052,7 @@ th {
 .currency-field {
   padding: 12px 14px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
 }
 
@@ -11102,7 +11114,7 @@ th {
 .gb-input-shell {
   padding: 12px 14px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
 }
 
@@ -11133,7 +11145,7 @@ th {
 .gb-helper-card {
   padding: 12px 14px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
 }
 
@@ -11207,7 +11219,7 @@ th {
   gap: 14px;
   padding: 14px 16px;
   border: 1px solid rgba(16, 185, 129, 0.4);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   background: linear-gradient(135deg, rgba(16, 185, 129, 0.1), rgba(30, 41, 59, 0.6));
 }
 .market-beacon-icon {
@@ -11248,7 +11260,7 @@ th {
 .spot-accordion-panel {
   display: none;
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
   padding: 12px 14px;
 }
@@ -11400,7 +11412,7 @@ th {
 /* Catalog rows */
 .catalog-row {
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
   margin-bottom: 10px;
   overflow: hidden;
@@ -13916,7 +13928,7 @@ th {
 .market-filter-pill {
   background: transparent;
   border: 1px solid var(--border, var(--bs-border-color));
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-pill);
   padding: 4px 12px;
   font-size: var(--font-size-xs);
   font-weight: 500;
@@ -13964,7 +13976,7 @@ th {
   background: transparent;
   border: 1.5px solid var(--bs-success, #059669);
   color: var(--bs-success, #059669);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-pill);
   padding: 6px 16px;
   font-size: var(--font-size-sm);
   font-weight: 600;
@@ -14204,7 +14216,7 @@ th {
   padding: 6px 14px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-pill);
   font-size: var(--font-size-sm);
   white-space: nowrap;
   transition: background 0.2s;

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.44 &ndash; STRK-27: CSS polish pass</strong>: Normalized border-radius tokens across the app &mdash; cards, pills, sliders, and inputs now use consistent semantic tokens instead of ad-hoc values. Reduced specificity debt by eliminating 21 <code>!important</code> declarations from the pill button block (STRK-27).</li>
     <li><strong>v3.34.42 &ndash; STRK-26: Cleaner card visuals</strong>: Removed decorative metal-color stripes from inventory cards in all three card layouts. Card C also lost a soft tinted glow on its image column. The cards now feel less &ldquo;templated&rdquo; and put more focus on your actual coin photos (STRK-26).</li>
     <li><strong>v3.34.41 &ndash; STRK-29: Monospace font consolidation</strong>: Added Geist Mono as the unified monospace font, replacing 6 inconsistent font stacks across CSS and JS. All monospace text now flows through a single <code>--font-mono</code> variable. Inline JS styles migrated to CSS classes (STRK-29).</li>
     <li><strong>v3.34.40 &ndash; Distinctive typography</strong>: Replaced the generic Inter font with Geist (body) and Instrument Serif (headings) &mdash; locally bundled, offline-ready, and tuned for dense data at 13px. The interface now feels like a precision instrument, not a template (STRK-24).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.42";
+const APP_VERSION = "3.34.44";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.42",
+  "version": "3.34.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.42",
+      "version": "3.34.44",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.42",
+  "version": "3.34.44",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.42-b1777902350";
+const CACHE_NAME = "staktrakr-v3.34.44-b1777919223";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.42",
+  "version": "3.34.44",
   "releaseDate": "2026-05-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

- **Radius normalization**: Reclassified 12 of 13 `--radius-xl` usages to semantic tokens — cards/panels → `--radius-lg`, pills/sliders/buttons → `--radius-pill`. Only the decorative about-logo retains `--radius-xl`.
- **!important reduction**: Eliminated 21 declarations (99 → 78) by converting `.img-btn` pill block to compound selectors (`.btn.img-btn`) that naturally beat `.btn` specificity.
- **Deferred**: `transition:width` → `scaleX()` (4/7 bars are flex children; remainder animate once on load — negligible ROI). `color-mix`/`rgba` standardization and `uppercase` audit deferred to separate issues.

## Issues

- [STRK-27: CSS polish pass](https://plane.lbruton.cc/lbruton/browse/STRK-27/) (In Progress)

## Test Plan

- [ ] Visual inspection of radius changes in all three themes (light/dark/sepia)
- [ ] Goldback calculator panel — input shells, helper card, currency field corners
- [ ] Market page — filter pills, sync button, ticker items, market beacon card
- [ ] Settings → Images — Upload/URL/Camera/Remove pill buttons still colored correctly
- [ ] Toggle sliders in settings tables render as fully-rounded pills
- [ ] No `!important` regressions on pill button hover states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated border-radius styling across UI components (buttons, switches, badges, panels, cards, and inputs) to use consistent semantic design tokens for improved visual harmony.
  * Refactored button styles with enhanced CSS selector specificity, removing style overrides for cleaner code.

* **Chores**
  * Version bump to v3.34.44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->