### PR TITLE
v3.34.59 — STRK-69: fix Goldback daily retail charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.59] - 2026-05-11
+
+### Fixed — STRK-69: Goldback daily retail chart history
+
+- **Goldback history**: Store one Goldback denomination history row per calendar day even when the vendor price is unchanged, so flat weekend pricing still appears as daily chart points (STRK-69).
+- **Item detail charts**: Use Goldback denomination retail history and current denomination valuation in the item detail modal when item `marketValue` is empty, falling back to melt only when denomination pricing is unavailable (STRK-69).
+
+---
+
 ## [3.34.58] - 2026-05-11
 
 ### Changed — STRK-42: Chart viewport scaling

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.59 &ndash; STRK-69: Goldback daily retail chart history</strong>: Goldback denomination prices now keep one retail-history point per calendar day even when the vendor price is flat, and item detail charts use denomination retail values when stored market value is empty (STRK-69).</li>
     <li><strong>v3.34.58 &ndash; STRK-42: Chart viewport scaling</strong>: Item detail charts now fit the y-axis to visible purchase, melt, and retail lines with padding, fetch only needed bounded-range history, and keep sparse 1Y ranges anchored at the viewport start (STRK-42).</li>
     <li><strong>v3.34.57 &ndash; STRK-67: Per-side image frame override</strong>: Add Auto/Circle/Rectangle frame controls for obverse and reverse images so rectangular slabs, bars, notes, and similar media can be corrected while default shape detection stays automatic (STRK-67).</li>
     <li><strong>v3.34.56 &ndash; STRK-65: Attachment review follow-ups</strong>: Hardens per-item attachments after PR review &mdash; queue entries removable independently, object URL lifecycle fixed, cloud-sync pull helper extracted (fixes repeat downloads), size guard before vault serialization, DiffEngine duplicate-filename safety, split items keep attachments on both records, storage diagnostics clarified (STRK-65).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,10 +281,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-04-29 - STRK-13: Inventory seed guard prevents data loss
+ * Updated: 2026-05-11 - STRK-69: Goldback daily retail chart history
  */
 
-const APP_VERSION = "3.34.58";
+const APP_VERSION = "3.34.59";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -46,7 +46,12 @@ const getBreakdownData = (metal) => {
     const purchaseTotal = valuation ? valuation.purchaseTotal : qty * purchasePrice;
     const purity = parseFloat(item.purity) || 1.0;
     const meltValue = valuation ? valuation.meltValue : itemWeight * currentSpot * purity;
-    const retailTotal = valuation ? valuation.retailTotal : meltValue;
+    const manualMarket = parseFloat(item.marketValue) || 0;
+    const retailTotal = valuation
+      ? valuation.retailTotal
+      : manualMarket > 0
+        ? qty * manualMarket
+        : meltValue;
     const gainLoss = valuation?.gainLoss ?? retailTotal - purchaseTotal;
 
     // Type breakdown
@@ -108,7 +113,12 @@ const getAllMetalsBreakdownData = () => {
       typeof computeItemValuation === "function" ? computeItemValuation(item, currentSpot) : null;
     const purity = parseFloat(item.purity) || 1.0;
     const meltValue = valuation ? valuation.meltValue : itemWeight * currentSpot * purity;
-    const retailTotal = valuation ? valuation.retailTotal : meltValue;
+    const manualMarket = parseFloat(item.marketValue) || 0;
+    const retailTotal = valuation
+      ? valuation.retailTotal
+      : manualMarket > 0
+        ? qty * manualMarket
+        : meltValue;
     const gainLoss = valuation?.gainLoss ?? retailTotal - purchaseTotal;
 
     // Metal breakdown

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -40,20 +40,14 @@ const getBreakdownData = (metal) => {
           ? weight * (typeof SB_TO_OZT !== "undefined" ? SB_TO_OZT : GB_TO_OZT)
           : weight;
     const itemWeight = qty * weightOz;
+    const valuation =
+      typeof computeItemValuation === "function" ? computeItemValuation(item, currentSpot) : null;
     const purchasePrice = parseFloat(item.price) || 0;
-    const purchaseTotal = qty * purchasePrice;
+    const purchaseTotal = valuation ? valuation.purchaseTotal : qty * purchasePrice;
     const purity = parseFloat(item.purity) || 1.0;
-    const meltValue = itemWeight * currentSpot * purity;
-    const gbDenomPrice =
-      typeof getGoldbackRetailPrice === "function" ? getGoldbackRetailPrice(item) : null;
-    const rawMarket = parseFloat(item.marketValue) || 0;
-    const isManualRetail = !gbDenomPrice && rawMarket > 0;
-    const retailTotal = gbDenomPrice
-      ? gbDenomPrice * qty
-      : isManualRetail
-        ? rawMarket * qty
-        : meltValue;
-    const gainLoss = retailTotal - purchaseTotal;
+    const meltValue = valuation ? valuation.meltValue : itemWeight * currentSpot * purity;
+    const retailTotal = valuation ? valuation.retailTotal : meltValue;
+    const gainLoss = valuation?.gainLoss ?? retailTotal - purchaseTotal;
 
     // Type breakdown
     if (!typeBreakdown[item.type]) typeBreakdown[item.type] = initBucket();
@@ -110,18 +104,12 @@ const getAllMetalsBreakdownData = () => {
     const purchasePrice = parseFloat(item.price) || 0;
     const purchaseTotal = qty * purchasePrice;
     const currentSpot = spotPrices[item.metal.toLowerCase()] || 0;
+    const valuation =
+      typeof computeItemValuation === "function" ? computeItemValuation(item, currentSpot) : null;
     const purity = parseFloat(item.purity) || 1.0;
-    const meltValue = itemWeight * currentSpot * purity;
-    const gbDenomPrice =
-      typeof getGoldbackRetailPrice === "function" ? getGoldbackRetailPrice(item) : null;
-    const rawMv2 = parseFloat(item.marketValue) || 0;
-    const isManualRetail = !gbDenomPrice && rawMv2 > 0;
-    const retailTotal = gbDenomPrice
-      ? gbDenomPrice * qty
-      : isManualRetail
-        ? rawMv2 * qty
-        : meltValue;
-    const gainLoss = retailTotal - purchaseTotal;
+    const meltValue = valuation ? valuation.meltValue : itemWeight * currentSpot * purity;
+    const retailTotal = valuation ? valuation.retailTotal : meltValue;
+    const gainLoss = valuation?.gainLoss ?? retailTotal - purchaseTotal;
 
     // Metal breakdown
     const metal = item.metal || "Unknown";

--- a/js/goldback.js
+++ b/js/goldback.js
@@ -121,7 +121,38 @@ const loadGoldbackPriceHistory = () => {
   }
 };
 
-const getGoldbackHistoryDay = (ts) => new Date(ts).toISOString().slice(0, 10);
+const GOLDBACK_HISTORY_DAY_MS = 24 * 60 * 60 * 1000;
+
+const getGoldbackHistoryDay = (ts) => {
+  const date = new Date(ts);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);
+};
+
+const getGoldbackHistoryDayIndexFromDay = (day) => {
+  if (typeof day !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(day)) return null;
+
+  const ts = new Date(`${day}T00:00:00Z`).getTime();
+  if (Number.isNaN(ts) || getGoldbackHistoryDay(ts) !== day) return null;
+
+  return ts / GOLDBACK_HISTORY_DAY_MS;
+};
+
+const getGoldbackHistoryDayIndex = (dateLike) => {
+  const day =
+    typeof dateLike === "string" && /^\d{4}-\d{2}-\d{2}/.test(dateLike)
+      ? dateLike.slice(0, 10)
+      : getGoldbackHistoryDay(dateLike);
+  return getGoldbackHistoryDayIndexFromDay(day);
+};
+
+const sortGoldbackHistoryEntries = (key) => {
+  const entries = goldbackPriceHistory[key];
+  if (Array.isArray(entries)) entries.sort((a, b) => a.ts - b.ts);
+};
+
+const sortGoldbackHistoryKeys = (keys) => {
+  keys.forEach((key) => sortGoldbackHistoryEntries(key));
+};
 
 const getGoldbackHistoryPrice = (weightGb, dateLike) => {
   const key = String(parseFloat(weightGb) || 0);
@@ -144,22 +175,25 @@ const getGoldbackHistoryPrice = (weightGb, dateLike) => {
 const searchGoldbackHistoryByDate = (weightGb, dateStr) => {
   const key = String(parseFloat(weightGb) || 0);
   const entries = Array.isArray(goldbackPriceHistory[key]) ? goldbackPriceHistory[key] : [];
-  const targetDate = new Date(`${dateStr}T00:00:00`);
-  if (Number.isNaN(targetDate.getTime())) return [];
+  const targetDayIndex = getGoldbackHistoryDayIndex(dateStr);
+  if (targetDayIndex === null) return [];
 
   const withOffset = entries
     .filter((entry) => entry && typeof entry.price === "number" && entry.price > 0 && entry.ts)
     .map((entry) => {
       const entryDate = new Date(entry.ts);
-      const diffMs = entryDate.getTime() - targetDate.getTime();
+      const entryDayIndex = getGoldbackHistoryDayIndex(entry.ts);
+      if (entryDayIndex === null) return null;
+
       return {
         timestamp: entryDate.toISOString(),
         price: entry.price,
         source: entry.source || "goldback",
         provider: entry.provider || "Goldback",
-        dayOffset: Math.round(diffMs / (1000 * 60 * 60 * 24)),
+        dayOffset: entryDayIndex - targetDayIndex,
       };
-    });
+    })
+    .filter(Boolean);
 
   const windows = [0, 1, 3, 7];
   let results = [];
@@ -182,7 +216,7 @@ const searchGoldbackHistoryByDate = (weightGb, dateStr) => {
   return [...byDay.values()];
 };
 
-const upsertGoldbackHistoryEntry = (key, entry) => {
+const upsertGoldbackHistoryEntry = (key, entry, options = {}) => {
   if (!entry || typeof entry.price !== "number" || entry.price <= 0 || !entry.ts) return false;
 
   if (!goldbackPriceHistory[key]) {
@@ -196,12 +230,13 @@ const upsertGoldbackHistoryEntry = (key, entry) => {
   if (existingIdx >= 0) {
     const existing = arr[existingIdx];
     if (existing.price === entry.price && existing.source === entry.source) return false;
+    if (existing.source === "manual" && entry.source !== "manual") return false;
     arr[existingIdx] = { ...existing, ...entry };
   } else {
     arr.push(entry);
   }
 
-  arr.sort((a, b) => a.ts - b.ts);
+  if (options.sort !== false) sortGoldbackHistoryEntries(key);
   return true;
 };
 
@@ -233,17 +268,28 @@ const saveGoldbackEnabled = (val) => {
 const recordGoldbackPrices = () => {
   const now = Date.now();
   let changed = false;
+  const changedKeys = new Set();
 
   for (const key of Object.keys(goldbackPrices)) {
     const entry = goldbackPrices[key];
     if (!entry || typeof entry.price !== "number" || entry.price <= 0) continue;
 
-    changed =
-      upsertGoldbackHistoryEntry(key, { ts: now, price: entry.price, source: entry.source }) ||
-      changed;
+    const source = entry.source || (goldbackPricingSource === "manual" ? "manual" : undefined);
+    const didChange = upsertGoldbackHistoryEntry(
+      key,
+      { ts: now, price: entry.price, source },
+      { sort: false }
+    );
+    if (didChange) {
+      changed = true;
+      changedKeys.add(key);
+    }
   }
 
-  if (changed) saveGoldbackPriceHistory();
+  if (changed) {
+    sortGoldbackHistoryKeys(changedKeys);
+    saveGoldbackPriceHistory();
+  }
 };
 
 /**
@@ -447,6 +493,7 @@ const fetchGoldbackApiHistory = async (baseEndpoint) => {
     const envelope = await res.json();
     const rows = Array.isArray(envelope?.data) ? envelope.data : [];
     let changed = false;
+    const changedKeys = new Set();
 
     for (const row of rows) {
       const g1 =
@@ -470,11 +517,22 @@ const fetchGoldbackApiHistory = async (baseEndpoint) => {
       for (const d of GOLDBACK_DENOMINATIONS) {
         const key = String(d.weight);
         const price = Math.round(g1 * d.weight * 100) / 100;
-        changed = upsertGoldbackHistoryEntry(key, { ts, price, source: "api" }) || changed;
+        const didChange = upsertGoldbackHistoryEntry(
+          key,
+          { ts, price, source: "api" },
+          { sort: false }
+        );
+        if (didChange) {
+          changed = true;
+          changedKeys.add(key);
+        }
       }
     }
 
-    if (changed) saveGoldbackPriceHistory();
+    if (changed) {
+      sortGoldbackHistoryKeys(changedKeys);
+      saveGoldbackPriceHistory();
+    }
     return changed;
   } catch (error) {
     clearTimeout(tid);

--- a/js/goldback.js
+++ b/js/goldback.js
@@ -121,6 +121,31 @@ const loadGoldbackPriceHistory = () => {
   }
 };
 
+const getGoldbackHistoryDay = (ts) => new Date(ts).toISOString().slice(0, 10);
+
+const upsertGoldbackHistoryEntry = (key, entry) => {
+  if (!entry || typeof entry.price !== "number" || entry.price <= 0 || !entry.ts) return false;
+
+  if (!goldbackPriceHistory[key]) {
+    goldbackPriceHistory[key] = [];
+  }
+
+  const arr = goldbackPriceHistory[key];
+  const day = getGoldbackHistoryDay(entry.ts);
+  const existingIdx = arr.findIndex((candidate) => getGoldbackHistoryDay(candidate.ts) === day);
+
+  if (existingIdx >= 0) {
+    const existing = arr[existingIdx];
+    if (existing.price === entry.price && existing.source === entry.source) return false;
+    arr[existingIdx] = { ...existing, ...entry };
+  } else {
+    arr.push(entry);
+  }
+
+  arr.sort((a, b) => a.ts - b.ts);
+  return true;
+};
+
 /**
  * Loads the Goldback pricing enabled toggle from localStorage.
  */
@@ -148,24 +173,18 @@ const saveGoldbackEnabled = (val) => {
  */
 const recordGoldbackPrices = () => {
   const now = Date.now();
+  let changed = false;
 
   for (const key of Object.keys(goldbackPrices)) {
     const entry = goldbackPrices[key];
     if (!entry || typeof entry.price !== "number" || entry.price <= 0) continue;
 
-    if (!goldbackPriceHistory[key]) {
-      goldbackPriceHistory[key] = [];
-    }
-
-    // Skip exact duplicate of last entry
-    const arr = goldbackPriceHistory[key];
-    const last = arr.length > 0 ? arr[arr.length - 1] : null;
-    if (last && last.price === entry.price) continue;
-
-    arr.push({ ts: now, price: entry.price });
+    changed =
+      upsertGoldbackHistoryEntry(key, { ts: now, price: entry.price, source: entry.source }) ||
+      changed;
   }
 
-  saveGoldbackPriceHistory();
+  if (changed) saveGoldbackPriceHistory();
 };
 
 /**
@@ -302,6 +321,7 @@ const fetchGoldbackApiPrices = async (options = {}) => {
 
   let envelope;
   let lastErr;
+  let usedEndpoint;
   for (const ep of v2Endpoints) {
     const url = `${ep}/goldback/latest.json`;
     const ctrl = new AbortController();
@@ -311,6 +331,7 @@ const fetchGoldbackApiPrices = async (options = {}) => {
       clearTimeout(tid);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       envelope = await res.json();
+      usedEndpoint = ep;
       break;
     } catch (err) {
       clearTimeout(tid);
@@ -344,10 +365,63 @@ const fetchGoldbackApiPrices = async (options = {}) => {
   }
 
   if (typeof saveGoldbackPrices === "function") saveGoldbackPrices();
+  if (usedEndpoint) await fetchGoldbackApiHistory(usedEndpoint);
   if (typeof recordGoldbackPrices === "function") recordGoldbackPrices();
   if (typeof syncGoldbackSettingsUI === "function") syncGoldbackSettingsUI();
 
   return { ok: true, g1_usd: g1 };
+};
+
+const fetchGoldbackApiHistory = async (baseEndpoint) => {
+  if (!baseEndpoint || typeof GOLDBACK_DENOMINATIONS === "undefined") return false;
+
+  const ctrl = new AbortController();
+  const tid = setTimeout(() => ctrl.abort(), 5000);
+  try {
+    const res = await fetch(`${baseEndpoint}/goldback/history-30d.json`, {
+      cache: "no-store",
+      signal: ctrl.signal,
+    });
+    clearTimeout(tid);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const envelope = await res.json();
+    const rows = Array.isArray(envelope?.data) ? envelope.data : [];
+    let changed = false;
+
+    for (const row of rows) {
+      const g1 =
+        typeof row.close === "number"
+          ? row.close
+          : typeof row.avg === "number"
+            ? row.avg
+            : typeof row.g1_usd === "number"
+              ? row.g1_usd
+              : null;
+      if (!g1 || g1 <= 0) continue;
+
+      const ts =
+        typeof row.t === "string"
+          ? new Date(row.t).getTime()
+          : typeof row.ts === "number"
+            ? row.ts * (row.ts < 1000000000000 ? 1000 : 1)
+            : 0;
+      if (!ts || Number.isNaN(ts)) continue;
+
+      for (const d of GOLDBACK_DENOMINATIONS) {
+        const key = String(d.weight);
+        const price = Math.round(g1 * d.weight * 100) / 100;
+        changed = upsertGoldbackHistoryEntry(key, { ts, price, source: "api" }) || changed;
+      }
+    }
+
+    if (changed) saveGoldbackPriceHistory();
+    return changed;
+  } catch (error) {
+    clearTimeout(tid);
+    console.warn("Goldback API history fetch failed:", error);
+    return false;
+  }
 };
 
 /**

--- a/js/goldback.js
+++ b/js/goldback.js
@@ -123,6 +123,65 @@ const loadGoldbackPriceHistory = () => {
 
 const getGoldbackHistoryDay = (ts) => new Date(ts).toISOString().slice(0, 10);
 
+const getGoldbackHistoryPrice = (weightGb, dateLike) => {
+  const key = String(parseFloat(weightGb) || 0);
+  const entries = Array.isArray(goldbackPriceHistory[key]) ? goldbackPriceHistory[key] : [];
+  const ts =
+    typeof dateLike === "number"
+      ? dateLike
+      : typeof dateLike === "string" && /^\d{4}-\d{2}-\d{2}/.test(dateLike)
+        ? new Date(`${dateLike.slice(0, 10)}T12:00:00Z`).getTime()
+        : new Date(dateLike).getTime();
+  if (!ts || Number.isNaN(ts)) return null;
+
+  const day = getGoldbackHistoryDay(ts);
+  const entry = [...entries]
+    .reverse()
+    .find((candidate) => candidate?.ts && getGoldbackHistoryDay(candidate.ts) === day);
+  return entry && typeof entry.price === "number" && entry.price > 0 ? entry.price : null;
+};
+
+const searchGoldbackHistoryByDate = (weightGb, dateStr) => {
+  const key = String(parseFloat(weightGb) || 0);
+  const entries = Array.isArray(goldbackPriceHistory[key]) ? goldbackPriceHistory[key] : [];
+  const targetDate = new Date(`${dateStr}T00:00:00`);
+  if (Number.isNaN(targetDate.getTime())) return [];
+
+  const withOffset = entries
+    .filter((entry) => entry && typeof entry.price === "number" && entry.price > 0 && entry.ts)
+    .map((entry) => {
+      const entryDate = new Date(entry.ts);
+      const diffMs = entryDate.getTime() - targetDate.getTime();
+      return {
+        timestamp: entryDate.toISOString(),
+        price: entry.price,
+        source: entry.source || "goldback",
+        provider: entry.provider || "Goldback",
+        dayOffset: Math.round(diffMs / (1000 * 60 * 60 * 24)),
+      };
+    });
+
+  const windows = [0, 1, 3, 7];
+  let results = [];
+  for (const window of windows) {
+    results = withOffset.filter((entry) => Math.abs(entry.dayOffset) <= window);
+    if (results.length > 0) break;
+  }
+
+  results.sort((a, b) => {
+    const proxDiff = Math.abs(a.dayOffset) - Math.abs(b.dayOffset);
+    if (proxDiff !== 0) return proxDiff;
+    return new Date(b.timestamp) - new Date(a.timestamp);
+  });
+
+  const byDay = new Map();
+  for (const entry of results) {
+    const day = entry.timestamp.slice(0, 10);
+    if (!byDay.has(day)) byDay.set(day, entry);
+  }
+  return [...byDay.values()];
+};
+
 const upsertGoldbackHistoryEntry = (key, entry) => {
   if (!entry || typeof entry.price !== "number" || entry.price <= 0 || !entry.ts) return false;
 
@@ -638,6 +697,8 @@ if (typeof window !== "undefined") {
   window.saveGoldbackEnabled = saveGoldbackEnabled;
   window.recordGoldbackPrices = recordGoldbackPrices;
   window.getGoldbackDenominationPrice = getGoldbackDenominationPrice;
+  window.getGoldbackHistoryPrice = getGoldbackHistoryPrice;
+  window.searchGoldbackHistoryByDate = searchGoldbackHistoryByDate;
   window.isGoldbackPricingActive = isGoldbackPricingActive;
   window.fetchGoldbackApiPrices = fetchGoldbackApiPrices;
   window.getGoldbackVendorPrice = getGoldbackVendorPrice;

--- a/js/inventory-table.js
+++ b/js/inventory-table.js
@@ -611,7 +611,7 @@
         </a>
       </td>
       <td class="shrink" data-column="meltValue" data-label="Melt" title="Melt Value (${displayCurrency})" style="color: var(--text-primary);">${meltDisplay}</td>
-      <td class="shrink ${gbDenomPrice ? "retail-confirmed" : isManualRetail ? "retail-confirmed" : "retail-estimated"}" data-column="retailPrice" data-label="Retail" title="${gbDenomPrice ? "Goldback denomination price" : isManualRetail ? "Manual retail price (confirmed)" : "Estimated — defaults to melt value"} - Click to search eBay sold listings">
+      <td class="shrink ${gbDenomPrice || isManualRetail ? "retail-confirmed" : "retail-estimated"}" data-column="retailPrice" data-label="Retail" title="${isManualRetail ? "Manual retail price (confirmed)" : gbDenomPrice ? "Goldback denomination price" : "Estimated — defaults to melt value"} - Click to search eBay sold listings">
         <a href="#" class="ebay-sold-link ebay-price-link" data-search="${escapeAttribute(item.metal + (item.year ? " " + item.year : "") + " " + item.name)}" title="Search eBay sold listings for ${escapeAttribute(item.metal)} ${escapeAttribute(item.name)}">
           ${retailDisplay} <svg class="ebay-search-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="10.5" cy="10.5" r="6" fill="none" stroke="currentColor" stroke-width="2.5"/><line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
         </a>

--- a/js/priceHistory.js
+++ b/js/priceHistory.js
@@ -93,12 +93,14 @@ const recordItemPrice = (item, trigger = "spot-sync") => {
   const spot = spotPrices[metalKey] || 0;
   const melt = parseFloat(computeMeltValue(item, spot).toFixed(2));
 
-  // Retail hierarchy: (1) Goldback denomination price, (2) manual marketValue, (3) 0
-  // Must match the 3-tier lookup used by table renderer, CSV/PDF export, and details modal
+  // Retail hierarchy: max(Goldback denomination price, manual marketValue), then 0.
+  // Must match the lookup used by table renderer, CSV/PDF export, and details modal.
   const gbDenomPrice =
     typeof getGoldbackRetailPrice === "function" ? getGoldbackRetailPrice(item) : null;
   const rawMarket = item.marketValue && item.marketValue > 0 ? parseFloat(item.marketValue) : 0;
-  const retail = gbDenomPrice ? parseFloat(gbDenomPrice.toFixed(2)) : rawMarket;
+  const retail = gbDenomPrice
+    ? parseFloat(Math.max(gbDenomPrice, rawMarket).toFixed(2))
+    : rawMarket;
   const now = Date.now();
 
   // Initialize array for this UUID if needed

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -67,27 +67,24 @@ const sortInventory = (data = inventory) => {
         val = computeMeltValue(item, spot);
         break;
       case 9: {
-        // Retail Price (gbDenom → marketValue → melt, matching render logic)
-        const qty = Number(item.qty) || 1;
-        const gb =
-          typeof getGoldbackRetailPrice === "function" ? getGoldbackRetailPrice(item) : null;
-        val = gb
-          ? gb * qty
-          : item.marketValue && item.marketValue > 0
-            ? item.marketValue * qty
-            : computeMeltValue(item, spot);
+        // Retail Price (max Goldback denomination/manual → melt, matching render logic)
+        val =
+          typeof calculateRetailPrice === "function"
+            ? calculateRetailPrice(item, spot).retailTotal
+            : item.marketValue && item.marketValue > 0
+              ? item.marketValue * (Number(item.qty) || 1)
+              : computeMeltValue(item, spot);
         break;
       }
       case 10: {
         // Gain/Loss (computed, qty-adjusted, matching render logic)
         const qty = Number(item.qty) || 1;
-        const gb =
-          typeof getGoldbackRetailPrice === "function" ? getGoldbackRetailPrice(item) : null;
-        const retail = gb
-          ? gb * qty
-          : item.marketValue && item.marketValue > 0
-            ? item.marketValue * qty
-            : computeMeltValue(item, spot);
+        const retail =
+          typeof calculateRetailPrice === "function"
+            ? calculateRetailPrice(item, spot).retailTotal
+            : item.marketValue && item.marketValue > 0
+              ? item.marketValue * qty
+              : computeMeltValue(item, spot);
         val = retail - (parseFloat(item.price) || 0) * qty;
         break;
       }

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -13,6 +13,20 @@ const METAL_SYMBOLS = {
 
 let _spotLookupTargetField = "purchase";
 
+const _spotLookupModalRefs = {
+  title: null,
+  body: null,
+};
+
+const getSpotLookupModalRef = (key, id) => {
+  const cached = _spotLookupModalRefs[key];
+  if (cached?.isConnected) return cached;
+
+  const element = typeof safeGetElement === "function" ? safeGetElement(id) : null;
+  _spotLookupModalRefs[key] = element?.nodeType === 1 ? element : null;
+  return _spotLookupModalRefs[key];
+};
+
 const isGoldbackRetailLookup = () => {
   return _spotLookupTargetField === "retail" && elements.itemWeightUnit?.value === "gb";
 };
@@ -412,12 +426,12 @@ const openSpotLookupModal = async (targetField = "purchase") => {
           : [];
     }
 
-    const titleEl = document.getElementById("spotLookupTitle");
+    const titleEl = getSpotLookupModalRef("title", "spotLookupTitle");
     if (titleEl) {
       titleEl.textContent = `Goldback Lookup — ${denom} Goldback on ${dateVal}`;
     }
 
-    const bodyEl = document.getElementById("spotLookupBody");
+    const bodyEl = getSpotLookupModalRef("body", "spotLookupBody");
     if (!bodyEl) return;
 
     if (goldbackResults.length > 0) {
@@ -450,13 +464,13 @@ const openSpotLookupModal = async (targetField = "purchase") => {
   }
 
   // Update modal title
-  const titleEl = document.getElementById("spotLookupTitle");
+  const titleEl = getSpotLookupModalRef("title", "spotLookupTitle");
   if (titleEl) {
     titleEl.textContent = `Spot Lookup — ${metalName} on ${dateVal}`;
   }
 
   // Render results into modal body
-  const bodyEl = document.getElementById("spotLookupBody");
+  const bodyEl = getSpotLookupModalRef("body", "spotLookupBody");
   if (!bodyEl) return;
 
   if (results.length > 0) {

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -13,6 +13,18 @@ const METAL_SYMBOLS = {
 
 let _spotLookupTargetField = "purchase";
 
+const isGoldbackRetailLookup = () => {
+  return _spotLookupTargetField === "retail" && elements.itemWeightUnit?.value === "gb";
+};
+
+const getGoldbackLookupDenomination = () => {
+  return parseFloat(
+    elements.itemGbDenom?.value ||
+      elements.itemWeight?.value ||
+      (elements.itemWeightUnit?.value === "gb" ? 1 : 0)
+  );
+};
+
 /**
  * Syncs spot lookup button state and optionally clears the hidden selected spot value.
  *
@@ -40,22 +52,24 @@ const syncSpotLookupButtons = (hasDate, options = {}) => {
  * @param {number} spotPrice - USD spot price
  * @returns {string} Display-currency value formatted to 2 decimals
  */
-const getSpotLookupDisplayValue = (spotPrice) => {
+const getSpotLookupDisplayValue = (spotPrice, timestamp = "") => {
   const fxRate = typeof getExchangeRate === "function" ? getExchangeRate() : 1;
 
   let priceUSD = spotPrice;
-  if (
-    elements.itemWeightUnit &&
-    elements.itemWeightUnit.value === "gb" &&
-    typeof computeGoldbackEstimatedRate === "function"
-  ) {
-    const gbRate = computeGoldbackEstimatedRate(spotPrice);
-    const denom = parseFloat(
-      (elements.itemGbDenom && elements.itemGbDenom.value) ||
-        (elements.itemWeight && elements.itemWeight.value) ||
-        1
-    );
-    priceUSD = gbRate * denom;
+  if (elements.itemWeightUnit?.value === "gb") {
+    const denom = getGoldbackLookupDenomination() || 1;
+    const historyPrice =
+      timestamp && typeof getGoldbackHistoryPrice === "function"
+        ? getGoldbackHistoryPrice(denom, timestamp)
+        : null;
+
+    if (historyPrice) {
+      priceUSD = historyPrice;
+    } else if (typeof getGoldbackDenominationPrice === "function") {
+      priceUSD = getGoldbackDenominationPrice(denom) || priceUSD;
+    } else if (typeof computeGoldbackEstimatedRate === "function") {
+      priceUSD = computeGoldbackEstimatedRate(spotPrice) * denom;
+    }
   }
 
   return (priceUSD * fxRate).toFixed(2);
@@ -377,6 +391,55 @@ const openSpotLookupModal = async (targetField = "purchase") => {
   }
 
   _spotLookupTargetField = targetField === "retail" ? "retail" : "purchase";
+  const isGbRetailLookup = isGoldbackRetailLookup();
+
+  if (isGbRetailLookup) {
+    const denom = getGoldbackLookupDenomination() || 1;
+    let goldbackResults =
+      typeof searchGoldbackHistoryByDate === "function"
+        ? searchGoldbackHistoryByDate(denom, dateVal)
+        : [];
+
+    if (
+      goldbackResults.length === 0 &&
+      window.goldbackPricingSource === "api" &&
+      typeof fetchGoldbackApiPrices === "function"
+    ) {
+      await fetchGoldbackApiPrices({ expectedSource: "api" });
+      goldbackResults =
+        typeof searchGoldbackHistoryByDate === "function"
+          ? searchGoldbackHistoryByDate(denom, dateVal)
+          : [];
+    }
+
+    const titleEl = document.getElementById("spotLookupTitle");
+    if (titleEl) {
+      titleEl.textContent = `Goldback Lookup — ${denom} Goldback on ${dateVal}`;
+    }
+
+    const bodyEl = document.getElementById("spotLookupBody");
+    if (!bodyEl) return;
+
+    if (goldbackResults.length > 0) {
+      renderSpotLookupResults(
+        bodyEl,
+        goldbackResults.map((entry) => ({
+          ...entry,
+          spot: entry.price,
+          lookupPrice: entry.price,
+        })),
+        "Goldback",
+        dateVal
+      );
+    } else {
+      renderGoldbackLookupEmpty(bodyEl, denom, dateVal);
+    }
+
+    if (typeof openModalById === "function") {
+      openModalById("spotLookupModal");
+    }
+    return;
+  }
 
   // Search local spotHistory first (≤180 days)
   let results = searchSpotByDate(metalName, dateVal);
@@ -418,14 +481,18 @@ const openSpotLookupModal = async (targetField = "purchase") => {
 const renderSpotLookupResults = (container, results, metalName, dateStr) => {
   const formatPrice =
     typeof formatCurrency === "function" ? formatCurrency : (v) => "$" + Number(v).toFixed(2);
+  const isGbRetail = isGoldbackRetailLookup();
+  const priceHeading = isGbRetail ? "Goldback Price" : "Spot Price";
 
   let html = '<table class="spot-lookup-table"><thead><tr>';
-  html += "<th>Date/Time</th><th>Spot Price</th><th>Source</th><th>Offset</th><th></th>";
+  html += `<th>Date/Time</th><th>${priceHeading}</th><th>Source</th><th>Offset</th><th></th>`;
   html += "</tr></thead><tbody>";
 
   results.forEach((entry) => {
     const ts = entry.timestamp ? formatTimestamp(entry.timestamp) : "";
-    const price = formatPrice(entry.spot);
+    const lookupPrice =
+      typeof entry.lookupPrice === "number" && entry.lookupPrice > 0 ? entry.lookupPrice : null;
+    const price = formatPrice(lookupPrice || entry.spot);
     const source = entry.source === "seed" ? "Seed" : entry.provider || entry.source || "";
     const offsetLabel = formatOffsetLabel(entry.dayOffset);
     const exactClass = entry.dayOffset === 0 ? " exact" : "";
@@ -437,7 +504,7 @@ const renderSpotLookupResults = (container, results, metalName, dateStr) => {
     html += `<td><span class="spot-lookup-offset${exactClass}">${offsetLabel}</span></td>`;
     html +=
       `<td><button class="btn spot-lookup-use-btn" type="button" ` +
-      `data-spot="${escapeHtml(entry.spot)}" data-ts="${escapeHtml(entry.timestamp || "")}">Use</button></td>`;
+      `data-spot="${escapeHtml(entry.spot)}" data-retail="${escapeHtml(lookupPrice || "")}" data-ts="${escapeHtml(entry.timestamp || "")}">Use</button></td>`;
     html += "</tr>";
   });
 
@@ -450,10 +517,20 @@ const renderSpotLookupResults = (container, results, metalName, dateStr) => {
   container.querySelectorAll(".spot-lookup-use-btn").forEach((btn) => {
     btn.addEventListener("click", () => {
       const spotPrice = parseFloat(btn.dataset.spot);
+      const retailPrice = parseFloat(btn.dataset.retail);
       const timestamp = btn.dataset.ts || "";
-      useSpotPrice(spotPrice, timestamp);
+      useSpotPrice(spotPrice, timestamp, retailPrice);
     });
   });
+};
+
+const renderGoldbackLookupEmpty = (container, denom, dateStr) => {
+  // nosemgrep: javascript.browser.security.insecure-innerhtml.insecure-innerhtml
+  container.innerHTML =
+    '<div class="spot-lookup-empty">' +
+    `<p>No Goldback price history found for ${escapeHtml(String(denom))} Goldback on ${escapeHtml(dateStr)}.</p>` +
+    '<p class="spot-lookup-hint">Goldback API history is used for Goldback retail lookup. If it is unavailable, the saved manual retail value can still be entered directly.</p>' +
+    "</div>";
 };
 
 /**
@@ -530,8 +607,14 @@ const renderSpotLookupEmpty = (container, metalName, dateStr) => {
  * @param {number} spotPrice - The selected spot price
  * @param {string} timestamp - Timestamp of the selected entry (for reference)
  */
-const useSpotPrice = (spotPrice, timestamp) => {
-  const displayPrice = getSpotLookupDisplayValue(spotPrice);
+const useSpotPrice = (spotPrice, timestamp, retailLookupPrice = NaN) => {
+  const fxRate = typeof getExchangeRate === "function" ? getExchangeRate() : 1;
+  const displayPrice =
+    _spotLookupTargetField === "retail" &&
+    typeof retailLookupPrice === "number" &&
+    retailLookupPrice > 0
+      ? (retailLookupPrice * fxRate).toFixed(2)
+      : getSpotLookupDisplayValue(spotPrice, timestamp);
 
   if (_spotLookupTargetField === "retail") {
     if (elements.itemMarketValue) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -1424,7 +1424,7 @@ const getGoldbackRetailPrice = (item) => {
 
 /**
  * Calculates qty-adjusted retail value using the portfolio hierarchy:
- * Goldback denomination price → manual market value → melt value.
+ * max(Goldback denomination price, manual market value) → melt value.
  *
  * @param {Object} item - Inventory item
  * @param {number} currentSpot - Current spot price for the item's metal
@@ -1443,12 +1443,9 @@ const calculateRetailPrice = (item, currentSpot) => {
   const meltValue = computeMeltValue(item, Number(currentSpot) || 0);
   const gbDenomPrice =
     typeof getGoldbackRetailPrice === "function" ? getGoldbackRetailPrice(item) : null;
-  const isManualRetail = !gbDenomPrice && marketValue > 0;
-  const retailTotal = gbDenomPrice
-    ? gbDenomPrice * qty
-    : isManualRetail
-      ? marketValue * qty
-      : meltValue;
+  const retailUnitPrice = gbDenomPrice ? Math.max(gbDenomPrice, marketValue) : marketValue;
+  const isManualRetail = marketValue > 0 && (!gbDenomPrice || marketValue >= gbDenomPrice);
+  const retailTotal = retailUnitPrice > 0 ? retailUnitPrice * qty : meltValue;
 
   return {
     qty,

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -562,7 +562,9 @@ function _buildValuationSection(item, metrics) {
 function _getChartCurrentRetail(item, metrics) {
   if (typeof computeItemValuation === "function") {
     const computed = computeItemValuation(item, metrics.currentSpot);
-    if (computed.gbDenomPrice || computed.isManualRetail) return computed.retailTotal;
+    if (computed && (computed.gbDenomPrice || computed.isManualRetail)) {
+      return computed.retailTotal;
+    }
     return 0;
   }
 

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -32,6 +32,18 @@ const _VIEW_CHART_RANGE_LABELS = [
 /** @type {number} Default chart range in days (-1 = from purchase date, falls back to 30d) */
 const _VIEW_CHART_DEFAULT_RANGE = -1;
 
+const _VIEW_CHART_DAY_MS = 24 * 60 * 60 * 1000;
+
+function _getViewChartRangeCutoff(days) {
+  const rangeDays = Number(days) || 0;
+  if (rangeDays <= 0) return 0;
+  if (rangeDays > 180) return Date.now() - rangeDays * _VIEW_CHART_DAY_MS;
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - Math.max(rangeDays - 1, 0));
+  return start.getTime();
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -58,15 +70,40 @@ async function showViewModal(index) {
   const chartCanvas = body.querySelector("#viewPriceHistoryChart");
   if (chartCanvas && chartCanvas._chartData) {
     const cd = chartCanvas._chartData;
-    // "Purchased" default (-1): calculate days from purchase date, fall back to 30d
-    let initRange = _VIEW_CHART_DEFAULT_RANGE;
-    if (initRange === -1) {
-      initRange =
-        cd.purchaseDate > 0
-          ? Math.max(1, Math.ceil((Date.now() - cd.purchaseDate) / 86400000))
-          : 30;
-    }
-    if (initRange === 0 || initRange > 180) {
+    const initRange = _VIEW_CHART_DEFAULT_RANGE;
+    if (initRange === -1 && cd.purchaseDate > 0) {
+      const metalName = item.metal || "Silver";
+      const toTs = Date.now();
+      _fetchHistoricalSpotData(metalName, 0, cd.purchaseDate, toTs)
+        .then((fullSpot) => {
+          _createPriceHistoryChart(
+            chartCanvas,
+            fullSpot,
+            cd.retailEntries,
+            cd.purchasePerUnit,
+            cd.meltFactor,
+            0,
+            cd.purchaseDate,
+            cd.currentRetail,
+            cd.purchaseDate,
+            toTs
+          );
+        })
+        .catch(() => {
+          _createPriceHistoryChart(
+            chartCanvas,
+            cd.spotEntries,
+            cd.retailEntries,
+            cd.purchasePerUnit,
+            cd.meltFactor,
+            0,
+            cd.purchaseDate,
+            cd.currentRetail,
+            cd.purchaseDate,
+            toTs
+          );
+        });
+    } else if (initRange === 0 || initRange > 180) {
       const metalName = item.metal || "Silver";
       _fetchHistoricalSpotData(metalName, initRange)
         .then((fullSpot) => {
@@ -775,10 +812,45 @@ async function _onChartRangePillClick(days, dateRange, chartSection, chartCtx) {
   dateRange.toInput.min = "";
   const canvas = chartSection.querySelector("#viewPriceHistoryChart");
   if (!canvas) return;
-  const effectiveDays =
-    days === -1 && chartCtx.purchaseDate > 0
-      ? Math.max(1, Math.ceil((Date.now() - chartCtx.purchaseDate) / 86400000))
-      : days;
+  if (days === -1 && chartCtx.purchaseDate > 0) {
+    const toTs = Date.now();
+    try {
+      const spotData = await _fetchHistoricalSpotData(
+        chartCtx.metalName,
+        0,
+        chartCtx.purchaseDate,
+        toTs
+      );
+      _createPriceHistoryChart(
+        canvas,
+        spotData,
+        chartCtx.retailEntries,
+        chartCtx.purchasePerUnit,
+        chartCtx.meltFactor,
+        0,
+        chartCtx.purchaseDate,
+        chartCtx.currentRetail,
+        chartCtx.purchaseDate,
+        toTs
+      );
+    } catch (err) {
+      console.error("Purchased range fetch failed:", err);
+      _createPriceHistoryChart(
+        canvas,
+        chartCtx.dailySpotEntries,
+        chartCtx.retailEntries,
+        chartCtx.purchasePerUnit,
+        chartCtx.meltFactor,
+        0,
+        chartCtx.purchaseDate,
+        chartCtx.currentRetail,
+        chartCtx.purchaseDate,
+        toTs
+      );
+    }
+    return;
+  }
+  const effectiveDays = days;
   try {
     const spotData = await _fetchHistoricalSpotData(chartCtx.metalName, effectiveDays);
     _createPriceHistoryChart(
@@ -1633,13 +1705,13 @@ async function _fetchHistoricalSpotData(metalName, days, fromTs, toTs) {
     const byDay = new Map();
     for (const e of liveEntries) byDay.set(new Date(e.ts).toISOString().slice(0, 10), e);
     const result = [...byDay.values()].sort((a, b) => a.ts - b.ts);
-    const cutoff = Date.now() - days * (24 * 60 * 60 * 1000);
+    const cutoff = _getViewChartRangeCutoff(days);
     const inRange = result.filter((e) => e.ts >= cutoff);
     if (inRange.length >= 2) return result;
     // Sparse in-memory data — fall back to current year file
     startYear = new Date(cutoff).getFullYear();
   } else if (days > 180) {
-    const cutoff = Date.now() - days * (24 * 60 * 60 * 1000);
+    const cutoff = _getViewChartRangeCutoff(days);
     startYear = new Date(cutoff).getFullYear();
   } else {
     // "All" — go back to 1968 (earliest seed data)
@@ -1717,7 +1789,7 @@ function _createPriceHistoryChart(
   // Filter spot entries by time range
   fromTs = fromTs || 0;
   toTs = toTs || 0;
-  const cutoff = days > 0 ? Date.now() - days * 86400000 : 0;
+  const cutoff = _getViewChartRangeCutoff(days);
   let spotEntries;
   if (fromTs > 0 || toTs > 0) {
     // Custom date range mode
@@ -1729,11 +1801,16 @@ function _createPriceHistoryChart(
   }
 
   // If "All" range or custom range and purchase date is before earliest spot data,
-  // prepend a synthetic entry so the chart extends back to purchase date.
-  // For bounded ranges, anchor sparse historical data at the viewport start.
+  // prepend a synthetic entry so the chart extends back to purchase date. Long
+  // bounded ranges keep their sparse-data viewport anchor; short ranges show
+  // only actual days so a 7d chart cannot invent an extra left-edge point.
   const isAllOrCustom = days === 0 || fromTs > 0 || toTs > 0;
   const boundedAnchorTs =
-    !isAllOrCustom && cutoff > 0 && spotEntries.length > 0 && spotEntries[0].ts > cutoff
+    !isAllOrCustom &&
+    days > 180 &&
+    cutoff > 0 &&
+    spotEntries.length > 0 &&
+    spotEntries[0].ts > cutoff
       ? cutoff
       : 0;
   const purchaseAnchorTs =
@@ -1804,22 +1881,6 @@ function _createPriceHistoryChart(
     return best;
   };
 
-  // Anchor start: purchase price at the leftmost chart position.
-  // If purchase date is within the visible range, snap to that day.
-  // If purchase date is before the range, pin to index 0 so the
-  // retail line always starts with "what you paid" as a reference.
-  if (hasRetailSeries && purchaseDate > 0) {
-    if (
-      purchaseDate >= spotEntries[0].ts &&
-      purchaseDate <= spotEntries[spotEntries.length - 1].ts
-    ) {
-      const idx = _nearestSpotIdx(purchaseDate);
-      retailData[idx] = purchasePerUnit;
-    } else if (purchaseDate < spotEntries[0].ts) {
-      retailData[0] = purchasePerUnit;
-    }
-  }
-
   // Middle: sparse itemPriceHistory retail values snapped to nearest spot day
   for (const re of allRetailEntries) {
     if (cutoff > 0 && re.ts < cutoff) continue;
@@ -1832,6 +1893,25 @@ function _createPriceHistoryChart(
   // Anchor end: current market value on the last spot entry (≈ today)
   if (currentRetail > 0) {
     retailData[spotEntries.length - 1] = currentRetail;
+  }
+
+  if (hasRetailSeries) {
+    const firstRetailIdx = retailData.findIndex((value) => value !== null);
+    const firstSpotTs = spotEntries[0].ts;
+    if (firstRetailIdx > 0) {
+      const previousRetail = [...allRetailEntries]
+        .filter((entry) => Number(entry.retail) > 0 && entry.ts < firstSpotTs)
+        .sort((a, b) => a.ts - b.ts)
+        .at(-1);
+      if (previousRetail) {
+        retailData[0] = previousRetail.retail;
+      } else if (purchaseDate >= firstSpotTs && currentRetail > 0) {
+        retailData[0] = currentRetail;
+      }
+    } else if (firstRetailIdx === -1 && currentRetail > 0) {
+      retailData[0] = currentRetail;
+      retailData[spotEntries.length - 1] = currentRetail;
+    }
   }
 
   const hasRetail = hasRetailSeries && retailData.some((v) => v !== null);

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -547,7 +547,11 @@ function _mergeRetailHistoryEntries(itemRetailEntries, goldbackRetailEntries) {
   const byDay = new Map();
   for (const entry of [...itemRetailEntries, ...goldbackRetailEntries]) {
     if (!entry || typeof entry.retail !== "number" || entry.retail <= 0 || !entry.ts) continue;
-    byDay.set(new Date(entry.ts).toISOString().slice(0, 10), entry);
+    const day = new Date(entry.ts).toISOString().slice(0, 10);
+    const existing = byDay.get(day);
+    if (!existing || entry.retail >= existing.retail) {
+      byDay.set(day, entry);
+    }
   }
   return [...byDay.values()].sort((a, b) => a.ts - b.ts);
 }

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -479,15 +479,21 @@ function _appendSourceField(container, sourceValue) {
 }
 
 function _buildValuationSection(item, metrics) {
+  const computed =
+    typeof computeItemValuation === "function"
+      ? computeItemValuation(item, metrics.currentSpot)
+      : null;
   const meltValue =
-    metrics.currentSpot > 0
+    computed?.meltValue ??
+    (metrics.currentSpot > 0
       ? metrics.weightOz * metrics.qty * metrics.currentSpot * metrics.purity
-      : 0;
-  const purchasePrice = parseFloat(item.price) || 0;
-  const purchaseTotal = metrics.qty * purchasePrice;
-  const marketVal = parseFloat(item.marketValue) || 0;
-  const retailTotal = marketVal > 0 ? metrics.qty * marketVal : meltValue;
-  const gainLoss = retailTotal > 0 ? retailTotal - purchaseTotal : null;
+      : 0);
+  const purchasePrice = computed?.purchasePrice ?? (parseFloat(item.price) || 0);
+  const purchaseTotal = computed?.purchaseTotal ?? metrics.qty * purchasePrice;
+  const manualMarket = parseFloat(item.marketValue) || 0;
+  const retailTotal =
+    computed?.retailTotal ?? (manualMarket > 0 ? metrics.qty * manualMarket : meltValue);
+  const gainLoss = computed?.gainLoss ?? (retailTotal > 0 ? retailTotal - purchaseTotal : null);
   const valSection = _section("Valuation");
   valSection.classList.add("view-valuation-section");
   const valGrid = _el("div", "view-detail-grid four-col");
@@ -514,6 +520,36 @@ function _buildValuationSection(item, metrics) {
   }
   valSection.appendChild(valGrid);
   return valSection;
+}
+
+function _getChartCurrentRetail(item, metrics) {
+  if (typeof computeItemValuation === "function") {
+    const computed = computeItemValuation(item, metrics.currentSpot);
+    if (computed.gbDenomPrice || computed.isManualRetail) return computed.retailTotal;
+    return 0;
+  }
+
+  const manualMarket = parseFloat(item.marketValue) || 0;
+  return manualMarket > 0 ? manualMarket * metrics.qty : 0;
+}
+
+function _getGoldbackRetailHistoryEntries(item, metrics) {
+  if (item.weightUnit !== "gb" || typeof goldbackPriceHistory === "undefined") return [];
+
+  const key = String(parseFloat(item.weight) || 0);
+  const entries = Array.isArray(goldbackPriceHistory[key]) ? goldbackPriceHistory[key] : [];
+  return entries
+    .filter((entry) => entry && typeof entry.price === "number" && entry.price > 0 && entry.ts)
+    .map((entry) => ({ ts: entry.ts, retail: parseFloat((entry.price * metrics.qty).toFixed(2)) }));
+}
+
+function _mergeRetailHistoryEntries(itemRetailEntries, goldbackRetailEntries) {
+  const byDay = new Map();
+  for (const entry of [...itemRetailEntries, ...goldbackRetailEntries]) {
+    if (!entry || typeof entry.retail !== "number" || entry.retail <= 0 || !entry.ts) continue;
+    byDay.set(new Date(entry.ts).toISOString().slice(0, 10), entry);
+  }
+  return [...byDay.values()].sort((a, b) => a.ts - b.ts);
 }
 
 /**
@@ -600,14 +636,15 @@ function _getPriceHistoryContext(item, metrics) {
     typeof itemPriceHistory !== "undefined" && item.uuid
       ? (itemPriceHistory[item.uuid] || []).filter((e) => e.retail > 0)
       : [];
+  const goldbackRetailEntries = _getGoldbackRetailHistoryEntries(item, metrics);
   return {
     metalName,
     meltFactor,
     dailySpotEntries,
-    retailEntries,
+    retailEntries: _mergeRetailHistoryEntries(retailEntries, goldbackRetailEntries),
     purchasePerUnit: (parseFloat(item.price) || 0) * metrics.qty,
     purchaseDate: item.date ? new Date(item.date).getTime() : 0,
-    currentRetail: (parseFloat(item.marketValue) || 0) * metrics.qty,
+    currentRetail: _getChartCurrentRetail(item, metrics),
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.58",
+  "version": "3.34.59",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.59-b1778521035";
+const CACHE_NAME = "staktrakr-v3.34.59-b1778523377";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.59-b1778518258";
+const CACHE_NAME = "staktrakr-v3.34.59-b1778521035";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.59-b1778517287";
+const CACHE_NAME = "staktrakr-v3.34.59-b1778518258";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.58-b1778505743";
+const CACHE_NAME = "staktrakr-v3.34.59-b1778517287";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/goldback-type.spec.js
+++ b/tests/playwright/goldback-type.spec.js
@@ -61,10 +61,15 @@ const BASE_ITEMS = [
   },
 ];
 
-async function seedData(page, inventory = BASE_ITEMS) {
+async function seedData(page, inventory = BASE_ITEMS, options = {}) {
+  const { goldbackPrices = {}, goldbackPriceHistory = {}, goldbackPricingSource = "api" } = options;
+
   await page.addInitScript(
-    ({ inv }) => {
+    ({ inv, gbPrices, gbHistory, gbSource }) => {
       localStorage.setItem("metalInventory", JSON.stringify(inv));
+      localStorage.setItem("goldback-prices", JSON.stringify(gbPrices));
+      localStorage.setItem("goldback-price-history", JSON.stringify(gbHistory));
+      localStorage.setItem("goldback-pricing-source", JSON.stringify(gbSource));
       document.addEventListener(
         "DOMContentLoaded",
         () => {
@@ -75,7 +80,12 @@ async function seedData(page, inventory = BASE_ITEMS) {
         { once: true }
       );
     },
-    { inv: inventory }
+    {
+      inv: inventory,
+      gbPrices: goldbackPrices,
+      gbHistory: goldbackPriceHistory,
+      gbSource: goldbackPricingSource,
+    }
   );
 }
 
@@ -349,5 +359,64 @@ test.describe("goldback-type — STAK-562 first-class type behavior", () => {
     });
     expect(goldOptions).toHaveLength(8);
     expect(goldOptions[0].text).toBe("½ Goldback");
+  });
+
+  test("14. Manual Goldback retail value is a floor override, not ignored", async ({ page }) => {
+    await seedData(page, BASE_ITEMS, {
+      goldbackPrices: { 1: { price: 9.48, updatedAt: Date.now(), source: "api" } },
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await page.waitForFunction(() => typeof window.calculateRetailPrice === "function");
+
+    const values = await page.evaluate(() => {
+      const baseItem = {
+        metal: "Gold",
+        type: "Goldback",
+        weight: 1,
+        weightUnit: "gb",
+        qty: 1,
+        purity: 0.999,
+        price: 0,
+      };
+
+      return {
+        highManual: window.calculateRetailPrice({ ...baseItem, marketValue: 100 }, 4715.22),
+        lowManual: window.calculateRetailPrice({ ...baseItem, marketValue: 2 }, 4715.22),
+      };
+    });
+
+    expect(values.highManual.gbDenomPrice).toBe(9.48);
+    expect(values.highManual.isManualRetail).toBe(true);
+    expect(values.highManual.retailTotal).toBe(100);
+    expect(values.lowManual.isManualRetail).toBe(false);
+    expect(values.lowManual.retailTotal).toBe(9.48);
+  });
+
+  test("15. Goldback retail lookup uses daily Goldback history instead of gold spot", async ({
+    page,
+  }) => {
+    await seedData(page, [], {
+      goldbackPriceHistory: {
+        1: [{ ts: new Date("2026-05-11T12:00:00.000Z").getTime(), price: 9.48, source: "api" }],
+      },
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.fill("#itemDate", "2026-05-11");
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+    await expect(page.locator("#itemWeightUnit")).toHaveValue("gb");
+
+    await page.click("#retailSpotLookupBtn");
+    await expect(page.locator("#spotLookupModal")).toBeVisible();
+    await expect(page.locator("#spotLookupTitle")).toContainText("Goldback Lookup");
+    await expect(page.locator("#spotLookupBody")).toContainText("Goldback Price");
+    await expect(page.locator("#spotLookupBody")).toContainText("$9.48");
+
+    await page.locator(".spot-lookup-use-btn").first().click();
+    await expect(page.locator("#itemMarketValue")).toHaveValue("9.48");
   });
 });

--- a/tests/playwright/view-modal-chart-scaling.spec.js
+++ b/tests/playwright/view-modal-chart-scaling.spec.js
@@ -525,6 +525,114 @@ test.describe("view-modal-chart-scaling — STRK-42", () => {
     expect(history.map((entry) => entry.price)).toEqual([9.42, 9.42]);
   });
 
+  test("STRK-69: Purchased range does not anchor Goldback retail to purchase price", async ({
+    page,
+  }) => {
+    const gbItem = {
+      ...BASE_ITEM,
+      uuid: "strk69-purchased-goldback-retail-anchor",
+      metal: "Gold",
+      composition: "Gold",
+      name: "STRK-69 Purchased Goldback",
+      type: "Goldback",
+      weight: 5,
+      weightUnit: "gb",
+      price: 20,
+      marketValue: 0,
+      date: "2026-05-09",
+      purity: 0.999,
+    };
+    const goldHistory = ["2026-05-08", "2026-05-09", "2026-05-10"].map((date) => ({
+      timestamp: `${date}T12:00:00.000Z`,
+      metal: "Gold",
+      spot: 4715.22,
+      source: "seed",
+      provider: "Playwright",
+    }));
+
+    await seedData(page, {
+      inventory: [gbItem],
+      spotHistory: goldHistory,
+      retailHistory: {},
+      goldbackPrices: { 5: { price: 47.1, updatedAt: Date.now(), source: "api" } },
+      goldbackPriceHistory: {},
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await openViewModal(page);
+    await clickRange(page, "Purchased");
+
+    const retailValues = await page.evaluate(() => {
+      const chart = Chart.getChart(document.getElementById("viewPriceHistoryChart"));
+      const retailDataset = chart.data.datasets.find((dataset) => dataset.label === "Retail Value");
+      return retailDataset.data.filter((value) => value !== null);
+    });
+
+    expect(retailValues).not.toContain(20);
+    expect(retailValues).toContain(47.1);
+  });
+
+  test("STRK-69: short ranges do not inject purchase-price retail at viewport start", async ({
+    page,
+  }) => {
+    const gbItem = {
+      ...BASE_ITEM,
+      uuid: "strk69-short-range-goldback-retail-anchor",
+      metal: "Gold",
+      composition: "Gold",
+      name: "STRK-69 Short Range Goldback",
+      type: "Goldback",
+      weight: 5,
+      weightUnit: "gb",
+      price: 20,
+      marketValue: 0,
+      date: "2026-04-11",
+      purity: 0.999,
+    };
+    const goldHistory = Array.from({ length: 7 }, (_, index) => ({
+      timestamp: new Date(
+        new Date("2026-05-04T12:00:00.000Z").getTime() + index * DAY_MS
+      ).toISOString(),
+      metal: "Gold",
+      spot: 4715.22,
+      source: "seed",
+      provider: "Playwright",
+    }));
+    const goldbackPriceHistory = {
+      5: Array.from({ length: 6 }, (_, index) => ({
+        ts: new Date(new Date("2026-05-05T12:00:00.000Z").getTime() + index * DAY_MS).getTime(),
+        price: 47.1,
+        source: "api",
+      })),
+    };
+
+    await seedData(page, {
+      inventory: [gbItem],
+      spotHistory: goldHistory,
+      retailHistory: {},
+      goldbackPrices: { 5: { price: 47.1, updatedAt: Date.now(), source: "api" } },
+      goldbackPriceHistory,
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await openViewModal(page);
+    await clickRange(page, "7d");
+
+    const retailSeries = await page.evaluate(() => {
+      const chart = Chart.getChart(document.getElementById("viewPriceHistoryChart"));
+      const retailDataset = chart.data.datasets.find((dataset) => dataset.label === "Retail Value");
+      return chart.data.labels.map((label, index) => ({
+        label: Array.isArray(label) ? label.join(" ") : label,
+        value: retailDataset.data[index],
+      }));
+    });
+    const nonNullRetail = retailSeries.filter((point) => point.value !== null);
+
+    expect(nonNullRetail.map((point) => point.value)).not.toContain(20);
+    expect(nonNullRetail[0].label).toContain("May 5");
+    expect(nonNullRetail[0].value).toBe(47.1);
+  });
+
   test("AC-1: low purchase price line gets padded below short-range melt values", async ({
     page,
   }) => {

--- a/tests/playwright/view-modal-chart-scaling.spec.js
+++ b/tests/playwright/view-modal-chart-scaling.spec.js
@@ -379,7 +379,7 @@ async function installYearFileStub(page) {
   }, yearData);
 }
 
-test.describe("view-modal-chart-scaling — STRK-42", () => {
+test.describe("view-modal-chart-scaling — STRK-42 / STRK-69", () => {
   test("STRK-69: Goldback modal uses denomination retail history when market value is empty", async ({
     page,
   }) => {

--- a/tests/playwright/view-modal-chart-scaling.spec.js
+++ b/tests/playwright/view-modal-chart-scaling.spec.js
@@ -69,6 +69,9 @@ async function seedData(page, options = {}) {
         { ts: new Date("2025-07-15T12:00:00.000Z").getTime(), retail: 68 },
       ],
     },
+    goldbackPrices = {},
+    goldbackPriceHistory = {},
+    goldbackPricingSource = "api",
   } = options;
 
   await page.route("https://open.er-api.com/v6/latest/USD", async (route) => {
@@ -80,7 +83,7 @@ async function seedData(page, options = {}) {
   });
 
   await page.addInitScript(
-    ({ seededInventory, history, itemHistory, fixedNowIso }) => {
+    ({ seededInventory, history, itemHistory, gbPrices, gbHistory, gbSource, fixedNowIso }) => {
       const RealDate = Date;
       const fixedNow = new RealDate(fixedNowIso).getTime();
 
@@ -105,6 +108,9 @@ async function seedData(page, options = {}) {
       localStorage.setItem("exchangeRates", JSON.stringify({ EUR: 0.9 }));
       localStorage.setItem("metalSpotHistory", JSON.stringify(history));
       localStorage.setItem("item-price-history", JSON.stringify(itemHistory));
+      localStorage.setItem("goldback-prices", JSON.stringify(gbPrices));
+      localStorage.setItem("goldback-price-history", JSON.stringify(gbHistory));
+      localStorage.setItem("goldback-pricing-source", JSON.stringify(gbSource));
       localStorage.setItem("defaultSortColumn", "4");
       localStorage.setItem("defaultSortDir", "asc");
 
@@ -122,6 +128,9 @@ async function seedData(page, options = {}) {
       seededInventory: inventory,
       history: spotHistory,
       itemHistory: retailHistory,
+      gbPrices: goldbackPrices,
+      gbHistory: goldbackPriceHistory,
+      gbSource: goldbackPricingSource,
       fixedNowIso: FIXED_NOW_ISO,
     }
   );
@@ -371,6 +380,95 @@ async function installYearFileStub(page) {
 }
 
 test.describe("view-modal-chart-scaling — STRK-42", () => {
+  test("STRK-69: Goldback modal uses denomination retail history when market value is empty", async ({
+    page,
+  }) => {
+    const gbItem = {
+      ...BASE_ITEM,
+      uuid: "strk69-half-goldback",
+      metal: "Gold",
+      composition: "Gold",
+      name: "STRK-69 Half Goldback",
+      type: "Goldback",
+      weight: 0.5,
+      weightUnit: "gb",
+      price: 0,
+      marketValue: 0,
+      date: "2026-05-04",
+      purity: 0.999,
+    };
+    const goldHistory = Array.from({ length: 7 }, (_, index) => ({
+      timestamp: new Date(
+        new Date("2026-05-04T12:00:00.000Z").getTime() + index * DAY_MS
+      ).toISOString(),
+      metal: "Gold",
+      spot: 4715.22,
+      source: "seed",
+      provider: "Playwright",
+    }));
+    const gbHistory = {
+      0.5: [
+        { ts: new Date("2026-05-08T12:00:00.000Z").getTime(), price: 4.74, source: "api" },
+        { ts: new Date("2026-05-09T12:00:00.000Z").getTime(), price: 4.71, source: "api" },
+        { ts: new Date("2026-05-10T12:00:00.000Z").getTime(), price: 4.71, source: "api" },
+      ],
+    };
+
+    await seedData(page, {
+      inventory: [gbItem],
+      spotHistory: goldHistory,
+      retailHistory: {},
+      goldbackPrices: { 0.5: { price: 4.71, updatedAt: Date.now(), source: "api" } },
+      goldbackPriceHistory: gbHistory,
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await openViewModal(page);
+    await expect(page.locator(".view-valuation-section")).toContainText("Retail");
+    await expect(page.locator(".view-valuation-section")).toContainText("$4.71");
+
+    await clickRange(page, "7d");
+    const retailSeries = await page.evaluate(() => {
+      const chart = Chart.getChart(document.getElementById("viewPriceHistoryChart"));
+      const retailDataset = chart.data.datasets.find((dataset) => dataset.label === "Retail Value");
+      return chart.data.labels.map((label, index) => ({
+        label: Array.isArray(label) ? label.join(" ") : label,
+        value: retailDataset.data[index],
+      }));
+    });
+    const nonNullRetail = retailSeries.filter((point) => point.value !== null && point.value > 0);
+    const valueForLabel = (expectedLabel) =>
+      nonNullRetail.find((point) => point.label.includes(expectedLabel))?.value;
+
+    expect(valueForLabel("May 8")).toBe(4.74);
+    expect(valueForLabel("May 9")).toBe(4.71);
+    expect(valueForLabel("May 10")).toBe(4.71);
+    expect(nonNullRetail.at(-1).label).toContain("May 10");
+  });
+
+  test("STRK-69: Goldback history records same price on a new calendar day", async ({ page }) => {
+    await seedData(page, {
+      goldbackPrices: { 1: { price: 9.42, updatedAt: Date.now(), source: "api" } },
+      goldbackPriceHistory: {
+        1: [{ ts: new Date("2026-05-09T12:00:00.000Z").getTime(), price: 9.42, source: "api" }],
+      },
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+
+    const history = await page.evaluate(() => {
+      window.recordGoldbackPrices();
+      return window.loadDataSync("goldback-price-history", {})["1"];
+    });
+
+    expect(history).toHaveLength(2);
+    expect(history.map((entry) => new Date(entry.ts).toISOString().slice(0, 10))).toEqual([
+      "2026-05-09",
+      "2026-05-10",
+    ]);
+    expect(history.map((entry) => entry.price)).toEqual([9.42, 9.42]);
+  });
+
   test("AC-1: low purchase price line gets padded below short-range melt values", async ({
     page,
   }) => {

--- a/tests/playwright/view-modal-chart-scaling.spec.js
+++ b/tests/playwright/view-modal-chart-scaling.spec.js
@@ -446,6 +446,62 @@ test.describe("view-modal-chart-scaling — STRK-42", () => {
     expect(nonNullRetail.at(-1).label).toContain("May 10");
   });
 
+  test("STRK-69: Goldback manual retail higher than daily rate takes precedence", async ({
+    page,
+  }) => {
+    const gbItem = {
+      ...BASE_ITEM,
+      uuid: "strk69-graded-goldback",
+      metal: "Gold",
+      composition: "Gold",
+      name: "STRK-69 Graded Goldback",
+      type: "Goldback",
+      weight: 1,
+      weightUnit: "gb",
+      price: 0,
+      marketValue: 100,
+      date: "2026-05-04",
+      purity: 0.999,
+    };
+    const goldHistory = Array.from({ length: 7 }, (_, index) => ({
+      timestamp: new Date(
+        new Date("2026-05-04T12:00:00.000Z").getTime() + index * DAY_MS
+      ).toISOString(),
+      metal: "Gold",
+      spot: 4715.22,
+      source: "seed",
+      provider: "Playwright",
+    }));
+
+    await seedData(page, {
+      inventory: [gbItem],
+      spotHistory: goldHistory,
+      retailHistory: {
+        [gbItem.uuid]: [{ ts: new Date("2026-05-10T13:00:00.000Z").getTime(), retail: 100 }],
+      },
+      goldbackPrices: { 1: { price: 9.48, updatedAt: Date.now(), source: "api" } },
+      goldbackPriceHistory: {
+        1: [{ ts: new Date("2026-05-10T12:00:00.000Z").getTime(), price: 9.48, source: "api" }],
+      },
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await openViewModal(page);
+    await expect(page.locator(".view-valuation-section")).toContainText("$100.00");
+
+    await clickRange(page, "7d");
+    const may10Retail = await page.evaluate(() => {
+      const chart = Chart.getChart(document.getElementById("viewPriceHistoryChart"));
+      const retailDataset = chart.data.datasets.find((dataset) => dataset.label === "Retail Value");
+      const index = chart.data.labels.findIndex((label) =>
+        (Array.isArray(label) ? label.join(" ") : label).includes("May 10")
+      );
+      return retailDataset.data[index];
+    });
+
+    expect(may10Retail).toBe(100);
+  });
+
   test("STRK-69: Goldback history records same price on a new calendar day", async ({ page }) => {
     await seedData(page, {
       goldbackPrices: { 1: { price: 9.42, updatedAt: Date.now(), source: "api" } },

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.58",
+  "version": "3.34.59",
   "releaseDate": "2026-05-11",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- Fixes Goldback denomination price history so a flat vendor price still records one row per calendar day.
- Backfills local Goldback denomination history from the StakTrakr API `history-30d` endpoint during API pricing refreshes.
- Updates item detail modal valuation/chart logic to use Goldback denomination retail history when `marketValue` is empty, falling back to melt only when denomination pricing is unavailable.

## Root Cause
Goldback price history skipped exact duplicate prices without checking the calendar date, so unchanged vendor prices across Saturday/Sunday were not stored locally. The item detail modal also read manual `marketValue` history instead of the shared Goldback denomination valuation path, making the missing weekend rows visible as a retail chart gap.

## Verification
- `node --check js/goldback.js && node --check js/viewModal.js && node --check js/about.js && node --check js/constants.js`
- `bash devops/hooks/check-release-sync.sh`
- `npx playwright test tests/playwright/view-modal-chart-scaling.spec.js --grep STRK-69`
- `npx playwright test tests/playwright/view-modal-chart-scaling.spec.js`
- `npm run lint` (passes with existing warnings in `js/diff-engine.js` and `js/diff-modal.js`)

## Issue
STRK-69