### PR TITLE
chore(STRK-39): dark theme warm gold accent

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -201,9 +201,9 @@
    Hue 85° (warm amber), chroma 0.005–0.015 for subtle warmth
    ============================================================================= */
 [data-theme="dark"] {
-  /* Primary Colors - Metallic Dark */
-  --primary: oklch(0.63 0.18 255);
-  --primary-hover: oklch(0.55 0.2 255);
+  /* Primary Colors - Metallic Dark (warm gold accent — STRK-39) */
+  --primary: oklch(0.72 0.16 75);
+  --primary-hover: oklch(0.64 0.18 75);
   --secondary: oklch(0.5 0.01 85);
   --secondary-hover: oklch(0.62 0.01 85);
   --success: oklch(0.64 0.17 155);
@@ -279,7 +279,7 @@
   --text-inverse: oklch(0.98 0 0);
 
   /* STRK-25 — Focus ring */
-  --focus-ring: oklch(0.63 0.18 255 / 0.2);
+  --focus-ring: oklch(0.72 0.16 75 / 0.2);
 
   /* STRK-25 — Hover-mix direction (white lightens for dark themes) */
   --hover-mix: white;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778022502";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778029102";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- Migrate `--primary` and `--primary-hover` in `[data-theme="dark"]` from Slate-era blue (`oklch(0.63 0.18 255)`) to warm gold (`oklch(0.72 0.16 75)`) that complements the gunmetal palette
- Update `--focus-ring` to match the new gold accent
- All interactive elements (buttons, toggles, checkboxes, scrollbar, sidebar active indicator, On/Off pills) inherit via `var(--primary)` — no additional changes needed

### Logo (Task 3)
Dark theme logo already uses gold TRAKR text (`#d4a017`) — no change needed. Splitting dark/slate into separate SVG groups for warmer dark-mode silver bars was considered and deferred as scope creep.

### Design rationale
- **Hue 75°** (amber-gold) creates perceptual separation from `--warning` (80°) and `--brand-gold` (85°)
- **Lightness 0.72** ensures ~7:1 contrast ratio against `oklch(0.18)` dark backgrounds — gold needs higher lightness than blue at equivalent chroma to read clearly
- `--authority-pcgs` blue intentionally preserved (PCGS brand color, not a theme accent)

Closes [STRK-39](https://plane.lbruton.cc/lbruton/browse/STRK-39/)

## Test plan
- [x] Visually verified dark theme: header, settings modal (checkboxes, toggles, sidebar active indicator, On/Off pills), footer links
- [x] Verified Slate theme still uses blue accent (no regression)
- [ ] Reviewer: cycle through all 4 themes to confirm no cross-theme bleed