### PR TITLE
chore(STRK-34): conditional carry-forward — carry price only for in-stock extraction failures

### DIFF
--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -327,6 +327,43 @@ async function queryLatestPerVendor(client, coinSlug, lookbackHours = 2) {
   return result.rows;
 }
 
+async function queryInStockNoPriceVendors(client, coinSlug, lookbackHours = 2) {
+  const cutoff = new Date(Date.now() - lookbackHours * MS_PER_HOUR)
+    .toISOString()
+    .replace(".000Z", "Z");
+  const result = await client.execute({
+    sql: `
+      SELECT ps.vendor, ps.in_stock, ps.scraped_at
+      FROM price_snapshots ps
+      INNER JOIN (
+        SELECT vendor, MAX(scraped_at) AS max_scraped
+        FROM price_snapshots
+        WHERE coin_slug = ? AND scraped_at >= ? AND is_failed = 0
+        GROUP BY vendor
+      ) latest ON ps.vendor = latest.vendor AND ps.scraped_at = latest.max_scraped
+      WHERE ps.coin_slug = ? AND ps.is_failed = 0 AND ps.price IS NULL AND ps.in_stock = 1
+    `,
+    args: [coinSlug, cutoff, coinSlug],
+  });
+  return result.rows;
+}
+
+async function queryCarryForwardPrice(client, coinSlug, vendorId) {
+  const cutoff = new Date(Date.now() - MS_PER_DAY).toISOString().replace(".000Z", "Z");
+  const result = await client.execute({
+    sql: `
+      SELECT price, scraped_at
+      FROM price_snapshots
+      WHERE coin_slug = ? AND vendor = ? AND is_failed = 0 AND price IS NOT NULL
+        AND scraped_at >= ?
+      ORDER BY scraped_at DESC
+      LIMIT 1
+    `,
+    args: [coinSlug, vendorId, cutoff],
+  });
+  return result.rows.length ? result.rows[0] : null;
+}
+
 async function queryRetailRange(client, coinSlug, startIso, endIso) {
   const result = await client.execute({
     sql: `
@@ -439,9 +476,37 @@ function buildRetailIntradayEntries(rows) {
   return entries;
 }
 
-function fillMissingVendors(currentVendors, configuredVendorIds) {
+async function applyConditionalCarryForward(
+  currentVendors,
+  slug,
+  client,
+  configuredVendorIds,
+  lookbackHours
+) {
+  const inStockNoPriceRows = await queryInStockNoPriceVendors(client, slug, lookbackHours);
+  const inStockNoPriceSet = new Set(inStockNoPriceRows.map((r) => String(r.vendor)));
+
   for (const vendorId of configuredVendorIds) {
     if (currentVendors[vendorId]) continue;
+
+    if (inStockNoPriceSet.has(vendorId)) {
+      try {
+        const carried = await queryCarryForwardPrice(client, slug, vendorId);
+        if (carried) {
+          currentVendors[vendorId] = {
+            price: parseFloat(Number(carried.price).toFixed(2)),
+            in_stock: true,
+            confidence: null,
+            carried: true,
+            carried_from: String(carried.scraped_at),
+          };
+          continue;
+        }
+      } catch (err) {
+        warn(`carry-forward ${slug}/${vendorId}: ${err.message}`);
+      }
+    }
+
     currentVendors[vendorId] = {
       price: null,
       in_stock: false,
@@ -510,11 +575,11 @@ async function exportRetail(client) {
         };
       }
 
-      fillMissingVendors(vendors, configuredVendorIds);
+      await applyConditionalCarryForward(vendors, slug, client, configuredVendorIds, 2);
 
-      // Aggregate fresh in-stock prices only
+      // Aggregate fresh in-stock prices only (carried prices excluded from aggregation)
       const allPrices = Object.values(vendors)
-        .filter((v) => v.price !== null && v.in_stock === true)
+        .filter((v) => v.price !== null && v.in_stock === true && !v.carried)
         .map((v) => v.price);
 
       const median = medianOf(allPrices);
@@ -601,6 +666,7 @@ async function exportRetail(client) {
         vendorCoinMap[vid][slug] = {
           price: vdata.price,
           in_stock: vdata.in_stock,
+          ...(vdata.carried ? { carried: true, carried_from: vdata.carried_from } : {}),
           product_url: providerEntry?.url || null,
         };
       }

--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -338,10 +338,10 @@ async function queryInStockNoPriceVendors(client, coinSlug, lookbackHours = 2) {
       INNER JOIN (
         SELECT vendor, MAX(scraped_at) AS max_scraped
         FROM price_snapshots
-        WHERE coin_slug = ? AND scraped_at >= ? AND is_failed = 0
+        WHERE coin_slug = ? AND scraped_at >= ?
         GROUP BY vendor
       ) latest ON ps.vendor = latest.vendor AND ps.scraped_at = latest.max_scraped
-      WHERE ps.coin_slug = ? AND ps.is_failed = 0 AND ps.price IS NULL AND ps.in_stock = 1
+      WHERE ps.coin_slug = ? AND ps.price IS NULL AND ps.in_stock = 1
     `,
     args: [coinSlug, cutoff, coinSlug],
   });

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -782,6 +782,7 @@ const openMarketDetailModal = async (slug) => {
         if (entry.carried) {
           tdStock.style.color = "var(--warning, #eab308)";
           tdStock.textContent = "Carried";
+          if (entry.carried_from) tdStock.title = `Last scraped: ${entry.carried_from}`;
         } else if (entry.in_stock) {
           tdStock.style.color = "var(--success)";
           tdStock.textContent = "In Stock";
@@ -1036,7 +1037,7 @@ const _renderVendorTable = async (metalCode) => {
       // STAK-515: Skip disabled vendors in price calculations
       if (typeof _isMarketItemEnabled === "function" && !_isMarketItemEnabled(slug, vid)) continue;
       const _vs = vData[vid];
-      if (_vs && _vs.price > 0 && (_vs.in_stock === true || _vs.inStock === true)) {
+      if (_vs && _vs.price > 0 && (_vs.in_stock === true || _vs.inStock === true) && !_vs.carried) {
         inStockPrices.push(vData[vid].price);
       }
     }

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -779,7 +779,10 @@ const openMarketDetailModal = async (slug) => {
 
         // Stock
         const tdStock = document.createElement("td");
-        if (entry.in_stock) {
+        if (entry.carried) {
+          tdStock.style.color = "var(--warning, #eab308)";
+          tdStock.textContent = "Carried";
+        } else if (entry.in_stock) {
           tdStock.style.color = "var(--success)";
           tdStock.textContent = "In Stock";
         } else {
@@ -1083,7 +1086,11 @@ const _renderVendorTable = async (metalCode) => {
         continue;
       }
 
-      if (vInfo.price === lowestPrice) td.classList.add("vp-best");
+      if (vInfo.carried && vInfo.price != null) {
+        td.style.opacity = "0.5";
+      }
+
+      if (vInfo.price === lowestPrice && !vInfo.carried) td.classList.add("vp-best");
 
       const priceSpan = document.createElement("span");
       priceSpan.className = "vp-price";

--- a/sw.js
+++ b/sw.js
@@ -4,9 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-
-const CACHE_NAME = "staktrakr-v3.34.44-b1777919223";
-
+const CACHE_NAME = "staktrakr-v3.34.44-b1777927962";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.44-b1777927962";
+const CACHE_NAME = "staktrakr-v3.34.44-b1777929510";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- Reintroduce carry-forward with conditional 3-state logic — only carries price when current scrape confirms in-stock but extraction failed (`in_stock=true, price=null`)
- OOS items and missing vendors remain `{price: null, in_stock: false}` — no stale data
- Carried prices excluded from median/low/high aggregation
- Frontend: "Carried" badge in detail modal, dimmed prices (opacity 0.5) in market matrix

## Context

STRK-33 removed carry-forward entirely, which caused in-stock items with intermittent extraction failures (e.g. BullionExchanges `generic-silver-round`) to show as OOS despite being purchasable. This PR restores carry-forward for that specific case while preserving the STRK-33 fix for genuinely OOS items.

## Three vendor states

| State | Condition | Action |
|-------|-----------|--------|
| 1. Has price | `price != null` | Use fresh data |
| 2. In-stock, no price | `in_stock=true, price=null` | Carry-forward last known price |
| 3. Missing / OOS | `in_stock=false` or absent | `{price: null, in_stock: false}` |

## Test plan

- [ ] Verify in-stock items with flaky extraction show carried price (dimmed) instead of OOS
- [ ] Verify genuinely OOS items still show OOS (no stale carried price)
- [ ] Verify missing vendors (scrape failed entirely) show OOS
- [ ] Verify carried prices NOT included in median/low/high
- [ ] Verify detail modal shows yellow "Carried" badge for carried vendors
- [ ] Deploy to home-poller and Fly.io; confirm next export cycle is clean

Closes STRK-34