### PR TITLE
v3.34.78 — STRK-92: Fill 90-day Market History All view with per-vendor data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.78] - 2026-05-22
+
+### Changed — STRK-92: Fill 90-day Market History with per-vendor data
+
+- **Feature**: 90-day retail history endpoint now includes per-vendor daily breakdown matching the 30-day schema, so Market History "All" view shows vendor prices for the full 90-day window instead of dashes on older rows (STRK-92).
+- **Bug fix**: Frontend dedup merge uses vendor-set union instead of all-or-nothing overwrite, retaining departed vendors on overlapping dates (STRK-92).
+
+---
+
 ## [3.34.77] - 2026-05-21
 
 ### Changed — STRK-93: Fix header Spot button 4× API sync

--- a/devops/pollers/shared/api-export-v2.js
+++ b/devops/pollers/shared/api-export-v2.js
@@ -639,14 +639,13 @@ async function exportRetail(client) {
       const daily30dEntries = buildDailyWithVendors(dailyAgg30d);
       writeV2File(`retail/${slug}/history-30d.json`, daily30dEntries, 86400);
 
-      // --- retail/{slug}/history-90d.json (daily OHLCA, no per-vendor) ---
+      // --- retail/{slug}/history-90d.json (daily OHLCA with per-vendor breakdown) ---
       const hist90dStart = new Date(now.getTime() - 90 * MS_PER_DAY)
         .toISOString()
         .replace(".000Z", "Z");
-      const hist90dRows = await queryRetailRange(client, slug, hist90dStart, nowIso);
-      const hist90dEntries = buildRetailOhlcaBuckets(hist90dRows, "daily");
-      const hist90dClean = hist90dEntries.map(({ _vendorPrices, ...rest }) => rest);
-      writeV2File(`retail/${slug}/history-90d.json`, hist90dClean, 86400);
+      const dailyAgg90d = await queryRetailDailyAggregates(client, slug, hist90dStart, nowIso);
+      const daily90dEntries = buildDailyWithVendors(dailyAgg90d);
+      writeV2File(`retail/${slug}/history-90d.json`, daily90dEntries, 86400);
 
       // --- retail/{slug}/{YYYY}/{MM}.json (monthly archive) ---
       const yyyy = String(now.getUTCFullYear());

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.78 &ndash; STRK-92: Fill 90-day Market History with per-vendor data</strong>: 90-day retail history now includes per-vendor daily breakdown; Market History &ldquo;All&rdquo; view shows vendor prices for the full window instead of dashes on older rows; departed vendors retained via union merge on overlapping dates (STRK-92).</li>
     <li><strong>v3.34.77 &ndash; STRK-93: Fix header Spot button 4&times; API sync</strong>: Header Spot sync button now triggers a single all-metals API sync instead of looping over four per-metal icons, eliminating redundant API calls, stacked cache-age dialogs, and duplicate toast notifications (STRK-93).</li>
     <li><strong>v3.34.76 &ndash; STRK-89: Add gold-api.com as first-class spot price provider</strong>: New built-in Gold API provider offers free unlimited real-time spot prices for all four metals with no API key required; optional premium key support via collapsible disclosure widget (STRK-89).</li>
     <li><strong>v3.34.75 &ndash; STRK-88: Lot/each purchase price rounding and CSV normalization</strong>: Preserves full precision for purchase prices in memory while displaying rounded inputs, handles lot/each toggle restoration on edit/duplicate, and normalizes CSV parsers/exporters (STRK-88).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.77";
+const APP_VERSION = "3.34.78";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail.js
+++ b/js/retail.js
@@ -911,12 +911,12 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
         });
       }
     };
+    // Coarsest-first: union spread in dedup relies on finer entries overwriting coarser
     addHistory(hist90);
     addHistory(hist30);
     addHistory(hist7);
 
-    // Deduplicate by date, preferring the latest (finest granularity) entry
-    // but preserving vendor data from coarser sources when finer source lacks it
+    // Deduplicate by date, preferring finest-granularity aggregates; union-merge vendors
     if (historyEntries.length) {
       const byDate = new Map();
       for (const e of historyEntries) {
@@ -925,12 +925,11 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
         if (!existing) {
           byDate.set(e.date, e);
         } else {
-          // Merge: take the newer entry's aggregates but keep vendors if the newer lacks them
           const merged = { ...e };
           const mergedHasVendors = merged.vendors && Object.keys(merged.vendors).length > 0;
           const existingHasVendors = existing.vendors && Object.keys(existing.vendors).length > 0;
-          if (!mergedHasVendors && existingHasVendors) {
-            merged.vendors = existing.vendors;
+          if (mergedHasVendors || existingHasVendors) {
+            merged.vendors = { ...(existing.vendors || {}), ...(merged.vendors || {}) };
           }
           byDate.set(e.date, merged);
         }

--- a/js/retail.js
+++ b/js/retail.js
@@ -893,10 +893,11 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
 
     // Merge history data (7d hourly, 30d daily, 90d daily)
     const historyEntries = [];
-    const addHistory = (data) => {
+    const addHistory = (data, sourceRank) => {
       if (!Array.isArray(data)) return;
       for (const entry of data) {
         historyEntries.push({
+          _sourceRank: sourceRank,
           date: entry.t ? entry.t.slice(0, 10) : null,
           t: entry.t,
           ts: entry.ts,
@@ -912,36 +913,72 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
       }
     };
     // Coarsest-first: union spread in dedup relies on finer entries overwriting coarser
-    addHistory(hist90);
-    addHistory(hist30);
-    addHistory(hist7);
+    addHistory(hist90, 0);
+    addHistory(hist30, 1);
+    addHistory(hist7, 2);
 
     // Deduplicate by date, preferring finest-granularity aggregates; union-merge vendors
     if (historyEntries.length) {
       const byDate = new Map();
+      const weightedAverage = (a, aWeight, b, bWeight) => {
+        if (a == null) return b;
+        if (b == null) return a;
+        return (a * aWeight + b * bWeight) / (aWeight + bWeight);
+      };
       for (const e of historyEntries) {
         if (!e.date) continue;
         const existing = byDate.get(e.date);
         if (!existing) {
           byDate.set(e.date, e);
         } else {
-          const merged = { ...e };
-          // Aggregate OHLC across entries sharing a date (hist7d is hourly)
-          if (existing.high != null && merged.high != null)
-            merged.high = Math.max(existing.high, merged.high);
-          if (existing.low != null && merged.low != null)
-            merged.low = Math.min(existing.low, merged.low);
-          if (existing.open != null && merged.open == null) merged.open = existing.open;
-          if (existing.n != null && merged.n != null) merged.n = existing.n + merged.n;
-          const mergedHasVendors = merged.vendors && Object.keys(merged.vendors).length > 0;
-          const existingHasVendors = existing.vendors && Object.keys(existing.vendors).length > 0;
-          if (mergedHasVendors || existingHasVendors) {
-            merged.vendors = { ...(existing.vendors || {}), ...(merged.vendors || {}) };
+          const eRank = e._sourceRank ?? 0;
+          const existingRank = existing._sourceRank ?? 0;
+          const finer = eRank > existingRank ? e : existing;
+          const coarser = eRank > existingRank ? existing : e;
+          const sameRank = eRank === existingRank;
+          const merged = { ...finer };
+
+          if (sameRank) {
+            const existingWeight = existing.n > 0 ? existing.n : 1;
+            const eWeight = e.n > 0 ? e.n : 1;
+            const totalWeight = existingWeight + eWeight;
+            merged.open = existing.open ?? e.open;
+            if (existing.high != null && e.high != null)
+              merged.high = Math.max(existing.high, e.high);
+            else merged.high = existing.high ?? e.high;
+            if (existing.low != null && e.low != null) merged.low = Math.min(existing.low, e.low);
+            else merged.low = existing.low ?? e.low;
+            merged.close = (e.ts ?? 0) >= (existing.ts ?? 0) ? e.close : existing.close;
+            merged.avg_median = weightedAverage(
+              existing.avg_median,
+              existingWeight,
+              e.avg_median,
+              eWeight
+            );
+            merged.avg_low = weightedAverage(existing.avg_low, existingWeight, e.avg_low, eWeight);
+            merged.n = totalWeight;
+          } else {
+            merged._sourceRank = finer._sourceRank;
+            merged.open = finer.open ?? coarser.open;
+            merged.high = finer.high ?? coarser.high;
+            merged.low = finer.low ?? coarser.low;
+            merged.close = finer.close ?? coarser.close;
+            merged.avg_median = finer.avg_median ?? coarser.avg_median;
+            merged.avg_low = finer.avg_low ?? coarser.avg_low;
+            merged.n = finer.n ?? coarser.n;
+          }
+
+          const primaryVendors = sameRank ? e.vendors : finer.vendors;
+          const fallbackVendors = sameRank ? existing.vendors : coarser.vendors;
+          if (primaryVendors || fallbackVendors) {
+            merged.vendors = { ...(fallbackVendors || {}), ...(primaryVendors || {}) };
           }
           byDate.set(e.date, merged);
         }
       }
-      retailPriceHistory[slug] = [...byDate.values()].sort((a, b) => (a.date > b.date ? 1 : -1));
+      retailPriceHistory[slug] = [...byDate.values()]
+        .map(({ _sourceRank, ...entry }) => entry)
+        .sort((a, b) => (a.date > b.date ? 1 : -1));
     }
   });
 

--- a/js/retail.js
+++ b/js/retail.js
@@ -926,6 +926,13 @@ async function _syncRetailV2({ ui, syncBtn, syncStatus }) {
           byDate.set(e.date, e);
         } else {
           const merged = { ...e };
+          // Aggregate OHLC across entries sharing a date (hist7d is hourly)
+          if (existing.high != null && merged.high != null)
+            merged.high = Math.max(existing.high, merged.high);
+          if (existing.low != null && merged.low != null)
+            merged.low = Math.min(existing.low, merged.low);
+          if (existing.open != null && merged.open == null) merged.open = existing.open;
+          if (existing.n != null && merged.n != null) merged.n = existing.n + merged.n;
           const mergedHasVendors = merged.vendors && Object.keys(merged.vendors).length > 0;
           const existingHasVendors = existing.vendors && Object.keys(existing.vendors).length > 0;
           if (mergedHasVendors || existingHasVendors) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.77",
+  "version": "3.34.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.77",
+      "version": "3.34.78",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.77",
+  "version": "3.34.78",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.78-b1779461104";
+const CACHE_NAME = "staktrakr-v3.34.78-b1779463556";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.78-b1779429293";
+const CACHE_NAME = "staktrakr-v3.34.78-b1779461104";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.77-b1779415858";
+const CACHE_NAME = "staktrakr-v3.34.78-b1779429293";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/retail/stak-582-market-survivors.spec.js
+++ b/tests/playwright/retail/stak-582-market-survivors.spec.js
@@ -121,6 +121,36 @@ const recentSilverEntry = {
   vendors: { apmex: { avg: 43.1 }, jmbullion: { avg: 41.95 } },
 };
 
+const recentSilverEarlyEntry = {
+  date: recentDate,
+  t: `${recentDate}T12:00:00Z`,
+  ts: olderTs,
+  open: 41.75,
+  high: 42.5,
+  low: 41.5,
+  close: 42,
+  avg_median: 42,
+  avg_low: 41.5,
+  avg: 42,
+  n: 2,
+  vendors: { apmex: { avg: 42.2 } },
+};
+
+const recentSilverLateEntry = {
+  date: recentDate,
+  t: `${recentDate}T18:00:00Z`,
+  ts: recentTs,
+  open: 43.75,
+  high: 44.5,
+  low: 43.5,
+  close: 44,
+  avg_median: 44,
+  avg_low: 43.5,
+  avg: 44,
+  n: 1,
+  vendors: { jmbullion: { avg: 44.1 } },
+};
+
 const recentGoldEntry = {
   date: recentDate,
   t: `${recentDate}T00:00:00Z`,
@@ -134,7 +164,7 @@ const recentGoldEntry = {
 };
 
 const history7dRows = {
-  [SLUG_SILVER]: [recentSilverEntry],
+  [SLUG_SILVER]: [recentSilverEarlyEntry, recentSilverLateEntry],
   [SLUG_GOLD]: [recentGoldEntry],
 };
 
@@ -485,6 +515,20 @@ test.describe("STAK-582 — surviving market retail surfaces", () => {
     await expect(overlapRow).toHaveCount(1);
     await expect(overlapRow).toContainText("$41.20");
     await expect(overlapRow).toContainText("$40.50");
+  });
+
+  test("7d hourly rows own aggregates without double-counting daily history", async ({ page }) => {
+    await page.evaluate(async () => await window.syncRetailPrices({ ui: false }));
+
+    await page.evaluate(() => window.showSettingsModal("changelog"));
+    await page.locator('[data-log-tab="market"]').click();
+
+    const recentRow = page.locator("#retailHistoryTableBody tr").filter({ hasText: recentDate });
+    await expect(recentRow).toHaveCount(1);
+    await expect(recentRow).toContainText("$42.67");
+    await expect(recentRow).toContainText("$42.17");
+    await expect(recentRow).toContainText("$42.20");
+    await expect(recentRow).toContainText("$44.10");
   });
 
   test("Market Filter Matrix toggles slug/vendor visibility and keeps matrix styling", async ({

--- a/tests/playwright/retail/stak-582-market-survivors.spec.js
+++ b/tests/playwright/retail/stak-582-market-survivors.spec.js
@@ -17,6 +17,8 @@ const daysAgo = (days) => {
 
 const recentDate = daysAgo(2);
 const oldDate = daysAgo(20);
+const veryOldDate = daysAgo(45);
+const overlapDate = daysAgo(15);
 const generatedAt = new Date().toISOString();
 const recentTs = Math.floor(new Date(`${recentDate}T18:00:00Z`).getTime() / 1000);
 const olderTs = Math.floor(new Date(`${recentDate}T12:00:00Z`).getTime() / 1000);
@@ -107,7 +109,36 @@ const syncedPrices = {
   },
 };
 
-const historyRows = {
+const recentSilverEntry = {
+  date: recentDate,
+  t: `${recentDate}T00:00:00Z`,
+  ts: recentTs,
+  avg_median: 42.25,
+  avg_low: 41.95,
+  avg: 42.25,
+  low: 41.95,
+  close: 42.25,
+  vendors: { apmex: { avg: 43.1 }, jmbullion: { avg: 41.95 } },
+};
+
+const recentGoldEntry = {
+  date: recentDate,
+  t: `${recentDate}T00:00:00Z`,
+  ts: recentTs,
+  avg_median: 3520.75,
+  avg_low: 3499.95,
+  avg: 3520.75,
+  low: 3499.95,
+  close: 3520.75,
+  vendors: { apmex: { avg: 3550.5 }, jmbullion: { avg: 3499.95 } },
+};
+
+const history7dRows = {
+  [SLUG_SILVER]: [recentSilverEntry],
+  [SLUG_GOLD]: [recentGoldEntry],
+};
+
+const history30dRows = {
   [SLUG_SILVER]: [
     {
       date: oldDate,
@@ -121,30 +152,59 @@ const historyRows = {
       vendors: { apmex: { avg: 40 }, jmbullion: { avg: 39 } },
     },
     {
-      date: recentDate,
-      t: `${recentDate}T00:00:00Z`,
-      ts: recentTs,
-      avg_median: 42.25,
-      avg_low: 41.95,
-      avg: 42.25,
-      low: 41.95,
-      close: 42.25,
-      vendors: { apmex: { avg: 43.1 }, jmbullion: { avg: 41.95 } },
+      date: overlapDate,
+      t: `${overlapDate}T00:00:00Z`,
+      ts: Math.floor(new Date(`${overlapDate}T00:00:00Z`).getTime() / 1000),
+      avg_median: 41.2,
+      avg_low: 41,
+      avg: 41.2,
+      low: 41,
+      close: 41.2,
+      vendors: { apmex: { avg: 41.2 } },
     },
+    recentSilverEntry,
   ],
-  [SLUG_GOLD]: [
+  [SLUG_GOLD]: [recentGoldEntry],
+};
+
+const history90dRows = {
+  [SLUG_SILVER]: [
     {
-      date: recentDate,
-      t: `${recentDate}T00:00:00Z`,
-      ts: recentTs,
-      avg_median: 3520.75,
-      avg_low: 3499.95,
-      avg: 3520.75,
-      low: 3499.95,
-      close: 3520.75,
-      vendors: { apmex: { avg: 3550.5 }, jmbullion: { avg: 3499.95 } },
+      date: veryOldDate,
+      t: `${veryOldDate}T00:00:00Z`,
+      ts: Math.floor(new Date(`${veryOldDate}T00:00:00Z`).getTime() / 1000),
+      avg_median: 38,
+      avg_low: 37,
+      avg: 38,
+      low: 37,
+      close: 38,
+      vendors: { apmex: { avg: 38.5 }, jmbullion: { avg: 37.5 } },
     },
+    {
+      date: oldDate,
+      t: `${oldDate}T00:00:00Z`,
+      ts: Math.floor(new Date(`${oldDate}T00:00:00Z`).getTime() / 1000),
+      avg_median: 39.5,
+      avg_low: 39,
+      avg: 39.5,
+      low: 39,
+      close: 39.5,
+      vendors: { apmex: { avg: 40 }, jmbullion: { avg: 39 } },
+    },
+    {
+      date: overlapDate,
+      t: `${overlapDate}T00:00:00Z`,
+      ts: Math.floor(new Date(`${overlapDate}T00:00:00Z`).getTime() / 1000),
+      avg_median: 40.75,
+      avg_low: 40.5,
+      avg: 40.75,
+      low: 40.5,
+      close: 40.75,
+      vendors: { apmex: { avg: 41 }, jmbullion: { avg: 40.5 } },
+    },
+    recentSilverEntry,
   ],
+  [SLUG_GOLD]: [recentGoldEntry],
 };
 
 const intradayRows = {
@@ -299,7 +359,7 @@ const setupRetailFixture = async (page) => {
     },
     {
       prices: initialPrices,
-      history: historyRows,
+      history: history90dRows,
       intraday: intradayRows,
       slugs: [SLUG_SILVER, SLUG_GOLD],
       meta: coinMeta,
@@ -363,9 +423,11 @@ const responseForPath = (path) => {
 
   if (file === "latest") return { v: 2, generated_at: generatedAt, data: syncedPrices[slug] };
   if (file === "intraday") return { v: 2, generated_at: generatedAt, data: intradayRows[slug] };
-  if (file === "history-7d" || file === "history-30d" || file === "history-90d") {
-    return { v: 2, generated_at: generatedAt, data: historyRows[slug] };
-  }
+  if (file === "history-7d") return { v: 2, generated_at: generatedAt, data: history7dRows[slug] };
+  if (file === "history-30d")
+    return { v: 2, generated_at: generatedAt, data: history30dRows[slug] };
+  if (file === "history-90d")
+    return { v: 2, generated_at: generatedAt, data: history90dRows[slug] };
   return null;
 };
 
@@ -391,6 +453,38 @@ test.describe("STAK-582 — surviving market retail surfaces", () => {
     await page.locator("#retailHistorySlugSelect").selectOption(SLUG_GOLD);
     await expect(page.locator("#retailHistoryTableBody")).toContainText("$3,520.75");
     await expect(page.locator("#retailHistoryTableBody")).not.toContainText("$42.25");
+  });
+
+  test("90d-only row renders vendor prices in All view", async ({ page }) => {
+    await page.evaluate(async () => await window.syncRetailPrices({ ui: false }));
+
+    await page.evaluate(() => window.showSettingsModal("changelog"));
+    await page.locator('[data-log-tab="market"]').click();
+    await page.locator('[data-retail-timeframe="all"]').click();
+
+    const tbody = page.locator("#retailHistoryTableBody");
+    await expect(tbody).toContainText(veryOldDate);
+
+    const veryOldRow = tbody.locator("tr").filter({ hasText: veryOldDate });
+    await expect(veryOldRow).toHaveCount(1);
+    await expect(veryOldRow).not.toContainText("—");
+    await expect(veryOldRow).toContainText("$38.50");
+  });
+
+  test("departed vendor retained via union merge on overlapping dates", async ({ page }) => {
+    await page.evaluate(async () => await window.syncRetailPrices({ ui: false }));
+
+    await page.evaluate(() => window.showSettingsModal("changelog"));
+    await page.locator('[data-log-tab="market"]').click();
+    await page.locator('[data-retail-timeframe="all"]').click();
+
+    const tbody = page.locator("#retailHistoryTableBody");
+    await expect(tbody).toContainText(overlapDate);
+
+    const overlapRow = tbody.locator("tr").filter({ hasText: overlapDate });
+    await expect(overlapRow).toHaveCount(1);
+    await expect(overlapRow).toContainText("$41.20");
+    await expect(overlapRow).toContainText("$40.50");
   });
 
   test("Market Filter Matrix toggles slug/vendor visibility and keeps matrix styling", async ({

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.77",
-  "releaseDate": "2026-05-21",
+  "version": "3.34.78",
+  "releaseDate": "2026-05-22",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

- **Publisher**: 90-day retail history endpoint (`history-90d.json`) now uses `queryRetailDailyAggregates` + `buildDailyWithVendors` instead of `queryRetailRange` + `buildRetailOhlcaBuckets`, matching the 30-day schema with per-vendor daily breakdown
- **Frontend**: Dedup merge uses vendor-set union (`{ ...coarser, ...finer }`) instead of all-or-nothing overwrite, retaining departed vendors on overlapping dates
- **Tests**: Endpoint-specific fixtures (7d/30d/90d) with 45-day-old entry and overlapping-date departed-vendor scenario; 2 new test cases pass GREEN

## Issues

- [STRK-92: Fill 90-day Market History All view with per-vendor data](https://plane.lbruton.cc/lbruton/browse/STRK-92/)
- Sketch: `DocVault/Projects/StakTrakr/sketches/STRK-92-90d-vendor-history/`

## Files Changed

| File | Change |
|------|--------|
| `devops/pollers/shared/api-export-v2.js` | Swap 90d pipeline to daily-with-vendors |
| `js/retail.js` | Union merge + coarsest-first ordering comment |
| `tests/playwright/retail/stak-582-market-survivors.spec.js` | Endpoint-specific fixtures + 2 new tests |
| `js/constants.js`, `package.json`, `package-lock.json`, `version.json`, `CHANGELOG.md`, `js/about.js` | v3.34.78 version bump |

## Test Plan

- [x] `npm test` — 694 passed, 12 pre-existing failures (unrelated), 0 new failures
- [x] New test: "90d-only row renders vendor prices in All view" — GREEN
- [x] New test: "departed vendor retained via union merge on overlapping dates" — GREEN
- [x] Codacy CLI — zero findings on changed files
- [ ] Post-deploy: fetch `history-90d.json` and confirm `vendors` object on entries >30d old