### PR TITLE
chore(STRK-40): fix theme picker button swatches and active state

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3526,7 +3526,7 @@ input[type="submit"] {
   cursor: pointer;
   transition:
     border-color 0.15s,
-    box-shadow 0.15s;
+    background 0.15s;
 }
 
 .theme-option[data-theme="light"] {

--- a/css/styles.css
+++ b/css/styles.css
@@ -3526,7 +3526,31 @@ input[type="submit"] {
   cursor: pointer;
   transition:
     border-color 0.15s,
-    background 0.15s;
+    box-shadow 0.15s;
+}
+
+.theme-option[data-theme="light"] {
+  background: #f8fafc;
+  color: #1e293b;
+  border-color: #cbd5e1;
+}
+
+.theme-option[data-theme="dark"] {
+  background: #2a2520;
+  color: #f0ebe5;
+  border-color: #3d3530;
+}
+
+.theme-option[data-theme="slate"] {
+  background: #1e293b;
+  color: #f8fafc;
+  border-color: #334155;
+}
+
+.theme-option[data-theme="sepia"] {
+  background: #f2e7d5;
+  color: #3e2f1e;
+  border-color: #d1c2a5;
 }
 
 .theme-option:hover {
@@ -3535,8 +3559,9 @@ input[type="submit"] {
 
 .theme-option.active {
   border-color: var(--primary);
-  background: var(--primary);
-  color: var(--text-inverse);
+  box-shadow:
+    0 0 0 1px var(--primary),
+    0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
 /* Provider tabs */

--- a/css/styles.css
+++ b/css/styles.css
@@ -3559,9 +3559,8 @@ input[type="submit"] {
 
 .theme-option.active {
   border-color: var(--primary);
-  box-shadow:
-    0 0 0 1px var(--primary),
-    0 2px 8px rgba(0, 0, 0, 0.15);
+  background: var(--primary);
+  color: var(--text-inverse);
 }
 
 /* Provider tabs */

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.45-b1778018526";
+const CACHE_NAME = "staktrakr-v3.34.45-b1778018648";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.45-b1778018648";
+const CACHE_NAME = "staktrakr-v3.34.45-b1778019335";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.45-b1778007053";
+const CACHE_NAME = "staktrakr-v3.34.45-b1778018526";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary
- Each theme-option button in the settings picker now shows a fixed preview swatch of its own theme (Light stays light, Dark stays gunmetal, etc.) instead of inheriting the active theme's `--bg-card`
- Active button retains the solid `--primary` accent fill for clear selection indication
- Swatch colors reuse the same hardcoded hex values as the header `.theme-btn` buttons for consistency

Closes [STRK-40](https://plane.lbruton.cc/lbruton/browse/STRK-40/)

## Test plan
- [ ] Open Settings → Appearance → Color scheme
- [ ] Verify each button shows its own theme's colors regardless of active theme
- [ ] Switch between all 4 themes and confirm the active button gets the accent fill
- [ ] Verify no visual overflow or sizing issues on the active highlight