### PR TITLE
chore: update Plane workflow guidance

### DIFF
--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -19,7 +19,7 @@ Guide completion of development work by presenting clear options and handling ch
 
 **Before anything else, verify three things:**
 
-**0a. Linear issue exists:** Every branch must trace to a Linear issue (STAK-XXX). If you can't name the issue, STOP — create one or find the existing one before proceeding.
+**0a. Plane issue exists:** Every runtime-code branch must trace to a Plane issue (`STRK-XXX`). If you can't name the issue, STOP — create one or find the existing one before proceeding. Legacy `STAK-XXX` references are historical only.
 
 **0b. Version number exists:** The branch must have a version bump (via `/release patch`). If `js/constants.js` hasn't been updated with a new version in this branch, STOP — run `/release patch` before proceeding. Un-versioned PRs are not allowed.
 
@@ -40,7 +40,7 @@ npm test / cargo test / pytest / go test ./...
 
 **If tests fail:**
 
-```
+```text
 Tests failing (<N> failures). Must fix before completing:
 
 [Show failures]
@@ -77,7 +77,7 @@ git merge-base HEAD dev 2>/dev/null || git merge-base HEAD main 2>/dev/null
 
 Present exactly these 4 options:
 
-```
+```text
 Implementation complete. What would you like to do?
 
 1. Merge back to <base-branch> locally
@@ -144,7 +144,7 @@ Report: "Keeping branch <name>. Worktree preserved at <path>."
 
 **Confirm first:**
 
-```
+```text
 This will permanently delete:
 - Branch <name>
 - All commits: <commit-list>
@@ -193,22 +193,22 @@ git worktree remove <worktree-path>
 
 ## Common Mistakes
 
-**Skipping test verification**
+### Skipping Test Verification
 
 - **Problem:** Merge broken code, create failing PR
 - **Fix:** Always verify tests before offering options
 
-**Open-ended questions**
+### Open-Ended Questions
 
 - **Problem:** "What should I do next?" → ambiguous
 - **Fix:** Present exactly 4 structured options
 
-**Automatic worktree cleanup**
+### Automatic Worktree Cleanup
 
 - **Problem:** Remove worktree when might need it (Option 2, 3)
 - **Fix:** Only cleanup for Options 1 and 4
 
-**No confirmation for discard**
+### No Confirmation For Discard
 
 - **Problem:** Accidentally delete work
 - **Fix:** Require typed "discard" confirmation

--- a/.claude/skills/staktrakr-ship/SKILL.md
+++ b/.claude/skills/staktrakr-ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Ship dev to main — collect version tags as changelog source, create the dev→main PR, mark it ready, resolve threads, create GitHub Release. ONLY run when user explicitly says "ready to ship", "release", or "merge to main" in this session. Never runs automatically.
-allowed-tools: Bash, Read, Task, mcp__github__create_pull_request, mcp__github__list_pull_requests, mcp__github__get_pull_request_status
+allowed-tools: Bash, Read, Task, mcp__github__create_pull_request, mcp__github__list_pull_requests, mcp__github__get_pull_request_status, mcp__plane__get_issue_using_readable_identifier, mcp__plane__list_states, mcp__plane__update_issue
 ---
 
 # Ship — StakTrakr (`dev → main`)

--- a/.claude/skills/staktrakr-ship/SKILL.md
+++ b/.claude/skills/staktrakr-ship/SKILL.md
@@ -195,5 +195,5 @@ Ship complete!
 Version:  vLATEST
 PR:       #XX merged
 Release:  https://github.com/lbruton/StakTrakr/releases/tag/vLATEST
-Issues:   STAK-XX → Done (DocVault)
+Issues:   STRK-XX → Done (Plane)
 ```

--- a/.claude/skills/start-patch/SKILL.md
+++ b/.claude/skills/start-patch/SKILL.md
@@ -16,16 +16,17 @@ Rapid session-start triage: fetch Plane issues, rank by priority + session conti
 
 ## Step 0: Project Detection
 
-Read `.claude/project.json` (in the current working directory):
+Read `.claude/project.json` and `.specflow/config.json` (in the current working directory):
 
 ```bash
 cat .claude/project.json
+cat .specflow/config.json
 ```
 
 Extract:
 
 - `plane_project_id` from `.specflow/config.json` → used for Plane queries
-- `name` → display label
+- `name` from `.claude/project.json` → display label
 
 Also capture git state:
 

--- a/.claude/skills/start-patch/SKILL.md
+++ b/.claude/skills/start-patch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: start-patch
-description: Use when starting a new patch session and needing to pick a DocVault issue to work on before claiming a version lock and creating a worktree.
+description: Use when starting a new patch session and needing to pick a Plane issue to work on before claiming a version lock and creating a worktree.
 user-invocable: true
-allowed-tools: Bash, Read, mcp__infisical__get-secret, mcp__mem0__search_memories
+allowed-tools: Bash, Read, mcp__mem0__search_memories, mcp__plane__list_issues
 ---
 
 # Start Patch
 
-Rapid session-start triage: fetch DocVault issues, rank by priority + session continuity, let the user pick, then hand off to `release patch` for lock + worktree creation.
+Rapid session-start triage: fetch Plane issues, rank by priority + session continuity, let the user pick, then hand off to `release patch` for lock + worktree creation.
 
 **Does NOT:** read CHANGELOG, constants, or the full codebase. That's `/prime`.
 **Does NOT:** claim a version lock or create a worktree. That's `/release patch`.
@@ -24,7 +24,7 @@ cat .claude/project.json
 
 Extract:
 
-- `linearTeamId` → used for all Linear queries
+- `plane_project_id` from `.specflow/config.json` → used for Plane queries
 - `name` → display label
 
 Also capture git state:
@@ -49,31 +49,22 @@ git log --oneline -5
 git status --short
 ```
 
-### Linear query (single GraphQL call replaces 3 MCP calls)
+### Plane query
 
-Fetch the API key from Infisical:
+Use the Plane MCP project ID from `.specflow/config.json` and fetch non-completed issues
+from the StakTrakr project. Do not query Linear and do not read DocVault issue files for
+active work.
 
-```
-mcp__infisical__get-secret(secretName: "LINEAR_API_KEY", environmentSlug: "dev", projectId: "319a1db5-207d-49d0-a61d-3f3e6b440ded")
-```
-
-Then run a single query that returns In Progress, Todo, and Backlog issues:
-
-```bash
-curl -s -X POST https://api.linear.app/graphql \
-  -H "Authorization: $LINEAR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d "$(cat <<'GRAPHQL'
-{"query": "{ team(id: \"<TEAM_ID>\") { issues(filter: { state: { type: { nin: [\"completed\", \"canceled\"] } } }, orderBy: priority, first: 50) { nodes { identifier title priority state { name type } assignee { name } labels { nodes { name } } createdAt } } }"}
-GRAPHQL
-)"
+```text
+mcp__plane__list_issues(project_id: "<plane_project_id>")
 ```
 
-> Linear priority values: 1 = Urgent, 2 = High, 3 = Medium, 4 = Low.
+Filter out completed and canceled states, then keep In Progress, Todo, and Backlog items.
+Plane priorities are strings such as `urgent`, `high`, `medium`, `low`, or `none`.
 
 ### mem0 — session continuity
 
-```
+```text
 mcp__mem0__search_memories
   query: "recent session handoff in progress"
   filters: { "AND": [{ "agent_id": "<project agent_id>" }] }
@@ -90,9 +81,9 @@ Note which issue IDs appear in the mem0 results — these get a continuity boost
 
 **If `devops/version.lock` exists with active (non-expired) claims:**
 
-```
+```text
 ⚠️  Active version claims:
-    - v3.32.29 — claude / STAK-315 (expires 10:30Z)
+    - v3.32.29 — claude / STRK-315 (expires 10:30Z)
     - v3.32.30 — user / hotfix (expires 10:35Z)
     Next available version: v3.32.31
     (Claims expire after 30 min and are pruned automatically on next lock read.)
@@ -100,7 +91,7 @@ Note which issue IDs appear in the mem0 results — these get a continuity boost
 
 **If local branch is behind origin/dev (rev-list count > 0): HARD STOP before showing table:**
 
-```
+```text
 ⛔ Local dev is N commits behind origin/dev.
 
 Run: git pull origin dev
@@ -111,7 +102,7 @@ Do not display the issue table. Stop here and wait for the user.
 
 ### Ranking algorithm (4-tier)
 
-Apply in order — within each tier, use Linear priority as the tiebreaker (Urgent > High > Medium > Low):
+Apply in order — within each tier, use Plane priority as the tiebreaker (urgent > high > medium > low):
 
 | Tier        | Criteria                                          |
 | ----------- | ------------------------------------------------- |
@@ -124,24 +115,24 @@ Apply in order — within each tier, use Linear priority as the tiebreaker (Urge
 
 ### Display table
 
-```
+```text
 ## [ProjectName] — Session Candidates  (YYYY-MM-DD)
 
  #  │ Issue    │ Title                          │ State       │ Priority │ Notes
 ────┼──────────┼────────────────────────────────┼─────────────┼──────────┼───────────────
- 1  │ STAK-183 │ Configurable vault timeout     │ In Progress │ High     │ 🔄 In Progress
- 2  │ STAK-199 │ API health badge               │ Todo        │ High     │ 📅 In cycle
- 3  │ STAK-201 │ Memory sync command            │ Todo        │ Medium   │ 🧠 mem0 recent
- 4  │ STAK-155 │ Mobile layout fixes            │ Backlog     │ High     │
- 5  │ STAK-177 │ Retail price confidence UI     │ Backlog     │ Medium   │
+ 1  │ STRK-183 │ Configurable vault timeout     │ In Progress │ high     │ 🔄 In Progress
+ 2  │ STRK-199 │ API health badge               │ Todo        │ high     │ 📅 In cycle
+ 3  │ STRK-201 │ Memory sync command            │ Todo        │ medium   │ 🧠 mem0 recent
+ 4  │ STRK-155 │ Mobile layout fixes            │ Backlog     │ high     │
+ 5  │ STRK-177 │ Retail price confidence UI     │ Backlog     │ medium   │
 
 Version lock: UNLOCKED  |  Branch: dev  |  Sync: ✅ up to date
 ```
 
 Notes legend:
 
-- `🔄 In Progress` — Linear state is In Progress
-- `📅 In cycle` — issue is in the active Linear cycle
+- `🔄 In Progress` — Plane state is In Progress
+- `📅 In cycle` — issue is in the active Plane cycle
 - `🧠 mem0 recent` — appeared in mem0 session-continuity results
 - (blank) — no special signal
 
@@ -153,7 +144,7 @@ Limit the table to **10 rows maximum.** If more issues qualify, show the top 10 
 
 Ask:
 
-```
+```text
 Which issue(s) will we work on? (Enter number(s), e.g. `1` or `1,3`)
 ```
 
@@ -161,10 +152,10 @@ Wait for the user's selection.
 
 Once selected, display a brief confirmation:
 
-```
+```text
 Selected:
-  1. STAK-183 — Configurable vault timeout
-  3. STAK-201 — Memory sync command
+  1. STRK-183 — Configurable vault timeout
+  3. STRK-201 — Memory sync command
 
 Invoking release patch to claim version lock and create worktree...
 ```
@@ -175,16 +166,16 @@ Invoking release patch to claim version lock and create worktree...
 
 Invoke the `release` skill with `patch` as the argument. Pass the selected issue title(s) as context so the release skill's Step 1 ("determine what's being released") is pre-populated.
 
-```
+```text
 Skill tool: skill="release", args="patch"
 ```
 
 Pre-populate Step 1 context for the release skill:
 
-```
+```text
 Context from /start-patch:
-  Working on: STAK-183 — Configurable vault timeout
-              STAK-201 — Memory sync command
+  Working on: STRK-183 — Configurable vault timeout
+              STRK-201 — Memory sync command
 ```
 
 The release skill takes full ownership from here — sync gate, lock claim, worktree, seed-sync, version bump, PR.

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,6 @@
+# Vendored dependencies and generated reports are not project documentation.
+node_modules
+**/node_modules
+playwright-report
+test-results
+.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,13 +42,13 @@ No application build step is required.
 
 - Follow recent commit style:
   - `fix: <summary>`
-  - `chore: <summary> (STAK-###)`
-  - `test(STAK-###): <summary>`
-  - Versioned releases: `vX.YY.ZZ — STAK-###: <summary>` (em dash `—`, not hyphen)
+  - `chore: <summary> (STRK-###)`
+  - `test(STRK-###): <summary>`
+  - Versioned releases: `vX.YY.ZZ — STRK-###: <summary>` (em dash `—`, not hyphen)
 - Keep commits scoped to one logical change.
 - PRs should include:
   - clear summary and rationale
-  - linked issue (`STAK-###`)
+  - linked Plane issue (`STRK-###`)
   - test evidence (`npm test`, `npm run lint`)
   - screenshots/GIFs for UI changes
 - PRs target `dev`, never `main`. Never push directly to `dev` or `main` — both are branch-protected.
@@ -58,7 +58,7 @@ No application build step is required.
 
 Every code change requires:
 
-1. A DocVault issue under `/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Issues/` with a `STAK-###` ID. The ID goes into the commit message, PR body, and version lock claim.
+1. A Plane issue in the StakTrakr project with a `STRK-###` ID. The ID goes into the commit message, PR body, and version lock claim. Legacy `STAK-###` references are historical only.
 2. A git worktree at `.worktrees/patch-<VERSION>/` on branch `patch/<VERSION>`. All edits/commits happen inside the worktree. Zero edits on `dev`.
 3. A version lock claim in `devops/version.lock` (gitignored — edit directly, never commit). Format and lifecycle in the Release Workflow doc below.
 
@@ -66,7 +66,9 @@ Exceptions: instruction-file-only edits (AGENTS.md, `.claude/`, DocVault) may by
 
 ## Release Workflow — Required on Every Code PR
 
-**Canonical reference:** `/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Release Workflow.md` — read it before your first release of the session.
+**Canonical reference:** `/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Foundation/coding-standards.md` — read the Release Process section before your first release of the session.
+
+The old `/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Depreciated/Release Workflow.md` page is archived and may contain stale Linear/DocVault issue references.
 
 Every PR that ships runtime code must bump the version and update the 5 release artifacts below. The `check-release-sync` pre-commit hook fails the commit if any artifact is out of sync.
 
@@ -75,8 +77,8 @@ Every PR that ships runtime code must bump the version and update the 5 release 
 | 1   | `js/constants.js` | `const APP_VERSION = "X.YY.ZZ"` — bump PATCH component                                                                                                             |
 | 2   | `package.json`    | `"version": "X.YY.ZZ"` — match APP_VERSION                                                                                                                         |
 | 3   | `version.json`    | `"version"` + `"releaseDate"` (today, ISO date)                                                                                                                    |
-| 4   | `CHANGELOG.md`    | Prepend `## [X.YY.ZZ] - YYYY-MM-DD` section with `### Changed — STAK-###: <title>` and bullets                                                                     |
-| 5   | `js/about.js`     | Prepend entry to `getEmbeddedWhatsNew()`: `<li><strong>vX.YY.ZZ &ndash; STAK-###: <Title></strong>: <summary></li>` — this is the in-app "What's New" announcement |
+| 4   | `CHANGELOG.md`    | Prepend `## [X.YY.ZZ] - YYYY-MM-DD` section with `### Changed — STRK-###: <title>` and bullets                                                                     |
+| 5   | `js/about.js`     | Prepend entry to `getEmbeddedWhatsNew()`: `<li><strong>vX.YY.ZZ &ndash; STRK-###: <Title></strong>: <summary></li>` — this is the in-app "What's New" announcement |
 
 Automatic (do NOT edit manually):
 
@@ -91,7 +93,7 @@ Version lock (`devops/version.lock`) claim lifecycle:
 4. Create the worktree: `git worktree add .worktrees/patch-<VERSION> -b patch/<VERSION>`.
 5. After PR merges, remove your claim entry. Delete file only if the array is empty.
 
-Commit message format: `vX.YY.ZZ — STAK-###: <summary>` (em dash).
+Commit message format: `vX.YY.ZZ — STRK-###: <summary>` (em dash).
 
 PR: `gh pr create --base dev --head patch/<VERSION> --draft --label codacy-review --title "vX.YY.ZZ — …" --body "…"`.
 
@@ -121,7 +123,7 @@ When handed a spec at the Tasks phase, the expected flow is:
 3. Claim a version in `devops/version.lock` and create the worktree before editing any file.
 4. Implement each task. After each task, call `mcp__specflow__log-implementation` BEFORE marking the task `[x]` in `tasks.md` — this is a hard gate.
 5. Run `npm run lint` and `npm test` (or `npm run test:offline` when network is unavailable). Fix failures before committing.
-6. Bump the 5 release artifacts above and commit with `vX.YY.ZZ — STAK-###: <summary>`. The pre-commit hooks must all pass.
+6. Bump the 5 release artifacts above and commit with `vX.YY.ZZ — STRK-###: <summary>`. The pre-commit hooks must all pass.
 7. Push to `patch/<VERSION>` and open a **draft** PR against `dev` with label `codacy-review`. Do not mark ready — leave the PR as draft for user review.
 8. Post a summary comment on the PR listing: version bumped, tasks completed, test results, any spec tasks deferred.
 
@@ -201,6 +203,7 @@ StakTrakr has commit hooks that can modify tracked files during commit. In parti
 For publish/PR flows in this repo:
 
 - Expect `sw.js` to appear in the final commit even if it was not manually staged
+- When a patch PR is refreshed after another PR merges, `sw.js` cache stamps may be the only conflict. Keep the active patch version's cache name, finish the merge, then let `stamp-sw-cache` restamp `CACHE_NAME` during the merge/review-fix commit.
 - Always inspect `git show --stat HEAD` after commit and before opening the PR
 - Do not assume the staged file list before commit exactly matches the committed PR scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,12 @@ No application build step is required.
 
 ## Commit & Pull Request Guidelines
 
+- Use `STRK-###` as the StakTrakr Plane issue prefix for current work.
 - Follow recent commit style:
   - `fix: <summary>`
   - `chore: <summary> (STRK-###)`
   - `test(STRK-###): <summary>`
-  - Versioned releases: `vX.YY.ZZ — STRK-###: <summary>` (em dash `—`, not hyphen)
+  - Versioned releases: `vX.YY.ZZ (Major.Minor.Patch) — STRK-###: <summary>` (em dash `—`, not hyphen)
 - Keep commits scoped to one logical change.
 - PRs should include:
   - clear summary and rationale
@@ -66,9 +67,9 @@ Exceptions: instruction-file-only edits (AGENTS.md, `.claude/`, DocVault) may by
 
 ## Release Workflow — Required on Every Code PR
 
-**Canonical reference:** `/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Foundation/coding-standards.md` — read the Release Process section before your first release of the session.
+**Canonical reference:** `../DocVault/Projects/StakTrakr/Foundation/coding-standards.md` from the repo root — read the Release Process section before your first release of the session.
 
-The old `/Volumes/DATA/GitHub/DocVault/Projects/StakTrakr/Depreciated/Release Workflow.md` page is archived and may contain stale Linear/DocVault issue references.
+The old `../DocVault/Projects/StakTrakr/Depreciated/Release Workflow.md` page is archived and may contain stale Linear/DocVault issue references. The DocVault folder is currently named `Depreciated`; treat it as a pre-Plane archive even though the spelling is unusual.
 
 Every PR that ships runtime code must bump the version and update the 5 release artifacts below. The `check-release-sync` pre-commit hook fails the commit if any artifact is out of sync.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,12 @@ No application build step is required.
 
 ## Commit & Pull Request Guidelines
 
-- Use `STRK-###` as the StakTrakr Plane issue prefix for current work.
+- Use `STRK-###` (StakTrakr Plane issue identifier) for current work.
 - Follow recent commit style:
   - `fix: <summary>`
   - `chore: <summary> (STRK-###)`
   - `test(STRK-###): <summary>`
-  - Versioned releases: `vX.YY.ZZ (Major.Minor.Patch) — STRK-###: <summary>` (em dash `—`, not hyphen)
+  - Versioned releases: `v<major>.<minor>.<patch> — STRK-###: <summary>` (em dash `—`, not hyphen)
 - Keep commits scoped to one logical change.
 - PRs should include:
   - clear summary and rationale
@@ -59,7 +59,7 @@ No application build step is required.
 
 Every code change requires:
 
-1. A Plane issue in the StakTrakr project with a `STRK-###` ID. The ID goes into the commit message, PR body, and version lock claim. Legacy `STAK-###` references are historical only.
+1. A Plane issue in the StakTrakr project with a `STRK-###` ID. The ID goes into the commit message, PR body, and version lock claim. Legacy `STAK-###` (StakTrakr pre-Plane issue identifier) references are historical only.
 2. A git worktree at `.worktrees/patch-<VERSION>/` on branch `patch/<VERSION>`. All edits/commits happen inside the worktree. Zero edits on `dev`.
 3. A version lock claim in `devops/version.lock` (gitignored — edit directly, never commit). Format and lifecycle in the Release Workflow doc below.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,7 +107,7 @@ Migrate to Playwright as the primary E2E test runner.
 
 ## Dependency Graph
 
-```
+```text
 STAK-532 (Playwright migration)
   └── STAK-539 (slug resolution regression test) — blocked until STAK-532 lands
 ```

--- a/devops/pollers/shared/spot-poller/README.md
+++ b/devops/pollers/shared/spot-poller/README.md
@@ -14,6 +14,7 @@ The poller runs in Docker and writes to disk. You commit the updated seed files 
 
 1. Get a free API key from [metalpriceapi.com](https://metalpriceapi.com)
 2. Copy the example env file and add your key:
+
    ```bash
    cp .env.example .env
    # Edit .env and replace your_api_key_here with your actual key

--- a/devops/version-lock-protocol.md
+++ b/devops/version-lock-protocol.md
@@ -12,7 +12,7 @@ This protocol solves both problems: a **version lock** claims the next version n
 **git worktree** gives each agent an isolated filesystem to work in.
 
 The actual lock state lives in `devops/version.lock` (gitignored). Worktrees live in
-`.claude/worktrees/` (also gitignored).
+`.worktrees/` (also gitignored).
 
 ---
 
@@ -86,9 +86,9 @@ Add a new entry to the `claims` array and write the file:
   "claims": [
     {
       "version": "3.32.29",
-      "claimed_by": "claude / STAK-315 vault images",
+      "claimed_by": "claude / STRK-315 vault images",
       "spec": "vault-image-upload",
-      "issue": "STAK-315",
+      "issue": "STRK-315",
       "files_touched": ["js/vault.js", "js/image-cache.js"],
       "status": "implementing",
       "claimed_at": "2026-02-24T10:00:00Z",
@@ -103,28 +103,28 @@ Fields:
 - `version` — the version number you are claiming (matches your computed version)
 - `claimed_by` — agent name + brief task description
 - `spec` — spec folder name (e.g. `"vault-image-upload"`), or `null` if not spec-driven
-- `issue` — Linear issue ID (e.g. `"STAK-315"`), or `null` if not issue-driven
+- `issue` — Plane issue ID (e.g. `"STRK-315"`), or `null` if not issue-driven
 - `files_touched` — list of files this agent will modify (enables conflict detection)
 - `status` — one of `"queued"` → `"implementing"` → `"pr_open"` → `"done"`
 - `claimed_at` / `expires_at` — ISO 8601 UTC timestamps; **30-minute TTL for hotfixes, 4-hour TTL for spec implementations**
 
-The `version` becomes the **anchor** for all work: Linear notes, changelog bullets,
+The `version` becomes the **anchor** for all work: Plane notes, changelog bullets,
 commit messages, and mem0 handoffs should all reference this version number.
 
 ### Step 5 — CREATE worktree + branch
 
 ```bash
-git worktree add .claude/worktrees/patch-VERSION -b patch/VERSION
+git worktree add .worktrees/patch-VERSION -b patch/VERSION
 ```
 
-Example: `git worktree add .claude/worktrees/patch-3.32.29 -b patch/3.32.29`
+Example: `git worktree add .worktrees/patch-3.32.29 -b patch/3.32.29`
 
 The new branch is created off the current HEAD of `dev`.
 
 ### Step 6 — DO ALL WORK in the worktree
 
 All file edits, the `/release patch` version bump, and test runs happen inside
-`.claude/worktrees/patch-VERSION/`. Do not make changes to the main `dev` working tree
+`.worktrees/patch-VERSION/`. Do not make changes to the main `dev` working tree
 while your claim is held.
 
 The `/release patch` skill reads `js/constants.js` relative to the worktree CWD, so
@@ -168,7 +168,7 @@ as other agents may still hold active claims:
 Remove the worktree and branch:
 
 ```bash
-git worktree remove .claude/worktrees/patch-VERSION --force
+git worktree remove .worktrees/patch-VERSION --force
 git branch -d patch/VERSION
 ```
 
@@ -187,9 +187,9 @@ git push origin --delete patch/VERSION
   "claims": [
     {
       "version": "3.32.29",
-      "claimed_by": "claude / STAK-315 vault images",
+      "claimed_by": "claude / STRK-315 vault images",
       "spec": "vault-image-upload",
-      "issue": "STAK-315",
+      "issue": "STRK-315",
       "files_touched": ["js/vault.js", "js/image-cache.js"],
       "status": "implementing",
       "claimed_at": "2026-02-24T10:00:00Z",
@@ -214,7 +214,7 @@ git push origin --delete patch/VERSION
 | `version`                   | Version number being worked on (matches `APP_VERSION` bump target)        |
 | `claimed_by`                | Agent name + brief task description (for human visibility)                |
 | `spec`                      | Spec folder name, or `null` if not spec-driven                            |
-| `issue`                     | Linear issue ID, or `null`                                                |
+| `issue`                     | Plane issue ID, or `null`                                                 |
 | `files_touched`             | Files this agent will modify — enables conflict detection by other agents |
 | `status`                    | `"queued"` → `"implementing"` → `"pr_open"` → `"done"`                    |
 | `claimed_at` / `expires_at` | ISO 8601 UTC timestamps                                                   |
@@ -257,7 +257,7 @@ Minor gaps in the version sequence are acceptable.
 
 ## Parallel Agent Example
 
-Agent A (STAK-315) and Agent B (hotfix) start at the same time:
+Agent A (STRK-315) and Agent B (hotfix) start at the same time:
 
 1. Both read the lock → `claims: []`
 2. Agent A computes `3.32.29`, writes claim → `claims: [{version: "3.32.29", ...}]`
@@ -298,7 +298,7 @@ The `/release` skill (`.claude/skills/release/SKILL.md`) integrates this protoco
 Each version tag is an **anchor** for a batch of work:
 
 - Version number is claimed _before_ any code is written
-- All Linear notes, changelog bullets, and mem0 handoffs reference that version
+- All Plane notes, changelog bullets, and mem0 handoffs reference that version
 - The git tag (`v3.32.29`) is the permanent breadcrumb
 - The PR body is assembled from all the patch tags between the last release and now
 
@@ -313,7 +313,7 @@ This means the version number is the _first_ thing decided, not the last.
 git worktree list
 
 # Remove a worktree (after merging)
-git worktree remove .claude/worktrees/patch-3.32.29 --force
+git worktree remove .worktrees/patch-3.32.29 --force
 
 # If a worktree directory was deleted manually, prune stale metadata
 git worktree prune
@@ -321,4 +321,4 @@ git worktree prune
 
 ---
 
-_Protocol established: 2026-02-22 | Worktree flow added: 2026-02-22 | Claims array: 2026-02-24_
+Protocol established: 2026-02-22 | Worktree flow added: 2026-02-22 | Claims array: 2026-02-24

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint js/*.js sw.js",
     "lint:md": "bash devops/hooks/lint-markdown-changed.sh --staged",
     "lint:md:changed": "bash devops/hooks/lint-markdown-changed.sh --changed",
-    "lint:md:all": "npx --yes markdownlint-cli --config .markdownlint.json \"**/*.md\" --ignore node_modules --ignore .git --ignore test-results",
+    "lint:md:all": "npx --yes markdownlint-cli --config .markdownlint.json --ignore-path .markdownlintignore \"**/*.md\"",
     "test": "npx playwright test",
     "test:offline": "npx playwright test --grep-invert @network",
     "format": "prettier --write .",

--- a/tests/runbook/00-setup.md
+++ b/tests/runbook/00-setup.md
@@ -70,7 +70,7 @@ Do not attempt to proceed without a valid session.
 
 Navigate to the application:
 
-```
+```text
 stagehand_navigate → {BASE_URL}/index.html
 ```
 

--- a/tests/runbook/01-page-load.md
+++ b/tests/runbook/01-page-load.md
@@ -1,5 +1,10 @@
 # Section 01 — Page Load
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 Tests for initial page load, version display, spot price rendering, and startup modals. These tests validate the fundamental "cold open" experience: that the application renders correctly at the PR preview URL, displays the expected version, shows the What's New modal on first visit (and suppresses it on subsequent visits within the same session), renders all four metal spot price cards with live values, and accurately reflects the seed inventory count.
 
 Run these tests first in any full-suite session. Tests 1.2 through 1.5 are sequentially dependent within this section — 1.4 must complete before 1.5 can be meaningful.

--- a/tests/runbook/03-backup-restore.md
+++ b/tests/runbook/03-backup-restore.md
@@ -1,5 +1,10 @@
 # Section 03 — Backup & Restore
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 This section covers all backup, restore, and encrypted vault operations in StakTrakr. Tests verify that inventory data and images can be exported in multiple formats (CSV, JSON, ZIP) and restored correctly, that conflict prompts appear when restoring over existing data, and that the encrypted vault flow completes without error.
 
 **File picker limitation:** Stagehand cannot interact with OS-level file picker dialogs. For any test that requires selecting a file from disk (restore, import), the test validates the UI flow up to the point where the file picker is triggered. Actual file selection and the downstream restore result require manual verification.

--- a/tests/runbook/04-import-export.md
+++ b/tests/runbook/04-import-export.md
@@ -1,5 +1,10 @@
 # Section 04 — Import & Export
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 This section covers CSV/eBay import flows, duplicate detection, the merge diff viewer, selective import, and PDF export. It is distinct from Section 03 (backup/restore) in that it focuses on structured data import from external sources and the merge/conflict resolution UX rather than full inventory backup cycles.
 
 **File picker limitation:** Stagehand cannot interact with OS-level file picker dialogs. For any test that requires selecting a file from disk, the test validates the UI flow up to the point where the file picker is triggered. Actual file selection and downstream import results require manual verification.

--- a/tests/runbook/05-market.md
+++ b/tests/runbook/05-market.md
@@ -1,5 +1,10 @@
 # Section 05 — Market
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 This section covers E2E tests for the Market feature area: opening the market panel, verifying API-loaded inventory and price data, searching and filtering by metal type, viewing price history, checking source badges, and the Goldback card. Tests 5.7 is marked as manual/visual because triggering a genuine 30-minute data stale state cannot be done programmatically within a Browserbase session.
 
 Each test in this section is independently runnable given that the application has loaded at the PR preview URL (see `00-setup.md`). Tests 5.2 through 5.10 depend on the market panel being open; each test that requires it includes this in Preconditions so that the section can be resumed mid-run without ambiguity.

--- a/tests/runbook/06-ui-ux.md
+++ b/tests/runbook/06-ui-ux.md
@@ -1,5 +1,10 @@
 # Section 06 — UI / UX
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 This section covers E2E tests for responsive layout, theme switching, totals accuracy, item count display, currency switching, and settings persistence. It validates that the application renders correctly at standard breakpoints, responds to user-initiated theme and currency changes, and that the Settings modal saves and persists state across a page reload.
 
 **Viewport note (applies to 6.1 and 6.2):** Browserbase sessions use a fixed viewport configured at session creation time. Mid-session viewport resizing via Stagehand is not supported. Tests 6.1 (375px) and 6.2 (768px) are best executed in separate targeted Browserbase sessions configured at those widths. Within a standard desktop session, those tests capture a screenshot for reference and rely on session recording for visual verification. Test 6.3 (1280px desktop) runs normally in any standard Browserbase session.

--- a/tests/runbook/07-activity-log.md
+++ b/tests/runbook/07-activity-log.md
@@ -1,5 +1,10 @@
 # Section 07 — Activity Log
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 Tests for activity log recording, display, and persistence. The activity log captures every Add, Edit, and Delete action performed during a session and displays each entry with a timestamp and item name. These tests verify that the log faithfully records all three action types, that the log panel opens and closes correctly via the header icon, and that logged entries survive a page reload.
 
 Note: Tests 7.1 through 7.3 require that CRUD actions have already been performed in this session. REQUIRES: run Section 02 (CRUD) before this section, or manually add, edit, and delete one item before starting 7.1. Running this section without prior CRUD actions will cause 7.1–7.3 to fail.

--- a/tests/runbook/08-spot-prices.md
+++ b/tests/runbook/08-spot-prices.md
@@ -1,5 +1,10 @@
 # Section 08 — Spot Prices
 
+<!-- markdownlint-disable MD001 -->
+<!-- All runbook files use h1 (# Section) directly followed by h3 (### Test X.Y);
+     test sections are intentionally skipped from h2 so bb-test parsers can match
+     ### headings as test boundaries. Repo-wide convention, not a per-file choice. -->
+
 Tests for spot price display, freshness, Goldback pricing, backfill behavior, and stale indicators. The spot price pipeline fetches hourly data from the StakTrakrApi Fly.io container and exposes it via `api.staktrakr.com/data/hourly/`. On page load, the frontend backfills the last 30 days of spot history and renders four metal cards (Gold, Silver, Platinum, Palladium) plus a Goldback value. These tests verify that all cards render with live data, that freshness thresholds are met, that melt values on inventory cards reflect current spot prices, and that stale indicators fire correctly when data is overdue.
 
 Test 8.6 is a controlled/manual test only — it cannot be automated without waiting 75+ minutes for real data aging. It is documented here for completeness and manual verification.

--- a/tests/runbook/README.md
+++ b/tests/runbook/README.md
@@ -6,7 +6,7 @@ The `tests/runbook/` directory is the living E2E test specification for StakTrak
 
 Each file in this directory is a **runbook section** — a plain Markdown file covering one feature area. The `/bb-test` skill reads these files at runtime and executes each step via Browserbase/Stagehand MCP tools against the PR preview URL. No build step. No compilation. No imports.
 
-The runbook grows with the product: every shipped spec (Phase 5) appends new test blocks to the relevant section file. The `_Added:` traceability line on each test block identifies which patch and Linear issue introduced it.
+The runbook grows with the product: every shipped spec (Phase 5) appends new test blocks to the relevant section file. The `_Added:` traceability line on each test block identifies which patch and Plane issue introduced it.
 
 ---
 
@@ -22,7 +22,7 @@ The runbook grows with the product: every shipped spec (Phase 5) appends new tes
 
 ### Full suite (all sections, all tests)
 
-```
+```text
 /bb-test
 ```
 
@@ -30,7 +30,7 @@ Runs all 8 sections in order (01 through 08) against the PR preview URL.
 
 ### Targeted sections by number
 
-```
+```text
 /bb-test sections=02,05
 ```
 
@@ -38,7 +38,7 @@ Runs only the CRUD section (`02-crud.md`) and the Market section (`05-market.md`
 
 ### Single section by filename
 
-```
+```text
 /bb-test section=03-backup-restore
 ```
 
@@ -46,7 +46,7 @@ Runs only the Backup & Restore section.
 
 ### Tag-filtered run (all sections, matching tests only)
 
-```
+```text
 /bb-test tags=crud
 ```
 
@@ -57,7 +57,7 @@ Reads all section files, runs only tests whose `**Tags:**` field includes `crud`
 | Argument                    | Effect                                                         |
 | --------------------------- | -------------------------------------------------------------- |
 | `pr=NNN`                    | Use PR number NNN to discover the Cloudflare Pages preview URL |
-| `dry-run`                   | Run all checks but do not file Linear issues                   |
+| `dry-run`                   | Run all checks but do not file Plane issues                    |
 | `sections=02,05`            | Comma-separated section numbers to run                         |
 | `section=03-backup-restore` | Single section by filename prefix                              |
 | `tags=crud`                 | Run only tests with this tag (across all sections)             |
@@ -88,7 +88,7 @@ This costs $0 (no Browserbase credits) and is appropriate when:
 - A quick visual check is sufficient
 - You want to verify a single step without a full session
 
-Reserve `/bb-test` (Browserbase) for full pre-release runs, comprehensive patch verification across an entire section, session recordings, and automated Linear issue filing.
+Reserve `/bb-test` (Browserbase) for full pre-release runs, comprehensive patch verification across an entire section, session recordings, and automated Plane issue filing.
 
 ---
 
@@ -106,7 +106,7 @@ Reserve `/bb-test` (Browserbase) for full pre-release runs, comprehensive patch 
 | [07-activity-log.md](./07-activity-log.md)     | Activity log panel, persistence               | 5     |
 | [08-spot-prices.md](./08-spot-prices.md)       | Spot cards, stale indicators, melt values     | 6     |
 
-**Total baseline tests: 84**
+Total baseline tests: 84.
 
 ---
 
@@ -117,7 +117,7 @@ Every test block in every section file uses this exact format. All 7 fields are 
 ```md
 ### Test N.M — {Test Name}
 
-_Added: v{VERSION} ({STAK-XXX})_
+_Added: v{VERSION} ({STRK-XXX})_
 **Preconditions:** {what must be true before this test runs}
 **Steps:**
 
@@ -134,7 +134,7 @@ _Added: v{VERSION} ({STAK-XXX})_
 | Field                | Description                                                                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Test N.M`           | Section number (N) and test number within section (M). Example: `2.7` = section 2, test 7.                                                                          |
-| `_Added:_`           | Traceability: patch version and Linear issue that introduced this test. Example: `_Added: v3.33.01 (STAK-396)_`                                                     |
+| `_Added:_`           | Traceability: patch version and Plane issue that introduced this test. Example: `_Added: v3.34.46 (STRK-18)_`                                                       |
 | `**Preconditions:**` | State that must be true before this test runs. Reference prior tests by ID if this test depends on their state (e.g., "Test 2.1 has run and added BB-SILVER-COIN"). |
 | `**Steps:**`         | Ordered list of step directives. See step types below.                                                                                                              |
 | `**Pass criteria:**` | Plain English statement of what constitutes a pass for this test as a whole.                                                                                        |
@@ -145,7 +145,7 @@ _Added: v{VERSION} ({STAK-XXX})_
 
 ## Step Types
 
-There are three valid step type prefixes. Each step is one line starting with `- `.
+There are three valid step type prefixes. Each step is one line starting with a dash and a space.
 
 ### `act:`
 
@@ -209,7 +209,7 @@ When implementing a spec (Phase 5), add new test blocks to the relevant section 
 2. **Find the last test number.** Open the target section file and note the highest test ID (e.g., if the last test is `2.20`, your first new test is `2.21`).
 
 3. **Write the test block.** Use the exact 7-field format above.
-   - `_Added:` line must include the current patch version and Linear issue (e.g., `_Added: v3.34.02 (STAK-420)_`)
+   - `_Added:` line must include the current patch version and Plane issue (e.g., `_Added: v3.34.46 (STRK-18)_`)
    - Each `act:` must be one atomic interaction
    - Each `extract:` must have `→ expect:`
    - Screenshot labels must follow the `{NN}-{section-short}-{description}` format
@@ -225,7 +225,7 @@ When implementing a spec (Phase 5), add new test blocks to the relevant section 
 ```md
 ### Test 2.21 — Add item — Copper Round
 
-_Added: v3.34.02 (STAK-420)_
+_Added: v3.34.46 (STRK-18)_
 **Preconditions:** 00-setup has run. Inventory shows 8 seed items.
 **Steps:**
 

--- a/tests/runbook/README.md
+++ b/tests/runbook/README.md
@@ -106,7 +106,7 @@ Reserve `/bb-test` (Browserbase) for full pre-release runs, comprehensive patch 
 | [07-activity-log.md](./07-activity-log.md)     | Activity log panel, persistence               | 5     |
 | [08-spot-prices.md](./08-spot-prices.md)       | Spot cards, stale indicators, melt values     | 6     |
 
-Total baseline tests: 84.
+Total baseline tests: over 80.
 
 ---
 
@@ -128,6 +128,9 @@ _Added: v{VERSION} ({STRK-XXX})_
   **Tags:** {comma-separated tags, e.g. crud, add, silver}
   **Section:** {section number and name, e.g. 02-crud}
 ```
+
+Legacy test blocks may still show `STAK-###` from pre-Plane history. Preserve existing
+historical `_Added` lines unless the test itself changes; new test blocks use `STRK-###`.
 
 ### Field definitions
 


### PR DESCRIPTION
Draft docs-only PR.

## Summary
- Update StakTrakr AGENTS guidance from DocVault/STAK active issues to Plane/STRK active issues.
- Point release workflow guidance at the live DocVault Foundation coding standards page and mark the old Depreciated release page as archived.
- Refresh version-lock, runbook, and Claude-side workflow skill docs to use Plane/STRK and `.worktrees/`.
- Add the `sw.js` cache-stamp merge-conflict note from PR #1079.
- Restore markdownlint ignore coverage with `.markdownlintignore` so generated/vendor markdown is excluded from repo-wide lint.

## Validation
- `npm run lint:md:all`
- `npx --yes markdownlint-cli --config .markdownlint.json AGENTS.md devops/version-lock-protocol.md tests/runbook/README.md .claude/skills/start-patch/SKILL.md .claude/skills/finishing-a-development-branch/SKILL.md .claude/skills/staktrakr-ship/SKILL.md`
- `git diff --check`

## Notes
- Did not move the deprecated DocVault Release Workflow page back; the live release section is in `DocVault/Projects/StakTrakr/Foundation/coding-standards.md`.
- Historical `STAK-###` archive notes remain only where they explain old commit references.