### PR TITLE
v3.34.61 — STRK-66: add ¼ Goldback denomination (Idaho, g0.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.61] - 2026-05-12
+
+### Changed — STRK-66: Add ¼ Goldback denomination support (Idaho, g0.25)
+
+- **GOLDBACK_DENOMINATIONS**: Prepend `{ weight: 0.25, label: "¼ Goldback", goldOz: 0.00025 }` as the new first entry; array now has 9 denominations (STRK-66).
+- **Label rendering**: Add `d.weight === 0.25 ? "¼"` branch in `updateDenomLabels` and `updateBulkDenomLabels` so the denomination shows as "¼ Goldback" in item add/edit and bulk-edit modals (STRK-66).
+- **Slug parser**: Add `"g0.25": 0.00025` to `GOLDBACK_WEIGHTS` so `goldback-idaho-g0.25` resolves to 0.00025 oz (STRK-66).
+- **Poller**: Add `g0.25` to `DENOMINATION_MULTIPLIERS` in `goldback-scraper.js` and to `buildGoldbackDenominations` in `api-export.js` and `api-export-v2.js` (STRK-66).
+- **Bounds-guard fix**: Update price-extract.js regex to `/goldback-.*?-?g(\d+(?:\.\d+)?)$/i` so decimal denomination slugs are matched and their multiplier is computed correctly (STRK-66).
+
+---
+
 ## [3.34.60] - 2026-05-11
 
 ### Changed — STRK-68: Chart unit alignment for lot/each pricing

--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -831,6 +831,7 @@ async function queryGoldbackRange(client, startIso, endIso) {
 
 function buildGoldbackDenominations(g1) {
   return {
+    "g0.25": Math.round(g1 * 0.25 * 100) / 100,
     g1: g1,
     g5: Math.round(g1 * 5 * 100) / 100,
     g10: Math.round(g1 * 10 * 100) / 100,

--- a/devops/pollers/shared/api-export.js
+++ b/devops/pollers/shared/api-export.js
@@ -962,6 +962,7 @@ async function main() {
           scraped_at: generatedAt,
           g1_usd: g1,
           denominations: {
+            "g0.25": Math.round(g1 * 0.25 * 100) / 100,
             g1: g1,
             g5: Math.round(g1 * 5 * 100) / 100,
             g10: Math.round(g1 * 10 * 100) / 100,

--- a/devops/pollers/shared/goldback-scraper.js
+++ b/devops/pollers/shared/goldback-scraper.js
@@ -51,7 +51,7 @@ const G1_MIN = 0.5;
 const G1_MAX = 20.0;
 
 // Denomination multipliers relative to G1
-const DENOMINATION_MULTIPLIERS = { g1: 1, g5: 5, g10: 10, g25: 25, g50: 50 };
+const DENOMINATION_MULTIPLIERS = { "g0.25": 0.25, g1: 1, g5: 5, g10: 10, g25: 25, g50: 50 };
 
 // ---------------------------------------------------------------------------
 // Logging

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1521,7 +1521,7 @@ async function main() {
    */
   function computeBaseline(coinSlug, coin) {
     if (coin.metal === "goldback") {
-      // Goldback denominations: G1, G5, G10, G25, G50
+      // Goldback denominations: g0.25, G1, G5, G10, G25, G50
       if (!_goldbackG1) return null;
       const denomMatch =
         coinSlug.match(/goldback-.*?-?g(\d+(?:\.\d+)?)$/i) ||

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -1524,7 +1524,8 @@ async function main() {
       // Goldback denominations: G1, G5, G10, G25, G50
       if (!_goldbackG1) return null;
       const denomMatch =
-        coinSlug.match(/goldback-.*?-?g(\d+)$/i) || coinSlug.match(/goldback-g(\d+)/i);
+        coinSlug.match(/goldback-.*?-?g(\d+(?:\.\d+)?)$/i) ||
+        coinSlug.match(/goldback-g(\d+(?:\.\d+)?)/i);
       const multiplier = denomMatch ? Number(denomMatch[1]) : 1;
       return _goldbackG1 * multiplier;
     }

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.61 &ndash; STRK-66: ¼ Goldback denomination (Idaho, g0.25)</strong>: Adds the 1/4 Goldback (1/4000 oz gold) as the ninth canonical denomination with correct label rendering in add/edit and bulk-edit dropdowns, slug resolution, poller publishing, and bounds-guard regex fix for decimal denomination suffixes (STRK-66).</li>
     <li><strong>v3.34.60 &ndash; STRK-68: Chart unit alignment for lot/each pricing</strong>: Purchase, melt, and retail chart lines now use consistent units based on the stored lot/each pricing choice; re-editing an item restores the toggle and lot-total price to the edit form (STRK-68).</li>
     <li><strong>v3.34.59 &ndash; STRK-69: Goldback daily retail chart history</strong>: Goldback denomination prices now keep one retail-history point per calendar day even when the vendor price is flat, and item detail charts use denomination retail values when stored market value is empty (STRK-69).</li>
     <li><strong>v3.34.58 &ndash; STRK-42: Chart viewport scaling</strong>: Item detail charts now fit the y-axis to visible purchase, melt, and retail lines with padding, fetch only needed bounded-range history, and keep sparse 1Y ranges anchored at the viewport start (STRK-42).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.56 &ndash; STRK-65: Attachment review follow-ups</strong>: Hardens per-item attachments after PR review &mdash; queue entries removable independently, object URL lifecycle fixed, cloud-sync pull helper extracted (fixes repeat downloads), size guard before vault serialization, DiffEngine duplicate-filename safety, split items keep attachments on both records, storage diagnostics clarified (STRK-65).</li>
     <li><strong>v3.34.55 &ndash; STRK-45: Per-item PDF/image attachments</strong>: Attach receipts, COAs, and dealer invoices directly to inventory items (PDF, PNG, JPG) from the Edit modal drag-drop zone. Attachments are persisted in IndexedDB, shown as a count badge on card, table, and detail views, included in zip/stvault backups and CSV exports, and synced via cloud sync with an opt-out toggle in Settings (STRK-45).</li>
     <li><strong>v3.34.54 &ndash; STRK-52: Numista re-sync tag membership</strong>: Existing on-item tags in the Numista re-sync picker are now shown checked and enabled instead of locked-disabled, letting you uncheck them to record an explicit opt-out. Uncheck-all also protects on-item tags from accidental mass-removal (STRK-52).</li>
-    <li><strong>v3.34.53 &ndash; STRK-46: Structured Capsule field + capsule notes</strong>: Inventory items now have dedicated Capsule and Capsule Notes fields with Air-Tite-style suggestions, autocomplete, search/filter support, view-modal display, and JSON backup round-trip preservation (STRK-46).</li>
   `;
 };
 

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -625,7 +625,7 @@ const renderBulkFieldPanel = () => {
       GOLDBACK_DENOMINATIONS.forEach((d) => {
         const opt = document.createElement("option");
         opt.value = String(d.weight);
-        const prefix = d.weight === 0.5 ? "½" : String(d.weight);
+        const prefix = d.weight === 0.25 ? "¼" : d.weight === 0.5 ? "½" : String(d.weight);
         opt.textContent = `${prefix} Goldback`;
         if (d.weight === 1) opt.selected = true;
         denomSelect.appendChild(opt);

--- a/js/bulkEdit.js
+++ b/js/bulkEdit.js
@@ -625,8 +625,7 @@ const renderBulkFieldPanel = () => {
       GOLDBACK_DENOMINATIONS.forEach((d) => {
         const opt = document.createElement("option");
         opt.value = String(d.weight);
-        const prefix = d.weight === 0.25 ? "¼" : d.weight === 0.5 ? "½" : String(d.weight);
-        opt.textContent = `${prefix} Goldback`;
+        opt.textContent = d.label;
         if (d.weight === 1) opt.selected = true;
         denomSelect.appendChild(opt);
       });

--- a/js/constants.js
+++ b/js/constants.js
@@ -586,6 +586,7 @@ const LB_TO_OZT = 14.58333;
  * @constant {Array<{weight: number, label: string, goldOz: number}>}
  */
 const GOLDBACK_DENOMINATIONS = [
+  { weight: 0.25, label: "¼ Goldback", goldOz: 0.00025 },
   { weight: 0.5, label: "½ Goldback", goldOz: 0.0005 },
   { weight: 1, label: "1 Goldback", goldOz: 0.001 },
   { weight: 2, label: "2 Goldback", goldOz: 0.002 },

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-11 - STRK-68: Chart unit alignment for lot/each pricing
  */
 
-const APP_VERSION = "3.34.60";
+const APP_VERSION = "3.34.61";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -281,7 +281,7 @@ const CERT_LOOKUP_URLS = {
  * Follows BRANCH.RELEASE.PATCH.state format
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
- * Updated: 2026-05-11 - STRK-68: Chart unit alignment for lot/each pricing
+ * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
 const APP_VERSION = "3.34.61";

--- a/js/events.js
+++ b/js/events.js
@@ -1950,7 +1950,7 @@ const updateDenomLabels = (typeValue = "") => {
   GOLDBACK_DENOMINATIONS.forEach((d) => {
     const opt = document.createElement("option");
     opt.value = String(d.weight);
-    const prefix = d.weight === 0.5 ? "½" : String(d.weight);
+    const prefix = d.weight === 0.25 ? "¼" : d.weight === 0.5 ? "½" : String(d.weight);
     opt.textContent = `${prefix} Goldback`;
     if (d.weight === 1) opt.selected = true;
     denomSelect.appendChild(opt);

--- a/js/events.js
+++ b/js/events.js
@@ -1950,8 +1950,7 @@ const updateDenomLabels = (typeValue = "") => {
   GOLDBACK_DENOMINATIONS.forEach((d) => {
     const opt = document.createElement("option");
     opt.value = String(d.weight);
-    const prefix = d.weight === 0.25 ? "¼" : d.weight === 0.5 ? "½" : String(d.weight);
-    opt.textContent = `${prefix} Goldback`;
+    opt.textContent = d.label;
     if (d.weight === 1) opt.selected = true;
     denomSelect.appendChild(opt);
   });

--- a/js/retail.js
+++ b/js/retail.js
@@ -41,6 +41,7 @@ const RETAIL_COIN_META = {
 
 /** Goldback denomination weights (troy oz) */
 const GOLDBACK_WEIGHTS = {
+  "g0.25": 0.00025,
   "g0.5": 0.0005,
   ghalf: 0.0005,
   g1: 0.001,

--- a/js/retail.js
+++ b/js/retail.js
@@ -63,7 +63,7 @@ const _parseGoldbackSlug = (slug) => {
   const weight = GOLDBACK_WEIGHTS[m[2]];
   if (weight == null) return null;
   const state = m[1].replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-  const denom = m[2] === "ghalf" ? "G\u00BD" : m[2].toUpperCase();
+  const denom = m[2] === "ghalf" ? "G\u00BD" : m[2] === "g0.25" ? "G\u00BC" : m[2].toUpperCase();
   return { name: `${denom} ${state} Goldback`, weight, metal: "goldback" };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.60",
+  "version": "3.34.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.60",
+      "version": "3.34.61",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.60",
+  "version": "3.34.61",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.61-b1778610584";
+const CACHE_NAME = "staktrakr-v3.34.61-b1778610948";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.60-b1778547828";
+const CACHE_NAME = "staktrakr-v3.34.60-b1778609911";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.61-b1778610948";
+const CACHE_NAME = "staktrakr-v3.34.61-b1778612349";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.60-b1778609911";
+const CACHE_NAME = "staktrakr-v3.34.61-b1778610584";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/goldback-type.spec.js
+++ b/tests/playwright/goldback-type.spec.js
@@ -266,7 +266,7 @@ test.describe("goldback-type — STAK-562 first-class type behavior", () => {
     await expect(page.locator("#itemGbDenom")).toBeHidden();
   });
 
-  test("9. Goldback type shows all 8 standard denominations", async ({ page }) => {
+  test("9. Goldback type shows all 9 standard denominations", async ({ page }) => {
     await seedData(page);
     await gotoApp(page);
     await openAddModal(page);
@@ -278,9 +278,10 @@ test.describe("goldback-type — STAK-562 first-class type behavior", () => {
       const sel = document.getElementById("itemGbDenom");
       return Array.from(sel.options).map((o) => ({ value: o.value, text: o.textContent }));
     });
-    expect(options).toHaveLength(8);
-    expect(options[0].text).toBe("½ Goldback");
-    expect(options[7].text).toBe("100 Goldback");
+    expect(options).toHaveLength(9);
+    expect(options[0].text).toBe("¼ Goldback");
+    expect(options[1].text).toBe("½ Goldback");
+    expect(options[8].text).toBe("100 Goldback");
   });
 
   test("10. Silverback has a dedicated silverback unit option", async ({ page }) => {
@@ -357,8 +358,8 @@ test.describe("goldback-type — STAK-562 first-class type behavior", () => {
       const sel = document.getElementById("bulkFieldVal_weightDenom");
       return Array.from(sel.options).map((o) => ({ value: o.value, text: o.textContent }));
     });
-    expect(goldOptions).toHaveLength(8);
-    expect(goldOptions[0].text).toBe("½ Goldback");
+    expect(goldOptions).toHaveLength(9);
+    expect(goldOptions[0].text).toBe("¼ Goldback");
   });
 
   test("14. Manual Goldback retail value is a floor override, not ignored", async ({ page }) => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.60",
-  "releaseDate": "2026-05-11",
+  "version": "3.34.61",
+  "releaseDate": "2026-05-12",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- Add `¼ Goldback` (1/4000 oz gold) as the ninth canonical denomination across UI, poller, and docs
- Fix bounds-guard regex in `price-extract.js` to correctly handle decimal denomination slugs (`g0.25`)
- Update Playwright denomination tests (TDD: tests updated first, implementation follows)

## Issues

- [STRK-66](https://plane.lbruton.cc/lbruton/browse/STRK-66/): Add 1/4 Goldback denomination support (Idaho first)

## Sketch

`DocVault/Projects/StakTrakr/sketches/STRK-66-quarter-goldback/`

## Test Plan

- [x] AC-1: `GOLDBACK_DENOMINATIONS[0]` is `{ weight: 0.25, label: "¼ Goldback", goldOz: 0.00025 }`, array length 9
- [x] AC-2: Item add/edit modal shows "¼ Goldback" as first option in denomination dropdown
- [x] AC-3: Bulk-edit modal shows "¼ Goldback" as first option; 9 entries total
- [x] AC-4: `GOLDBACK_WEIGHTS["g0.25"] === 0.00025`; `goldback-idaho-g0.25` resolves correctly
- [x] AC-5: `goldback-scraper.js`, `api-export.js`, `api-export-v2.js` all emit `g0.25`
- [x] AC-6: Bounds-guard regex matches `g0.25` (captures `"0.25"` → multiplier 0.25); integer slugs unchanged; `ghalf` unaffected
- [x] AC-7: Playwright tests 9 and 13 pass (9 denominations, `options[0].text === "¼ Goldback"`)
- [x] AC-8: `data-pipelines.md` Idaho row + g0.25 denom row; `reusable-patterns.md` slug list updated
- [ ] AC-9 (manual post-deploy): Add a ¼ Idaho Goldback, verify gold content shows 0.00025 oz

## Post-Merge Ops

- Rebuild home poller container so `goldback-scraper.js` / `price-extract.js` changes take effect
- Verify scraper emits `g0.25` entries once Idaho 1/4 listings appear at vendors

## Files Changed

| File | Change |
|------|--------|
| `js/constants.js` | Prepend `{ weight: 0.25, label: "¼ Goldback", goldOz: 0.00025 }` to `GOLDBACK_DENOMINATIONS` |
| `js/events.js` | Add `d.weight === 0.25 ? "¼"` branch in `updateDenomLabels` |
| `js/bulkEdit.js` | Same branch in `updateBulkDenomLabels` |
| `js/retail.js` | Add `"g0.25": 0.00025` to `GOLDBACK_WEIGHTS` |
| `devops/pollers/shared/goldback-scraper.js` | Add `"g0.25": 0.25` to `DENOMINATION_MULTIPLIERS` |
| `devops/pollers/shared/api-export.js` | Add `g0.25` to inline denominations object |
| `devops/pollers/shared/api-export-v2.js` | Add `g0.25` to `buildGoldbackDenominations` |
| `devops/pollers/shared/price-extract.js` | Regex `g(\d+)` → `g(\d+(?:\.\d+)?)` |
| `tests/playwright/goldback-type.spec.js` | Tests 9 and 13: length 8→9, first option "¼ Goldback" |