### PR TITLE
v3.34.60 — STRK-68: view modal lot each chart toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.60] - 2026-05-11
+
+### Changed — STRK-68: View modal lot/each chart toggle
+
+- **Item detail valuation**: Add a Lot/Each toggle for multi-quantity item detail modals so purchase, melt, retail, and gain/loss can switch between stack totals and per-unit values (STRK-68).
+- **Item detail charts**: Keep the price history chart in the same unit mode as the valuation section while preserving the active chart range or custom date window (STRK-68).
+
+---
+
 ## [3.34.59] - 2026-05-11
 
 ### Fixed — STRK-69: Goldback daily retail chart history

--- a/css/styles.css
+++ b/css/styles.css
@@ -6323,6 +6323,24 @@ td input:checked + .slider:before {
   background: var(--bg-secondary);
 }
 
+.view-valuation-unit-toggle {
+  display: inline-flex;
+  align-self: flex-start;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: var(--spacing-xs);
+}
+
+.view-valuation-unit-toggle .chip-sort-btn {
+  padding: 0.1rem 0.5rem;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+}
+
 /* --- Chart range pills --- */
 .view-chart-range-bar {
   display: flex;

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.60 &ndash; STRK-68: View modal lot/each chart toggle</strong>: Multi-quantity item detail modals now include a Lot/Each toggle that switches valuation totals and price history chart lines together, preserving the selected chart range while comparing stack totals or per-unit values (STRK-68).</li>
     <li><strong>v3.34.59 &ndash; STRK-69: Goldback daily retail chart history</strong>: Goldback denomination prices now keep one retail-history point per calendar day even when the vendor price is flat, and item detail charts use denomination retail values when stored market value is empty (STRK-69).</li>
     <li><strong>v3.34.58 &ndash; STRK-42: Chart viewport scaling</strong>: Item detail charts now fit the y-axis to visible purchase, melt, and retail lines with padding, fetch only needed bounded-range history, and keep sparse 1Y ranges anchored at the viewport start (STRK-42).</li>
     <li><strong>v3.34.57 &ndash; STRK-67: Per-side image frame override</strong>: Add Auto/Circle/Rectangle frame controls for obverse and reverse images so rectangular slabs, bars, notes, and similar media can be corrected while default shape detection stays automatic (STRK-67).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,10 +281,10 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-05-11 - STRK-69: Goldback daily retail chart history
+ * Updated: 2026-05-11 - STRK-68: View modal lot/each chart toggle
  */
 
-const APP_VERSION = "3.34.59";
+const APP_VERSION = "3.34.60";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/viewModal.js
+++ b/js/viewModal.js
@@ -76,71 +76,22 @@ async function showViewModal(index) {
       const toTs = Date.now();
       _fetchHistoricalSpotData(metalName, 0, cd.purchaseDate, toTs)
         .then((fullSpot) => {
-          _createPriceHistoryChart(
-            chartCanvas,
-            fullSpot,
-            cd.retailEntries,
-            cd.purchasePerUnit,
-            cd.meltFactor,
-            0,
-            cd.purchaseDate,
-            cd.currentRetail,
-            cd.purchaseDate,
-            toTs
-          );
+          _renderPriceHistoryChart(chartCanvas, fullSpot, cd, 0, cd.purchaseDate, toTs);
         })
         .catch(() => {
-          _createPriceHistoryChart(
-            chartCanvas,
-            cd.spotEntries,
-            cd.retailEntries,
-            cd.purchasePerUnit,
-            cd.meltFactor,
-            0,
-            cd.purchaseDate,
-            cd.currentRetail,
-            cd.purchaseDate,
-            toTs
-          );
+          _renderPriceHistoryChart(chartCanvas, cd.spotEntries, cd, 0, cd.purchaseDate, toTs);
         });
     } else if (initRange === 0 || initRange > 180) {
       const metalName = item.metal || "Silver";
       _fetchHistoricalSpotData(metalName, initRange)
         .then((fullSpot) => {
-          _createPriceHistoryChart(
-            chartCanvas,
-            fullSpot,
-            cd.retailEntries,
-            cd.purchasePerUnit,
-            cd.meltFactor,
-            initRange,
-            cd.purchaseDate,
-            cd.currentRetail
-          );
+          _renderPriceHistoryChart(chartCanvas, fullSpot, cd, initRange);
         })
         .catch(() => {
-          _createPriceHistoryChart(
-            chartCanvas,
-            cd.spotEntries,
-            cd.retailEntries,
-            cd.purchasePerUnit,
-            cd.meltFactor,
-            initRange,
-            cd.purchaseDate,
-            cd.currentRetail
-          );
+          _renderPriceHistoryChart(chartCanvas, cd.spotEntries, cd, initRange);
         });
     } else {
-      _createPriceHistoryChart(
-        chartCanvas,
-        cd.spotEntries,
-        cd.retailEntries,
-        cd.purchasePerUnit,
-        cd.meltFactor,
-        initRange,
-        cd.purchaseDate,
-        cd.currentRetail
-      );
+      _renderPriceHistoryChart(chartCanvas, cd.spotEntries, cd, initRange);
     }
   }
 
@@ -516,47 +467,129 @@ function _appendSourceField(container, sourceValue) {
 }
 
 function _buildValuationSection(item, metrics) {
+  const chartCtx = _getPriceHistoryContext(item, metrics);
+  return _buildValuationSectionWithChartContext(item, metrics, chartCtx);
+}
+
+function _buildValuationSectionWithChartContext(item, metrics, chartCtx) {
+  const valSection = _section("Valuation");
+  valSection.classList.add("view-valuation-section");
+  const canToggleUnits = metrics.qty > 1;
+  if (canToggleUnits) {
+    valSection.appendChild(_buildValuationUnitToggle(valSection, item, metrics, chartCtx));
+  }
+  const valGrid = _el("div", "view-detail-grid four-col");
+  valGrid.dataset.unitGrid = "valuation";
+  _renderValuationGrid(valGrid, _getValuationDisplayValues(item, metrics, "lot"));
+  valSection.appendChild(valGrid);
+  return valSection;
+}
+
+function _buildValuationUnitToggle(valSection, item, metrics, chartCtx) {
+  const toggle = _el("div", "view-valuation-unit-toggle");
+  toggle.setAttribute("role", "group");
+  toggle.setAttribute("aria-label", "Valuation unit");
+  ["lot", "each"].forEach((mode) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "chip-sort-btn" + (mode === "lot" ? " active" : "");
+    btn.dataset.unitMode = mode;
+    btn.setAttribute("aria-pressed", String(mode === "lot"));
+    btn.textContent = mode === "lot" ? "Lot" : "Each";
+    btn.addEventListener("click", () => {
+      if (chartCtx.unitMode === mode) return;
+      chartCtx.unitMode = mode;
+      toggle.querySelectorAll("[data-unit-mode]").forEach((button) => {
+        const isActive = button.dataset.unitMode === mode;
+        button.classList.toggle("active", isActive);
+        button.setAttribute("aria-pressed", String(isActive));
+      });
+      const grid = valSection.querySelector('[data-unit-grid="valuation"]');
+      if (grid) {
+        const unitValues = _getValuationDisplayValues(item, metrics, mode);
+        _renderValuationGrid(grid, unitValues);
+      }
+      _rerenderCurrentPriceHistoryChart(chartCtx);
+    });
+    toggle.appendChild(btn);
+  });
+  return toggle;
+}
+
+function _getValuationDisplayValues(item, metrics, unitMode) {
   const computed =
     typeof computeItemValuation === "function"
       ? computeItemValuation(item, metrics.currentSpot)
       : null;
+  const purchasePrice = computed?.purchasePrice ?? (parseFloat(item.price) || 0);
+  const purchaseTotal = computed?.purchaseTotal ?? metrics.qty * purchasePrice;
   const meltValue =
     computed?.meltValue ??
     (metrics.currentSpot > 0
       ? metrics.weightOz * metrics.qty * metrics.currentSpot * metrics.purity
       : 0);
-  const purchasePrice = computed?.purchasePrice ?? (parseFloat(item.price) || 0);
-  const purchaseTotal = computed?.purchaseTotal ?? metrics.qty * purchasePrice;
   const manualMarket = parseFloat(item.marketValue) || 0;
   const retailTotal =
     computed?.retailTotal ?? (manualMarket > 0 ? metrics.qty * manualMarket : meltValue);
   const gainLoss = computed?.gainLoss ?? (retailTotal > 0 ? retailTotal - purchaseTotal : null);
-  const valSection = _section("Valuation");
-  valSection.classList.add("view-valuation-section");
-  const valGrid = _el("div", "view-detail-grid four-col");
   const purchaseDateStr = item.date
     ? typeof formatDisplayDate === "function"
       ? formatDisplayDate(item.date)
       : item.date
     : "";
-  const purchaseBody =
-    metrics.qty > 1
-      ? `${formatCurrency(purchaseTotal)} total \u00b7 ${formatCurrency(purchasePrice)} each`
-      : formatCurrency(purchasePrice);
-  const purchaseLabel = purchaseDateStr ? `${purchaseBody} (${purchaseDateStr})` : purchaseBody;
-  _addDetail(valGrid, "Purchase", purchaseLabel);
-  _addDetail(valGrid, "Melt Value", metrics.currentSpot > 0 ? formatCurrency(meltValue) : "—");
-  _addDetail(valGrid, "Retail", retailTotal > 0 ? formatCurrency(retailTotal) : "—");
-  if (gainLoss !== null && retailTotal > 0) {
-    const glItem = _detailItem("Gain/Loss", (gainLoss >= 0 ? "+" : "") + formatCurrency(gainLoss));
-    const valEl = glItem.querySelector(".view-detail-value");
-    if (valEl) valEl.classList.add(gainLoss >= 0 ? "gain" : "loss");
-    valGrid.appendChild(glItem);
-  } else {
-    _addDetail(valGrid, "Gain/Loss", "—", "muted");
+
+  if (unitMode !== "each") {
+    return {
+      unitMode: "lot",
+      qty: metrics.qty,
+      purchaseDateStr,
+      purchasePrice,
+      purchaseTotal,
+      meltValue,
+      retailTotal,
+      gainLoss,
+      hasSpot: metrics.currentSpot > 0,
+    };
   }
-  valSection.appendChild(valGrid);
-  return valSection;
+
+  return {
+    unitMode: "each",
+    qty: metrics.qty,
+    purchaseDateStr,
+    purchasePrice,
+    purchaseTotal: purchasePrice,
+    meltValue: metrics.qty > 0 ? meltValue / metrics.qty : meltValue,
+    retailTotal: metrics.qty > 0 ? retailTotal / metrics.qty : retailTotal,
+    gainLoss: gainLoss !== null && metrics.qty > 0 ? gainLoss / metrics.qty : gainLoss,
+    hasSpot: metrics.currentSpot > 0,
+  };
+}
+
+function _renderValuationGrid(grid, values) {
+  grid.textContent = "";
+  const purchaseBody =
+    values.unitMode === "lot" && values.qty > 1
+      ? `${formatCurrency(values.purchaseTotal)} total \u00b7 ${formatCurrency(values.purchasePrice)} each`
+      : values.unitMode === "each" && values.qty > 1
+        ? `${formatCurrency(values.purchasePrice)} each`
+        : formatCurrency(values.purchasePrice);
+  const purchaseLabel = values.purchaseDateStr
+    ? `${purchaseBody} (${values.purchaseDateStr})`
+    : purchaseBody;
+  _addDetail(grid, "Purchase", purchaseLabel);
+  _addDetail(grid, "Melt Value", values.hasSpot ? formatCurrency(values.meltValue) : "—");
+  _addDetail(grid, "Retail", values.retailTotal > 0 ? formatCurrency(values.retailTotal) : "—");
+  if (values.gainLoss !== null && values.retailTotal > 0) {
+    const glItem = _detailItem(
+      "Gain/Loss",
+      (values.gainLoss >= 0 ? "+" : "") + formatCurrency(values.gainLoss)
+    );
+    const valEl = glItem.querySelector(".view-detail-value");
+    if (valEl) valEl.classList.add(values.gainLoss >= 0 ? "gain" : "loss");
+    grid.appendChild(glItem);
+  } else {
+    _addDetail(grid, "Gain/Loss", "—", "muted");
+  }
 }
 
 function _getChartCurrentRetail(item, metrics) {
@@ -677,11 +710,18 @@ function _getPriceHistoryContext(item, metrics) {
   const dailySpotEntries = [...spotByDay.values()];
   const retailEntries =
     typeof itemPriceHistory !== "undefined" && item.uuid
-      ? (itemPriceHistory[item.uuid] || []).filter((e) => e.retail > 0)
+      ? (itemPriceHistory[item.uuid] || [])
+          .filter((e) => e.retail > 0)
+          .map((e) => ({
+            ...e,
+            retail: parseFloat((Number(e.retail) * metrics.qty).toFixed(2)),
+          }))
       : [];
   const goldbackRetailEntries = _getGoldbackRetailHistoryEntries(item, metrics);
   return {
     metalName,
+    unitMode: "lot",
+    qty: metrics.qty,
     meltFactor,
     dailySpotEntries,
     retailEntries: _mergeRetailHistoryEntries(retailEntries, goldbackRetailEntries),
@@ -689,6 +729,35 @@ function _getPriceHistoryContext(item, metrics) {
     purchaseDate: item.date ? new Date(item.date).getTime() : 0,
     currentRetail: _getChartCurrentRetail(item, metrics),
   };
+}
+
+function _getPriceHistoryUnitValues(chartCtx) {
+  const divisor = chartCtx.unitMode === "each" && chartCtx.qty > 1 ? chartCtx.qty : 1;
+  return {
+    retailEntries: chartCtx.retailEntries.map((entry) => ({
+      ...entry,
+      retail: parseFloat((Number(entry.retail) / divisor).toFixed(2)),
+    })),
+    purchasePerUnit: chartCtx.purchasePerUnit / divisor,
+    meltFactor: chartCtx.meltFactor / divisor,
+    currentRetail: chartCtx.currentRetail / divisor,
+  };
+}
+
+function _renderPriceHistoryChart(canvas, spotEntries, chartCtx, days, fromTs, toTs) {
+  const unitValues = _getPriceHistoryUnitValues(chartCtx);
+  _createPriceHistoryChart(
+    canvas,
+    spotEntries,
+    unitValues.retailEntries,
+    unitValues.purchasePerUnit,
+    unitValues.meltFactor,
+    days,
+    chartCtx.purchaseDate,
+    unitValues.currentRetail,
+    fromTs,
+    toTs
+  );
 }
 
 function _buildPriceHistorySection(chartCtx) {
@@ -774,32 +843,10 @@ function _buildChartDateRangePicker(rangeBar, chartSection, chartCtx) {
     if (!canvas) return;
     try {
       const fullSpot = await _fetchHistoricalSpotData(chartCtx.metalName, 0, fromTs, toTs);
-      _createPriceHistoryChart(
-        canvas,
-        fullSpot,
-        chartCtx.retailEntries,
-        chartCtx.purchasePerUnit,
-        chartCtx.meltFactor,
-        0,
-        chartCtx.purchaseDate,
-        chartCtx.currentRetail,
-        fromTs,
-        toTs
-      );
+      _renderPriceHistoryChart(canvas, fullSpot, chartCtx, 0, fromTs, toTs);
     } catch (err) {
       console.error("Custom date range fetch failed:", err);
-      _createPriceHistoryChart(
-        canvas,
-        [],
-        chartCtx.retailEntries,
-        chartCtx.purchasePerUnit,
-        chartCtx.meltFactor,
-        0,
-        chartCtx.purchaseDate,
-        chartCtx.currentRetail,
-        fromTs,
-        toTs
-      );
+      _renderPriceHistoryChart(canvas, [], chartCtx, 0, fromTs, toTs);
     }
   };
   fromInput.addEventListener("change", onDateChange);
@@ -823,29 +870,14 @@ async function _onChartRangePillClick(days, dateRange, chartSection, chartCtx) {
         chartCtx.purchaseDate,
         toTs
       );
-      _createPriceHistoryChart(
-        canvas,
-        spotData,
-        chartCtx.retailEntries,
-        chartCtx.purchasePerUnit,
-        chartCtx.meltFactor,
-        0,
-        chartCtx.purchaseDate,
-        chartCtx.currentRetail,
-        chartCtx.purchaseDate,
-        toTs
-      );
+      _renderPriceHistoryChart(canvas, spotData, chartCtx, 0, chartCtx.purchaseDate, toTs);
     } catch (err) {
       console.error("Purchased range fetch failed:", err);
-      _createPriceHistoryChart(
+      _renderPriceHistoryChart(
         canvas,
         chartCtx.dailySpotEntries,
-        chartCtx.retailEntries,
-        chartCtx.purchasePerUnit,
-        chartCtx.meltFactor,
+        chartCtx,
         0,
-        chartCtx.purchaseDate,
-        chartCtx.currentRetail,
         chartCtx.purchaseDate,
         toTs
       );
@@ -855,28 +887,70 @@ async function _onChartRangePillClick(days, dateRange, chartSection, chartCtx) {
   const effectiveDays = days;
   try {
     const spotData = await _fetchHistoricalSpotData(chartCtx.metalName, effectiveDays);
-    _createPriceHistoryChart(
-      canvas,
-      spotData,
-      chartCtx.retailEntries,
-      chartCtx.purchasePerUnit,
-      chartCtx.meltFactor,
-      effectiveDays,
-      chartCtx.purchaseDate,
-      chartCtx.currentRetail
-    );
+    _renderPriceHistoryChart(canvas, spotData, chartCtx, effectiveDays);
   } catch (err) {
     console.error("Range pill fetch failed:", err);
-    _createPriceHistoryChart(
-      canvas,
-      chartCtx.dailySpotEntries,
-      chartCtx.retailEntries,
-      chartCtx.purchasePerUnit,
-      chartCtx.meltFactor,
-      effectiveDays,
-      chartCtx.purchaseDate,
-      chartCtx.currentRetail
-    );
+    _renderPriceHistoryChart(canvas, chartCtx.dailySpotEntries, chartCtx, effectiveDays);
+  }
+}
+
+async function _rerenderCurrentPriceHistoryChart(chartCtx) {
+  const canvas = document.getElementById("viewPriceHistoryChart");
+  const chartSection = canvas?.closest(".view-detail-section");
+  if (!canvas || !chartSection) return;
+
+  const inputs = chartSection.querySelectorAll(".view-chart-date-input");
+  const fromValue = inputs[0]?.value || "";
+  const toValue = inputs[1]?.value || "";
+  const fromTs = fromValue ? new Date(fromValue + "T00:00:00").getTime() : 0;
+  const toTs = toValue ? new Date(toValue + "T23:59:59").getTime() : 0;
+  if (fromTs > 0 || toTs > 0) {
+    try {
+      const fullSpot = await _fetchHistoricalSpotData(chartCtx.metalName, 0, fromTs, toTs);
+      _renderPriceHistoryChart(canvas, fullSpot, chartCtx, 0, fromTs, toTs);
+    } catch (err) {
+      console.error("Unit toggle date-range refresh failed:", err);
+      _renderPriceHistoryChart(canvas, [], chartCtx, 0, fromTs, toTs);
+    }
+    return;
+  }
+
+  const activePill = chartSection.querySelector(".view-chart-range-pill.active");
+  const days = activePill
+    ? Number(activePill.dataset.days)
+    : chartCtx.purchaseDate
+      ? _VIEW_CHART_DEFAULT_RANGE
+      : 30;
+  if (days === -1 && chartCtx.purchaseDate > 0) {
+    const toTsCurrent = Date.now();
+    try {
+      const spotData = await _fetchHistoricalSpotData(
+        chartCtx.metalName,
+        0,
+        chartCtx.purchaseDate,
+        toTsCurrent
+      );
+      _renderPriceHistoryChart(canvas, spotData, chartCtx, 0, chartCtx.purchaseDate, toTsCurrent);
+    } catch (err) {
+      console.error("Unit toggle purchased-range refresh failed:", err);
+      _renderPriceHistoryChart(
+        canvas,
+        chartCtx.dailySpotEntries,
+        chartCtx,
+        0,
+        chartCtx.purchaseDate,
+        toTsCurrent
+      );
+    }
+    return;
+  }
+
+  try {
+    const spotData = await _fetchHistoricalSpotData(chartCtx.metalName, days);
+    _renderPriceHistoryChart(canvas, spotData, chartCtx, days);
+  } catch (err) {
+    console.error("Unit toggle range refresh failed:", err);
+    _renderPriceHistoryChart(canvas, chartCtx.dailySpotEntries, chartCtx, days);
   }
 }
 
@@ -1089,7 +1163,7 @@ function buildViewContent(item, index) {
   const sectionBuilders = {
     images: () => _buildImageSection(item, metrics),
     priceHistory: () => _buildPriceHistorySection(chartCtx),
-    valuation: () => _buildValuationSection(item, metrics),
+    valuation: () => _buildValuationSectionWithChartContext(item, metrics, chartCtx),
     inventory: () => _buildInventorySection(item, metrics),
     grading: () => _buildGradingSection(item),
     numista: () => _buildNumistaPlaceholderSection(),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.59",
+  "version": "3.34.60",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.59-b1778523377";
+const CACHE_NAME = "staktrakr-v3.34.60-b1778530723";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/view-modal-chart-scaling.spec.js
+++ b/tests/playwright/view-modal-chart-scaling.spec.js
@@ -738,10 +738,13 @@ test.describe("view-modal-chart-scaling — STRK-42 / STRK-69", () => {
   test("regression: quantity items chart purchase, melt, and retail as totals", async ({
     page,
   }) => {
+    const item = { ...BASE_ITEM, qty: 3, price: 10, marketValue: 20, purity: 1 };
     await seedData(page, {
-      inventory: [{ ...BASE_ITEM, qty: 3, price: 10, marketValue: 20, purity: 1 }],
+      inventory: [item],
       spotHistory: makeSpotHistory(40, 15),
-      retailHistory: {},
+      retailHistory: {
+        [item.uuid]: [{ ts: new Date("2026-05-09T12:00:00.000Z").getTime(), retail: 21 }],
+      },
     });
     await gotoApp(page);
     await openViewModal(page);
@@ -758,7 +761,117 @@ test.describe("view-modal-chart-scaling — STRK-42 / STRK-69", () => {
 
     expect(new Set(purchaseDataset.data)).toEqual(new Set([30]));
     expect(meltDataset.data.every((value) => value > 0)).toBe(true);
+    expect(retailDataset.data).toContain(63);
     expect(retailDataset.data.at(-1)).toBe(60);
+  });
+
+  test("STRK-68: view modal Lot/Each toggle switches valuation and chart units", async ({
+    page,
+  }) => {
+    const item = { ...BASE_ITEM, qty: 3, price: 10, marketValue: 20, purity: 1 };
+    await seedData(page, {
+      inventory: [item],
+      spotHistory: makeSpotHistory(40, 15),
+      retailHistory: {
+        [item.uuid]: [{ ts: new Date("2026-05-09T12:00:00.000Z").getTime(), retail: 21 }],
+      },
+    });
+    await gotoApp(page);
+    await openViewModal(page);
+
+    await clickRange(page, "7d");
+    await expect(page.locator(".view-valuation-unit-toggle [data-unit-mode='lot']")).toHaveClass(
+      /active/
+    );
+    await expect(page.locator(".view-valuation-section")).toContainText("$30.00 total");
+    await expect(page.locator(".view-chart-range-pill.active")).toHaveText("7d");
+
+    let snapshot = await chartSnapshot(page);
+    let purchaseDataset = snapshot.visibleDatasets.find(
+      (dataset) => dataset.label === "Purchase Price"
+    );
+    let meltDataset = snapshot.visibleDatasets.find((dataset) => dataset.label === "Melt Value");
+    let retailDataset = snapshot.visibleDatasets.find(
+      (dataset) => dataset.label === "Retail Value"
+    );
+    expect(new Set(purchaseDataset.data)).toEqual(new Set([30]));
+    const lotMeltData = meltDataset.data;
+    expect(lotMeltData.every((value) => value > 0)).toBe(true);
+    expect(retailDataset.data).toContain(63);
+    expect(retailDataset.data.at(-1)).toBe(60);
+
+    await page.locator(".view-valuation-unit-toggle [data-unit-mode='each']").click();
+    await page.waitForFunction(() => {
+      const chart = Chart.getChart(document.getElementById("viewPriceHistoryChart"));
+      const purchaseDataset = chart.data.datasets.find(
+        (dataset) => dataset.label === "Purchase Price"
+      );
+      return purchaseDataset?.data?.every((value) => Number(value) === 10);
+    });
+    await expect(page.locator(".view-valuation-unit-toggle [data-unit-mode='each']")).toHaveClass(
+      /active/
+    );
+    await expect(page.locator(".view-valuation-section")).toContainText("$10.00 each");
+    await expect(page.locator(".view-valuation-section")).toContainText("$20.00");
+    await expect(page.locator(".view-chart-range-pill.active")).toHaveText("7d");
+
+    snapshot = await chartSnapshot(page);
+    purchaseDataset = snapshot.visibleDatasets.find(
+      (dataset) => dataset.label === "Purchase Price"
+    );
+    meltDataset = snapshot.visibleDatasets.find((dataset) => dataset.label === "Melt Value");
+    retailDataset = snapshot.visibleDatasets.find((dataset) => dataset.label === "Retail Value");
+    expect(new Set(purchaseDataset.data)).toEqual(new Set([10]));
+    meltDataset.data.forEach((value, index) => {
+      expect(value).toBeCloseTo(lotMeltData[index] / 3, 2);
+    });
+    expect(retailDataset.data).toContain(21);
+    expect(retailDataset.data.at(-1)).toBe(20);
+    expectVisibleDatasetsWithinScale(snapshot);
+
+    await page.locator(".view-valuation-unit-toggle [data-unit-mode='lot']").click();
+    await page.waitForFunction(() => {
+      const chart = Chart.getChart(document.getElementById("viewPriceHistoryChart"));
+      const purchaseDataset = chart.data.datasets.find(
+        (dataset) => dataset.label === "Purchase Price"
+      );
+      return purchaseDataset?.data?.every((value) => Number(value) === 30);
+    });
+    snapshot = await chartSnapshot(page);
+    purchaseDataset = snapshot.visibleDatasets.find(
+      (dataset) => dataset.label === "Purchase Price"
+    );
+    retailDataset = snapshot.visibleDatasets.find((dataset) => dataset.label === "Retail Value");
+    expect(new Set(purchaseDataset.data)).toEqual(new Set([30]));
+    expect(retailDataset.data.at(-1)).toBe(60);
+    await expect(page.locator(".view-chart-range-pill.active")).toHaveText("7d");
+  });
+
+  test("STRK-68: single-quantity items keep the chart unchanged and hide unit toggle", async ({
+    page,
+  }) => {
+    await seedData(page, {
+      inventory: [{ ...BASE_ITEM, qty: 1, price: 10, marketValue: 20, purity: 1 }],
+      spotHistory: makeSpotHistory(40, 15),
+      retailHistory: {},
+    });
+    await gotoApp(page);
+    await openViewModal(page);
+
+    await expect(page.locator(".view-valuation-unit-toggle")).toHaveCount(0);
+    await clickRange(page, "7d");
+    const snapshot = await chartSnapshot(page);
+    const purchaseDataset = snapshot.visibleDatasets.find(
+      (dataset) => dataset.label === "Purchase Price"
+    );
+    const meltDataset = snapshot.visibleDatasets.find((dataset) => dataset.label === "Melt Value");
+    const retailDataset = snapshot.visibleDatasets.find(
+      (dataset) => dataset.label === "Retail Value"
+    );
+
+    expect(new Set(purchaseDataset.data)).toEqual(new Set([10]));
+    expect(meltDataset.data.every((value) => value > 0)).toBe(true);
+    expect(retailDataset.data.at(-1)).toBe(20);
   });
 
   test("AC-4/AC-5: wide ranges keep purchase, melt, and retail lines inside y-axis bounds", async ({

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.59",
+  "version": "3.34.60",
   "releaseDate": "2026-05-11",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Add a Lot/Each segmented toggle to multi-quantity item detail valuation sections.
- Keep valuation values and price history chart datasets in the same unit mode.
- Preserve active chart range/custom date inputs while toggling, and keep qty=1 behavior unchanged.
- Bump release artifacts for v3.34.60.

## Validation

- `npx playwright test tests/playwright/view-modal-chart-scaling.spec.js` — 17 passed
- `npm run lint` — passed with existing warnings in `js/diff-engine.js` and `js/diff-modal.js` for unused eslint-disable directives
- `npm run test:offline` — 602 passed, 2 failed; focused rerun showed the autocomplete failure cleared, remaining `theme-tokens.spec.js` failure is live API CORS noise from `https://api.staktrakr.com/data/v2/...` fetches being counted as runtime errors

## Notes

Draft PR for user review. No schema or persistence changes; the toggle resets to Lot on each View modal open.