### PR TITLE
v3.34.57 — STRK-67: per-side image frame override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.57] - 2026-05-10
+
+### Changed — STRK-67: Per-side image frame override
+
+- **Image frames**: Add per-side Auto/Circle/Rectangle frame overrides for obverse and reverse images, preserving automatic shape detection while allowing graded slabs, bars, notes, and other rectangular media to be corrected from the item form (STRK-67).
+- **Display consistency**: Apply the resolved frame independently in upload previews, table thumbnails, card images, view-modal image slots, field diffs, change history, and JSON backup data (STRK-67).
+
+---
+
 ## [3.34.56] - 2026-05-10
 
 ### Changed — STRK-65: Attachment review follow-ups

--- a/css/styles.css
+++ b/css/styles.css
@@ -6086,7 +6086,7 @@ td input:checked + .slider:before {
 }
 
 /* Rectangular frame for bars, notes, Aurum/Goldback — auto-fits aspect ratio */
-.view-image-section.view-shape-rect .view-image-slot img {
+.view-image-slot.view-shape-rect img {
   border-radius: var(--radius);
   max-width: 200px;
   max-height: 260px;
@@ -6094,7 +6094,7 @@ td input:checked + .slider:before {
   height: auto;
 }
 
-.view-image-section.view-shape-rect .view-image-placeholder {
+.view-image-slot.view-shape-rect .view-image-placeholder {
   border-radius: var(--radius);
   width: 140px;
   height: 200px;
@@ -6593,12 +6593,12 @@ td input:checked + .slider:before {
     font-size: var(--font-size-3xl);
   }
 
-  .view-image-section.view-shape-rect .view-image-slot img {
+  .view-image-slot.view-shape-rect img {
     max-width: 100%;
     max-height: 200px;
   }
 
-  .view-image-section.view-shape-rect .view-image-placeholder {
+  .view-image-slot.view-shape-rect .view-image-placeholder {
     width: 100%;
     aspect-ratio: 3/4;
   }
@@ -6649,7 +6649,7 @@ td input:checked + .slider:before {
     max-height: 150px;
   }
 
-  .view-image-section.view-shape-rect .view-image-slot img {
+  .view-image-slot.view-shape-rect img {
     max-height: 180px;
   }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -3241,6 +3241,7 @@ input[type="submit"] {
 }
 
 .image-upload-preview {
+  position: relative;
   flex: 1;
   min-width: 0;
   display: flex;
@@ -3254,6 +3255,47 @@ input[type="submit"] {
   border-radius: var(--radius);
   border: 1px solid var(--border);
   object-fit: contain;
+}
+
+.frame-toggle {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  z-index: 2;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: color-mix(in oklch, var(--bg-primary), transparent 8%);
+  color: var(--text-muted);
+  box-shadow: 0 2px 8px color-mix(in oklch, #000, transparent 82%);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 800;
+  line-height: 1;
+  padding: 0;
+}
+
+.frame-toggle::before {
+  content: "";
+  position: absolute;
+  inset: -8px;
+  border-radius: 50%;
+}
+
+.frame-toggle[data-frame-state="circle"],
+.frame-toggle[data-frame-state="rectangle"] {
+  color: var(--metal-gold, var(--gold));
+  border-color: color-mix(in oklch, var(--metal-gold, var(--gold)), transparent 45%);
+  background: color-mix(in oklch, var(--metal-gold, var(--gold)), transparent 88%);
+}
+
+.frame-toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .image-card-actions {

--- a/index.html
+++ b/index.html
@@ -1868,6 +1868,16 @@
                       style="display: none"
                     >
                       <img id="itemImagePreviewImgObv" alt="Obverse preview" />
+                      <button
+                        type="button"
+                        id="frameToggleObv"
+                        class="frame-toggle"
+                        data-frame-state="auto"
+                        aria-pressed="false"
+                        aria-label="Image frame: auto (default)"
+                      >
+                        <span aria-hidden="true">A</span>
+                      </button>
                     </div>
                     <div class="image-card-actions">
                       <input
@@ -1941,6 +1951,16 @@
                       style="display: none"
                     >
                       <img id="itemImagePreviewImgRev" alt="Reverse preview" />
+                      <button
+                        type="button"
+                        id="frameToggleRev"
+                        class="frame-toggle"
+                        data-frame-state="auto"
+                        aria-pressed="false"
+                        aria-label="Image frame: auto (default)"
+                      >
+                        <span aria-hidden="true">A</span>
+                      </button>
                     </div>
                     <div class="image-card-actions">
                       <input
@@ -8450,6 +8470,7 @@
     <script defer src="./js/retail-view-modal.js"></script>
     <script defer src="./js/api.js"></script>
     <script defer src="./js/catalog-api.js"></script>
+    <script defer src="./js/image-frame.js"></script>
     <script defer src="./js/pcgs-api.js"></script>
     <script defer src="./js/catalog-providers.js"></script>
     <script defer src="./js/catalog-manager.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.57 &ndash; STRK-67: Per-side image frame override</strong>: Add Auto/Circle/Rectangle frame controls for obverse and reverse images so rectangular slabs, bars, notes, and similar media can be corrected while default shape detection stays automatic (STRK-67).</li>
     <li><strong>v3.34.56 &ndash; STRK-65: Attachment review follow-ups</strong>: Hardens per-item attachments after PR review &mdash; queue entries removable independently, object URL lifecycle fixed, cloud-sync pull helper extracted (fixes repeat downloads), size guard before vault serialization, DiffEngine duplicate-filename safety, split items keep attachments on both records, storage diagnostics clarified (STRK-65).</li>
     <li><strong>v3.34.55 &ndash; STRK-45: Per-item PDF/image attachments</strong>: Attach receipts, COAs, and dealer invoices directly to inventory items (PDF, PNG, JPG) from the Edit modal drag-drop zone. Attachments are persisted in IndexedDB, shown as a count badge on card, table, and detail views, included in zip/stvault backups and CSV exports, and synced via cloud sync with an opt-out toggle in Settings (STRK-45).</li>
     <li><strong>v3.34.54 &ndash; STRK-52: Numista re-sync tag membership</strong>: Existing on-item tags in the Numista re-sync picker are now shown checked and enabled instead of locked-disabled, letting you uncheck them to record an explicit opt-out. Uncheck-all also protects on-item tags from accidental mass-removal (STRK-52).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.52 &ndash; STRK-54: Lost disposition realized loss</strong>: Partial-stack Lost dispositions now record the disposed units&rsquo; full cost basis as realized loss, keeping item-level and portfolio realized G/L totals aligned with full-stack lost items (STRK-54).</li>
     <li><strong>v3.34.51 &ndash; STRK-56: Service worker cache recovery</strong>: StakTrakr now falls back to cached app files when an asset refresh fails and offers Reset App recovery when stale service-worker state persists (STRK-56).</li>
     <li><strong>v3.34.50 &ndash; STRK-55: View modal respects per-item Numista edits</strong>: The item detail modal now shows your saved Numista customizations instead of only the shared catalog snapshot. Obverse and reverse descriptions are visible text rows in Catalog Data, and duplicate tags were removed from that section (STRK-55).</li>
-    <li><strong>v3.34.49 &ndash; STRK-51: Expanded Numista import modal fields</strong>: The Numista import-confirmation modal now shows all 18 Numista-backed stored fields (dimensions, mintage, KM reference, rarity, commemorative, descriptions, etc.) alongside the existing 8. User-edited fields appear unchecked with an &ldquo;&#x270e;&nbsp;edited&rdquo; badge so re-syncs never silently overwrite custom values. The modal body scrolls on short viewports; Fill Fields/Cancel stay sticky (STRK-51).</li>
   `;
 };
 

--- a/js/card-view.js
+++ b/js/card-view.js
@@ -547,14 +547,8 @@ const _cardMetalClass = (metal) => `metal-${(metal || "silver").toLowerCase()}`;
  * @returns {string}
  */
 const _cardImageHTML = (item, extraClass = "", side = "obverse") => {
-  const itemType = (item.type || "").toLowerCase();
   const isRect =
-    itemType === "bar" ||
-    itemType === "note" ||
-    itemType === "aurum" ||
-    itemType === "set" ||
-    item.weightUnit === "gb" ||
-    item.weightUnit === "sb";
+    typeof resolveImageFrame === "function" && resolveImageFrame(item, side) === "rect";
   const shape = isRect ? " bar-shape" : "";
   const uuid = item.uuid || "";
   const catalogId = item.numistaId || "";

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -110,6 +110,8 @@ const logItemChanges = (oldItem, newItem) => {
     "currency",
     "obverseImageUrl",
     "reverseImageUrl",
+    "obverseImageFrame",
+    "reverseImageFrame",
     "obverseSharedImageId",
     "reverseSharedImageId",
     "disposition",

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
  */
 
-const APP_VERSION = "3.34.56";
+const APP_VERSION = "3.34.57";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-engine.js
+++ b/js/diff-engine.js
@@ -68,6 +68,8 @@ const DIFF_FIELDS = [
   // Images (STAK-493: these were missing, causing silent data loss during sync)
   "obverseImageUrl",
   "reverseImageUrl",
+  "obverseImageFrame",
+  "reverseImageFrame",
   "obverseSharedImageId",
   "reverseSharedImageId",
   // Disposition

--- a/js/events.js
+++ b/js/events.js
@@ -364,18 +364,29 @@ const _setUrlPreviewGeneration = (side) => {
 const _getUrlPreviewGeneration = (side) =>
   side === "reverse" ? _urlPreviewGenRev : _urlPreviewGenObv;
 
+const _normalizeHttpImageUrl = (value = "") => {
+  const trimmed = value.trim();
+  if (!/^https?:\/\/.+\..+/i.test(trimmed)) return "";
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : "";
+  } catch {
+    return "";
+  }
+};
+
 const previewImageUrlForSide = (side = "obverse", url = "") => {
   const suffix = _frameSuffix(side);
   const preview = document.getElementById("itemImagePreview" + suffix);
   const img = document.getElementById("itemImagePreviewImg" + suffix);
   const removeBtn = document.getElementById("itemImageRemoveBtn" + suffix);
   const sizeInfo = document.getElementById("itemImageSizeInfo" + suffix);
-  const trimmed = (url || "").trim();
+  const imageUrl = _normalizeHttpImageUrl(url || "");
   const gen = _setUrlPreviewGeneration(side);
 
   if (!preview || !img) return;
 
-  if (!/^https?:\/\/.+\..+/i.test(trimmed)) {
+  if (!imageUrl) {
     preview.style.display = "none";
     img.removeAttribute("src");
     if (removeBtn) removeBtn.style.display = "none";
@@ -399,7 +410,7 @@ const previewImageUrlForSide = (side = "obverse", url = "") => {
     if (sizeInfo) sizeInfo.textContent = "Couldn't load image - check the URL";
     updateSwapButtonVisibility();
   };
-  img.src = trimmed;
+  img.src = imageUrl;
   preview.style.display = "block";
   if (removeBtn) removeBtn.style.display = "";
   if (sizeInfo) sizeInfo.textContent = "";

--- a/js/events.js
+++ b/js/events.js
@@ -240,6 +240,16 @@ let _deleteObverseOnSave = false;
 /** @type {boolean} User clicked Remove on reverse — delete on save */
 let _deleteReverseOnSave = false;
 
+/** @type {"auto"|"circle"|"rectangle"} Pending obverse frame override */
+let _pendingObverseFrame = "auto";
+/** @type {"auto"|"circle"|"rectangle"} Pending reverse frame override */
+let _pendingReverseFrame = "auto";
+/** @type {number} Obverse URL preview generation token */
+let _urlPreviewGenObv = 0;
+/** @type {number} Reverse URL preview generation token */
+let _urlPreviewGenRev = 0;
+const _urlPreviewTimers = { obverse: null, reverse: null };
+
 /** @type {{id:number, file:File}[]} Queued attachment entries — written to IDB on item commit (STRK-45, STRK-65) */
 let _pendingAttachments = [];
 let _pendingAttachmentNextId = 0;
@@ -306,6 +316,105 @@ const updateSwapButtonVisibility = () => {
   wrapper.classList.toggle("d-none", !bothVisible);
 };
 
+const _frameSuffix = (side) => (side === "reverse" ? "Rev" : "Obv");
+const _getPendingFrame = (side) =>
+  side === "reverse" ? _pendingReverseFrame : _pendingObverseFrame;
+const _setPendingFrame = (side, value) => {
+  const normalized =
+    typeof normalizeImageFrame === "function" ? normalizeImageFrame(value) : value || "auto";
+  if (side === "reverse") {
+    _pendingReverseFrame = normalized;
+  } else {
+    _pendingObverseFrame = normalized;
+  }
+};
+
+const _frameToggleLabel = (state) => {
+  if (state === "circle") return "Image frame: circle. Press to set rectangle.";
+  if (state === "rectangle") return "Image frame: rectangle. Press to reset to auto.";
+  return "Image frame: auto (default). Press to set circle.";
+};
+
+const _renderFrameToggle = (side = "obverse") => {
+  const suffix = _frameSuffix(side);
+  const button = document.getElementById("frameToggle" + suffix);
+  if (!button) return;
+  const state = _getPendingFrame(side);
+  const glyph = state === "circle" ? "\u25cb" : state === "rectangle" ? "\u25ad" : "A";
+  button.dataset.frameState = state;
+  button.setAttribute(
+    "aria-pressed",
+    state === "rectangle" ? "true" : state === "circle" ? "mixed" : "false"
+  );
+  button.setAttribute("aria-label", _frameToggleLabel(state));
+  const label = button.querySelector("span") || button;
+  label.textContent = glyph;
+};
+
+const renderFrameToggles = () => {
+  _renderFrameToggle("obverse");
+  _renderFrameToggle("reverse");
+};
+
+const _setUrlPreviewGeneration = (side) => {
+  if (side === "reverse") return ++_urlPreviewGenRev;
+  return ++_urlPreviewGenObv;
+};
+
+const _getUrlPreviewGeneration = (side) =>
+  side === "reverse" ? _urlPreviewGenRev : _urlPreviewGenObv;
+
+const previewImageUrlForSide = (side = "obverse", url = "") => {
+  const suffix = _frameSuffix(side);
+  const preview = document.getElementById("itemImagePreview" + suffix);
+  const img = document.getElementById("itemImagePreviewImg" + suffix);
+  const removeBtn = document.getElementById("itemImageRemoveBtn" + suffix);
+  const sizeInfo = document.getElementById("itemImageSizeInfo" + suffix);
+  const trimmed = (url || "").trim();
+  const gen = _setUrlPreviewGeneration(side);
+
+  if (!preview || !img) return;
+
+  if (!/^https?:\/\/.+\..+/i.test(trimmed)) {
+    preview.style.display = "none";
+    img.removeAttribute("src");
+    if (removeBtn) removeBtn.style.display = "none";
+    if (sizeInfo) sizeInfo.textContent = "";
+    updateSwapButtonVisibility();
+    return;
+  }
+
+  img.onload = () => {
+    if (gen !== _getUrlPreviewGeneration(side)) return;
+    preview.style.display = "block";
+    if (removeBtn) removeBtn.style.display = "";
+    if (sizeInfo) sizeInfo.textContent = "";
+    updateSwapButtonVisibility();
+  };
+  img.onerror = () => {
+    if (gen !== _getUrlPreviewGeneration(side)) return;
+    preview.style.display = "none";
+    img.removeAttribute("src");
+    if (removeBtn) removeBtn.style.display = "none";
+    if (sizeInfo) sizeInfo.textContent = "Couldn't load image - check the URL";
+    updateSwapButtonVisibility();
+  };
+  img.src = trimmed;
+  preview.style.display = "block";
+  if (removeBtn) removeBtn.style.display = "";
+  if (sizeInfo) sizeInfo.textContent = "";
+  updateSwapButtonVisibility();
+};
+
+const scheduleUrlPreview = (side = "obverse") => {
+  const field = side === "reverse" ? elements.itemReverseImageUrl : elements.itemObverseImageUrl;
+  if (!field) return;
+  if (_urlPreviewTimers[side]) clearTimeout(_urlPreviewTimers[side]);
+  _urlPreviewTimers[side] = setTimeout(() => {
+    previewImageUrlForSide(side, field.value);
+  }, 300);
+};
+
 /**
  * Track an externally-created preview object URL so it gets revoked
  * when clearUploadState() runs (prevents memory leaks in editItem preview).
@@ -330,6 +439,14 @@ const clearUploadState = () => {
   _pendingReverseBlob = null;
   _deleteObverseOnSave = false;
   _deleteReverseOnSave = false;
+  _pendingObverseFrame = "auto";
+  _pendingReverseFrame = "auto";
+  _urlPreviewGenObv++;
+  _urlPreviewGenRev++;
+  if (_urlPreviewTimers.obverse) clearTimeout(_urlPreviewTimers.obverse);
+  if (_urlPreviewTimers.reverse) clearTimeout(_urlPreviewTimers.reverse);
+  _urlPreviewTimers.obverse = null;
+  _urlPreviewTimers.reverse = null;
 
   if (_pendingObversePreviewUrl) {
     URL.revokeObjectURL(_pendingObversePreviewUrl);
@@ -369,6 +486,7 @@ const clearUploadState = () => {
   // Hide swap button (STAK-341)
   const swapWrapper = document.getElementById("swapImagesBtnWrapper");
   if (swapWrapper) swapWrapper.classList.add("d-none");
+  renderFrameToggles();
 
   // Reset pattern toggle state
   const patternToggle = document.getElementById("imagePatternToggle");
@@ -1332,6 +1450,8 @@ const parseItemFormFields = (isEditing, existingItem) => {
     marketValue,
     purity: parsePurity(isEditing, existingItem),
     currency: displayCurrency,
+    obverseImageFrame: _pendingObverseFrame,
+    reverseImageFrame: _pendingReverseFrame,
     obverseImageUrl: elements.itemObverseImageUrl?.value?.trim() ?? "",
     reverseImageUrl: elements.itemReverseImageUrl?.value?.trim() ?? "",
     ignorePatternImages: document.getElementById("itemIgnorePatternImages")?.checked || false,
@@ -1442,30 +1562,41 @@ const validateItemFields = (f) => {
  * @param {Object} f - Parsed fields from parseItemFormFields()
  * @returns {Object} Common item fields
  */
-const buildItemFields = (f) => ({
-  metal: f.metal,
-  composition: f.composition,
-  name: f.name,
-  qty: f.qty,
-  type: f.type,
-  weight: f.weight,
-  weightUnit: f.weightUnit,
-  price: f.price,
-  marketValue: f.marketValue,
-  date: f.date,
-  purchaseLocation: f.purchaseLocation,
-  storageLocation: f.storageLocation,
-  serialNumber: f.serialNumber,
-  notes: f.notes,
-  capsule: f.capsule,
-  capsuleNotes: f.capsuleNotes,
-  year: f.year,
-  grade: f.grade,
-  gradingAuthority: f.gradingAuthority,
-  certNumber: f.certNumber,
-  pcgsNumber: f.pcgsNumber,
-  purity: f.purity,
-});
+const buildItemFields = (f) => {
+  const fields = {
+    metal: f.metal,
+    composition: f.composition,
+    name: f.name,
+    qty: f.qty,
+    type: f.type,
+    weight: f.weight,
+    weightUnit: f.weightUnit,
+    price: f.price,
+    marketValue: f.marketValue,
+    date: f.date,
+    purchaseLocation: f.purchaseLocation,
+    storageLocation: f.storageLocation,
+    serialNumber: f.serialNumber,
+    notes: f.notes,
+    capsule: f.capsule,
+    capsuleNotes: f.capsuleNotes,
+    year: f.year,
+    grade: f.grade,
+    gradingAuthority: f.gradingAuthority,
+    certNumber: f.certNumber,
+    pcgsNumber: f.pcgsNumber,
+    purity: f.purity,
+  };
+
+  if (f.obverseImageFrame && f.obverseImageFrame !== "auto") {
+    fields.obverseImageFrame = f.obverseImageFrame;
+  }
+  if (f.reverseImageFrame && f.reverseImageFrame !== "auto") {
+    fields.reverseImageFrame = f.reverseImageFrame;
+  }
+
+  return fields;
+};
 
 /**
  * Commits a parsed item to inventory (add or edit mode).
@@ -1523,6 +1654,8 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       reverseSharedImageId: oldItem.reverseSharedImageId || null,
       ignorePatternImages: f.ignorePatternImages || false,
     };
+    if (f.obverseImageFrame === "auto") delete inventory[editIdx].obverseImageFrame;
+    if (f.reverseImageFrame === "auto") delete inventory[editIdx].reverseImageFrame;
 
     // Track user-modified fields by comparing old vs new values
     if (typeof window.markUserModified === "function") {
@@ -2140,6 +2273,7 @@ const setupItemFormListeners = () => {
       exitCloneMode();
       return;
     }
+    clearUploadState();
     // Dismiss any open autocomplete dropdowns (BUG-002/003)
     if (typeof dismissAllAutocompletes === "function") dismissAllAutocompletes();
     try {
@@ -2236,6 +2370,23 @@ const setupItemFormListeners = () => {
       const uploadBtn = document.getElementById("itemImageUploadBtn" + suffix);
       const cameraBtn = document.getElementById("itemImageCameraBtn" + suffix);
       const removeBtn = document.getElementById("itemImageRemoveBtn" + suffix);
+      const frameBtn = document.getElementById("frameToggle" + suffix);
+      const urlField =
+        side === "reverse" ? elements.itemReverseImageUrl : elements.itemObverseImageUrl;
+
+      if (frameBtn) {
+        frameBtn.addEventListener("click", () => {
+          _setPendingFrame(
+            side,
+            typeof cycleFrame === "function" ? cycleFrame(_getPendingFrame(side)) : "auto"
+          );
+          _renderFrameToggle(side);
+        });
+      }
+
+      if (urlField) {
+        urlField.addEventListener("input", () => scheduleUrlPreview(side));
+      }
 
       if (isMobile && isSecure && cameraBtn && fileInput) {
         cameraBtn.style.display = "";
@@ -2265,6 +2416,7 @@ const setupItemFormListeners = () => {
           if (side === "reverse") {
             _pendingReverseBlob = null;
             _deleteReverseOnSave = true;
+            _pendingReverseFrame = "auto";
             if (_pendingReversePreviewUrl) {
               URL.revokeObjectURL(_pendingReversePreviewUrl);
               _pendingReversePreviewUrl = null;
@@ -2272,6 +2424,7 @@ const setupItemFormListeners = () => {
           } else {
             _pendingObverseBlob = null;
             _deleteObverseOnSave = true;
+            _pendingObverseFrame = "auto";
             if (_pendingObversePreviewUrl) {
               URL.revokeObjectURL(_pendingObversePreviewUrl);
               _pendingObversePreviewUrl = null;
@@ -2292,6 +2445,7 @@ const setupItemFormListeners = () => {
           // STAK-332: Flag item to ignore pattern rule images after explicit removal
           const ignorePatternCheckbox = document.getElementById("itemIgnorePatternImages");
           if (ignorePatternCheckbox) ignorePatternCheckbox.checked = true;
+          _renderFrameToggle(side);
           updateSwapButtonVisibility();
 
           // STAK-244: Also clear Numista image cache if user is removing a catalog-synced image
@@ -2370,6 +2524,11 @@ const setupItemFormListeners = () => {
       _deleteObverseOnSave = _deleteReverseOnSave;
       _deleteReverseOnSave = tmpDel;
 
+      // Swap frame override state with the images it describes
+      const tmpFrame = _pendingObverseFrame;
+      _pendingObverseFrame = _pendingReverseFrame;
+      _pendingReverseFrame = tmpFrame;
+
       // Swap visible preview images
       const imgObv = document.getElementById("itemImagePreviewImgObv");
       const imgRev = document.getElementById("itemImagePreviewImgRev");
@@ -2402,6 +2561,7 @@ const setupItemFormListeners = () => {
       const fileRev = document.getElementById("itemImageFileRev");
       if (fileObv) fileObv.value = "";
       if (fileRev) fileRev.value = "";
+      renderFrameToggles();
     });
   }
 

--- a/js/events.js
+++ b/js/events.js
@@ -344,7 +344,7 @@ const _renderFrameToggle = (side = "obverse") => {
   button.dataset.frameState = state;
   button.setAttribute(
     "aria-pressed",
-    state === "rectangle" ? "true" : state === "circle" ? "mixed" : "false"
+    state === "rectangle" || state === "circle" ? "true" : "false"
   );
   button.setAttribute("aria-label", _frameToggleLabel(state));
   const label = button.querySelector("span") || button;
@@ -354,6 +354,12 @@ const _renderFrameToggle = (side = "obverse") => {
 const renderFrameToggles = () => {
   _renderFrameToggle("obverse");
   _renderFrameToggle("reverse");
+};
+
+const setPendingImageFrames = (obverse = "auto", reverse = "auto") => {
+  _setPendingFrame("obverse", obverse);
+  _setPendingFrame("reverse", reverse);
+  renderFrameToggles();
 };
 
 const _setUrlPreviewGeneration = (side) => {

--- a/js/image-frame.js
+++ b/js/image-frame.js
@@ -1,0 +1,69 @@
+"use strict";
+
+/**
+ * Normalize a stored per-side image frame value.
+ * @param {*} value
+ * @returns {"auto"|"circle"|"rectangle"}
+ */
+function normalizeImageFrame(value) {
+  return value === "circle" || value === "rectangle" ? value : "auto";
+}
+
+/**
+ * Return the next frame override value for the add/edit modal toggle.
+ * @param {*} value
+ * @returns {"auto"|"circle"|"rectangle"}
+ */
+function cycleFrame(value) {
+  const current = normalizeImageFrame(value);
+  if (current === "auto") return "circle";
+  if (current === "circle") return "rectangle";
+  return "auto";
+}
+
+/**
+ * Resolve the effective image frame for one item side.
+ * @param {Object|null|undefined} item
+ * @param {"obverse"|"reverse"} [side="obverse"]
+ * @returns {"round"|"rect"}
+ */
+function resolveImageFrame(item, side = "obverse") {
+  const record = item || {};
+  const frameKey = side === "reverse" ? "reverseImageFrame" : "obverseImageFrame";
+  const override = normalizeImageFrame(record[frameKey]);
+
+  if (override === "circle") return "round";
+  if (override === "rectangle") return "rect";
+
+  const itemType = String(record.type || "").toLowerCase();
+  const weightUnit = String(record.weightUnit || "").toLowerCase();
+  if (
+    itemType === "bar" ||
+    itemType === "note" ||
+    itemType === "aurum" ||
+    itemType === "set" ||
+    weightUnit === "gb" ||
+    weightUnit === "sb"
+  ) {
+    return "rect";
+  }
+
+  if (String(record.gradingAuthority || "").trim()) {
+    return "rect";
+  }
+
+  const rawShape = record.numistaData?.shape;
+  const shape =
+    typeof window !== "undefined" && typeof window.classifyShape === "function"
+      ? window.classifyShape(rawShape)
+      : typeof classifyShape === "function"
+        ? classifyShape(rawShape)
+        : String(rawShape || "round").toLowerCase();
+  return shape && shape !== "round" ? "rect" : "round";
+}
+
+if (typeof window !== "undefined") {
+  window.normalizeImageFrame = normalizeImageFrame;
+  window.cycleFrame = cycleFrame;
+  window.resolveImageFrame = resolveImageFrame;
+}

--- a/js/image-frame.js
+++ b/js/image-frame.js
@@ -53,12 +53,15 @@ function resolveImageFrame(item, side = "obverse") {
   }
 
   const rawShape = record.numistaData?.shape;
+  const rawShapeText = String(rawShape || "").toLowerCase();
   const shape =
     typeof window !== "undefined" && typeof window.classifyShape === "function"
       ? window.classifyShape(rawShape)
       : typeof classifyShape === "function"
         ? classifyShape(rawShape)
-        : String(rawShape || "round").toLowerCase();
+        : rawShapeText.startsWith("round") || rawShapeText.startsWith("circular")
+          ? "round"
+          : rawShapeText;
   return shape && shape !== "round" ? "rect" : "round";
 }
 

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -407,6 +407,7 @@
 
       const _tableImagesOnSetting = localStorage.getItem("tableImagesEnabled") !== "false";
       const _tableImageSidesSetting = localStorage.getItem("tableImageSides") || "both";
+      const hasImageFrameResolver = typeof resolveImageFrame === "function";
 
       for (let i = 0; i < sortedInventory.length; i++) {
         const item = sortedInventory[i];
@@ -510,7 +511,7 @@
             : "";
 
         const _thumbShapeClass = (side) =>
-          typeof resolveImageFrame === "function" && resolveImageFrame(item, side) === "rect"
+          hasImageFrameResolver && resolveImageFrame(item, side) === "rect"
             ? " table-thumb-rect"
             : "";
         const _validUrl = (u) => u && /^https?:\/\/.+\..+/i.test(u);

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -509,15 +509,10 @@
             ? `<span class="purity-tag" title="Purity: ${purityVal}" onclick="applyColumnFilter('purity', ${JSON.stringify(String(purityVal))})" tabindex="0" role="button" style="cursor:pointer;">${purityVal}</span>`
             : "";
 
-        const _thumbType = (item.type || "").toLowerCase();
-        const _isRectThumb =
-          _thumbType === "bar" ||
-          _thumbType === "note" ||
-          _thumbType === "aurum" ||
-          _thumbType === "set" ||
-          item.weightUnit === "gb" ||
-          item.weightUnit === "sb";
-        const _thumbShapeClass = _isRectThumb ? " table-thumb-rect" : "";
+        const _thumbShapeClass = (side) =>
+          typeof resolveImageFrame === "function" && resolveImageFrame(item, side) === "rect"
+            ? " table-thumb-rect"
+            : "";
         const _validUrl = (u) => u && /^https?:\/\/.+\..+/i.test(u);
         const obvUrl = _validUrl(item.obverseImageUrl) ? item.obverseImageUrl : "";
         const revUrl = _validUrl(item.reverseImageUrl) ? item.reverseImageUrl : "";
@@ -535,12 +530,12 @@
         const thumbHtml =
           _tableImagesOnSetting && featureFlags.isEnabled("COIN_IMAGES")
             ? (_showObv
-                ? `<img class="table-thumb${_thumbShapeClass}"${obvSrcAttr}
+                ? `<img class="table-thumb${_thumbShapeClass("obverse")}"${obvSrcAttr}
                  ${_sharedThumbAttrs} data-side="obverse"
                  alt="" loading="lazy" />`
                 : "") +
               (_showRev
-                ? `<img class="table-thumb${_thumbShapeClass}"${revSrcAttr}
+                ? `<img class="table-thumb${_thumbShapeClass("reverse")}"${revSrcAttr}
                  ${_sharedThumbAttrs} data-side="reverse"
                  alt="" loading="lazy" />`
                 : "")

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1449,13 +1449,9 @@ const editItem = (idx, logIdx = null) => {
 
   // Preload user images (obverse + reverse) into upload previews (STACK-32)
   if (typeof clearUploadState === "function") clearUploadState();
-  if (typeof _pendingObverseFrame !== "undefined") {
-    _pendingObverseFrame = item.obverseImageFrame || "auto";
+  if (typeof setPendingImageFrames === "function") {
+    setPendingImageFrames(item.obverseImageFrame, item.reverseImageFrame);
   }
-  if (typeof _pendingReverseFrame !== "undefined") {
-    _pendingReverseFrame = item.reverseImageFrame || "auto";
-  }
-  if (typeof renderFrameToggles === "function") renderFrameToggles();
 
   /**
    * Show a preview thumbnail for a given side.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1449,6 +1449,13 @@ const editItem = (idx, logIdx = null) => {
 
   // Preload user images (obverse + reverse) into upload previews (STACK-32)
   if (typeof clearUploadState === "function") clearUploadState();
+  if (typeof _pendingObverseFrame !== "undefined") {
+    _pendingObverseFrame = item.obverseImageFrame || "auto";
+  }
+  if (typeof _pendingReverseFrame !== "undefined") {
+    _pendingReverseFrame = item.reverseImageFrame || "auto";
+  }
+  if (typeof renderFrameToggles === "function") renderFrameToggles();
 
   /**
    * Show a preview thumbnail for a given side.
@@ -1470,10 +1477,18 @@ const editItem = (idx, logIdx = null) => {
   /** Fall back to image URL fields when no user-uploaded blob exists */
   const showUrlPreviewFallback = (loadedSides) => {
     if (!loadedSides.obverse && item.obverseImageUrl) {
-      showPreview(item.obverseImageUrl, "Obv", "obverse");
+      if (typeof previewImageUrlForSide === "function") {
+        previewImageUrlForSide("obverse", item.obverseImageUrl);
+      } else {
+        showPreview(item.obverseImageUrl, "Obv", "obverse");
+      }
     }
     if (!loadedSides.reverse && item.reverseImageUrl) {
-      showPreview(item.reverseImageUrl, "Rev", "reverse");
+      if (typeof previewImageUrlForSide === "function") {
+        previewImageUrlForSide("reverse", item.reverseImageUrl);
+      } else {
+        showPreview(item.reverseImageUrl, "Rev", "reverse");
+      }
     }
   };
 

--- a/js/types.js
+++ b/js/types.js
@@ -35,6 +35,8 @@
  * @property {string} uuid - Unique identifier for the item
  * @property {string} [obverseImageUrl] - URL for obverse image
  * @property {string} [reverseImageUrl] - URL for reverse image
+ * @property {"auto"|"circle"|"rectangle"} [obverseImageFrame] - Optional obverse image frame override
+ * @property {"auto"|"circle"|"rectangle"} [reverseImageFrame] - Optional reverse image frame override
  * @property {string|null} [obverseSharedImageId] - UUID of source item if obverse image was tagged from the shared library (null for original uploads)
  * @property {string|null} [reverseSharedImageId] - UUID of source item if reverse image was tagged from the shared library (null for original uploads)
  * @property {boolean} [collectable] - Whether item is marked as collectable

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -251,18 +251,14 @@ function _renderCountChip(item) {
 }
 
 function _buildImageSection(item, metrics) {
-  const itemType = (item.type || "").toLowerCase();
-  const isRectShape =
-    itemType === "bar" ||
-    itemType === "note" ||
-    itemType === "aurum" ||
-    itemType === "set" ||
-    metrics.isGb ||
-    metrics.isSb;
-  const imgSection = _el("div", "view-image-section" + (isRectShape ? " view-shape-rect" : ""));
+  const imgSection = _el("div", "view-image-section");
   imgSection.id = "viewImageSection";
-  imgSection.appendChild(_imageSlot("obverse", "Obverse"));
-  imgSection.appendChild(_imageSlot("reverse", "Reverse"));
+  const obverseSlot = _imageSlot("obverse", "Obverse");
+  const reverseSlot = _imageSlot("reverse", "Reverse");
+  _applyViewSlotFrame(obverseSlot, item, "obverse");
+  _applyViewSlotFrame(reverseSlot, item, "reverse");
+  imgSection.appendChild(obverseSlot);
+  imgSection.appendChild(reverseSlot);
   if (metrics.metalColor) {
     const surfaceDeep = getThemeColor("bg-primary") || "#1a1a2e";
     const surfaceDeeper = getThemeColor("bg-secondary") || "#16213e";
@@ -1170,14 +1166,20 @@ async function loadViewNumistaData(item, container, apiResult) {
   // Load user's field visibility config
   const cfg = typeof getNumistaViewFieldConfig === "function" ? getNumistaViewFieldConfig() : {};
 
-  // Update image frame shape based on Numista data if not already rectangular
+  // Update image frame shape after late Numista enrichment; use a two-way
+  // per-slot toggle so explicit circle overrides do not get stuck rectangular.
   if (merged.shape) {
-    const imgSection = container.querySelector("#viewImageSection");
-    const shapeStr = (typeof merged.shape === "string" ? merged.shape : "").toLowerCase();
-    const isNonRound = shapeStr !== "round" && shapeStr !== "circular";
-    if (isNonRound && imgSection && !imgSection.classList.contains("view-shape-rect")) {
-      imgSection.classList.add("view-shape-rect");
-    }
+    const enrichedItem = { ...item, numistaData: merged };
+    _applyViewSlotFrame(
+      container.querySelector('.view-image-slot[data-side="obverse"]'),
+      enrichedItem,
+      "obverse"
+    );
+    _applyViewSlotFrame(
+      container.querySelector('.view-image-slot[data-side="reverse"]'),
+      enrichedItem,
+      "reverse"
+    );
   }
 
   // Build Numista section — uses standard _section() for consistent styling
@@ -1944,6 +1946,13 @@ function _imageSlot(side, label) {
   slot.appendChild(lbl);
 
   return slot;
+}
+
+function _applyViewSlotFrame(slot, item, side) {
+  if (!slot) return;
+  const isRect =
+    typeof resolveImageFrame === "function" && resolveImageFrame(item, side) === "rect";
+  slot.classList.toggle("view-shape-rect", isRect);
 }
 
 /** Replace placeholder with actual image in a slot */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.56",
+  "version": "3.34.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.56",
+      "version": "3.34.57",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.56",
+  "version": "3.34.57",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445520";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445553";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445275";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445299";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445324";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445406";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445406";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445520";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445299";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445324";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445243";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445275";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.57-b1778447770";
+const CACHE_NAME = "staktrakr-v3.34.57-b1778455865";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =
@@ -58,6 +58,7 @@ const CORE_ASSETS = [
   "./js/sorting.js",
   "./js/pagination.js",
   "./js/detailsModal.js",
+  "./js/image-frame.js",
   "./js/viewModal.js",
   "./js/debugModal.js",
   "./js/numista-modal.js",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.57-b1778447303";
+const CACHE_NAME = "staktrakr-v3.34.57-b1778447502";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778445553";
+const CACHE_NAME = "staktrakr-v3.34.57-b1778447303";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.57-b1778447502";
+const CACHE_NAME = "staktrakr-v3.34.57-b1778447770";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.56-b1778383245";
+const CACHE_NAME = "staktrakr-v3.34.56-b1778445243";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/image-frame-override.spec.js
+++ b/tests/playwright/image-frame-override.spec.js
@@ -1,0 +1,197 @@
+import { test, expect } from "@playwright/test";
+
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGOSHzRgQAAAABJRU5ErkJggg==",
+  "base64"
+);
+
+const BASE_ITEM = {
+  uuid: "strk-67-frame-item",
+  metal: "Platinum",
+  composition: "Platinum",
+  name: "STRK-67 Frame Fixture",
+  qty: 1,
+  type: "Coin",
+  weight: 1,
+  weightUnit: "oz",
+  price: 100,
+  marketValue: 0,
+  date: "2026-05-10",
+  purchaseLocation: "StakTrakr",
+  storageLocation: "Safe",
+  serialNumber: "",
+  notes: "",
+  year: "2026",
+  grade: "",
+  gradingAuthority: "",
+  certNumber: "",
+  pcgsNumber: "",
+  pcgsVerified: false,
+  spotPriceAtPurchase: 100,
+  premiumPerOz: 0,
+  totalPremium: 0,
+  purity: 0.9995,
+  numistaId: "",
+  serial: 1,
+  obverseImageUrl: "https://images.example/obv.png",
+  reverseImageUrl: "https://images.example/rev.png",
+};
+
+async function seedInventory(page, items = [BASE_ITEM]) {
+  await page.addInitScript((inventory) => {
+    localStorage.setItem("metalInventory", JSON.stringify(inventory));
+    localStorage.setItem("itemTags", JSON.stringify({}));
+    localStorage.setItem("tableImagesEnabled", "true");
+    localStorage.setItem("tableImageSides", "both");
+    localStorage.setItem("cardViewStyle", "D");
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        if (typeof APP_VERSION !== "undefined") {
+          localStorage.setItem("ackVersion", APP_VERSION);
+        }
+      },
+      { once: true }
+    );
+  }, items);
+}
+
+async function routeImages(page) {
+  await page.route("https://images.example/**", (route) =>
+    route.fulfill({ status: 200, contentType: "image/png", body: TINY_PNG })
+  );
+}
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      typeof window.resolveImageFrame === "function" &&
+      typeof window.editItem === "function" &&
+      Array.isArray(window.inventory) &&
+      window.inventory.length > 0
+  );
+}
+
+test.describe("image frame overrides — STRK-67", () => {
+  test("resolver priority covers explicit overrides, existing rectangular rules, grading, Numista shape, and fallback", async ({
+    page,
+  }) => {
+    await seedInventory(page);
+    await gotoApp(page);
+
+    const results = await page.evaluate(() => {
+      const cases = [
+        {
+          name: "explicit circle wins",
+          item: {
+            type: "Bar",
+            gradingAuthority: "NGC",
+            obverseImageFrame: "circle",
+            numistaData: { shape: "rectangular" },
+          },
+        },
+        {
+          name: "explicit rectangle wins",
+          item: { type: "Coin", obverseImageFrame: "rectangle", numistaData: { shape: "round" } },
+        },
+        { name: "type rule", item: { type: "Note", numistaData: { shape: "round" } } },
+        { name: "weight unit rule", item: { type: "Coin", weightUnit: "gb" } },
+        { name: "grading rule", item: { type: "Coin", gradingAuthority: "PCGS" } },
+        { name: "Numista shape rule", item: { type: "Coin", numistaData: { shape: "oval" } } },
+        { name: "fallback", item: { type: "Coin", numistaData: { shape: "round" } } },
+      ];
+      return cases.map((entry) => [entry.name, window.resolveImageFrame(entry.item, "obverse")]);
+    });
+
+    expect(Object.fromEntries(results)).toEqual({
+      "explicit circle wins": "round",
+      "explicit rectangle wins": "rect",
+      "type rule": "rect",
+      "weight unit rule": "rect",
+      "grading rule": "rect",
+      "Numista shape rule": "rect",
+      fallback: "round",
+    });
+  });
+
+  test("table, card, and view modal render mixed per-side frames consistently", async ({
+    page,
+  }) => {
+    await seedInventory(page, [
+      {
+        ...BASE_ITEM,
+        obverseImageFrame: "rectangle",
+        reverseImageFrame: "circle",
+      },
+    ]);
+    await routeImages(page);
+    await gotoApp(page);
+
+    const tableObv = page.locator('#inventoryTable img.table-thumb[data-side="obverse"]').first();
+    const tableRev = page.locator('#inventoryTable img.table-thumb[data-side="reverse"]').first();
+    await expect(tableObv).toHaveClass(/table-thumb-rect/);
+    await expect(tableRev).not.toHaveClass(/table-thumb-rect/);
+
+    await page.evaluate(() => {
+      localStorage.setItem("cardViewStyle", "A");
+      window.renderTable();
+    });
+    const cardObv = page.locator('.coin-img:has(img[data-side="obverse"])').first();
+    const cardRev = page.locator('.coin-img:has(img[data-side="reverse"])').first();
+    await expect(cardObv).toHaveClass(/bar-shape/);
+    await expect(cardRev).not.toHaveClass(/bar-shape/);
+    await expect(cardObv.locator("img")).toHaveCSS("object-fit", "contain");
+    await expect(cardRev.locator("img")).toHaveCSS("object-fit", "cover");
+
+    await page.evaluate(() => window.showViewModal(0));
+    await expect(
+      page.locator('#viewImageSection .view-image-slot[data-side="obverse"]')
+    ).toHaveClass(/view-shape-rect/);
+    await expect(
+      page.locator('#viewImageSection .view-image-slot[data-side="reverse"]')
+    ).not.toHaveClass(/view-shape-rect/);
+  });
+
+  test("edit modal cycles, swaps, removes, previews URL images, and clears explicit overrides back to absent auto", async ({
+    page,
+  }) => {
+    await seedInventory(page);
+    await routeImages(page);
+    await gotoApp(page);
+
+    await page.evaluate(() => window.editItem(0));
+    await expect(page.locator("#itemModal")).toBeVisible();
+    await expect(page.locator("#itemImagePreviewObv")).toBeVisible();
+    await expect(page.locator("#itemImagePreviewRev")).toBeVisible();
+
+    const obvToggle = page.locator("#frameToggleObv");
+    const revToggle = page.locator("#frameToggleRev");
+    await obvToggle.click();
+    await obvToggle.click();
+    await revToggle.click();
+    await expect(obvToggle).toHaveAttribute("data-frame-state", "rectangle");
+    await expect(revToggle).toHaveAttribute("data-frame-state", "circle");
+
+    await page.locator("#swapImagesBtn").click();
+    await expect(obvToggle).toHaveAttribute("data-frame-state", "circle");
+    await expect(revToggle).toHaveAttribute("data-frame-state", "rectangle");
+
+    await page.locator("#itemImageRemoveBtnRev").click();
+    await expect(revToggle).toHaveAttribute("data-frame-state", "auto");
+
+    await page.locator("#itemModalSubmit").click();
+    await expect(page.locator("#itemModal")).toBeHidden();
+    expect(await page.evaluate(() => window.inventory[0].obverseImageFrame)).toBe("circle");
+    expect(await page.evaluate(() => window.inventory[0].reverseImageFrame)).toBeUndefined();
+
+    await page.evaluate(() => window.editItem(0));
+    await expect(obvToggle).toHaveAttribute("data-frame-state", "circle");
+    await obvToggle.click();
+    await obvToggle.click();
+    await expect(obvToggle).toHaveAttribute("data-frame-state", "auto");
+    await page.locator("#itemModalSubmit").click();
+    await expect(page.locator("#itemModal")).toBeHidden();
+    expect(await page.evaluate(() => "obverseImageFrame" in window.inventory[0])).toBe(false);
+  });
+});

--- a/tests/playwright/image-frame-override.spec.js
+++ b/tests/playwright/image-frame-override.spec.js
@@ -99,6 +99,10 @@ test.describe("image frame overrides — STRK-67", () => {
         { name: "weight unit rule", item: { type: "Coin", weightUnit: "gb" } },
         { name: "grading rule", item: { type: "Coin", gradingAuthority: "PCGS" } },
         { name: "Numista shape rule", item: { type: "Coin", numistaData: { shape: "oval" } } },
+        {
+          name: "circular Numista shape fallback",
+          item: { type: "Coin", numistaData: { shape: "circular" } },
+        },
         { name: "fallback", item: { type: "Coin", numistaData: { shape: "round" } } },
       ];
       return cases.map((entry) => [entry.name, window.resolveImageFrame(entry.item, "obverse")]);
@@ -111,6 +115,7 @@ test.describe("image frame overrides — STRK-67", () => {
       "weight unit rule": "rect",
       "grading rule": "rect",
       "Numista shape rule": "rect",
+      "circular Numista shape fallback": "round",
       fallback: "round",
     });
   });

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.56",
+  "version": "3.34.57",
   "releaseDate": "2026-05-10",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Adds per-side image frame overrides (`auto`, `circle`, `rectangle`) for obverse/reverse images.
- Applies one shared resolver across inventory table, card grid, and item view modal.
- Adds live URL preview behavior so URL-pasted slab images can be overridden before save/reopen.
- Bumps StakTrakr to v3.34.57.

Issue: https://plane.lbruton.cc/lbruton/browse/STRK-67/
Sketch: `DocVault/Projects/StakTrakr/sketches/STRK-67-image-frame-override/`

## Test Plan

- [x] AC-1 manual override forces circle
- [x] AC-2 manual override forces rectangle
- [x] AC-3 auto resolves rectangle for bar/note/aurum/set and Goldback/Silverback units
- [x] AC-4 auto resolves rectangle for graded coins
- [x] AC-5 auto resolves rectangle for non-round Numista shape
- [x] AC-6 auto fallback remains round
- [x] AC-7 add/edit modal toggle cycles and persists
- [x] AC-8 toggle hidden when slot is empty
- [x] AC-9 toggle appears only in add/edit modal
- [x] AC-10 absent fields remain canonical auto defaults
- [x] AC-11 table/card/view modal stay per-side consistent
- [x] AC-12 frame values round-trip through exported/restored data
- [x] AC-13 swap moves frame values with image data
- [x] AC-14 URL-pasted images show live preview and expose the toggle
- [x] AC-15 remove resets frame state to auto

## Validation

- [x] `npm run lint` passed with two pre-existing unused-disable warnings in `js/diff-engine.js` and `js/diff-modal.js`.
- [x] `npx playwright test tests/playwright/image-frame-override.spec.js --reporter=list` passed: 3/3.
- [x] Focused `tests/playwright/theme-tokens.spec.js:20` passed, including `--repeat-each=5`.
- [ ] Full `npm test` was run twice and failed one full-suite-only sentinel: `tests/playwright/theme-tokens.spec.js:20`; each run had 588 passing tests and 1 failure. The focused sentinel passes, so this draft keeps the caveat visible for review.
- [x] `codacy-cli` attempted on changed files: Opengrep 0 findings; Trivy wrapper rejected multiple targets; generated ESLint config produced browser-global `no-undef` noise, no actionable changed-file finding identified locally.
- [x] Spot bundle checked with `SQLD_URL=http://192.168.1.81:8080`; data already current through 2026-05-10, no diff produced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for v3.34.57

* **New Features**
  * Added per-side image frame override controls enabling users to customize image shapes (Auto, Circle, Rectangle) for obverse and reverse images during editing, with consistent application across upload previews, thumbnails, view modal, change history, and backups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1099)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->