### PR TITLE
chore: trim skill descriptions and update tool permissions

### DIFF
--- a/.Codex/config.toml
+++ b/.Codex/config.toml
@@ -1,1 +1,1 @@
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"

--- a/.Codex/config.toml
+++ b/.Codex/config.toml
@@ -1,1 +1,1 @@
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,10 +59,10 @@
       "mcp__github__get_issue",
       "mcp__plane__get_issue_using_readable_identifier",
       "mcp__plane__list_states",
+      "mcp__plane__list_project_issues",
       "mcp__codacy__codacy_cli_analyze",
       "mcp__firecrawl-local__firecrawl_scrape",
       "mcp__firecrawl-local__firecrawl_search",
-      "mcp__plane__list_project_issues",
       "Bash(node -c *)"
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,7 @@
       "mcp__specflow__spec-workflow-guide",
       "mcp__specflow__spec-status",
       "mcp__mem0__add_memory",
+      "mcp__mem0__update_memory",
       "mcp__mem0__search_memories",
       "mcp__claude-context__get_indexing_status",
       "mcp__claude-context__search_code",
@@ -58,7 +59,11 @@
       "mcp__github__get_issue",
       "mcp__plane__get_issue_using_readable_identifier",
       "mcp__plane__list_states",
-      "mcp__codacy__codacy_cli_analyze"
+      "mcp__codacy__codacy_cli_analyze",
+      "mcp__firecrawl-local__firecrawl_scrape",
+      "mcp__firecrawl-local__firecrawl_search",
+      "mcp__plane__list_project_issues",
+      "Bash(node -c *)"
     ]
   },
   "hooks": {

--- a/.claude/skills/api-infrastructure/SKILL.md
+++ b/.claude/skills/api-infrastructure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-infrastructure
-description: Use when making any change to API feeds, pollers, feed thresholds, data file paths, or StakTrakrApi repo structure. Also use when diagnosing stale health badges, feed failures, or Fly.io/GHA poller issues. Triggers on any mention of manifest.json, goldback-spot.json, hourly files, spot-poller, retail-poller, Fly.io staktrakr app, or api.staktrakr.com.
+description: API feeds, pollers, feed thresholds, data paths, StakTrakrApi structure, Fly.io and health badge issues.
 ---
 
 # API Infrastructure

--- a/.claude/skills/faq/SKILL.md
+++ b/.claude/skills/faq/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: faq
+description: Use when adding, editing, or removing StakTrakr in-app FAQ entries in the Settings FAQ tab, including known or honest limitation copy.
+---
+
 # FAQ — StakTrakr In-App FAQ Management
 
 Update the in-app FAQ in Settings > FAQ. Use when adding, editing, or removing FAQ entries. Triggers on: "faq", "add faq", "update faq", "faq entry", "known limitation", "honest limitation".
@@ -68,8 +73,8 @@ The FAQ is organized into collapsible sections using `<details>` + `<summary>` e
 </details>
 ```
 
-3. **Use `&mdash;` for em dashes, `&amp;` for ampersands** — standard HTML entities
-4. **Commit to the current working branch** (not a separate PR for FAQ-only changes)
+1. **Use `&mdash;` for em dashes, `&amp;` for ampersands** — standard HTML entities
+1. **Commit to the current working branch** (not a separate PR for FAQ-only changes)
 
 ### Style Guidelines
 

--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+description: Guide branch completion — structured options for merge, PR, or cleanup when implementation is done.
 ---
 
 # Finishing a Development Branch

--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-ready
-description: Pre-PR readiness checklist for StakTrakr. Verifies version bump, sw.js and index.html registrations for new JS files, DocVault update status, and Codacy findings before pushing.
+description: Pre-PR checklist — version bump, sw.js registration, DocVault status, Codacy findings.
 allowed-tools: Bash, Read, Grep, Glob, mcp__codacy__codacy_get_repository_with_analysis, mcp__codacy__codacy_list_repository_issues
 ---
 

--- a/.claude/skills/retail-poller/SKILL.md
+++ b/.claude/skills/retail-poller/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retail-poller
-description: Use when working on the retail market price poller — debugging scraping failures, wrong prices, confidence scores, providers.json config, adding vendors or coins, understanding the data pipeline, or investigating what latest.json contains.
+description: Retail market price poller — scraping failures, confidence scores, providers.json, data pipeline.
 ---
 
 # StakTrakr Retail Price Poller
@@ -11,7 +11,7 @@ Reference guide for the retail market price polling system. Scrapes dealer websi
 
 ## Architecture Overview
 
-```
+```text
 providers.json (api branch)
        ↓
 price-extract.js  (Firecrawl → sqld)
@@ -160,7 +160,7 @@ Two provider groups with different strategies:
 
 **Metal price ranges** (per oz, used to filter out accessories/spot tickers):
 
-```
+```text
 silver:    $40–200/oz
 gold:      $1,500–15,000/oz
 platinum:  $500–6,000/oz
@@ -317,7 +317,7 @@ PATCH_GAPS=1 DATA_DIR=/path/to/api-branch/data node price-extract.js
 
 `run-local.sh` uses `git pull --rebase origin api` before each scrape. If another agent commits to the api branch **between** the poller's pull and its final push, the rebase of the local export commit will fail with:
 
-```
+```text
 fatal: It seems that there is already a rebase-merge directory
 ```
 

--- a/.claude/skills/retail-provider-fix/SKILL.md
+++ b/.claude/skills/retail-provider-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retail-provider-fix
-description: Use when retail prices are failing for a vendor — wrong prices, fractional_weight warnings, all-zeros for a provider, page-loaded-no-price errors, or after a dealer changes their site structure. Covers live diagnostics on the home poller, interpreting PROVIDER_CONFIG, phase routing (phase0/firecrawl/cf-clearance-first), and editing provider URLs via the home dashboard.
+description: Diagnose and fix retail scraping failures for individual dealers — wrong prices, OOS, site structure changes.
 ---
 
 # Retail Provider Fix

--- a/.claude/skills/staktrakr-ship/SKILL.md
+++ b/.claude/skills/staktrakr-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Ship dev to main — collect version tags as changelog source, create the dev→main PR, mark it ready, resolve threads, create GitHub Release. ONLY run when user explicitly says "ready to ship", "release", or "merge to main" in this session. Never runs automatically.
+description: Ship dev→main — PR, resolve threads, GitHub Release. Only on explicit user "ready to ship".
 allowed-tools: Bash, Read, Task, mcp__github__create_pull_request, mcp__github__list_pull_requests, mcp__github__get_pull_request_status, mcp__plane__get_issue_using_readable_identifier, mcp__plane__list_states, mcp__plane__update_issue
 ---
 


### PR DESCRIPTION
## Summary
- Trim all project skill descriptions under 150 chars to fit within `skillListingBudgetFraction` budget
- Add missing MCP tool permissions (mem0 update, firecrawl scrape/search, plane list)
- Codex sandbox set to `danger-full-access`
- Add faq skill frontmatter
- Fix pre-existing markdown lint in faq and retail-poller skills

## Context
Removing the `skillListingBudgetFraction: 1` setting caused "83 skill descriptions dropped" warning. Fix is two-pronged: re-add the setting at 0.1 (in global `~/.claude/settings.json`, not in this PR) and trim all project-level skill descriptions under 150 chars (this PR).

## Test plan
- [ ] Verify no "skill descriptions dropped" warning on next session
- [ ] Confirm all skills still trigger correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sandbox configuration to enable full access permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->