### PR TITLE
v3.34.70 — STRK-86: Search ignores Numista catalog data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.70] - 2026-05-17
+
+### Changed — STRK-86: Search ignores Numista catalog data
+
+- **Catalog-aware search**: Inventory search now matches against Numista-synced catalog data (country, denomination, composition, technique, obverse/reverse/edge descriptions, KM reference, etc.), not just title and top-level item fields. Searching "Australia" now returns coins whose Country catalog field equals Australia even when the title does not contain the word (STRK-86).
+- **Cache-aware integration**: New `catalogText` field is computed once per item and stored in the existing `searchCache` WeakMap; cache invalidates automatically on item edit, so no migration is required (STRK-86).
+
+---
+
 ## [3.34.69] - 2026-05-16
 
 ### Changed — STRK-73: Make Disposition section position-configurable

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.70 &ndash; STRK-86: Search ignores Numista catalog data</strong>: Inventory search now matches against Numista-synced catalog fields (country, denomination, composition, technique, obverse/reverse/edge descriptions, KM reference) in addition to title and notes. Searching &ldquo;Australia&rdquo; now returns coins whose Country catalog field is Australia even when the title does not contain the word (STRK-86).</li>
     <li><strong>v3.34.69 &ndash; STRK-73: Configurable Disposition section</strong>: The Disposition section is now a draggable row in Settings &rarr; Appearance &rarr; Item Detail Modal; legacy configs auto-upgrade with Disposition appended last, and items without a valid disposition payload never render the section (STRK-73).</li>
     <li><strong>v3.34.68 &ndash; STRK-79: Market API service-worker routing</strong>: New <code>sw-router.js</code> classifier routes all StakTrakr API and spot-history requests through cache-first-with-TTL; per-family freshness windows use envelope <code>stale_after</code> when present, falling back to floor TTLs; 26 unit tests + 3 Playwright integration tests (STRK-79).</li>
     <li><strong>v3.34.67 &ndash; STRK-78: Playwright test suite mock audit and consolidation</strong>: New shared mock layer eliminates real external API calls across the Playwright test suite; 47 spec files migrated to deterministic fixtures with zero network dependency (STRK-78).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.65 &ndash; STRK-75: All tab as default in vendor price matrix</strong>: Adds an All tab as the first and default tab in the market price matrix; market-tracked metals appear grouped Gold &rarr; Silver &rarr; Platinum &rarr; Palladium &rarr; Goldback, while per-metal tabs and saved tab preferences are fully preserved (STRK-75).</li>
     <li><strong>v3.34.64 &ndash; STRK-50: Optional structured Payment Method dropdown</strong>: Adds an optional payment method selector that persists through edit, clone, bulk edit, import/export, backup, filtering, search, and item details without affecting valuation math (STRK-50).</li>
     <li><strong>v3.34.63 &ndash; STRK-71: Attachment chip in inline chip settings</strong>: The attachment count badge is now toggleable and reorderable in Settings &rarr; Appearance &rarr; Layout &rarr; Inline Name Chips, just like the other name-cell chips (STRK-71).</li>
-    <li><strong>v3.34.62 &ndash; STRK-53: Constrained quantity selector</strong>: Dispose modal now uses chip buttons (stacks &le; 8) or a native select (stacks &gt; 8) to make invalid quantities unreachable via the UI. Single-item stacks show a pre-selected, dimmed chip instead of hiding the control (STRK-53).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -284,7 +284,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.69";
+const APP_VERSION = "3.34.70";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/filters.js
+++ b/js/filters.js
@@ -890,6 +890,66 @@ const getChipColors = (field, value, index) => {
 };
 
 /**
+ * Recursively collect all string/number leaf values from a Numista catalog object,
+ * walking nested objects (obverse, reverse, edge, etc.) while skipping booleans and arrays.
+ *
+ * Defined at module scope so a single function object is reused for every item
+ * rather than a new closure being allocated per filter-loop iteration.
+ *
+ * @param {object} obj - The object to flatten
+ * @returns {string[]} Array of stringified leaf values
+ */
+const collectNumistaStrings = (obj) =>
+  Object.values(obj).flatMap((v) => {
+    if ((typeof v === "string" || typeof v === "number") && v !== "") return [String(v)];
+    if (v && typeof v === "object" && !Array.isArray(v)) return collectNumistaStrings(v);
+    return [];
+  });
+
+/**
+ * Build the full-text search haystack for a single inventory item.
+ * Extracts and joins all searchable fields (including recursively-flattened
+ * Numista catalog data) into a single lowercase string.
+ *
+ * Extracted from `filterInventoryAdvanced` to reduce its cyclomatic complexity
+ * and make the indexing logic independently testable.
+ *
+ * @param {InventoryItem} item - The inventory item to index
+ * @param {string} searchTags - Pre-joined tag string for the item
+ * @param {string} formattedDate - Pre-formatted display date (lowercase)
+ * @returns {string} Lowercase haystack string
+ */
+const getItemSearchHaystack = (item, searchTags, formattedDate) => {
+  let catalogText = "";
+  if (item.numistaData && typeof item.numistaData === "object") {
+    catalogText = collectNumistaStrings(item.numistaData).join(" ").toLowerCase();
+  }
+
+  return [
+    item.metal,
+    item.composition || "",
+    item.name,
+    item.type,
+    item.purchaseLocation,
+    item.storageLocation || "",
+    item.notes || "",
+    item.capsule || "",
+    item.capsuleNotes || "",
+    String(item.year || ""),
+    item.grade || "",
+    item.gradingAuthority || "",
+    String(item.certNumber || ""),
+    String(item.numistaId || ""),
+    item.serialNumber || "",
+    searchTags,
+    formattedDate,
+    catalogText,
+  ]
+    .join(" ")
+    .toLowerCase();
+};
+
+/**
  * Enhanced filter inventory function that includes advanced filters.
  * Applies all active filters in `activeFilters` to the inventory.
  *
@@ -1132,49 +1192,15 @@ const filterInventoryAdvanced = () => {
       const _searchTags = typeof getItemTags === "function" ? getItemTags(item.uuid).join(" ") : "";
       const _formattedDate = formatDisplayDate(item.date).toLowerCase();
 
-      // STRK-86: Flatten Numista catalog data (country, denomination, descriptions, etc.)
-      // into the searchable haystack so items match by catalog fields, not just title/notes.
-      // Booleans are skipped — they're never useful matches and would inject literal "true"/"false".
-      // Nested objects (obverse/reverse/edge descriptions) are walked recursively.
-      let _catalogText = "";
-      if (item.numistaData && typeof item.numistaData === "object") {
-        const collectNumistaStrings = (obj) =>
-          Object.values(obj).flatMap((v) => {
-            if ((typeof v === "string" || typeof v === "number") && v !== "") return [String(v)];
-            if (v && typeof v === "object" && !Array.isArray(v)) return collectNumistaStrings(v);
-            return [];
-          });
-        _catalogText = collectNumistaStrings(item.numistaData).join(" ").toLowerCase();
-      }
+      // STRK-86: Delegate haystack assembly to getItemSearchHaystack so that
+      // filterInventoryAdvanced stays focused on filter orchestration only.
+      const itemText = getItemSearchHaystack(item, _searchTags, _formattedDate);
 
-      const itemText = [
-        item.metal,
-        item.composition || "",
-        item.name,
-        item.type,
-        item.purchaseLocation,
-        item.storageLocation || "",
-        item.notes || "",
-        item.capsule || "",
-        item.capsuleNotes || "",
-        String(item.year || ""),
-        item.grade || "",
-        item.gradingAuthority || "",
-        String(item.certNumber || ""),
-        String(item.numistaId || ""),
-        item.serialNumber || "",
-        _searchTags,
-        _formattedDate,
-        _catalogText,
-      ]
-        .join(" ")
-        .toLowerCase();
-
-      cached = { text: itemText, formattedDate: _formattedDate, catalogText: _catalogText };
+      cached = { text: itemText, formattedDate: _formattedDate };
       searchCache.set(item, cached);
     }
 
-    const { text: itemText, formattedDate, catalogText } = cached;
+    const { text: itemText, formattedDate } = cached;
 
     // Handle comma-separated terms (OR logic between comma terms)
     return parsedTerms.some((termData) => {

--- a/js/filters.js
+++ b/js/filters.js
@@ -1132,6 +1132,21 @@ const filterInventoryAdvanced = () => {
       const _searchTags = typeof getItemTags === "function" ? getItemTags(item.uuid).join(" ") : "";
       const _formattedDate = formatDisplayDate(item.date).toLowerCase();
 
+      // STRK-86: Flatten Numista catalog data (country, denomination, descriptions, etc.)
+      // into the searchable haystack so items match by catalog fields, not just title/notes.
+      // Booleans are skipped — they're never useful matches and would inject literal "true"/"false".
+      let _catalogText = "";
+      if (item.numistaData && typeof item.numistaData === "object") {
+        const parts = [];
+        for (const key in item.numistaData) {
+          const v = item.numistaData[key];
+          if ((typeof v === "string" || typeof v === "number") && v !== "") {
+            parts.push(String(v));
+          }
+        }
+        _catalogText = parts.join(" ").toLowerCase();
+      }
+
       const itemText = [
         item.metal,
         item.composition || "",
@@ -1150,15 +1165,16 @@ const filterInventoryAdvanced = () => {
         item.serialNumber || "",
         _searchTags,
         _formattedDate,
+        _catalogText,
       ]
         .join(" ")
         .toLowerCase();
 
-      cached = { text: itemText, formattedDate: _formattedDate };
+      cached = { text: itemText, formattedDate: _formattedDate, catalogText: _catalogText };
       searchCache.set(item, cached);
     }
 
-    const { text: itemText, formattedDate } = cached;
+    const { text: itemText, formattedDate, catalogText } = cached;
 
     // Handle comma-separated terms (OR logic between comma terms)
     return parsedTerms.some((termData) => {
@@ -1283,7 +1299,8 @@ const filterInventoryAdvanced = () => {
           (item.numistaId && wordRegex.test(String(item.numistaId))) ||
           (item.serialNumber && wordRegex.test(item.serialNumber)) ||
           (typeof getItemTags === "function" &&
-            getItemTags(item.uuid).some((t) => wordRegex.test(t)))
+            getItemTags(item.uuid).some((t) => wordRegex.test(t))) ||
+          (catalogText && wordRegex.test(catalogText))
         );
       });
       if (fieldMatch) return true;

--- a/js/filters.js
+++ b/js/filters.js
@@ -1135,16 +1135,16 @@ const filterInventoryAdvanced = () => {
       // STRK-86: Flatten Numista catalog data (country, denomination, descriptions, etc.)
       // into the searchable haystack so items match by catalog fields, not just title/notes.
       // Booleans are skipped — they're never useful matches and would inject literal "true"/"false".
+      // Nested objects (obverse/reverse/edge descriptions) are walked recursively.
       let _catalogText = "";
       if (item.numistaData && typeof item.numistaData === "object") {
-        const parts = [];
-        for (const key in item.numistaData) {
-          const v = item.numistaData[key];
-          if ((typeof v === "string" || typeof v === "number") && v !== "") {
-            parts.push(String(v));
-          }
-        }
-        _catalogText = parts.join(" ").toLowerCase();
+        const collectNumistaStrings = (obj) =>
+          Object.values(obj).flatMap((v) => {
+            if ((typeof v === "string" || typeof v === "number") && v !== "") return [String(v)];
+            if (v && typeof v === "object" && !Array.isArray(v)) return collectNumistaStrings(v);
+            return [];
+          });
+        _catalogText = collectNumistaStrings(item.numistaData).join(" ").toLowerCase();
       }
 
       const itemText = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.69",
+  "version": "3.34.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.69",
+      "version": "3.34.70",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.69",
+  "version": "3.34.70",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.69-b1778952650";
+const CACHE_NAME = "staktrakr-v3.34.70-b1779030794";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.70-b1779030794";
+const CACHE_NAME = "staktrakr-v3.34.70-b1779036097";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.70-b1779036097";
+const CACHE_NAME = "staktrakr-v3.34.70-b1779037282";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.69",
-  "releaseDate": "2026-05-16",
+  "version": "3.34.70",
+  "releaseDate": "2026-05-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

Inventory search was only matching against top-level item fields (title, metal, notes, tags, year, etc.) and silently ignored everything stored in `item.numistaData`. As a result, searching by country, denomination, or catalog description returned only items that happened to repeat the term in their title.

For example, searching `Australia` returned coins with "Australian" in the name (Kookaburras, Kangaroos) but missed a 1 Dollar Elizabeth II Koala whose `numistaData.country === "Australia"` even though the modal clearly shows Country = Australia.

## Changes

- **`js/filters.js` (`filterInventoryAdvanced`)** — flattens `item.numistaData` string/number values into a precomputed `catalogText` lowercase haystack, stored alongside the existing `searchCache` entry so it's built once per item rather than per term. Appended to the cached `itemText` blob for multi-word phrase matching and added as an additional regex check in the single-word OR chain. Booleans (e.g., `commemorative`) are skipped to avoid the literal `"true"`/`"false"` tokens leaking into the haystack.
- **6-file version bump** — `js/constants.js`, `package.json`, `package-lock.json`, `version.json`, `CHANGELOG.md`, `js/about.js` (prepended What's New entry, trimmed to 8). `sw.js` auto-stamped by `stamp-sw-cache` pre-commit hook to `staktrakr-v3.34.70-b1779030794`.

## Issues

- [STRK-86](https://plane.lbruton.cc/lbruton/projects/026dbe54-fe52-4a9f-9f1b-7edcb9bbdceb/) — Search ignores Numista catalog data (country, denomination, descriptions)

## How to verify

1. Have an item whose title does NOT contain a country name but whose Numista Country field is set (e.g., a "Koala" coin with Country = Australia).
2. Type `Australia` in the search box.
3. Expected: the Koala appears in the result set alongside the Australian Kookaburras/Kangaroos.
4. Repeat with `Cupronickel` (composition), a KM reference number, or any obverse/reverse description fragment — each should now match.

## Notes

- The legacy `filterInventory` in `js/search.js` has the same bug shape but is **unreachable in production** because `search.js:15` short-circuits to `filterInventoryAdvanced` whenever it's defined. Left unchanged here to keep the diff minimal; consolidating the two paths is a worthwhile follow-up.
- WeakMap-based `searchCache` invalidates per-item on edit and is rebuilt fresh each page load, so no migration is required for existing inventories.
- Spot bundle (`data/spot-history-bundle.js`) was not regenerated for this release — bundle was already current with sqld.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now includes Numista-synced catalog field data for enhanced item discovery. The search engine matches queries against catalog metadata in addition to title and base item information, providing broader coverage of searchable content.

* **Updates**
  * Version bumped to 3.34.70 (May 17, 2026).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->