### PR TITLE
v3.34.80 — STRK-85: Goldback premium in ticker + tiered premium colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.80] - 2026-05-23
+
+### Changed — STRK-85: Goldback premium in ticker + tiered premium colors
+
+- **Goldback premium**: Ticker now shows G1-rate-based premium % for Goldback items; three-tier color scheme (low <2%, mid 2–5%, high ≥5%) applied consistently across ticker, vendor price Matrix, and market detail modal via shared `_calcMarketPremium` helper (STRK-85).
+
+---
+
 ## [3.34.79] - 2026-05-22
 
 ### Changed — STRK-74: Align inline chip config to saveData wrapper

--- a/css/styles.css
+++ b/css/styles.css
@@ -14709,6 +14709,18 @@ th {
   font-size: var(--font-size-xs);
   color: var(--text-muted);
 }
+.ticker-item .premium.low {
+  color: var(--success);
+  opacity: 0.8;
+}
+.ticker-item .premium.mid {
+  color: oklch(0.55 0.15 60);
+  opacity: 0.8;
+}
+.ticker-item .premium.high {
+  color: var(--danger);
+  opacity: 0.8;
+}
 
 /* ── Metal Dot Helper ── */
 .metal-dot {
@@ -14845,7 +14857,10 @@ th {
   margin-top: 2px;
 }
 .vp-premium.low {
-  color: var(--warning);
+  color: var(--success);
+}
+.vp-premium.mid {
+  color: oklch(0.55 0.15 60);
 }
 .vp-premium.high {
   color: var(--danger);

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.80 &ndash; STRK-85: Goldback premium in ticker + tiered premium colors</strong>: Ticker now shows G1-rate-based premium % for Goldback items; three-tier color scheme (low &lt;2%, mid 2&ndash;5%, high &ge;5%) applied across ticker, vendor price Matrix, and market detail modal via a shared helper (STRK-85).</li>
     <li><strong>v3.34.79 &ndash; STRK-74: Align inline chip config to saveData wrapper</strong>: Inline chip display preferences now save and load through the project-standard storage wrappers for consistent compression, quota handling, and future storage middleware coverage (STRK-74).</li>
     <li><strong>v3.34.78 &ndash; STRK-92: Fill 90-day Market History with per-vendor data</strong>: 90-day retail history now includes per-vendor daily breakdown; Market History &ldquo;All&rdquo; view shows vendor prices for the full window instead of dashes on older rows; departed vendors retained via union merge on overlapping dates (STRK-92).</li>
     <li><strong>v3.34.77 &ndash; STRK-93: Fix header Spot button 4&times; API sync</strong>: Header Spot sync button now triggers a single all-metals API sync instead of looping over four per-metal icons, eliminating redundant API calls, stacked cache-age dialogs, and duplicate toast notifications (STRK-93).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.75 &ndash; STRK-88: Lot/each purchase price rounding and CSV normalization</strong>: Preserves full precision for purchase prices in memory while displaying rounded inputs, handles lot/each toggle restoration on edit/duplicate, and normalizes CSV parsers/exporters (STRK-88).</li>
     <li><strong>v3.34.74 &ndash; STRK-87: Add Item Numista reset hygiene</strong>: Add Item now explicitly clears stale Numista catalog and tag UI state after editing another item, preventing previous item catalog data or tag handlers from leaking into a new inventory entry (STRK-87).</li>
     <li><strong>v3.34.73 &ndash; STRK-84: Numista picker tags on first Fill Fields</strong>: Tag checkboxes selected in the Numista picker now persist on the first Fill Fields click when adding a new item &mdash; no second sync required; unchecked default-on tags are recorded as opt-outs for new items (STRK-84).</li>
-    <li><strong>v3.34.72 &ndash; STRK-48: Per-oz/per-coin premium display</strong>: Valuation section shows premium % over spot at purchase, gain/loss %, and lot-aware rows (total + per-unit) in a 6-column grid; new synchronous spot lookup resolves nearest trading day from historical cache; also fixes catalogText search scope bug from STRK-86 (STRK-48).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.79";
+const APP_VERSION = "3.34.80";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -786,7 +786,7 @@ const openMarketDetailModal = async (slug) => {
         let _modalPremium = null;
         if (entry.price > 0 && spotPrice && spotPrice > 0 && weightOz > 0) {
           _modalPremium = _calcMarketPremium(entry.price, spotPrice * weightOz);
-        } else if (entry.price > 0 && _goldbackG1Rate && _goldbackG1Rate > 0) {
+        } else if (entry.price > 0 && metalCode === "goldback" && _goldbackG1Rate > 0) {
           _modalPremium = _calcMarketPremium(entry.price, _goldbackG1Rate);
         }
         if (_modalPremium != null) {
@@ -1155,7 +1155,7 @@ const _renderVendorTable = async (metalCode) => {
       let premium = null;
       if (spotPrice && spotPrice > 0 && weightOz > 0) {
         premium = _calcMarketPremium(vInfo.price, spotPrice * weightOz);
-      } else if (_goldbackG1Rate && _goldbackG1Rate > 0 && vInfo.price > 0) {
+      } else if (isoCode === "goldback" && _goldbackG1Rate > 0 && vInfo.price > 0) {
         premium = _calcMarketPremium(vInfo.price, _goldbackG1Rate);
       }
       if (premium != null) {

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -9,6 +9,18 @@ const _ISO_TO_METAL = { xag: "silver", xau: "gold", xpt: "platinum", xpd: "palla
 
 const _isSafeUrl = (url) => typeof url === "string" && /^https?:\/\//i.test(url);
 
+// Shared premium helpers — used across ticker, Matrix, and detail modal (AC-4)
+const _calcMarketPremium = (price, referenceRate) => {
+  if (!referenceRate || referenceRate <= 0 || !price || price <= 0) return null;
+  return ((price - referenceRate) / referenceRate) * 100;
+};
+const _premiumTierClass = (pct) => {
+  if (pct == null || !Number.isFinite(pct)) return "low";
+  if (pct >= 5) return "high";
+  if (pct >= 2) return "mid";
+  return "low";
+};
+
 let _cachedSlugDetail = {};
 let _goldbackG1Rate = null;
 
@@ -293,8 +305,9 @@ const renderBestPriceTicker = () => {
     const spot = _getSpotPrice(metalLower);
     let premium = null;
     if (spot && spot > 0 && weightOz > 0) {
-      const meltValue = spot * weightOz;
-      premium = ((bestPrice - meltValue) / meltValue) * 100;
+      premium = _calcMarketPremium(bestPrice, spot * weightOz);
+    } else if (metalLower === "goldback" && _goldbackG1Rate > 0) {
+      premium = _calcMarketPremium(bestPrice, _goldbackG1Rate);
     }
 
     // Get vendor display info
@@ -387,6 +400,7 @@ const renderBestPriceTicker = () => {
     premiumSpan.className = "premium";
     if (item.premium != null) {
       premiumSpan.textContent = (item.premium >= 0 ? "+" : "") + item.premium.toFixed(1) + "%";
+      premiumSpan.classList.add(_premiumTierClass(item.premium));
     }
     el.appendChild(premiumSpan);
 
@@ -769,13 +783,16 @@ const openMarketDetailModal = async (slug) => {
 
         // Premium
         const tdPrem = document.createElement("td");
+        let _modalPremium = null;
         if (entry.price > 0 && spotPrice && spotPrice > 0 && weightOz > 0) {
-          const meltValue = spotPrice * weightOz;
-          const premium = ((entry.price - meltValue) / meltValue) * 100;
-          const premClass = premium < 10 ? "low" : "high";
+          _modalPremium = _calcMarketPremium(entry.price, spotPrice * weightOz);
+        } else if (entry.price > 0 && _goldbackG1Rate && _goldbackG1Rate > 0) {
+          _modalPremium = _calcMarketPremium(entry.price, _goldbackG1Rate);
+        }
+        if (_modalPremium != null) {
           const badge = document.createElement("span");
-          badge.className = "vp-premium " + premClass;
-          badge.textContent = (premium >= 0 ? "+" : "") + premium.toFixed(1) + "%";
+          badge.className = "vp-premium " + _premiumTierClass(_modalPremium);
+          badge.textContent = (_modalPremium >= 0 ? "+" : "") + _modalPremium.toFixed(1) + "%";
           tdPrem.appendChild(badge);
         } else {
           tdPrem.textContent = "\u2014";
@@ -1137,16 +1154,13 @@ const _renderVendorTable = async (metalCode) => {
 
       let premium = null;
       if (spotPrice && spotPrice > 0 && weightOz > 0) {
-        const meltValue = spotPrice * weightOz;
-        premium = ((vInfo.price - meltValue) / meltValue) * 100;
+        premium = _calcMarketPremium(vInfo.price, spotPrice * weightOz);
       } else if (_goldbackG1Rate && _goldbackG1Rate > 0 && vInfo.price > 0) {
-        // Goldback premium over the official G1 rate from goldback.com
-        premium = ((vInfo.price - _goldbackG1Rate) / _goldbackG1Rate) * 100;
+        premium = _calcMarketPremium(vInfo.price, _goldbackG1Rate);
       }
       if (premium != null) {
-        const premClass = premium < 10 ? "low" : "high";
         const premBadge = document.createElement("span");
-        premBadge.className = "vp-premium " + premClass;
+        premBadge.className = "vp-premium " + _premiumTierClass(premium);
         premBadge.textContent = (premium >= 0 ? "+" : "") + premium.toFixed(1) + "%";
         td.appendChild(premBadge);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.79",
+  "version": "3.34.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.79",
+      "version": "3.34.80",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.79",
+  "version": "3.34.80",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.79-b1779523034";
+const CACHE_NAME = "staktrakr-v3.34.80-b1779524076";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.79-b1779521433";
+const CACHE_NAME = "staktrakr-v3.34.79-b1779523034";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.80-b1779524076";
+const CACHE_NAME = "staktrakr-v3.34.80-b1779529279";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.79-b1779503948";
+const CACHE_NAME = "staktrakr-v3.34.79-b1779521433";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/market-premium-tiers.spec.js
+++ b/tests/playwright/market-premium-tiers.spec.js
@@ -198,7 +198,11 @@ test.describe("STRK-85 — Goldback premium tiers", () => {
     await page.evaluate(() => window.renderVendorPrices());
     await page.waitForSelector(".vendor-prices-table", { timeout: 10000 });
 
-    const matrixBadge = page.locator(".vendor-prices-table .vp-premium").first();
+    // Scope Matrix badge to the goldback row (background sync adds other coins to the table)
+    const matrixBadge = page
+      .locator(".vendor-prices-table tbody tr")
+      .filter({ hasText: "Goldback" })
+      .locator(".vp-premium");
 
     // Before C.1: ticker shows no premium text; only Matrix shows it (via G1 rate branch).
     await expect(goldbackTickerPremium(page)).toHaveText("+20.0%");

--- a/tests/playwright/market-premium-tiers.spec.js
+++ b/tests/playwright/market-premium-tiers.spec.js
@@ -1,9 +1,8 @@
 /**
  * STRK-85 — Goldback premium in ticker + tiered premium colors
  *
- * TDD RED phase. These tests encode the acceptance criteria and MUST fail before Cohort C
- * (C.1) is implemented. They pass after _calcMarketPremium is wired into all three render
- * surfaces (ticker, Matrix, detail modal).
+ * Acceptance / regression tests. Implementation ships in this same PR (Cohort C).
+ * Covers _calcMarketPremium wired into all three render surfaces: ticker, Matrix, detail modal.
  *
  * AC-1: Goldback ticker items render a premium percentage.
  * AC-2: Premium math matches ((bestPrice - g1Rate) / g1Rate) * 100.

--- a/tests/playwright/market-premium-tiers.spec.js
+++ b/tests/playwright/market-premium-tiers.spec.js
@@ -1,0 +1,209 @@
+/**
+ * STRK-85 — Goldback premium in ticker + tiered premium colors
+ *
+ * TDD RED phase. These tests encode the acceptance criteria and MUST fail before Cohort C
+ * (C.1) is implemented. They pass after _calcMarketPremium is wired into all three render
+ * surfaces (ticker, Matrix, detail modal).
+ *
+ * AC-1: Goldback ticker items render a premium percentage.
+ * AC-2: Premium math matches ((bestPrice - g1Rate) / g1Rate) * 100.
+ * AC-3: Three-tier class scheme (low <2%, mid 2–5%, high ≥5%) applied consistently.
+ * AC-5: Premium value and tier class identical across ticker and Matrix.
+ *
+ * Note: AC-4 (single shared helper, no inline threshold duplication) is verified
+ * structurally via source grep in CLOSE-3, not through DOM assertions here.
+ */
+
+import { test, expect } from "@playwright/test";
+import { installStakTrakrNetworkMocks } from "./helpers/mocks/routes.js";
+import { injectSeedInventory } from "./helpers/seed.js";
+
+// ── Fixture constants ─────────────────────────────────────────────────────────
+
+const SLUG = "utah-1-goldback";
+const G1_RATE = 4.25;
+
+// HIGH tier: vendor $5.10 → ((5.10 - 4.25) / 4.25) * 100 = +20.0% (≥5%)
+const HIGH_PRICE = 5.1;
+// MID tier: vendor $4.3775 → ((4.3775 - 4.25) / 4.25) * 100 = +3.0% (≥2% and <5%)
+const MID_PRICE = 4.3775;
+// LOW tier: vendor $4.2925 → ((4.2925 - 4.25) / 4.25) * 100 = +1.0% (<2%)
+const LOW_PRICE = 4.2925;
+
+const makeVendorData = (price) => ({
+  median_price: price,
+  lowest_price: price,
+  highest_price: price,
+  vendors: {
+    herobullion: { price, inStock: true, in_stock: true },
+  },
+});
+
+const makePricesBlob = (price) => ({
+  lastSync: new Date().toISOString(),
+  window_start: new Date().toISOString(),
+  prices: { [SLUG]: makeVendorData(price) },
+});
+
+const COIN_META = {
+  [SLUG]: { name: "Utah 1 Goldback", weight: 0.001, metal: "goldback" },
+};
+
+const VENDOR_META = {
+  herobullion: { name: "Hero Bullion", color: "#10b981", url: "https://herobullion.com" },
+};
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+const setupFixture = async (page, vendorPrice) => {
+  await injectSeedInventory(page);
+
+  await installStakTrakrNetworkMocks(page, {
+    goldback: { g1_usd: G1_RATE },
+    retailLatest: { [SLUG]: makeVendorData(vendorPrice) },
+  });
+
+  await page.addInitScript(
+    ({ prices, coinMeta, vendorMeta }) => {
+      const writeJson = (key, val) => localStorage.setItem(key, JSON.stringify(val));
+      writeJson("v2RetailPrices", prices);
+      writeJson("retailPrices", prices);
+      writeJson("retailManifestCoinMeta", coinMeta);
+      writeJson("retailManifestVendorMeta", vendorMeta);
+      writeJson("retailManifestSlugs", Object.keys(coinMeta));
+      writeJson("spotGold", 2000);
+      writeJson("spotSilver", 36);
+      // Stub LightweightCharts so openMarketDetailModal works without the CDN
+      window.LightweightCharts = {
+        CrosshairMode: { Normal: 0 },
+        createChart(container) {
+          const root = document.createElement("div");
+          root.className = "tv-lightweight-charts";
+          container.appendChild(root);
+          return {
+            addLineSeries() {
+              return { setData() {} };
+            },
+            addHistogramSeries() {
+              return { setData() {} };
+            },
+            addAreaSeries() {
+              return { setData() {} };
+            },
+            timeScale() {
+              return { fitContent() {}, applyOptions() {} };
+            },
+            applyOptions() {},
+            resize() {},
+            remove() {
+              root.remove();
+            },
+          };
+        },
+      };
+    },
+    { prices: makePricesBlob(vendorPrice), coinMeta: COIN_META, vendorMeta: VENDOR_META }
+  );
+
+  await page.goto("/index.html");
+  await page.waitForFunction(
+    () =>
+      typeof window.initMarketData === "function" && typeof window.refreshMarketData === "function"
+  );
+  await page.evaluate(async () => {
+    if (typeof spotPrices !== "undefined") {
+      spotPrices.gold = 2000;
+      spotPrices.silver = 36;
+    }
+    await window.initMarketData();
+    window.refreshMarketData();
+  });
+  await page.waitForSelector(".ticker-item", { timeout: 10000 });
+};
+
+const openDetailModal = async (page) => {
+  await page.evaluate(() => window.openMarketDetailModal("utah-1-goldback"));
+  await page.waitForSelector("#marketDetailModal:not([hidden]) .vendor-prices-table", {
+    timeout: 10000,
+  });
+};
+
+// ── Locator helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Locates the .premium span inside the goldback ticker item specifically.
+ *
+ * Context: startRetailBackgroundSync() fires on page load (missingProviders=true)
+ * and overwrites v2RetailPrices with all manifest coins (silver eagle, gold eagle,
+ * goldback). Using .first() grabs the gold eagle "+2.0%" span instead of goldback.
+ * Filtering by "Goldback" text always targets the correct ticker item.
+ */
+const goldbackTickerPremium = (page) =>
+  page
+    .locator(".ticker-block[data-ticker-block='primary'] .ticker-item")
+    .filter({ hasText: "Goldback" })
+    .locator(".premium");
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("STRK-85 — Goldback premium tiers", () => {
+  test("AC-1 — Goldback ticker item renders a non-empty premium span", async ({ page }) => {
+    await setupFixture(page, HIGH_PRICE);
+    // Before C.1: ticker skips goldback premium (spot returns null) — span is empty.
+    await expect(goldbackTickerPremium(page)).not.toBeEmpty();
+  });
+
+  test("AC-2 — Goldback ticker premium matches ((price - g1Rate) / g1Rate) * 100", async ({
+    page,
+  }) => {
+    await setupFixture(page, HIGH_PRICE);
+    const expected = `+${(((HIGH_PRICE - G1_RATE) / G1_RATE) * 100).toFixed(1)}%`; // "+20.0%"
+    await expect(goldbackTickerPremium(page)).toHaveText(expected);
+  });
+
+  test("AC-3 ticker — ≥5% premium renders with .high class", async ({ page }) => {
+    await setupFixture(page, HIGH_PRICE);
+    await expect(goldbackTickerPremium(page)).toHaveClass(/\bhigh\b/);
+  });
+
+  test("AC-3 ticker — 2–5% premium renders with .mid class", async ({ page }) => {
+    await setupFixture(page, MID_PRICE);
+    await expect(goldbackTickerPremium(page)).toHaveClass(/\bmid\b/);
+  });
+
+  test("AC-3 ticker — <2% premium renders with .low class", async ({ page }) => {
+    await setupFixture(page, LOW_PRICE);
+    await expect(goldbackTickerPremium(page)).toHaveClass(/\blow\b/);
+  });
+
+  test("AC-3 Matrix — 2–5% premium renders with .vp-premium.mid class", async ({ page }) => {
+    await setupFixture(page, MID_PRICE);
+    await page.evaluate(() => window.renderVendorPrices());
+    await page.waitForSelector(".vendor-prices-table", { timeout: 10000 });
+    // Before C.1: Matrix uses binary scheme (< 10 = low, ≥ 10 = high) — no .mid class exists.
+    const midBadge = page.locator(".vendor-prices-table .vp-premium.mid");
+    await expect(midBadge.first()).toBeVisible();
+  });
+
+  test("AC-3 detail modal — goldback vendor row renders a .vp-premium badge", async ({ page }) => {
+    await setupFixture(page, HIGH_PRICE);
+    await openDetailModal(page);
+    // Before C.1: detail modal uses spotPrice (null for goldbacks) — shows "—" instead of a badge.
+    const badge = page.locator("#marketDetailContent .vp-premium");
+    await expect(badge.first()).toBeVisible();
+  });
+
+  test("AC-5 — premium text and tier class match across ticker and Matrix", async ({ page }) => {
+    await setupFixture(page, HIGH_PRICE);
+    await page.evaluate(() => window.renderVendorPrices());
+    await page.waitForSelector(".vendor-prices-table", { timeout: 10000 });
+
+    const matrixBadge = page.locator(".vendor-prices-table .vp-premium").first();
+
+    // Before C.1: ticker shows no premium text; only Matrix shows it (via G1 rate branch).
+    await expect(goldbackTickerPremium(page)).toHaveText("+20.0%");
+    await expect(goldbackTickerPremium(page)).toHaveClass(/\bhigh\b/);
+    await expect(matrixBadge).toHaveText("+20.0%");
+    await expect(matrixBadge).toHaveClass(/\bhigh\b/);
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.79",
-  "releaseDate": "2026-05-22",
+  "version": "3.34.80",
+  "releaseDate": "2026-05-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Changes

- Ticker now shows G1-rate-based premium % for Goldback items — uses `_goldbackG1Rate` from `goldback/latest.json` as the reference rate when no spot/weight is available
- Three-tier color scheme applied across ticker, vendor price Matrix, and market detail modal:
  - **Low** (<2%) → `--success` green
  - **Mid** (2–5%) → custom WCAG-AA amber (`oklch(0.55 0.15 60)`)
  - **High** (≥5%) → `--danger` red
- Shared helpers `_calcMarketPremium` and `_premiumTierClass` in `market-data.js` replace three independent inline premium calculations — single source of truth for math and tier logic
- 8 Playwright tests in `market-premium-tiers.spec.js` covering all ACs (ticker display, math accuracy, three-tier CSS classes, goldback G1 fallback, Matrix badge)

## Issues (DocVault)

- STRK-85: Goldback premium in ticker + tiered premium colors (in progress)