### PR TITLE
chore(STRK-36): card view chip styling — type colors, metal chip, tag pills

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13270,6 +13270,8 @@ th {
 .cv-chip-metal {
   font-weight: 600;
   text-transform: capitalize;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
 }
 .cv-chip-metal.gold {
   background: color-mix(in oklch, var(--gold) 18%, var(--bg-tertiary));

--- a/css/styles.css
+++ b/css/styles.css
@@ -13239,6 +13239,54 @@ th {
   background: var(--type-bar-bg, #946d00);
   color: var(--type-bar-text, #fff);
 }
+.cv-chip-type.round {
+  background: var(--type-round-bg);
+  color: var(--type-round-text, #fff);
+}
+.cv-chip-type.goldback {
+  background: var(--type-goldback-bg);
+  color: var(--type-goldback-text, #fff);
+}
+.cv-chip-type.silverback {
+  background: var(--type-silverback-bg);
+  color: var(--type-silverback-text, #fff);
+}
+.cv-chip-type.aurum {
+  background: var(--type-aurum-bg);
+  color: var(--type-aurum-text, #fff);
+}
+.cv-chip-type.set {
+  background: var(--type-set-bg);
+  color: var(--type-set-text, #fff);
+}
+.cv-chip-type.other {
+  background: var(--type-other-bg);
+  color: var(--type-other-text, #fff);
+}
+.cv-chip-type.note {
+  background: var(--type-note-bg);
+  color: var(--type-note-text, #fff);
+}
+.cv-chip-metal {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.cv-chip-metal.gold {
+  background: color-mix(in oklch, var(--gold) 18%, var(--bg-tertiary));
+  color: var(--gold);
+}
+.cv-chip-metal.silver {
+  background: color-mix(in oklch, var(--silver) 18%, var(--bg-tertiary));
+  color: var(--silver);
+}
+.cv-chip-metal.platinum {
+  background: color-mix(in oklch, var(--platinum) 18%, var(--bg-tertiary));
+  color: var(--platinum);
+}
+.cv-chip-metal.palladium {
+  background: color-mix(in oklch, var(--palladium) 18%, var(--bg-tertiary));
+  color: var(--palladium);
+}
 
 .cv-gain {
   color: var(--success);

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -606,10 +606,12 @@ const _cvEscapeAttr = (s) => {
  */
 const _cardChipsHTML = (item, small = false) => {
   const s = small ? ' style="font-size:0.58rem;padding:0.05rem 0.35rem"' : "";
-  const type = (item.type || "coin").toLowerCase();
+  const type = (item.type || "coin").toLowerCase().replace(/[^a-z0-9-]/g, "");
   let h = `<span class="cv-chip cv-chip-type ${type}"${s}>${sanitizeHtml(type)}</span>`;
-  const metal = (item.metal || "silver").toLowerCase();
-  h += `<span class="cv-chip cv-chip-metal ${metal}"${s}>${sanitizeHtml(metal)}</span>`;
+  if (item.metal) {
+    const metal = item.metal.toLowerCase().replace(/[^a-z0-9-]/g, "");
+    h += `<span class="cv-chip cv-chip-metal ${metal}"${s}>${sanitizeHtml(metal)}</span>`;
+  }
   if (item.year)
     h += `<span class="cv-chip cv-chip-year"${s}>${sanitizeHtml(String(item.year))}</span>`;
   if (item.grade) h += `<span class="cv-chip cv-chip-grade"${s}>${sanitizeHtml(item.grade)}</span>`;

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -608,6 +608,8 @@ const _cardChipsHTML = (item, small = false) => {
   const s = small ? ' style="font-size:0.58rem;padding:0.05rem 0.35rem"' : "";
   const type = (item.type || "coin").toLowerCase();
   let h = `<span class="cv-chip cv-chip-type ${type}"${s}>${sanitizeHtml(type)}</span>`;
+  const metal = (item.metal || "silver").toLowerCase();
+  h += `<span class="cv-chip cv-chip-metal ${metal}"${s}>${sanitizeHtml(metal)}</span>`;
   if (item.year)
     h += `<span class="cv-chip cv-chip-year"${s}>${sanitizeHtml(String(item.year))}</span>`;
   if (item.grade) h += `<span class="cv-chip cv-chip-grade"${s}>${sanitizeHtml(item.grade)}</span>`;
@@ -615,12 +617,15 @@ const _cardChipsHTML = (item, small = false) => {
   if (qty > 1) h += `<span class="cv-chip cv-chip-qty"${s}>x${qty}</span>`;
   h += `<span class="cv-chip cv-chip-weight"${s}>${sanitizeHtml(formatWeight(item.weight, item.weightUnit))}</span>`;
 
-  // STAK-343: Inline tags in card view (show first 2, ellipsis if more)
   const _cardTags = typeof getItemTags === "function" ? getItemTags(item.uuid) : [];
   if (_cardTags.length > 0) {
-    const tagText =
-      sanitizeHtml(_cardTags.slice(0, 2).join(", ")) + (_cardTags.length > 2 ? "\u2026" : "");
-    h += `<span class="cv-chip cv-chip-tags"${s} title="${_cvEscapeAttr(_cardTags.join(", "))}">${tagText}</span>`;
+    const show = _cardTags.slice(0, 2);
+    show.forEach((t) => {
+      h += `<span class="cv-chip cv-chip-tags"${s} title="${_cvEscapeAttr(t)}">${sanitizeHtml(t)}</span>`;
+    });
+    if (_cardTags.length > 2) {
+      h += `<span class="cv-chip cv-chip-tags"${s} title="${_cvEscapeAttr(_cardTags.join(", "))}">+${_cardTags.length - 2}</span>`;
+    }
   }
 
   return h;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778036202";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778037075";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778037075";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778037631";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778032635";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778036202";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Fixes three card view chip issues (STRK-36):

- **Type chip transparency** — Added missing `.cv-chip-type` CSS variants for round, goldback, silverback, aurum, set, other, and note. Previously only coin and bar had colored backgrounds; all other types rendered transparent.
- **Missing metal chip** — Added a color-coded metal indicator chip (gold/silver/platinum/palladium) using `color-mix` tinted backgrounds that adapt across all four themes. Includes fallback styling for unknown metals.
- **Tags concatenated into one pill** — Split the comma-joined tag string into individual pill chips. Shows first 2 tags plus a `+N` overflow chip with full list as tooltip.

All changes apply to `_cardChipsHTML()` which is shared by card views A, B, and C.

## Test plan

- [x] Card View C — type chips (coin, bar, round, goldback, set, other, note) all render with distinct colored backgrounds
- [x] Card View C — metal chips appear with tinted backgrounds matching filter chip palette
- [x] Card View C — tags render as individual pills with overflow chip for 3+ tags
- [x] Card View A and B — chips render correctly (shared function)
- [x] Dark theme — all chips visible with good contrast
- [x] Light theme — all chips readable (verified via close-up screenshots)
- [x] Sepia theme — all chips visible
- [x] Slate theme — confirmed dark background, metal color contrast is fine
- [x] ESLint + Prettier clean