### PR TITLE
v3.34.52 — STRK-54: Lost disposition realized loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.52] - 2026-05-08
+
+### Changed — STRK-54: Lost disposition realized loss
+
+- **Disposition**: Partial-stack Lost dispositions now record zero proceeds and a realized loss equal to the disposed units' cost basis, so item-level and portfolio realized G/L totals match full-stack lost behavior (STRK-54).
+
+---
+
 ## [3.34.51] - 2026-05-08
 
 ### Changed — STRK-56: Service worker cache recovery

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.52 &ndash; STRK-54: Lost disposition realized loss</strong>: Partial-stack Lost dispositions now record the disposed units&rsquo; full cost basis as realized loss, keeping item-level and portfolio realized G/L totals aligned with full-stack lost items (STRK-54).</li>
     <li><strong>v3.34.51 &ndash; STRK-56: Service worker cache recovery</strong>: StakTrakr now falls back to cached app files when an asset refresh fails and offers Reset App recovery when stale service-worker state persists (STRK-56).</li>
     <li><strong>v3.34.50 &ndash; STRK-55: View modal respects per-item Numista edits</strong>: The item detail modal now shows your saved Numista customizations instead of only the shared catalog snapshot. Obverse and reverse descriptions are visible text rows in Catalog Data, and duplicate tags were removed from that section (STRK-55).</li>
     <li><strong>v3.34.49 &ndash; STRK-51: Expanded Numista import modal fields</strong>: The Numista import-confirmation modal now shows all 18 Numista-backed stored fields (dimensions, mintage, KM reference, rarity, commemorative, descriptions, etc.) alongside the existing 8. User-edited fields appear unchecked with an &ldquo;&#x270e;&nbsp;edited&rdquo; badge so re-syncs never silently overwrite custom values. The modal body scrolls on short viewports; Fill Fields/Cancel stay sticky (STRK-51).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.51";
+const APP_VERSION = "3.34.52";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -997,8 +997,19 @@ const splitInventoryItem = async (originalIdx, disposedQty, dispositionInput) =>
   clone.serial = getNextSerial();
   clone.qty = qty;
   const disposedAt = new Date().toISOString();
-  const pricePerUnit = original.price || 0;
-  const totalAmount = dispositionInput.amount != null ? Number(dispositionInput.amount) : undefined;
+  const pricePerUnit = parseFloat(original.price) || 0;
+  const rawTotalAmount =
+    dispositionInput.amount != null ? Number(dispositionInput.amount) : undefined;
+  const typeInfo =
+    typeof DISPOSITION_TYPES !== "undefined" && dispositionInput.type
+      ? DISPOSITION_TYPES[dispositionInput.type]
+      : null;
+  const totalAmount =
+    rawTotalAmount != null && Number.isFinite(rawTotalAmount)
+      ? rawTotalAmount
+      : typeInfo && !typeInfo.requiresAmount
+        ? 0
+        : undefined;
   const realizedGainLoss =
     totalAmount != null && Number.isFinite(totalAmount)
       ? totalAmount - pricePerUnit * qty

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.51",
+  "version": "3.34.52",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.51-b1778273719";
+const CACHE_NAME = "staktrakr-v3.34.52-b1778277698";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/inventory/partial-stack-disposition.spec.js
+++ b/tests/playwright/inventory/partial-stack-disposition.spec.js
@@ -629,6 +629,60 @@ test.describe("STRK-44 Partial-Stack Disposition", () => {
     expect(gl).toBeCloseTo(15, 2);
   });
 
+  test("22a. STRK-54 — Partial-stack Lost records full disposed cost as realized loss", async ({
+    page,
+  }) => {
+    await seedData(page, { inventory: [BASE_ITEM] });
+    await gotoApp(page);
+
+    await openDisposeModal(page, 0);
+    await page.selectOption("#dispositionType", "Lost");
+    await setDisposeQty(page, 3);
+    await confirmDispose(page);
+
+    const result = await page.evaluate(() => {
+      if (typeof window.updateSummary === "function") window.updateSummary();
+      const clone = window.inventory.find((i) => i.disposition && i.disposition.splitFromUuid);
+      return {
+        cloneAmount: clone ? clone.disposition.amount : null,
+        cloneRealizedGainLoss: clone ? clone.disposition.realizedGainLoss : null,
+        silverRealized: document.getElementById("realizedGainLossSilver")?.textContent || "",
+        allRealized: document.getElementById("realizedGainLossAll")?.textContent || "",
+      };
+    });
+
+    expect(result.cloneAmount).toBe(0);
+    expect(result.cloneRealizedGainLoss).toBeCloseTo(-90, 2);
+    expect(result.silverRealized).toContain("-$90.00");
+    expect(result.allRealized).toContain("-$90.00");
+  });
+
+  test("22b. STRK-54 — Full-stack Lost records full item cost as realized loss", async ({
+    page,
+  }) => {
+    await seedData(page, { inventory: [BASE_ITEM] });
+    await gotoApp(page);
+
+    await openDisposeModal(page, 0);
+    await page.selectOption("#dispositionType", "Lost");
+    await confirmDispose(page);
+
+    const result = await page.evaluate(() => {
+      if (typeof window.updateSummary === "function") window.updateSummary();
+      return {
+        amount: window.inventory[0].disposition?.amount,
+        realizedGainLoss: window.inventory[0].disposition?.realizedGainLoss,
+        silverRealized: document.getElementById("realizedGainLossSilver")?.textContent || "",
+        allRealized: document.getElementById("realizedGainLossAll")?.textContent || "",
+      };
+    });
+
+    expect(result.amount).toBe(0);
+    expect(result.realizedGainLoss).toBeCloseTo(-300, 2);
+    expect(result.silverRealized).toContain("-$300.00");
+    expect(result.allRealized).toContain("-$300.00");
+  });
+
   test("23. REQ-4.2 — G/L equals full amount when no purchase price recorded", async ({ page }) => {
     const noPriceItem = { ...BASE_ITEM, uuid: "strk44-noprice-uuid", price: 0 };
     await seedData(page, { inventory: [noPriceItem] });

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.51",
+  "version": "3.34.52",
   "releaseDate": "2026-05-08",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- Fix partial-stack Lost dispositions so no-sale dispositions use zero proceeds and record realized loss against the disposed units' cost basis.
- Add focused coverage for both partial-stack and full-stack Lost realized-loss totals.
- Bump release artifacts to v3.34.52; pre-commit stamped sw.js.

## Validation
- npm run lint (passes; existing warnings in js/diff-engine.js and js/diff-modal.js for unused eslint-disable directives)
- npx playwright test tests/playwright/inventory/partial-stack-disposition.spec.js -g "STRK-54" (2 passed)
- bash devops/hooks/check-release-sync.sh (passes)
- git diff --check (passes)
- npm run test:offline (516 passed, 1 unrelated repeat failure: tests/playwright/stak-437-search-tab-removal.spec.js:384, "Deleting pre-seeded pattern → does not reappear on reload"; focused rerun of that test passed once, then full-suite rerun timed out in the same test)

## Follow-up
- Created STRK-57 to quiet Playwright local web server asset-request logging after STRK-54 ships.

## Issue
- STRK-54