### PR TITLE
fix(STRK-84): Show Numista tag preview chips in Add mode

### DIFF
--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -2471,25 +2471,10 @@ const fillFormFromNumistaResult = () => {
  * Close Numista results modal and clean up state
  */
 const closeNumistaResultsModal = (opts) => {
-  console.log(
-    "[STRK-84:TRACE] closeNumistaResultsModal called — opts:",
-    JSON.stringify(opts),
-    "snapshot before:",
-    JSON.stringify(window.pendingNumistaPickerSnapshot)
-  );
   const modal = document.getElementById("numistaResultsModal");
   if (modal) modal.style.display = "none";
   selectedNumistaResult = null;
   const willClear = opts == null || opts.clearPendingSnapshot !== false;
-  console.log(
-    "[STRK-84:TRACE] closeModal willClear:",
-    willClear,
-    "(opts==null:",
-    opts == null,
-    "clearPendingSnapshot:",
-    opts?.clearPendingSnapshot,
-    ")"
-  );
   if (willClear) {
     window.pendingNumistaPickerSnapshot = null;
   }
@@ -2918,14 +2903,6 @@ document.addEventListener("DOMContentLoaded", function () {
       // tears down the picker DOM. The snapshot is consumed by the Add-branch
       // submit handler in events.js after commitItemToInventory mints the UUID.
       const pickerContainer = document.getElementById("numistaFieldCheckboxes");
-      console.log(
-        "[STRK-84:TRACE] Fill Fields clicked. pickerContainer:",
-        !!pickerContainer,
-        "selectedNumistaResult:",
-        !!selectedNumistaResult,
-        "catalogId:",
-        selectedNumistaResult?.catalogId
-      );
       if (pickerContainer && selectedNumistaResult) {
         const checked = [];
         const removed = [];
@@ -2942,12 +2919,6 @@ document.addEventListener("DOMContentLoaded", function () {
           checked,
           removed,
         };
-        console.log(
-          "[STRK-84:TRACE] Snapshot captured:",
-          JSON.stringify(window.pendingNumistaPickerSnapshot)
-        );
-      } else {
-        console.warn("[STRK-84:TRACE] Snapshot NOT captured — missing container or result");
       }
 
       if (selectedNumistaResult) {
@@ -2964,25 +2935,24 @@ document.addEventListener("DOMContentLoaded", function () {
             .catch((e) => console.warn("Metadata cache failed:", e));
         }
       }
-      console.log(
-        "[STRK-84:TRACE] Before closeModal — editingIndex:",
-        typeof editingIndex !== "undefined" ? editingIndex : "UNDEFINED",
-        "clearPendingSnapshot:",
-        editingIndex != null
-      );
-      console.log(
-        "[STRK-84:TRACE] Snapshot BEFORE closeModal:",
-        JSON.stringify(window.pendingNumistaPickerSnapshot)
-      );
       closeNumistaResultsModal({ clearPendingSnapshot: editingIndex != null });
-      console.log(
-        "[STRK-84:TRACE] Snapshot AFTER closeModal:",
-        JSON.stringify(window.pendingNumistaPickerSnapshot)
-      );
-      console.log(
-        "[STRK-84:TRACE] itemCatalog value after fill:",
-        document.getElementById("itemCatalog")?.value
-      );
+
+      // STRK-84: render preview tag chips in Add mode so the user sees
+      // which Numista tags will be applied after submit
+      const _addSnap = window.pendingNumistaPickerSnapshot;
+      if (_addSnap && _addSnap.checked.length > 0 && editingIndex == null) {
+        const chipsEl = document.getElementById("itemModalTagsChips");
+        if (chipsEl) {
+          chipsEl.textContent = "";
+          _addSnap.checked.forEach((tag) => {
+            const chip = document.createElement("span");
+            chip.className = "tag-chip";
+            chip.textContent = tag;
+            chip.title = "Pending Numista tag — applied on save";
+            chipsEl.appendChild(chip);
+          });
+        }
+      }
     });
   }
 

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -2940,7 +2940,7 @@ document.addEventListener("DOMContentLoaded", function () {
       // STRK-84: render preview tag chips in Add mode so the user sees
       // which Numista tags will be applied after submit
       const _addSnap = window.pendingNumistaPickerSnapshot;
-      if (_addSnap && _addSnap.checked.length > 0 && editingIndex == null) {
+      if (_addSnap && editingIndex == null) {
         const chipsEl = document.getElementById("itemModalTagsChips");
         if (chipsEl) {
           chipsEl.textContent = "";

--- a/js/catalog-api.js
+++ b/js/catalog-api.js
@@ -2471,10 +2471,26 @@ const fillFormFromNumistaResult = () => {
  * Close Numista results modal and clean up state
  */
 const closeNumistaResultsModal = (opts) => {
+  console.log(
+    "[STRK-84:TRACE] closeNumistaResultsModal called — opts:",
+    JSON.stringify(opts),
+    "snapshot before:",
+    JSON.stringify(window.pendingNumistaPickerSnapshot)
+  );
   const modal = document.getElementById("numistaResultsModal");
   if (modal) modal.style.display = "none";
   selectedNumistaResult = null;
-  if (opts == null || opts.clearPendingSnapshot !== false) {
+  const willClear = opts == null || opts.clearPendingSnapshot !== false;
+  console.log(
+    "[STRK-84:TRACE] closeModal willClear:",
+    willClear,
+    "(opts==null:",
+    opts == null,
+    "clearPendingSnapshot:",
+    opts?.clearPendingSnapshot,
+    ")"
+  );
+  if (willClear) {
     window.pendingNumistaPickerSnapshot = null;
   }
 };
@@ -2902,6 +2918,14 @@ document.addEventListener("DOMContentLoaded", function () {
       // tears down the picker DOM. The snapshot is consumed by the Add-branch
       // submit handler in events.js after commitItemToInventory mints the UUID.
       const pickerContainer = document.getElementById("numistaFieldCheckboxes");
+      console.log(
+        "[STRK-84:TRACE] Fill Fields clicked. pickerContainer:",
+        !!pickerContainer,
+        "selectedNumistaResult:",
+        !!selectedNumistaResult,
+        "catalogId:",
+        selectedNumistaResult?.catalogId
+      );
       if (pickerContainer && selectedNumistaResult) {
         const checked = [];
         const removed = [];
@@ -2918,6 +2942,12 @@ document.addEventListener("DOMContentLoaded", function () {
           checked,
           removed,
         };
+        console.log(
+          "[STRK-84:TRACE] Snapshot captured:",
+          JSON.stringify(window.pendingNumistaPickerSnapshot)
+        );
+      } else {
+        console.warn("[STRK-84:TRACE] Snapshot NOT captured — missing container or result");
       }
 
       if (selectedNumistaResult) {
@@ -2934,7 +2964,25 @@ document.addEventListener("DOMContentLoaded", function () {
             .catch((e) => console.warn("Metadata cache failed:", e));
         }
       }
+      console.log(
+        "[STRK-84:TRACE] Before closeModal — editingIndex:",
+        typeof editingIndex !== "undefined" ? editingIndex : "UNDEFINED",
+        "clearPendingSnapshot:",
+        editingIndex != null
+      );
+      console.log(
+        "[STRK-84:TRACE] Snapshot BEFORE closeModal:",
+        JSON.stringify(window.pendingNumistaPickerSnapshot)
+      );
       closeNumistaResultsModal({ clearPendingSnapshot: editingIndex != null });
+      console.log(
+        "[STRK-84:TRACE] Snapshot AFTER closeModal:",
+        JSON.stringify(window.pendingNumistaPickerSnapshot)
+      );
+      console.log(
+        "[STRK-84:TRACE] itemCatalog value after fill:",
+        document.getElementById("itemCatalog")?.value
+      );
     });
   }
 

--- a/js/events.js
+++ b/js/events.js
@@ -1893,17 +1893,49 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
 
     // STRK-84: consume pending picker snapshot to apply tags for new Add Item
     const snap = window.pendingNumistaPickerSnapshot;
+    console.log("[STRK-84:TRACE] Submit consumer — snap:", JSON.stringify(snap));
+    console.log(
+      "[STRK-84:TRACE] f.catalog:",
+      JSON.stringify(f.catalog),
+      "addedItem.uuid:",
+      addedItem.uuid
+    );
+    console.log(
+      "[STRK-84:TRACE] applyNumistaTags available:",
+      typeof applyNumistaTags === "function"
+    );
     if (snap && typeof applyNumistaTags === "function") {
       const newUuid = addedItem.uuid;
+      console.log(
+        "[STRK-84:TRACE] snap.resultId:",
+        JSON.stringify(snap.resultId),
+        "=== f.catalog:",
+        snap.resultId === f.catalog,
+        "(types:",
+        typeof snap.resultId,
+        typeof f.catalog,
+        ")"
+      );
       if (snap.resultId === f.catalog) {
         if (snap.checked.length > 0) {
-          applyNumistaTags(newUuid, snap.checked, true, true);
+          console.log("[STRK-84:TRACE] Calling applyNumistaTags with:", newUuid, snap.checked);
+          const tagResult = applyNumistaTags(newUuid, snap.checked, true, true);
+          console.log("[STRK-84:TRACE] applyNumistaTags returned:", JSON.stringify(tagResult));
         }
         if (snap.removed.length > 0 && typeof addRemovedTag === "function") {
           snap.removed.forEach((tag) => addRemovedTag(newUuid, tag));
         }
+      } else {
+        console.warn("[STRK-84:TRACE] resultId/catalog MISMATCH — tags NOT applied");
       }
       window.pendingNumistaPickerSnapshot = null;
+    } else {
+      console.warn(
+        "[STRK-84:TRACE] No snapshot or applyNumistaTags missing — snap:",
+        !!snap,
+        "fn:",
+        typeof applyNumistaTags
+      );
     }
 
     // Record initial price data point (STACK-43)

--- a/js/events.js
+++ b/js/events.js
@@ -1893,49 +1893,17 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
 
     // STRK-84: consume pending picker snapshot to apply tags for new Add Item
     const snap = window.pendingNumistaPickerSnapshot;
-    console.log("[STRK-84:TRACE] Submit consumer — snap:", JSON.stringify(snap));
-    console.log(
-      "[STRK-84:TRACE] f.catalog:",
-      JSON.stringify(f.catalog),
-      "addedItem.uuid:",
-      addedItem.uuid
-    );
-    console.log(
-      "[STRK-84:TRACE] applyNumistaTags available:",
-      typeof applyNumistaTags === "function"
-    );
     if (snap && typeof applyNumistaTags === "function") {
       const newUuid = addedItem.uuid;
-      console.log(
-        "[STRK-84:TRACE] snap.resultId:",
-        JSON.stringify(snap.resultId),
-        "=== f.catalog:",
-        snap.resultId === f.catalog,
-        "(types:",
-        typeof snap.resultId,
-        typeof f.catalog,
-        ")"
-      );
       if (snap.resultId === f.catalog) {
         if (snap.checked.length > 0) {
-          console.log("[STRK-84:TRACE] Calling applyNumistaTags with:", newUuid, snap.checked);
-          const tagResult = applyNumistaTags(newUuid, snap.checked, true, true);
-          console.log("[STRK-84:TRACE] applyNumistaTags returned:", JSON.stringify(tagResult));
+          applyNumistaTags(newUuid, snap.checked, true, true);
         }
         if (snap.removed.length > 0 && typeof addRemovedTag === "function") {
           snap.removed.forEach((tag) => addRemovedTag(newUuid, tag));
         }
-      } else {
-        console.warn("[STRK-84:TRACE] resultId/catalog MISMATCH — tags NOT applied");
       }
       window.pendingNumistaPickerSnapshot = null;
-    } else {
-      console.warn(
-        "[STRK-84:TRACE] No snapshot or applyNumistaTags missing — snap:",
-        !!snap,
-        "fn:",
-        typeof applyNumistaTags
-      );
     }
 
     // Record initial price data point (STACK-43)

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.73-b1779166931";
+const CACHE_NAME = "staktrakr-v3.34.73-b1779168366";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.73-b1779168366";
+const CACHE_NAME = "staktrakr-v3.34.73-b1779168703";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.73-b1779163879";
+const CACHE_NAME = "staktrakr-v3.34.73-b1779166931";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

- **Fix**: After Fill Fields in Add mode, the form's Tags section showed "No tags" even though the snapshot mechanism would correctly persist tags on submit. Users saw this as tags not working.
- **Root cause**: Tag chip rendering in `inventory.js` is gated behind `item.uuid`, which doesn't exist until `commitItemToInventory` mints one post-submit.
- **Solution**: Added a 12-line preview renderer in the Fill Fields handler (`catalog-api.js`) that populates `itemModalTagsChips` with cosmetic chips from the pending snapshot. Display-only — the data path is unchanged.
- **Cleanup**: Removed all `[STRK-84:TRACE]` debug instrumentation from both `catalog-api.js` and `events.js` (net -62 lines).

## Test plan

- [ ] Open Add Item modal → search Numista catalog ID (e.g. N#298883) → click Fill Fields → verify Tags section shows tag chips (Bird, Eagle, Allegory, Flag)
- [ ] Submit the item → verify tags persist to localStorage
- [ ] Edit the saved item → verify tags appear with × remove buttons
- [ ] Verify Edit mode still applies tags directly (no regression)
- [ ] Console shows no `STRK-84:TRACE` messages