### PR TITLE
chore(STRK-37): item detail modal — chart, catalog, serial number fixes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6516,6 +6516,10 @@ td input:checked + .slider:before {
     grid-template-columns: 1fr 1fr;
   }
 
+  .view-numista-section .view-detail-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
   .view-chart-container {
     height: 160px;
   }

--- a/css/styles.css
+++ b/css/styles.css
@@ -6311,42 +6311,7 @@ td input:checked + .slider:before {
   font-style: italic;
 }
 
-/* --- Numista enrichment section — distinct separator --- */
-.view-numista-section {
-  padding: var(--spacing) var(--spacing-xl);
-  background: var(--bg-secondary);
-  border-top: 2px solid var(--border);
-  position: relative;
-}
-
-.view-numista-section::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: var(--spacing-xl);
-  right: var(--spacing-xl);
-  height: 2px;
-  background: linear-gradient(90deg, transparent, var(--primary), transparent);
-  opacity: 0.3;
-  margin-top: -2px;
-}
-
-.view-numista-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--font-size-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 8%, transparent);
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  margin-bottom: var(--spacing-sm);
-}
-
-/* Numista section uses 3 columns by default for compact layout */
+/* Catalog Data (Numista) section — 3-column grid override */
 .view-numista-section .view-detail-grid {
   grid-template-columns: 1fr 1fr 1fr;
 }
@@ -6556,10 +6521,6 @@ td input:checked + .slider:before {
   }
 
   .view-detail-section {
-    padding: var(--spacing-sm) var(--spacing);
-  }
-
-  .view-numista-section {
     padding: var(--spacing-sm) var(--spacing);
   }
 

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -1470,11 +1470,11 @@ async function _fetchHistoricalSpotData(metalName, days, fromTs, toTs) {
     const byDay = new Map();
     for (const e of liveEntries) byDay.set(new Date(e.ts).toISOString().slice(0, 10), e);
     const result = [...byDay.values()].sort((a, b) => a.ts - b.ts);
-    const cutoff = Date.now() - days * 86400000;
+    const cutoff = Date.now() - days * (24 * 60 * 60 * 1000);
     const inRange = result.filter((e) => e.ts >= cutoff);
     if (inRange.length >= 2) return result;
     // Sparse in-memory data — fall back to current year file
-    startYear = new Date(Date.now() - days * 86400000).getFullYear();
+    startYear = new Date(cutoff).getFullYear();
   } else {
     // "All" — go back to 1968 (earliest seed data)
     startYear = 1968;
@@ -1661,7 +1661,7 @@ function _createPriceHistoryChart(
     retailData[spotEntries.length - 1] = currentRetail;
   }
 
-  const hasRetail = allRetailEntries.length > 1;
+  const hasRetail = retailData.some((v) => v !== null);
 
   const showPoints = spotEntries.length <= 30;
 

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -448,6 +448,7 @@ function _buildInventorySection(item, metrics) {
   invSection.appendChild(invGrid2);
   const storGrid = _el("div", "view-detail-grid");
   _addDetail(storGrid, "Storage", item.storageLocation || "\u2014");
+  if (item.serialNumber) _addDetail(storGrid, "Serial #", item.serialNumber);
   invSection.appendChild(storGrid);
   return invSection;
 }
@@ -741,44 +742,31 @@ async function _onChartRangePillClick(days, dateRange, chartSection, chartCtx) {
     days === -1 && chartCtx.purchaseDate > 0
       ? Math.max(1, Math.ceil((Date.now() - chartCtx.purchaseDate) / 86400000))
       : days;
-  if (effectiveDays === 0 || effectiveDays > 180) {
-    try {
-      const fullSpot = await _fetchHistoricalSpotData(chartCtx.metalName, effectiveDays);
-      _createPriceHistoryChart(
-        canvas,
-        fullSpot,
-        chartCtx.retailEntries,
-        chartCtx.purchasePerUnit,
-        chartCtx.meltFactor,
-        effectiveDays,
-        chartCtx.purchaseDate,
-        chartCtx.currentRetail
-      );
-    } catch (err) {
-      console.error("Range pill fetch failed:", err);
-      _createPriceHistoryChart(
-        canvas,
-        chartCtx.dailySpotEntries,
-        chartCtx.retailEntries,
-        chartCtx.purchasePerUnit,
-        chartCtx.meltFactor,
-        effectiveDays,
-        chartCtx.purchaseDate,
-        chartCtx.currentRetail
-      );
-    }
-    return;
+  try {
+    const spotData = await _fetchHistoricalSpotData(chartCtx.metalName, effectiveDays);
+    _createPriceHistoryChart(
+      canvas,
+      spotData,
+      chartCtx.retailEntries,
+      chartCtx.purchasePerUnit,
+      chartCtx.meltFactor,
+      effectiveDays,
+      chartCtx.purchaseDate,
+      chartCtx.currentRetail
+    );
+  } catch (err) {
+    console.error("Range pill fetch failed:", err);
+    _createPriceHistoryChart(
+      canvas,
+      chartCtx.dailySpotEntries,
+      chartCtx.retailEntries,
+      chartCtx.purchasePerUnit,
+      chartCtx.meltFactor,
+      effectiveDays,
+      chartCtx.purchaseDate,
+      chartCtx.currentRetail
+    );
   }
-  _createPriceHistoryChart(
-    canvas,
-    chartCtx.dailySpotEntries,
-    chartCtx.retailEntries,
-    chartCtx.purchasePerUnit,
-    chartCtx.meltFactor,
-    effectiveDays,
-    chartCtx.purchaseDate,
-    chartCtx.currentRetail
-  );
 }
 
 function _buildGradingSection(item) {
@@ -1098,12 +1086,9 @@ async function loadViewNumistaData(item, container, apiResult) {
     }
   }
 
-  // Build Numista section
-  const section = _el("div", "view-numista-section");
-
-  const badge = _el("span", "view-numista-badge");
-  badge.textContent = "Catalog Data";
-  section.appendChild(badge);
+  // Build Numista section — uses standard _section() for consistent styling
+  const section = _section("Catalog Data");
+  section.classList.add("view-numista-section");
 
   const grid = _el("div", "view-detail-grid");
 
@@ -1477,14 +1462,19 @@ async function _fetchHistoricalSpotData(metalName, days, fromTs, toTs) {
   if (fromTs > 0) {
     startYear = new Date(fromTs).getFullYear();
   } else if (days > 0 && days <= 180) {
-    // Short range — in-memory spotHistory is sufficient
+    // Short range — try in-memory spotHistory first
     const liveEntries = (typeof spotHistory !== "undefined" ? spotHistory : [])
       .filter((e) => e.metal === metalName)
       .map((e) => ({ ts: new Date(e.timestamp).getTime(), spot: e.spot }));
     liveEntries.sort((a, b) => a.ts - b.ts);
     const byDay = new Map();
     for (const e of liveEntries) byDay.set(new Date(e.ts).toISOString().slice(0, 10), e);
-    return [...byDay.values()].sort((a, b) => a.ts - b.ts);
+    const result = [...byDay.values()].sort((a, b) => a.ts - b.ts);
+    const cutoff = Date.now() - days * 86400000;
+    const inRange = result.filter((e) => e.ts >= cutoff);
+    if (inRange.length >= 2) return result;
+    // Sparse in-memory data — fall back to current year file
+    startYear = new Date(Date.now() - days * 86400000).getFullYear();
   } else {
     // "All" — go back to 1968 (earliest seed data)
     startYear = 1968;
@@ -1671,7 +1661,7 @@ function _createPriceHistoryChart(
     retailData[spotEntries.length - 1] = currentRetail;
   }
 
-  const hasRetail = retailData.some((v) => v !== null);
+  const hasRetail = allRetailEntries.length > 1;
 
   const showPoints = spotEntries.length <= 30;
 
@@ -1722,8 +1712,8 @@ function _createPriceHistoryChart(
       fill: "origin",
       tension: 0.3,
       spanGaps: true,
-      pointRadius: 4,
-      pointHoverRadius: 6,
+      pointRadius: showPoints ? 3 : 0,
+      pointHoverRadius: showPoints ? 5 : 3,
       borderWidth: 2,
       hidden: !hasRetail,
       order: 1,

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778037631";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778041550";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.46-b1778041550";
+const CACHE_NAME = "staktrakr-v3.34.46-b1778078900";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary
- **Chart dots:** retail line `pointRadius` now adaptive — visible on short ranges (≤30 data points), hidden on 30d+ to reduce clutter
- **7d melt value:** unified all chart range clicks through `_fetchHistoricalSpotData` with year-file fallback when in-memory spot data is sparse
- **Retail line auto-hide:** gated on `allRetailEntries.length > 1` instead of the synthetic `retailData` array which always had non-null values from the purchase-price anchor
- **Catalog Data section:** refactored to use `_section("Catalog Data")` for consistent styling; stripped special `bg-secondary`, `border-top`, `::before` gradient, and badge CSS (-38 lines)
- **Serial number:** `item.serialNumber` now displays in the Inventory section when populated

Closes [STRK-37](https://plane.lbruton.cc/lbruton/browse/STRK-37/)

## Test plan
- [x] Chart 7d: melt value line renders with data points visible
- [x] Chart 90d: no dots on melt or retail lines
- [x] Retail line hidden when no tracked price history (legend shows strikethrough)
- [x] Serial number renders next to Storage when populated
- [x] Serial number hidden when field is empty
- [x] Verified in dark and light themes
- [ ] Catalog Data section styling (needs Numista API — verified structurally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Serial numbers now display in the Inventory view when available for tracked items

* **Performance Improvements**
  * Optimized price history chart performance, prioritizing in-memory data for faster rendering of recent price ranges

* **Style & Layout**
  * Catalog Data section refreshed with improved grid layout and consistent visual styling across the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->