### PR TITLE
chore(STRK-57): suppress Playwright webServer stderr noise

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,5 +16,6 @@ export default defineConfig({
     command: "python3 -m http.server 3000",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    stderr: "ignore",
   },
 });


### PR DESCRIPTION
## Summary

Adds `stderr: "ignore"` to `webServer` in `playwright.config.js`. Suppresses 100s of `[WebServer]` access-log lines per test run. No runtime code touched; no release artifact bump.

- Issue: [STRK-57](https://plane.lbruton.cc/lbruton/browse/STRK-57/)
- Sketch: `DocVault/Projects/StakTrakr/sketches/STRK-57-quiet-playwright-logs/`
- No `/release` bump or release artifact update — test-harness only.

## Test plan

- [x] **B.1 smoke** — `npx playwright test tests/playwright/01-page-load/page-load.spec.js`: 12/12 passed, zero `[WebServer]` lines
- [x] **B.2 full suite** — `npm test`: 606 ran, 604 passed, zero `[WebServer]` lines. The 2 failures (`stak-437-search-tab-removal.spec.js:384`, `theme-tokens.spec.js:20`) verified pre-existing on clean dev HEAD `de15913f` — a state-flake and a CORS-race respectively, not caused by this change.
- [x] **B.3 failure signal** — renamed `css/styles.css` → test 1.4 failed at Playwright assertion layer; zero `code 404` Python stderr lines. Real failures still surface via Playwright; only redundant Python access-log chatter is gone.

## Acceptance criteria

- [x] AC-1 — Request log suppression (zero `[WebServer]` lines)
- [x] AC-2 — Failure signal preserved (verified via B.3)
- [x] AC-3 — No regressions (604/606 with 2 pre-existing failures verified on dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)