### PR TITLE
chore(STRK-41): sweep hardcoded rgba colors to token-derived color-mix

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -395,7 +395,7 @@
   --text-inverse: #ffffff;
 
   /* STRK-25 — Focus ring */
-  --focus-ring: rgba(59, 130, 246, 0.2);
+  --focus-ring: oklch(0.623 0.188 259.8 / 0.2);
 
   /* STRK-25 — Hover-mix direction (white lightens for dark themes) */
   --hover-mix: white;
@@ -6340,7 +6340,7 @@ td input:checked + .slider:before {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--primary);
-  background: rgba(59, 130, 246, 0.08);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
   padding: 2px 8px;
   border-radius: var(--radius-sm);
   margin-bottom: var(--spacing-sm);
@@ -7493,7 +7493,7 @@ a.about-badge:hover {
 
 :is([data-theme="dark"], [data-theme="slate"]) .modern-icon-btn:hover {
   background: var(--primary);
-  box-shadow: 0 2px 12px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 2px 12px color-mix(in srgb, var(--primary) 30%, transparent);
 }
 
 [data-theme="sepia"] .modern-icon-btn {
@@ -7588,7 +7588,7 @@ a.about-badge:hover {
 
 :is([data-theme="dark"], [data-theme="slate"]) .search-action-btn.log-btn:hover {
   background: var(--info);
-  box-shadow: 0 2px 12px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 2px 12px color-mix(in srgb, var(--info) 30%, transparent);
 }
 
 [data-theme="sepia"] .search-action-btn {
@@ -7608,7 +7608,7 @@ a.about-badge:hover {
 
 [data-theme="sepia"] .search-action-btn.log-btn:hover {
   background: var(--info);
-  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--info) 20%, transparent);
 }
 
 .autocomplete-dropdown {
@@ -9792,7 +9792,7 @@ th {
   border-radius: var(--radius-pill);
   padding: 0.3rem 0.85rem;
   min-height: auto;
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--warning) 20%, transparent);
 }
 
 /* --- Numista status dot — position fix inside pill button --------------- */
@@ -11257,7 +11257,7 @@ th {
 /* Allow inline edit icons to remain functional with subtle hover */
 #inventoryTable .inline-edit-icon:hover {
   opacity: 1 !important;
-  background: rgba(59, 130, 246, 0.1) !important;
+  background: color-mix(in srgb, var(--primary) 10%, transparent) !important;
   border-radius: 50% !important;
 }
 
@@ -12608,15 +12608,11 @@ th {
 }
 
 .bulk-edit-selected {
-  background: rgba(59, 130, 246, 0.08) !important;
+  background: color-mix(in srgb, var(--primary) 8%, transparent) !important;
 }
 
 :is([data-theme="dark"], [data-theme="slate"]) .bulk-edit-selected {
-  background: rgba(59, 130, 246, 0.18) !important;
-}
-
-[data-theme="sepia"] .bulk-edit-selected {
-  background: rgba(139, 92, 42, 0.08) !important;
+  background: color-mix(in srgb, var(--primary) 18%, transparent) !important;
 }
 
 /* Pinned section — selected items not matching current search */
@@ -12661,15 +12657,11 @@ th {
 }
 
 .bulk-edit-pinned.bulk-edit-selected {
-  background: rgba(59, 130, 246, 0.12) !important;
+  background: color-mix(in srgb, var(--primary) 12%, transparent) !important;
 }
 
 :is([data-theme="dark"], [data-theme="slate"]) .bulk-edit-pinned.bulk-edit-selected {
-  background: rgba(59, 130, 246, 0.22) !important;
-}
-
-[data-theme="sepia"] .bulk-edit-pinned.bulk-edit-selected {
-  background: rgba(139, 92, 42, 0.12) !important;
+  background: color-mix(in srgb, var(--primary) 22%, transparent) !important;
 }
 
 .bulk-edit-pinned-divider td {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778029102";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778032635";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- Replace 11 hardcoded `rgba(59,130,246,...)` (Slate-era blue) and 2 `rgba(139,92,42,...)` (sepia brown) values with `color-mix(in srgb, var(--token) N%, transparent)`
- Each replacement derives from the **correct semantic token** for its context: `--primary` for accent, `--info` for log-btn glow, `--warning` for submit-btn glow
- Delete 2 redundant sepia overrides for `.bulk-edit-selected` — base rule now auto-derives from sepia's own `--primary`
- Convert Slate `--focus-ring` from rgba to oklch for format consistency with other theme blocks

**Issue:** [STRK-41](https://plane.lbruton.cc/lbruton/browse/STRK-41/)
**Scope:** 1 file (`css/styles.css`), 11 insertions / 19 deletions (net -8 lines)

## Test plan

- [ ] Dark theme: verify selection highlights, icon-btn hover glows, and submit button shadow are gold-tinted (not blue)
- [ ] Slate theme: verify all elements still render blue (unchanged visual behavior)
- [ ] Sepia theme: verify bulk-edit selection uses warm-tinted highlight derived from sepia `--primary`
- [ ] Light theme: verify no visual regression
- [ ] Focus ring: verify focus outline renders correctly in all 4 themes