### PR TITLE
feat(STRK-53): constrained quantity selector for partial-stack disposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.62] - 2026-05-12
+
+### Changed — STRK-53: Constrained quantity selector for partial-stack disposition
+
+- **Chip mode**: Dispose modal now renders chip buttons (1–N) for stacks of 8 or fewer, making invalid quantities unreachable. Chips use roving tabindex with ArrowLeft/Right/Home/End keyboard navigation and aria-pressed state (STRK-53).
+- **Select mode**: Stacks larger than 8 use a native `<select>` pre-populated with options 1–N and the maximum quantity pre-selected, replacing the free-entry number input (STRK-53).
+- **Single-item stacks**: A stack of 1 now shows a pre-selected, dimmed chip control instead of hiding the quantity field, making the affordance consistent and accessible (STRK-53).
+- **Hidden carrier**: Both modes write through a hidden `<input id="removeItemQty">` via `writeDisposeQty()` so the existing preview-update handler fires without modification (STRK-53).
+
+---
+
 ## [3.34.61] - 2026-05-12
 
 ### Changed — STRK-66: Add ¼ Goldback denomination support (Idaho, g0.25)

--- a/css/styles.css
+++ b/css/styles.css
@@ -7977,9 +7977,6 @@ a.about-badge:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
-.chip-sort-toggle--quantity .chip-sort-btn:not(:last-child) {
-  border-right: 1px solid var(--border); /* override the in-pill divider — chips are individual buttons here */
-}
 .chip-sort-toggle--quantity.is-disabled .chip-sort-btn {
   opacity: 0.55;
   cursor: default;

--- a/css/styles.css
+++ b/css/styles.css
@@ -7963,6 +7963,37 @@ a.about-badge:hover {
   line-height: 1;
 }
 
+/* STRK-53: dispose-modal quantity selector — AAA touch targets + wrap on narrow viewports */
+.chip-sort-toggle--quantity {
+  flex-wrap: wrap;
+  gap: 8px;
+  overflow: visible;
+  border: none;
+}
+.chip-sort-toggle--quantity .chip-sort-btn {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.chip-sort-toggle--quantity .chip-sort-btn:not(:last-child) {
+  border-right: 1px solid var(--border); /* override the in-pill divider — chips are individual buttons here */
+}
+.chip-sort-toggle--quantity.is-disabled .chip-sort-btn {
+  opacity: 0.55;
+  cursor: default;
+}
+.qty-max-suffix {
+  color: var(--text-secondary);
+  font-weight: 400;
+  font-size: var(--font-size-sm);
+  margin-left: 0.4rem;
+}
+#removeItemQtySelect {
+  min-height: 44px;
+}
+
 #purchasePriceModeToggle.is-hidden {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -8304,7 +8304,7 @@
 
           <div id="removeItemDisposeFields" style="display: none">
             <div id="removeItemQtyGroup" class="form-group" style="display: none">
-              <label id="removeItemQtyLabel" for="removeItemQty">
+              <label id="removeItemQtyLabel">
                 Quantity to dispose<span id="removeItemQtyLabelMax" class="qty-max-suffix"></span>
               </label>
               <div

--- a/index.html
+++ b/index.html
@@ -8303,7 +8303,7 @@
           </label>
 
           <div id="removeItemDisposeFields" style="display: none">
-            <div class="form-group" style="display: none">
+            <div id="removeItemQtyGroup" class="form-group" style="display: none">
               <label id="removeItemQtyLabel" for="removeItemQty">
                 Quantity to dispose<span id="removeItemQtyLabelMax" class="qty-max-suffix"></span>
               </label>

--- a/index.html
+++ b/index.html
@@ -8304,8 +8304,21 @@
 
           <div id="removeItemDisposeFields" style="display: none">
             <div class="form-group" style="display: none">
-              <label for="removeItemQty">Quantity to dispose</label>
-              <input type="number" id="removeItemQty" min="1" />
+              <label id="removeItemQtyLabel" for="removeItemQty">
+                Quantity to dispose<span id="removeItemQtyLabelMax" class="qty-max-suffix"></span>
+              </label>
+              <div
+                id="removeItemQtyChips"
+                role="group"
+                aria-labelledby="removeItemQtyLabel"
+                style="display: none"
+              ></div>
+              <select
+                id="removeItemQtySelect"
+                aria-labelledby="removeItemQtyLabel"
+                style="display: none"
+              ></select>
+              <input type="hidden" id="removeItemQty" />
               <p
                 id="removeItemDisposePreview"
                 class="form-helper"

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.62 &ndash; STRK-53: Constrained quantity selector</strong>: Dispose modal now uses chip buttons (stacks &le; 8) or a native select (stacks &gt; 8) to make invalid quantities unreachable via the UI. Single-item stacks show a pre-selected, dimmed chip instead of hiding the control (STRK-53).</li>
     <li><strong>v3.34.61 &ndash; STRK-66: ¼ Goldback denomination (Idaho, g0.25)</strong>: Adds the 1/4 Goldback (1/4000 oz gold) as the ninth canonical denomination with correct label rendering in add/edit and bulk-edit dropdowns, slug resolution, poller publishing, and bounds-guard regex fix for decimal denomination suffixes (STRK-66).</li>
     <li><strong>v3.34.60 &ndash; STRK-68: Chart unit alignment for lot/each pricing</strong>: Purchase, melt, and retail chart lines now use consistent units based on the stored lot/each pricing choice; re-editing an item restores the toggle and lot-total price to the edit form (STRK-68).</li>
     <li><strong>v3.34.59 &ndash; STRK-69: Goldback daily retail chart history</strong>: Goldback denomination prices now keep one retail-history point per calendar day even when the vendor price is flat, and item detail charts use denomination retail values when stored market value is empty (STRK-69).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.57 &ndash; STRK-67: Per-side image frame override</strong>: Add Auto/Circle/Rectangle frame controls for obverse and reverse images so rectangular slabs, bars, notes, and similar media can be corrected while default shape detection stays automatic (STRK-67).</li>
     <li><strong>v3.34.56 &ndash; STRK-65: Attachment review follow-ups</strong>: Hardens per-item attachments after PR review &mdash; queue entries removable independently, object URL lifecycle fixed, cloud-sync pull helper extracted (fixes repeat downloads), size guard before vault serialization, DiffEngine duplicate-filename safety, split items keep attachments on both records, storage diagnostics clarified (STRK-65).</li>
     <li><strong>v3.34.55 &ndash; STRK-45: Per-item PDF/image attachments</strong>: Attach receipts, COAs, and dealer invoices directly to inventory items (PDF, PNG, JPG) from the Edit modal drag-drop zone. Attachments are persisted in IndexedDB, shown as a count badge on card, table, and detail views, included in zip/stvault backups and CSV exports, and synced via cloud sync with an opt-out toggle in Settings (STRK-45).</li>
-    <li><strong>v3.34.54 &ndash; STRK-52: Numista re-sync tag membership</strong>: Existing on-item tags in the Numista re-sync picker are now shown checked and enabled instead of locked-disabled, letting you uncheck them to record an explicit opt-out. Uncheck-all also protects on-item tags from accidental mass-removal (STRK-52).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.61";
+const APP_VERSION = "3.34.62";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -675,6 +675,7 @@ const renderDisposeQtyChips = (stackQty, labelMaxEl) => {
     btn.className = "chip-sort-btn";
     btn.dataset.qty = String(n);
     btn.textContent = String(n);
+    btn.setAttribute("aria-label", `Dispose ${n} of ${stackQty}`);
     const isLast = n === stackQty;
     btn.setAttribute("aria-pressed", isLast ? "true" : "false");
     btn.tabIndex = isLast ? 0 : -1;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -624,6 +624,123 @@ window.startCellEdit = startCellEdit;
  */
 let _removeItemQtyPreviewHandler = null;
 let _confirmRemoveItemInFlight = false;
+const DISPOSE_QTY_CHIP_MAX = 8;
+let _removeItemQtyChipKeyHandler = null;
+let _removeItemQtySelectChangeHandler = null;
+
+const writeDisposeQty = (n) => {
+  const el = safeGetElement("removeItemQty");
+  if (!el) return;
+  el.value = String(n);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+};
+
+const renderDisposeQtyChips = (stackQty, labelMaxEl) => {
+  const chipsEl = safeGetElement("removeItemQtyChips");
+  const selectEl = safeGetElement("removeItemQtySelect");
+  if (!chipsEl || !selectEl) return;
+
+  chipsEl.innerHTML = "";
+  chipsEl.className = "chip-sort-toggle chip-sort-toggle--quantity";
+  chipsEl.style.display = "";
+  selectEl.style.display = "none";
+
+  if (labelMaxEl) labelMaxEl.textContent = ` (max ${stackQty})`;
+
+  if (stackQty === 1) {
+    chipsEl.classList.add("is-disabled");
+    chipsEl.setAttribute("aria-disabled", "true");
+  } else {
+    chipsEl.classList.remove("is-disabled");
+    chipsEl.removeAttribute("aria-disabled");
+  }
+
+  const selectChip = (n) => {
+    const disabled = chipsEl.classList.contains("is-disabled");
+    for (const btn of chipsEl.children) {
+      const active = btn.dataset.qty === String(n);
+      btn.setAttribute("aria-pressed", active ? "true" : "false");
+      btn.tabIndex = active ? 0 : -1;
+      btn.classList.toggle("active", active);
+    }
+    writeDisposeQty(n);
+    if (!disabled) {
+      chipsEl.querySelector(`[data-qty="${n}"]`)?.focus();
+    }
+  };
+
+  for (let n = 1; n <= stackQty; n++) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "chip-sort-btn";
+    btn.dataset.qty = String(n);
+    btn.textContent = String(n);
+    const isLast = n === stackQty;
+    btn.setAttribute("aria-pressed", isLast ? "true" : "false");
+    btn.tabIndex = isLast ? 0 : -1;
+    if (isLast) btn.classList.add("active");
+    btn.addEventListener("click", () => selectChip(n));
+    chipsEl.appendChild(btn);
+  }
+
+  if (_removeItemQtyChipKeyHandler) {
+    chipsEl.removeEventListener("keydown", _removeItemQtyChipKeyHandler);
+  }
+  _removeItemQtyChipKeyHandler = (event) => {
+    if (chipsEl.classList.contains("is-disabled")) return;
+    const chips = Array.from(chipsEl.children);
+    const currentIdx = chips.findIndex((b) => b.tabIndex === 0);
+    let targetIdx = currentIdx;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      targetIdx = (currentIdx + 1) % chips.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      targetIdx = (currentIdx - 1 + chips.length) % chips.length;
+    } else if (event.key === "Home") {
+      targetIdx = 0;
+    } else if (event.key === "End") {
+      targetIdx = chips.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    selectChip(parseInt(chips[targetIdx].dataset.qty, 10));
+  };
+  chipsEl.addEventListener("keydown", _removeItemQtyChipKeyHandler);
+
+  writeDisposeQty(stackQty);
+  if (!chipsEl.classList.contains("is-disabled")) {
+    chipsEl.querySelector(`[data-qty="${stackQty}"]`)?.focus();
+  }
+};
+
+const renderDisposeQtySelect = (stackQty, labelMaxEl) => {
+  const chipsEl = safeGetElement("removeItemQtyChips");
+  const selectEl = safeGetElement("removeItemQtySelect");
+  if (!chipsEl || !selectEl) return;
+
+  chipsEl.style.display = "none";
+  selectEl.style.display = "";
+
+  if (labelMaxEl) labelMaxEl.textContent = ` (max ${stackQty})`;
+
+  selectEl.innerHTML = "";
+  for (let n = 1; n <= stackQty; n++) {
+    const opt = document.createElement("option");
+    opt.value = String(n);
+    opt.textContent = String(n);
+    if (n === stackQty) opt.selected = true;
+    selectEl.appendChild(opt);
+  }
+
+  if (_removeItemQtySelectChangeHandler) {
+    selectEl.removeEventListener("change", _removeItemQtySelectChangeHandler);
+  }
+  _removeItemQtySelectChangeHandler = (e) => writeDisposeQty(parseInt(e.target.value, 10));
+  selectEl.addEventListener("change", _removeItemQtySelectChangeHandler);
+
+  writeDisposeQty(stackQty);
+  selectEl.focus();
+};
 
 const openRemoveItemModal = (idx, preDispose = false) => {
   const item = inventory[idx];
@@ -678,15 +795,15 @@ const openRemoveItemModal = (idx, preDispose = false) => {
 
   const stackQty = Number(item.qty) || 1;
 
-  if (stackQty > 1) {
-    if (qtyGroup) qtyGroup.style.display = "";
-    if (qtyInput) {
-      qtyInput.value = stackQty;
-      qtyInput.max = stackQty;
-    }
+  // STRK-53: control is always visible — qty=1 shows pre-selected, dimmed.
+  if (qtyGroup) qtyGroup.style.display = "";
+  const labelMaxEl = safeGetElement("removeItemQtyLabelMax");
+  if (stackQty <= DISPOSE_QTY_CHIP_MAX) {
+    renderDisposeQtyChips(stackQty, labelMaxEl);
   } else {
-    if (qtyGroup) qtyGroup.style.display = "none";
+    renderDisposeQtySelect(stackQty, labelMaxEl);
   }
+  // qtyInput.value is set by writeDisposeQty inside the helpers; no direct write here.
 
   window.disposeAmountToggle?.setMode("each", { convertInput: false });
   window.disposeAmountToggle?.updateVisibility();
@@ -770,12 +887,16 @@ const confirmRemoveItem = async () => {
         disposedQty = Number(item.qty) || 1;
       } else {
         disposedQty = Number(qtyInputEl.value);
+        // STRK-53: defense-in-depth. The chip/<select> UI does not expose a path to a non-integer
+        // value. This branch is reachable only via programmatic DOM access — keep as a safety net.
         if (!Number.isInteger(disposedQty)) {
           showToast("Please enter a whole number quantity to dispose.");
           return;
         }
       }
 
+      // STRK-53: defense-in-depth. Same reasoning as above — out-of-range values are not
+      // selectable through the UI.
       if (
         !Number.isFinite(disposedQty) ||
         disposedQty < 1 ||

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -704,7 +704,8 @@ const renderDisposeQtyChips = (stackQty, labelMaxEl) => {
       return;
     }
     event.preventDefault();
-    selectChip(parseInt(chips[targetIdx].dataset.qty, 10));
+    const parsedQty = Number(chips[targetIdx].dataset.qty);
+    selectChip(Number.isNaN(parsedQty) ? 1 : parsedQty);
   };
   chipsEl.addEventListener("keydown", _removeItemQtyChipKeyHandler);
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -630,7 +630,7 @@ let _removeItemQtySelectChangeHandler = null;
 
 const writeDisposeQty = (n) => {
   const el = safeGetElement("removeItemQty");
-  if (!el) return;
+  if (!(el instanceof HTMLElement)) return;
   el.value = String(n);
   el.dispatchEvent(new Event("input", { bubbles: true }));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.61",
+  "version": "3.34.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.61",
+      "version": "3.34.62",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.61",
+  "version": "3.34.62",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.62-b1778622183";
+const CACHE_NAME = "staktrakr-v3.34.62-b1778628255";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.61-b1778619573";
+const CACHE_NAME = "staktrakr-v3.34.61-b1778620697";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.62-b1778621906";
+const CACHE_NAME = "staktrakr-v3.34.62-b1778622183";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.61-b1778620697";
+const CACHE_NAME = "staktrakr-v3.34.62-b1778621527";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.61-b1778619380";
+const CACHE_NAME = "staktrakr-v3.34.61-b1778619573";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.61-b1778612349";
+const CACHE_NAME = "staktrakr-v3.34.61-b1778619380";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.62-b1778621527";
+const CACHE_NAME = "staktrakr-v3.34.62-b1778621906";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/inventory/partial-stack-disposition.spec.js
+++ b/tests/playwright/inventory/partial-stack-disposition.spec.js
@@ -120,7 +120,13 @@ async function openDisposeModal(page, idx) {
 }
 
 async function setDisposeQty(page, qty) {
-  await page.fill("#removeItemQty", String(qty));
+  await page.waitForSelector("#removeItemModal", { state: "visible" });
+  const chipsVisible = await page.locator("#removeItemQtyChips:visible").count();
+  if (chipsVisible > 0) {
+    await page.locator(`#removeItemQtyChips button[data-qty="${qty}"]`).click();
+  } else {
+    await page.selectOption("#removeItemQtySelect", String(qty));
+  }
 }
 
 async function fillDisposeFields(page, { type = "Sold", date = "2026-05-01", amount = "90" } = {}) {
@@ -217,12 +223,13 @@ async function installSyncPushSpy(page) {
 // ---------------------------------------------------------------------------
 
 test.describe("STRK-44 Partial-Stack Disposition", () => {
-  test("1. REQ-1.1 — Quantity field visible when stack qty > 1", async ({ page }) => {
+  test("1. REQ-1.1 — Quantity selector visible when stack qty > 1", async ({ page }) => {
     await seedData(page, { inventory: [BASE_ITEM] });
     await gotoApp(page);
     await openDisposeModal(page, 0);
 
-    await expect(page.locator("#removeItemQty")).toBeVisible();
+    // BASE_ITEM.qty = 10 (> DISPOSE_QTY_CHIP_MAX=8) → select mode
+    await expect(page.locator("#removeItemQtySelect")).toBeVisible();
   });
 
   test("2. REQ-1.1 — Quantity field pre-filled with full stack qty", async ({ page }) => {
@@ -233,12 +240,20 @@ test.describe("STRK-44 Partial-Stack Disposition", () => {
     await expect(page.locator("#removeItemQty")).toHaveValue("10");
   });
 
-  test("3. REQ-1.2 — Quantity field hidden when stack qty = 1", async ({ page }) => {
+  test("3. REQ-1.1 — Quantity control visible with disabled-look when stack qty = 1", async ({
+    page,
+  }) => {
     await seedData(page, { inventory: [SINGLE_ITEM] });
     await gotoApp(page);
     await openDisposeModal(page, 0);
 
-    await expect(page.locator("#removeItemQty")).toBeHidden();
+    await expect(page.locator("#removeItemQtyGroup")).toBeVisible();
+    await expect(page.locator("#removeItemQtyChips")).toBeVisible();
+    await expect(page.locator("#removeItemQtyChips")).toHaveAttribute("aria-disabled", "true");
+    await expect(page.locator('#removeItemQtyChips button[data-qty="1"]')).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
   });
 
   test("4. REQ-1.3 — Full-stack qty produces no split (existing behavior)", async ({ page }) => {
@@ -294,32 +309,38 @@ test.describe("STRK-44 Partial-Stack Disposition", () => {
     await expect(preview).toContainText("7");
   });
 
-  test("7. REQ-1.6 — Zero qty blocks submission with validation message", async ({ page }) => {
-    await seedData(page, { inventory: [BASE_ITEM] });
+  test("7. REQ-1.6 — Zero qty is not selectable in the UI", async ({ page }) => {
+    const stack4Item = { ...BASE_ITEM, qty: 4, uuid: "strk53-stack4-uuid" };
+    const stack20Item = { ...BASE_ITEM, qty: 20, uuid: "strk53-stack20-uuid" };
+
+    // Chip mode (qty=4 ≤ DISPOSE_QTY_CHIP_MAX=8): no chip for qty 0
+    await seedData(page, { inventory: [stack4Item] });
     await gotoApp(page);
     await openDisposeModal(page, 0);
+    await expect(page.locator('#removeItemQtyChips button[data-qty="0"]')).toHaveCount(0);
 
-    await setDisposeQty(page, 0);
-    await confirmDispose(page);
-
-    await expect(page.locator("#removeItemModal")).toBeVisible();
-    const inventoryLength = await page.evaluate(() => window.inventory.length);
-    expect(inventoryLength).toBe(1);
+    // Select mode (qty=20 > 8): no option for qty 0
+    await seedData(page, { inventory: [stack20Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+    await expect(page.locator('#removeItemQtySelect option[value="0"]')).toHaveCount(0);
   });
 
-  test("8. REQ-1.6 — Qty greater than stack blocks submission with validation message", async ({
-    page,
-  }) => {
-    await seedData(page, { inventory: [BASE_ITEM] });
+  test("8. REQ-1.6 — Qty greater than stack is not selectable in the UI", async ({ page }) => {
+    const stack4Item = { ...BASE_ITEM, qty: 4, uuid: "strk53-stack4b-uuid" };
+    const stack20Item = { ...BASE_ITEM, qty: 20, uuid: "strk53-stack20b-uuid" };
+
+    // Chip mode: no chip for qty > stack (e.g. qty=5 for a stack-4 item)
+    await seedData(page, { inventory: [stack4Item] });
     await gotoApp(page);
     await openDisposeModal(page, 0);
+    await expect(page.locator('#removeItemQtyChips button[data-qty="5"]')).toHaveCount(0);
 
-    await setDisposeQty(page, 999);
-    await confirmDispose(page);
-
-    await expect(page.locator("#removeItemModal")).toBeVisible();
-    const inventoryLength = await page.evaluate(() => window.inventory.length);
-    expect(inventoryLength).toBe(1);
+    // Select mode: no option for qty > stack (e.g. value=999 for a stack-20 item)
+    await seedData(page, { inventory: [stack20Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+    await expect(page.locator('#removeItemQtySelect option[value="999"]')).toHaveCount(0);
   });
 
   test("9. REQ-1.7 — Split clone appears adjacent to original in inventory order", async ({
@@ -1882,14 +1903,96 @@ test.describe("STRK-44 Partial-Stack Disposition", () => {
   // Qty input max attribute — UI spinner upper-bound (bug fix regression)
   // ---------------------------------------------------------------------------
 
-  test("60. REQ-1.1 — Qty input max attribute clamped to stack qty when modal opens", async ({
+  test("60. REQ-1.1 — Select has exactly stack-qty options, last pre-selected", async ({
     page,
   }) => {
+    // BASE_ITEM.qty = 10 > DISPOSE_QTY_CHIP_MAX=8 → select mode
     await seedData(page, { inventory: [BASE_ITEM] });
     await gotoApp(page);
     await openDisposeModal(page, 0);
 
-    const maxAttr = await page.getAttribute("#removeItemQty", "max");
-    expect(maxAttr).toBe(String(BASE_ITEM.qty)); // "10"
+    const optionCount = await page.locator("#removeItemQtySelect option").count();
+    expect(optionCount).toBe(BASE_ITEM.qty); // 10 options
+    await expect(page.locator("#removeItemQtySelect")).toHaveValue(String(BASE_ITEM.qty)); // "10" selected
+  });
+
+  // ---------------------------------------------------------------------------
+  // STRK-53 — Chip keyboard nav, touch targets, viewport wrap
+  // ---------------------------------------------------------------------------
+
+  test("STRK-53 — Chip ArrowLeft moves selection", async ({ page }) => {
+    const stack4Item = { ...BASE_ITEM, qty: 4, uuid: "strk53-kbd-uuid" };
+    await seedData(page, { inventory: [stack4Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+
+    // Chip 4 is focused by default (last chip, pre-selected)
+    await page.locator('#removeItemQtyChips button[data-qty="4"]').focus();
+    await page.keyboard.press("ArrowLeft");
+
+    await expect(page.locator('#removeItemQtyChips button[data-qty="3"]')).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(await page.locator("#removeItemQty").inputValue()).toBe("3");
+  });
+
+  test("STRK-53 — Chip Home/End jump to bounds", async ({ page }) => {
+    const stack6Item = { ...BASE_ITEM, qty: 6, uuid: "strk53-homeend-uuid" };
+    await seedData(page, { inventory: [stack6Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+
+    await page.locator('#removeItemQtyChips button[data-qty="6"]').focus();
+    await page.keyboard.press("Home");
+    await expect(page.locator('#removeItemQtyChips button[data-qty="1"]')).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    await page.keyboard.press("End");
+    await expect(page.locator('#removeItemQtyChips button[data-qty="6"]')).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  test("STRK-53 — Chip touch target ≥ 44×44 px", async ({ page }) => {
+    const stack4Item = { ...BASE_ITEM, qty: 4, uuid: "strk53-target-uuid" };
+    await seedData(page, { inventory: [stack4Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+
+    const box = await page.locator('#removeItemQtyChips button[data-qty="1"]').boundingBox();
+    expect(box.width).toBeGreaterThanOrEqual(44);
+    expect(box.height).toBeGreaterThanOrEqual(44);
+  });
+
+  test("STRK-53 — Chip group wraps at 360 px viewport", async ({ page }) => {
+    const stack8Item = { ...BASE_ITEM, qty: 8, uuid: "strk53-wrap-uuid" };
+    await page.setViewportSize({ width: 360, height: 800 });
+    await seedData(page, { inventory: [stack8Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+
+    const box1 = await page.locator('#removeItemQtyChips button[data-qty="1"]').boundingBox();
+    const box8 = await page.locator('#removeItemQtyChips button[data-qty="8"]').boundingBox();
+    expect(box8.y).toBeGreaterThan(box1.y);
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+  });
+
+  test("STRK-53 — Select type-ahead reaches qty 47 of 50 in ≤ 3 interactions", async ({ page }) => {
+    const stack50Item = { ...BASE_ITEM, qty: 50, uuid: "strk53-typeahead-uuid" };
+    await seedData(page, { inventory: [stack50Item] });
+    await gotoApp(page);
+    await openDisposeModal(page, 0);
+
+    await page.locator("#removeItemQtySelect").focus();
+    await page.keyboard.press("4");
+    await page.keyboard.press("7");
+    await page.keyboard.press("Tab");
+
+    expect(await page.locator("#removeItemQty").inputValue()).toBe("47");
   });
 });

--- a/tests/playwright/inventory/partial-stack-disposition.spec.js
+++ b/tests/playwright/inventory/partial-stack-disposition.spec.js
@@ -1962,6 +1962,8 @@ test.describe("STRK-44 Partial-Stack Disposition", () => {
     await seedData(page, { inventory: [stack4Item] });
     await gotoApp(page);
     await openDisposeModal(page, 0);
+    // Wait for modal slide-in animation (scale 0.95→1) to settle before measuring
+    await page.waitForTimeout(400);
 
     const box = await page.locator('#removeItemQtyChips button[data-qty="1"]').boundingBox();
     expect(box.width).toBeGreaterThanOrEqual(44);

--- a/tests/playwright/inventory/partial-stack-disposition.spec.js
+++ b/tests/playwright/inventory/partial-stack-disposition.spec.js
@@ -1991,8 +1991,7 @@ test.describe("STRK-44 Partial-Stack Disposition", () => {
     await openDisposeModal(page, 0);
 
     await page.locator("#removeItemQtySelect").focus();
-    await page.keyboard.press("4");
-    await page.keyboard.press("7");
+    await page.keyboard.type("47", { delay: 100 });
     await page.keyboard.press("Tab");
 
     expect(await page.locator("#removeItemQty").inputValue()).toBe("47");

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.61",
+  "version": "3.34.62",
   "releaseDate": "2026-05-12",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

- Replaces the free-entry number input in the dispose modal with chip buttons (stacks ≤ 8) or a native `<select>` (stacks > 8), making invalid quantities structurally unreachable
- Roving-tabindex keyboard nav (Arrow/Home/End), `aria-pressed`, `aria-disabled` on qty=1
- Single-item stacks now show a pre-selected, dimmed chip instead of hiding the control (deliberate AC-3 change — see note below)
- Both modes write through a hidden `<input id="removeItemQty">` via `writeDisposeQty()`, preserving existing preview-handler wiring without modification
- 67 E2E tests in `tests/playwright/inventory/partial-stack-disposition.spec.js`

## AC-3 Visibility Change (deliberate)

The original UX hid the quantity field for qty=1 stacks. This PR deliberately shows a pre-selected, dimmed chip control instead. Rationale: consistent affordance — the user sees that a quantity exists (1) and that it cannot be changed, rather than inferring it from a missing field. This matches the STRK-53 requirements spec which listed "no dead states" as an explicit goal.

## Sketch

DocVault: `Projects/StakTrakr/sketches/STRK-53-quantity-selector-ux/`

## Test Plan

- [ ] Open dispose modal on a stack of 1 — chip "1" shown, disabled, pre-selected
- [ ] Open dispose modal on a stack of 5 — chips 1–5 shown, chip "5" active
- [ ] Open dispose modal on a stack of 9 — native select shown, "9" pre-selected
- [ ] Click each chip — preview updates, only one chip shows `.active`
- [ ] Keyboard: ArrowLeft/Right/Home/End navigate chips; Enter/Space activate
- [ ] Mobile: 44×44px touch targets on each chip
- [ ] 360px viewport: chips wrap, no horizontal overflow
- [ ] Screen reader: group labelled by "Quantity", chips announce pressed state
- [ ] `npm test` — 67 partial-stack-disposition tests + full suite pass

## Issues

- STRK-53: Constrained quantity selector for partial-stack dispose (done)