### PR TITLE
chore: add project-level release skill with What's New trim

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -27,9 +27,9 @@ Update the root `version` field:
 "version": "NEW_VERSION",
 ```
 
-### 3. `package-lock.json` (lines 3 and 9 ONLY)
+### 3. `package-lock.json`
 
-Update the root-level `version` field (line 3) and the `packages[""].version` field (line 9). These are the two project version entries — every other `"version"` field is a dependency. Do NOT touch dependency versions.
+Update two fields only — the root-level `"version"` field and the `packages[""].version` field (the self-reference entry). Every other `"version"` field is a dependency. Do NOT touch dependency versions.
 
 ### 4. `version.json`
 
@@ -89,14 +89,16 @@ Format rules:
 
 After all edits, run these checks:
 
+Substitute the actual old and new version strings in all grep commands below.
+
 ```bash
 # 1. Version string appears in all 6 edited files
 grep -l "NEW_VERSION" js/constants.js package.json package-lock.json version.json CHANGELOG.md js/about.js
 
 # 2. Exactly 6 files listed (if fewer, one was missed)
 
-# 3. What's New entry count is <= 8
-grep -c '<li>' js/about.js  # Should be 9 or 10 (8 What's New + 1-2 Roadmap)
+# 3. What's New entry count is exactly 8 (versioned entries only)
+grep -c '<li><strong>v' js/about.js  # Should be 8
 
 # 4. No stale version in edited files
 grep -n "OLD_VERSION" js/constants.js package.json version.json

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: release
+description: StakTrakr-specific Phase 1 version bump — edits 6 files, trims What's New, delegates sw.js to pre-commit hook.
+---
+
+# StakTrakr Release — Phase 1 Override
+
+Project-level override for the global `/release` skill. This file defines **Phase 1 (version bump)** and **Phase 2 (verification)** for StakTrakr. All other phases (lock, worktree, PR, GitHub Release, cleanup) are handled by the global skill.
+
+## Phase 1: Version Bump — 6 Files
+
+The global skill provides `NEW_VERSION` (e.g. `3.34.47`) and the confirmed changelog bullets from Phase 0.4. Edit these 6 files in order:
+
+### 1. `js/constants.js` (line ~287)
+
+Replace the `APP_VERSION` string literal:
+
+```javascript
+const APP_VERSION = "NEW_VERSION";
+```
+
+### 2. `package.json` (line 4)
+
+Update the root `version` field:
+
+```json
+"version": "NEW_VERSION",
+```
+
+### 3. `package-lock.json` (lines 3 and 9 ONLY)
+
+Update the root-level `version` field (line 3) and the `packages[""].version` field (line 9). These are the two project version entries — every other `"version"` field is a dependency. Do NOT touch dependency versions.
+
+### 4. `version.json`
+
+Update both fields:
+
+```json
+{
+  "version": "NEW_VERSION",
+  "releaseDate": "YYYY-MM-DD",
+  "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
+}
+```
+
+### 5. `CHANGELOG.md`
+
+Insert a new section between `## [Unreleased]` and the `---` separator above the previous version:
+
+```markdown
+## [NEW_VERSION] - YYYY-MM-DD
+
+### Changed — ISSUE-ID: Title
+
+- **Label**: Description (ISSUE-ID)
+
+---
+```
+
+Use the confirmed changelog bullets from Phase 0.4. Match the existing format: `### Changed —` with em dash, issue reference in parentheses on each bullet.
+
+### 6. `js/about.js` — What's New (PREPEND + TRIM)
+
+Edit `getEmbeddedWhatsNew()` (starts at line ~140):
+
+**Prepend** a new `<li>` entry at the top of the return template:
+
+```html
+<li>
+  <strong>vNEW_VERSION &ndash; ISSUE-ID: Title</strong>: One-sentence summary of the change
+  (ISSUE-ID).
+</li>
+```
+
+Format rules:
+
+- Use `&ndash;` (en dash entity), not `—` or `–`
+- Wrap version + title in `<strong>` tags
+- End with issue reference in parentheses
+- Match the style of existing entries
+
+**Trim** the list to keep the **8 most recent entries**. Remove the oldest `<li>` elements from the bottom of the list until only 8 remain.
+
+### Handled Automatically — DO NOT EDIT
+
+**`sw.js`** — The `stamp-sw-cache` pre-commit hook reads `APP_VERSION` from `constants.js` at commit time and stamps `CACHE_NAME` automatically. Do NOT manually edit `sw.js` during a release. The hook produces: `staktrakr-v{APP_VERSION}-b{EPOCH}`.
+
+## Phase 2: Verification
+
+After all edits, run these checks:
+
+```bash
+# 1. Version string appears in all 6 edited files
+grep -l "NEW_VERSION" js/constants.js package.json package-lock.json version.json CHANGELOG.md js/about.js
+
+# 2. Exactly 6 files listed (if fewer, one was missed)
+
+# 3. What's New entry count is <= 8
+grep -c '<li>' js/about.js  # Should be 9 or 10 (8 What's New + 1-2 Roadmap)
+
+# 4. No stale version in edited files
+grep -n "OLD_VERSION" js/constants.js package.json version.json
+# Should return nothing
+
+# 5. Diff check — confirm expected files changed
+git diff --stat
+```
+
+If any check fails, fix before committing.
+
+## Phase 3: Post-Commit
+
+No additional post-commit steps. The global skill handles PR creation and resolution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 ## Git Topology
 
 - **Branch model:** `feature/* → dev → main`. All commits go through worktree branch → PR → dev. Both `dev` and `main` are protected — no direct pushes.
-- **Version format:** `MAJOR.MINOR.PATCH` in `js/constants.js` (code comment calls these `BRANCH.RELEASE.PATCH`). Use `/release` to bump — touches 7 files: `js/constants.js`, `package.json`, `package-lock.json` (two occurrences), `sw.js`, `version.json`, `js/about.js`, `CHANGELOG.md`.
+- **Version format:** `MAJOR.MINOR.PATCH` in `js/constants.js` (code comment calls these `BRANCH.RELEASE.PATCH`). Use `/release` to bump — edits 6 files (`js/constants.js`, `package.json`, `package-lock.json`, `version.json`, `js/about.js`, `CHANGELOG.md`) + `sw.js` is stamped automatically by the `stamp-sw-cache` pre-commit hook. Project-level recipe lives in `.claude/skills/release/SKILL.md`.
 - **`/release` is the only valid version-bump path.** `/spec`'s shipping tasks (10–12) say "version bump" — that means _invoke `/release patch`_, not hand-edit version files. A spec PR that bumps `package.json` but forgets `about.js` What's New, manifest, or `version.json` will still pass the `check-release-sync` hook but ship incomplete. If the spec workflow appears to do its own bump, treat that as a bug — invoke `/release`.
 - **Version lock:** `devops/version.lock` is gitignored — local coordination only.
 - **Worktrees:** `.worktrees/<issue>-<slug>/` (issue-named, via `/start-patch`) or `.worktrees/patch-<version>/` (version-named, via `/release`). Both conventions are in use; pick whichever the entry skill creates and stick with it for the lifetime of the branch. Before creating: `git fetch origin dev` to sync remote dev (works from any worktree — no branch checkout needed). Then: `git worktree add .worktrees/<name>/ -b <branch-name> origin/dev`. After: `cp CLAUDE.md .worktrees/<name>/CLAUDE.md` then `npm install --no-audit --no-fund`.
@@ -84,6 +84,7 @@ Pre-migration DocVault issues (STAK-) are archived at `DocVault/Archive/Issues-P
 | `/faq`                            | Add, edit, or remove in-app FAQ entries                                                                           |
 | `/finishing-a-development-branch` | Implementation complete — guides merge/PR/cleanup decision                                                        |
 | `/pr-ready`                       | Pre-PR checklist — version bump, sw.js, DocVault status, Codacy                                                   |
+| `/release`                        | Version bump — edits 6 files + trims What's New to 8 entries. Project override of global `/release`               |
 | `/start-patch`                    | Pick a Plane issue, claim version lock, create worktree                                                           |
 | `/ui-mockup`                      | New multi-element UI — Playground prototype before production code                                                |
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/release/SKILL.md` — StakTrakr's Phase 1 override for the global `/release` skill
- Covers all 6 manually-edited files: `constants.js`, `package.json`, `package-lock.json`, `version.json`, `CHANGELOG.md`, `about.js`
- Adds explicit 8-entry trim cap for `getEmbeddedWhatsNew()` in `about.js` (was growing unbounded at 13 entries)
- Documents `sw.js` as hook-managed (via `stamp-sw-cache`) — not a manual edit target
- Updates `CLAUDE.md` with corrected file count and adds `/release` to the Skills table

## Test plan

- [ ] Run `/release dry-run` and verify it picks up the project-level skill
- [ ] Confirm Phase 1 recipe lists all 6 files
- [ ] Verify sw.js is NOT listed as a manual edit target