### PR TITLE
fix(STRK-77): goldback purchase-price lookup + remove orphan offset column

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10632,21 +10632,6 @@ th {
   border-bottom: none;
 }
 
-.spot-lookup-offset {
-  display: inline-block;
-  font-size: var(--font-size-xs);
-  font-weight: 600;
-  padding: 0.15rem 0.45rem;
-  border-radius: var(--radius-lg);
-  background: var(--bg-secondary);
-  color: var(--text-muted);
-}
-
-.spot-lookup-offset.exact {
-  background: var(--primary);
-  color: var(--text-inverse);
-}
-
 .spot-lookup-use-btn {
   padding: 0.25rem 0.75rem;
   font-size: var(--font-size-base);

--- a/index.html
+++ b/index.html
@@ -2509,9 +2509,8 @@
                         class="inline-search-btn"
                         id="retailSpotLookupBtn"
                         type="button"
-                        disabled
-                        title="Search for spot price on purchase date"
-                        aria-label="Search for spot price on purchase date"
+                        title="Look up current retail price"
+                        aria-label="Look up current retail price"
                       >
                         <svg
                           xmlns="http://www.w3.org/2000/svg"

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -50,7 +50,7 @@ const syncSpotLookupButtons = (hasDate, options = {}) => {
     elements.spotLookupBtn.disabled = !hasDate;
   }
   if (elements.retailSpotLookupBtn) {
-    elements.retailSpotLookupBtn.disabled = false;
+    elements.retailSpotLookupBtn.disabled = !hasDate;
   }
   if (clearSelectedSpot && elements.itemSpotPrice) {
     elements.itemSpotPrice.value = "";
@@ -379,10 +379,8 @@ const openSpotLookupModal = async (targetField = "purchase") => {
 
   // Retail snapshots use today's date; purchase lookups use the entered purchase date.
   const dateVal = isRetailTarget
-    ? new Date().toISOString().slice(0, 10)
-    : elements.itemDate
-      ? elements.itemDate.value
-      : "";
+    ? new Date().toLocaleDateString("en-CA")
+    : (elements.itemDate?.value ?? "");
 
   if (!dateVal) {
     appAlert("Please select a purchase date first.");
@@ -436,9 +434,7 @@ const openSpotLookupModal = async (targetField = "purchase") => {
           ...entry,
           spot: entry.price,
           lookupPrice: entry.price,
-        })),
-        "Goldback",
-        dateVal
+        }))
       );
     } else {
       renderGoldbackLookupEmpty(bodyEl, denom, dateVal);
@@ -469,7 +465,7 @@ const openSpotLookupModal = async (targetField = "purchase") => {
   if (!bodyEl) return;
 
   if (results.length > 0) {
-    renderSpotLookupResults(bodyEl, results, metalName, dateVal);
+    renderSpotLookupResults(bodyEl, results);
   } else {
     renderSpotLookupEmpty(bodyEl, metalName, dateVal);
   }
@@ -484,10 +480,8 @@ const openSpotLookupModal = async (targetField = "purchase") => {
  * Renders spot lookup results into the modal body.
  * @param {HTMLElement} container - The modal body element
  * @param {Array} results - Search results with dayOffset
- * @param {string} metalName - Metal name for API fallback context
- * @param {string} dateStr - Target date for API fallback context
  */
-const renderSpotLookupResults = (container, results, metalName, dateStr) => {
+const renderSpotLookupResults = (container, results) => {
   const formatPrice =
     typeof formatCurrency === "function" ? formatCurrency : (v) => "$" + Number(v).toFixed(2);
   const isGb = isGoldbackLookup();
@@ -586,7 +580,7 @@ const renderSpotLookupEmpty = (container, metalName, dateStr) => {
         const fetched = await fetchSpotForDate(metal, date);
         if (fetched.length > 0) {
           // Re-render with results
-          renderSpotLookupResults(container, fetched, metal, date);
+          renderSpotLookupResults(container, fetched);
         } else {
           fetchBtn.textContent = "No data returned";
           fetchBtn.disabled = true;

--- a/js/spotLookup.js
+++ b/js/spotLookup.js
@@ -27,9 +27,7 @@ const getSpotLookupModalRef = (key, id) => {
   return _spotLookupModalRefs[key];
 };
 
-const isGoldbackRetailLookup = () => {
-  return _spotLookupTargetField === "retail" && elements.itemWeightUnit?.value === "gb";
-};
+const isGoldbackLookup = () => elements.itemWeightUnit?.value === "gb";
 
 const getGoldbackLookupDenomination = () => {
   return parseFloat(
@@ -52,7 +50,7 @@ const syncSpotLookupButtons = (hasDate, options = {}) => {
     elements.spotLookupBtn.disabled = !hasDate;
   }
   if (elements.retailSpotLookupBtn) {
-    elements.retailSpotLookupBtn.disabled = !hasDate;
+    elements.retailSpotLookupBtn.disabled = false;
   }
   if (clearSelectedSpot && elements.itemSpotPrice) {
     elements.itemSpotPrice.value = "";
@@ -154,16 +152,6 @@ const searchSpotByDate = (metalName, dateStr) => {
   });
 
   return [...byDay.values()];
-};
-
-/**
- * Formats a day offset into a human-readable badge label.
- * @param {number} offset - Day offset from target date
- * @returns {string} Label like "Exact", "+1d", "-2d"
- */
-const formatOffsetLabel = (offset) => {
-  if (offset === 0) return "Exact";
-  return (offset > 0 ? "+" : "") + offset + "d";
 };
 
 /**
@@ -385,29 +373,36 @@ const searchHistoricalByDate = async (metalName, dateStr) => {
  * for the date and metal currently selected in the add/edit form.
  */
 const openSpotLookupModal = async (targetField = "purchase") => {
-  const dateVal = elements.itemDate ? elements.itemDate.value : "";
-  const metalVal = elements.itemMetal ? elements.itemMetal.value : "";
+  _spotLookupTargetField = targetField === "retail" ? "retail" : "purchase";
+  const isRetailTarget = _spotLookupTargetField === "retail";
+  const isGb = isGoldbackLookup();
+
+  // Retail snapshots use today's date; purchase lookups use the entered purchase date.
+  const dateVal = isRetailTarget
+    ? new Date().toISOString().slice(0, 10)
+    : elements.itemDate
+      ? elements.itemDate.value
+      : "";
 
   if (!dateVal) {
     appAlert("Please select a purchase date first.");
     return;
   }
 
-  // Derive metal name from composition (same logic as parseItemFormFields)
+  // Derive metal name from composition (same logic as parseItemFormFields).
+  // Skipped for goldback lookups since the goldback branch doesn't use metalName.
+  const metalVal = elements.itemMetal ? elements.itemMetal.value : "";
   const composition =
     typeof getCompositionFirstWords === "function" ? getCompositionFirstWords(metalVal) : metalVal;
   const metalName =
     typeof parseNumistaMetal === "function" ? parseNumistaMetal(composition) : composition;
 
-  if (!metalName || metalName === "Alloy") {
+  if (!isGb && (!metalName || metalName === "Alloy")) {
     appAlert("Please select a supported metal (Silver, Gold, Platinum, or Palladium).");
     return;
   }
 
-  _spotLookupTargetField = targetField === "retail" ? "retail" : "purchase";
-  const isGbRetailLookup = isGoldbackRetailLookup();
-
-  if (isGbRetailLookup) {
+  if (isGb) {
     const denom = getGoldbackLookupDenomination() || 1;
     let goldbackResults =
       typeof searchGoldbackHistoryByDate === "function"
@@ -495,11 +490,11 @@ const openSpotLookupModal = async (targetField = "purchase") => {
 const renderSpotLookupResults = (container, results, metalName, dateStr) => {
   const formatPrice =
     typeof formatCurrency === "function" ? formatCurrency : (v) => "$" + Number(v).toFixed(2);
-  const isGbRetail = isGoldbackRetailLookup();
-  const priceHeading = isGbRetail ? "Goldback Price" : "Spot Price";
+  const isGb = isGoldbackLookup();
+  const priceHeading = isGb ? "Goldback Price" : "Spot Price";
 
   let html = '<table class="spot-lookup-table"><thead><tr>';
-  html += `<th>Date/Time</th><th>${priceHeading}</th><th>Source</th><th>Offset</th><th></th>`;
+  html += `<th>Date/Time</th><th>${priceHeading}</th><th>Source</th><th></th>`;
   html += "</tr></thead><tbody>";
 
   results.forEach((entry) => {
@@ -508,14 +503,11 @@ const renderSpotLookupResults = (container, results, metalName, dateStr) => {
       typeof entry.lookupPrice === "number" && entry.lookupPrice > 0 ? entry.lookupPrice : null;
     const price = formatPrice(lookupPrice || entry.spot);
     const source = entry.source === "seed" ? "Seed" : entry.provider || entry.source || "";
-    const offsetLabel = formatOffsetLabel(entry.dayOffset);
-    const exactClass = entry.dayOffset === 0 ? " exact" : "";
 
     html += "<tr>";
     html += `<td>${ts}</td>`;
     html += `<td><strong>${price}</strong></td>`;
     html += `<td>${escapeHtml(source)}</td>`;
-    html += `<td><span class="spot-lookup-offset${exactClass}">${offsetLabel}</span></td>`;
     html +=
       `<td><button class="btn spot-lookup-use-btn" type="button" ` +
       `data-spot="${escapeHtml(entry.spot)}" data-retail="${escapeHtml(lookupPrice || "")}" data-ts="${escapeHtml(entry.timestamp || "")}">Use</button></td>`;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.64-b1778719021";
+const CACHE_NAME = "staktrakr-v3.34.64-b1778721092";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.64-b1778705767";
+const CACHE_NAME = "staktrakr-v3.34.64-b1778719021";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/goldback-type.spec.js
+++ b/tests/playwright/goldback-type.spec.js
@@ -420,4 +420,32 @@ test.describe("goldback-type — STAK-562 first-class type behavior", () => {
     await page.locator(".spot-lookup-use-btn").first().click();
     await expect(page.locator("#itemMarketValue")).toHaveValue("9.48");
   });
+
+  test("16. Goldback purchase-price lookup uses Goldback history, not gold spot (STRK-77)", async ({
+    page,
+  }) => {
+    await seedData(page, [], {
+      goldbackPriceHistory: {
+        1: [{ ts: new Date("2026-05-11T12:00:00.000Z").getTime(), price: 9.48, source: "api" }],
+      },
+      goldbackPricingSource: "manual",
+    });
+    await gotoApp(page);
+    await openAddModal(page);
+
+    await page.fill("#itemDate", "2026-05-11");
+    await page.selectOption("#itemMetal", "Gold");
+    await page.selectOption("#itemType", "Goldback");
+    await expect(page.locator("#itemWeightUnit")).toHaveValue("gb");
+
+    await page.click("#spotLookupBtn");
+    await expect(page.locator("#spotLookupModal")).toBeVisible();
+    await expect(page.locator("#spotLookupTitle")).toContainText("Goldback Lookup");
+    await expect(page.locator("#spotLookupBody")).toContainText("Goldback Price");
+    await expect(page.locator("#spotLookupBody")).toContainText("$9.48");
+    await expect(page.locator("#spotLookupBody")).not.toContainText("Offset");
+
+    await page.locator(".spot-lookup-use-btn").first().click();
+    await expect(page.locator("#itemPrice")).toHaveValue("9.48");
+  });
 });


### PR DESCRIPTION
## Summary

- **Bug**: Adding a Goldback item — the **Purchase Price `$`** helper opened *Spot Lookup — Gold* instead of the Goldback price modal. The Retail `$` helper handled this case correctly.
- **Cleanup**: Both lookup modals still rendered an orphan **Offset** column (`Exact`, `+1d`, …) from a long-removed feature.

## Changes

- `js/spotLookup.js` — replace `isGoldbackRetailLookup()` (target+unit) with `isGoldbackLookup()` (unit only). The Purchase helper now routes to Goldback Lookup when `unit === "gb"`.
- Retail lookups now key off **today's date** (current-market snapshot), so retail and purchase track gain/loss separately.
- Retail `$` button is always enabled (HTML `disabled` removed, `syncSpotLookupButtons` no longer gates it on `hasDate`).
- Removed Offset table column, unused `formatOffsetLabel` helper, and `.spot-lookup-offset` CSS.
- Updated tooltip on `#retailSpotLookupBtn` to reflect the new behavior.

## Test plan

- [x] `npm run lint` (pre-existing warnings only)
- [x] `npx prettier --check` on changed files
- [x] `tests/playwright/goldback-type.spec.js` — 16/16 pass (incl. new test 16 for purchase-price goldback lookup)
- [x] `tests/playwright/inventory/lot-each-purchase-price.spec.js` — 17/17 pass
- [x] Manual: Add Inventory → Type=Goldback → click Purchase `$` shows Goldback Lookup; click Retail `$` shows today's Goldback price; Type=Gold (non-Goldback) still shows Spot Lookup; no Offset column in any modal.

Closes STRK-77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goldback items now use dedicated Goldback price history for lookups

* **Bug Fixes**
  * Retail price lookup button no longer restricted by date

* **Changes**
  * Removed "Offset" column from spot lookup results table
  * Updated lookup button labels and descriptions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1113)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->