### PR TITLE
v3.34.82 — STRK-99: skip JSON-LD offer.price fallback for SDB + BE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.82] - 2026-05-23
+
+### Changed — STRK-99: SDB + BE bulk-tier scrape fix
+
+- **Retail poller**: Add `UNTRUSTED_OFFER_PRICE_VENDORS` denylist
+  (`sdbullion`, `bullionexchanges`) in `extractJsonLdPrice()` to skip the bare
+  `offer.price` JSON-LD fallback when no `priceSpecification` is present.
+  Both vendors recently shipped a Magento template change that publishes the
+  deepest "As Low As" bulk-tier price as `offer.price`, causing the home poller
+  to record bulk prices instead of single-unit Check/Wire prices. With the
+  denylist, `extractPrice()` falls through to the markdown-table extractor
+  which reads the 1-unit row correctly. Tiered `priceSpecification` blocks and
+  the zero-price OOS sentinel still apply for denied vendors. (STRK-99)
+- **Tests**: 6 new fixtures in `price-extract-jsonld.test.mjs` lock in the
+  STRK-99 behavior, including a verbatim capture of SDB's live Product JSON-LD
+  payload from 2026-05-23. (STRK-99)
+
+---
+
 ## [3.34.81] - 2026-05-23
 
 ### Changed — STRK-91: Bulk editor mobile parity + field gap closure

--- a/devops/pollers/shared/price-extract-jsonld.test.mjs
+++ b/devops/pollers/shared/price-extract-jsonld.test.mjs
@@ -20,7 +20,12 @@ const METAL_PRICE_RANGE_PER_OZ = {
   gold: { min: 1500, max: 15000 },
 };
 
-function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1) {
+// STRK-99: vendors whose JSON-LD offer.price is the deepest "As Low As" bulk
+// tier. For these vendors, skip the bare offer.price fallback so extractPrice()
+// can read the correct 1-unit price from the markdown table instead.
+const UNTRUSTED_OFFER_PRICE_VENDORS = new Set(["sdbullion", "bullionexchanges"]);
+
+function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerId = "") {
   if (!jsonLdScripts || jsonLdScripts.length === 0) return null;
   const perOz = METAL_PRICE_RANGE_PER_OZ[metal];
   if (!perOz) return null;
@@ -77,6 +82,7 @@ function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1) {
 
           const price = parseFloat(String(offer.price ?? "").replace(/,/g, ""));
           if (!isNaN(price) && price === 0) return JSONLD_ZERO_PRICE;
+          if (UNTRUSTED_OFFER_PRICE_VENDORS.has(providerId)) continue;
           if (inRange(price)) return price;
         }
       }
@@ -565,6 +571,124 @@ assert(
     10
   ),
   893.33
+);
+
+// ---------------------------------------------------------------------------
+// STRK-99: UNTRUSTED_OFFER_PRICE_VENDORS — SDB + BE publish bulk-tier in
+// offer.price with no priceSpecification. The denylist must skip the bare
+// offer.price fallback so extractPrice() can read the correct 1-unit price
+// from the markdown table. Fixture captured live from SDB on 2026-05-23.
+// ---------------------------------------------------------------------------
+
+// Live SDB Product JSON-LD payload (captured via Playwright with real Chrome UA
+// against https://sdbullion.com/canadian-silver-maple-leaf-coin-random-year).
+// The visible 1-unit Check/Wire price was $79.23 at capture time; SDB publishes
+// the 50+ bulk tier ($78.23) as offer.price.
+const SDB_LIVE_JSONLD_2026_05_23 = {
+  "@context": "http://schema.org",
+  "@type": "Product",
+  "@id": "https://sdbullion.com/canadian-silver-maple-leaf-coin-random-year",
+  name: "Canadian Silver Maple Leaf Coin - Random Year",
+  sku: "SRCMAPLE-1",
+  offers: {
+    "@type": "Offer",
+    price: "78.23",
+    priceCurrency: "USD",
+    availability: "https://schema.org/InStock",
+    url: "https://sdbullion.com/canadian-silver-maple-leaf-coin-random-year",
+    seller: { "@type": "Organization", name: "SD Bullion" },
+    itemCondition: "https://schema.org/NewCondition",
+  },
+};
+
+assert(
+  "18. STRK-99: bare offer.price skipped for sdbullion (no priceSpecification)",
+  extractJsonLdPrice(scripts(SDB_LIVE_JSONLD_2026_05_23), "silver", 1, "sdbullion"),
+  null
+);
+
+assert(
+  "19. STRK-99: bare offer.price skipped for bullionexchanges (no priceSpecification)",
+  extractJsonLdPrice(
+    scripts({
+      "@type": "Product",
+      offers: {
+        "@type": "Offer",
+        price: "77.22",
+        priceCurrency: "USD",
+        availability: "https://schema.org/InStock",
+      },
+    }),
+    "silver",
+    1,
+    "bullionexchanges"
+  ),
+  null
+);
+
+assert(
+  "20. STRK-99: bare offer.price honored for non-denied vendor (jmbullion)",
+  extractJsonLdPrice(
+    scripts({
+      "@type": "Product",
+      offers: { "@type": "Offer", price: "79.23", priceCurrency: "USD" },
+    }),
+    "silver",
+    1,
+    "jmbullion"
+  ),
+  79.23
+);
+
+assert(
+  "21. STRK-99: tiered priceSpecification still honored for denied vendor",
+  extractJsonLdPrice(
+    scripts({
+      "@type": "Product",
+      offers: {
+        price: "78.23", // bulk in offer.price — would be picked without the fix
+        priceSpecification: [
+          {
+            appliesToPaymentMethod:
+              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            eligibleQuantity: { minValue: "1", maxValue: "49" },
+            price: "79.23", // single-unit wire — should win
+          },
+        ],
+      },
+    }),
+    "silver",
+    1,
+    "sdbullion"
+  ),
+  79.23
+);
+
+assert(
+  "22. STRK-99: zero-price OOS sentinel still returned for denied vendor",
+  extractJsonLdPrice(
+    scripts({
+      "@type": "Product",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    }),
+    "silver",
+    1,
+    "sdbullion"
+  ),
+  JSONLD_ZERO_PRICE
+);
+
+assert(
+  "23. STRK-99: empty providerId (legacy callers) keeps old behavior",
+  extractJsonLdPrice(
+    scripts({
+      "@type": "Product",
+      offers: { "@type": "Offer", price: "79.23", priceCurrency: "USD" },
+    }),
+    "silver",
+    1
+  ),
+  79.23
 );
 
 // ---------------------------------------------------------------------------

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -332,7 +332,19 @@ function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "") {
 // grab ticker/carousel prices from a zero-priced product page (STAK-475 P1).
 const JSONLD_ZERO_PRICE = Symbol("jsonld-zero-price");
 
-function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1) {
+// Vendors whose JSON-LD `offer.price` is the deepest "As Low As" bulk tier
+// rather than the 1-unit retail price (STRK-99). For these vendors, we still
+// honor a tier-aware `priceSpecification` block if present (qty-1 wire entry),
+// but we skip the bare `offer.price` fallback so extractPrice() can pull the
+// correct 1-unit Check/Wire price from the markdown table instead.
+//
+// Verified 2026-05-23: SDB and BE both publish only `offer.price` (no
+// priceSpecification array, no eligibleQuantity, no appliesToPaymentMethod).
+// Add a vendor here only after confirming via live JSON-LD capture that the
+// bare offer.price is consistently the bulk-tier value.
+const UNTRUSTED_OFFER_PRICE_VENDORS = new Set(["sdbullion", "bullionexchanges"]);
+
+function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerId = "") {
   if (!jsonLdScripts || jsonLdScripts.length === 0) return null;
   const perOz = METAL_PRICE_RANGE_PER_OZ[metal];
   if (!perOz) return null;
@@ -392,7 +404,15 @@ function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1) {
           }
 
           const price = parseFloat(String(offer.price ?? "").replace(/,/g, ""));
+          // Always honor the zero-price OOS sentinel — even for denied vendors.
+          // A zero offer.price reliably signals "real product page, no price"
+          // (STAK-475 P1); only the in-range fallback is untrustworthy.
           if (!isNaN(price) && price === 0) return JSONLD_ZERO_PRICE;
+          // STRK-99: SDB and BE publish offer.price as the deepest bulk tier.
+          // Skip the bare-offer fallback for these vendors so extractPrice()
+          // can read the correct 1-unit Check/Wire price from the markdown table.
+          // Tiered priceSpecification above is still honored if a vendor adds one.
+          if (UNTRUSTED_OFFER_PRICE_VENDORS.has(providerId)) continue;
           if (inRange(price)) return price;
         }
       }
@@ -1075,7 +1095,12 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     const textStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
     const isInStock = !jsonLdOos && textStock.inStock;
 
-    const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
+    const jsonLdPrice = extractJsonLdPrice(
+      jsonLdScripts,
+      coin.metal,
+      coin.weight_oz || 1,
+      providerId
+    );
     if (jsonLdPrice === JSONLD_ZERO_PRICE) {
       log(`[cf-clearance] ${providerId}: JSON-LD price=0 in Byparr HTML -> OOS`);
       return { price: null, inStock: false, source: "cf-clearance:jsonLd" };
@@ -1160,7 +1185,12 @@ async function scrapeViaCFClearance(url, providerId, coin) {
     const cleaned = preprocessMarkdown(text, providerId);
     const inStock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
     // JSON-LD is authoritative — avoids related-product / spot ticker false positives.
-    const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
+    const jsonLdPrice = extractJsonLdPrice(
+      jsonLdScripts,
+      coin.metal,
+      coin.weight_oz || 1,
+      providerId
+    );
     if (jsonLdPrice === JSONLD_ZERO_PRICE) {
       log(`[cf-clearance] ${providerId}: JSON-LD price=0 → OOS, skipping HTML extraction`);
       return { price: null, inStock: false, source: "cf-clearance" };
@@ -1374,7 +1404,12 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
 
     // JSON-LD is authoritative — check before regex fallbacks to avoid
     // grabbing spot ticker deltas or related-product prices from innerText.
-    const jsonLdPrice = extractJsonLdPrice(jsonLdScripts, coin.metal, coin.weight_oz || 1);
+    const jsonLdPrice = extractJsonLdPrice(
+      jsonLdScripts,
+      coin.metal,
+      coin.weight_oz || 1,
+      providerId
+    );
     if (jsonLdPrice === JSONLD_ZERO_PRICE) {
       log(`  ${providerId}: JSON-LD price=0 → OOS, skipping HTML extraction`);
       return { price: null, inStock: false, source: "playwright-direct" };

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -321,10 +321,22 @@ function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "") {
  * the authoritative structured price set by the merchant, and avoids
  * false positives from spot ticker values appearing earlier in innerText.
  *
+ * Resolution order per Product/Offer:
+ *   1. `priceSpecification` with qty-1 + wire/eCheck `appliesToPaymentMethod` (preferred)
+ *   2. Bare `offer.price` in metal range — SKIPPED when providerId is in
+ *      UNTRUSTED_OFFER_PRICE_VENDORS (STRK-99); caller then falls through to
+ *      markdown-table extraction in `extractPrice()`.
+ *   3. `offer.price === 0` → returns JSONLD_ZERO_PRICE sentinel (OOS signal,
+ *      STAK-475 P1) — honored for ALL vendors including denied ones.
+ *
  * @param {string[]} jsonLdScripts  textContent of each ld+json script tag
  * @param {string}   metal
- * @param {number}   weightOz
- * @returns {number|null}
+ * @param {number}   [weightOz=1]
+ * @param {string}   [providerId=""]  Used to consult UNTRUSTED_OFFER_PRICE_VENDORS
+ *                                    denylist (STRK-99). Empty string keeps the
+ *                                    legacy "always honor offer.price" behavior.
+ * @returns {number|symbol|null}  Numeric price, JSONLD_ZERO_PRICE sentinel for
+ *                                OOS, or null if no usable price was found.
  */
 // Sentinel returned by extractJsonLdPrice when JSON-LD has a valid Product
 // with price=0 — signals "real product page, no price (OOS)". Callers must

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.82 &ndash; STRK-99: Fix SDB + Bullion Exchanges bulk-tier scrape</strong>: Retail poller now skips the bare <code>offer.price</code> JSON-LD fallback for SD Bullion and Bullion Exchanges; both vendors recently changed their templates to publish the deepest &ldquo;As Low As&rdquo; bulk price as <code>offer.price</code>, which caused the dashboard to display bulk-tier values instead of the 1-unit Check/Wire price. Markdown-table extraction now handles these two vendors correctly (STRK-99).</li>
     <li><strong>v3.34.81 &ndash; STRK-91: Bulk editor mobile parity + field gap closure</strong>: Sticky identity columns and 44px mobile tap targets make the bulk editor usable on phones and zoomed displays; new bulk-editable shape, capsule, and capsule-notes fields write through nested storage paths; catalog composition and diameter render as read-only reference columns with search and sort routed through a dot-path resolver (STRK-91).</li>
     <li><strong>v3.34.80 &ndash; STRK-85: Goldback premium in ticker + tiered premium colors</strong>: Ticker now shows G1-rate-based premium % for Goldback items; three-tier color scheme (low &lt;2%, mid 2&ndash;5%, high &ge;5%) applied across ticker, vendor price Matrix, and market detail modal via a shared helper (STRK-85).</li>
     <li><strong>v3.34.79 &ndash; STRK-74: Align inline chip config to saveData wrapper</strong>: Inline chip display preferences now save and load through the project-standard storage wrappers for consistent compression, quota handling, and future storage middleware coverage (STRK-74).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.77 &ndash; STRK-93: Fix header Spot button 4&times; API sync</strong>: Header Spot sync button now triggers a single all-metals API sync instead of looping over four per-metal icons, eliminating redundant API calls, stacked cache-age dialogs, and duplicate toast notifications (STRK-93).</li>
     <li><strong>v3.34.76 &ndash; STRK-89: Add gold-api.com as first-class spot price provider</strong>: New built-in Gold API provider offers free unlimited real-time spot prices for all four metals with no API key required; optional premium key support via collapsible disclosure widget (STRK-89).</li>
     <li><strong>v3.34.75 &ndash; STRK-88: Lot/each purchase price rounding and CSV normalization</strong>: Preserves full precision for purchase prices in memory while displaying rounded inputs, handles lot/each toggle restoration on edit/duplicate, and normalizes CSV parsers/exporters (STRK-88).</li>
-    <li><strong>v3.34.74 &ndash; STRK-87: Add Item Numista reset hygiene</strong>: Add Item now explicitly clears stale Numista catalog and tag UI state after editing another item, preventing previous item catalog data or tag handlers from leaking into a new inventory entry (STRK-87).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.81";
+const APP_VERSION = "3.34.82";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.81",
+  "version": "3.34.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.81",
+      "version": "3.34.82",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.81",
+  "version": "3.34.82",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.81-b1779538129";
+const CACHE_NAME = "staktrakr-v3.34.82-b1779539503";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.81",
+  "version": "3.34.82",
   "releaseDate": "2026-05-23",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after CI + review.

## Summary

Fixes [STRK-99](https://plane.lbruton.cc/lbruton/projects/026dbe54-fe52-4a9f-9f1b-7edcb9bbdceb/issues/138ff49f-cfde-4efc-8755-99616f76aae8) — SD Bullion and Bullion Exchanges retail prices were stuck on the deepest bulk tier ($78.23 instead of $79.23 for SDB silver maple; $77.22 instead of $77.82 for BE silver maple).

Both vendors recently shipped a Magento template change that publishes the deepest "As Low As" bulk-tier price as the canonical `offer.price` in their JSON-LD Product schema, with no tiered `priceSpecification` array. The home poller's `extractJsonLdPrice()` fell through to the bare `offer.price` extractor and recorded the bulk value.

## Root cause (verified live 2026-05-23)

Captured via Playwright with real Chrome UA against `https://sdbullion.com/canadian-silver-maple-leaf-coin-random-year`:

```json
"offers": {
  "@type": "Offer",
  "price": "78.23",       ← 50+ bulk tier, NOT 1-unit
  "priceCurrency": "USD",
  "availability": "https://schema.org/InStock"
}
```

No `priceSpecification`. No `eligibleQuantity`. Just bare `offer.price`.

Cross-confirmed in `price_snapshots`: both vendors record `source = *:jsonLd` with prices matching their advertised bulk tier exactly.

## Fix

Add `UNTRUSTED_OFFER_PRICE_VENDORS = new Set(["sdbullion", "bullionexchanges"])` denylist in `devops/pollers/shared/price-extract.js`. For denied vendors:

- **Skipped:** bare `offer.price` in-range fallback (line ~394)
- **Still honored:** tiered `priceSpecification` with qty-1 wire entry (if a denied vendor ever adds one back, we'll use it)
- **Still honored:** the `JSONLD_ZERO_PRICE` OOS sentinel (STAK-475 P1)

When the denylist blocks the JSON-LD path, `extractPrice()` falls through to the markdown-table extractor (`firstTableRowFirstPrice` → `firstInRangePriceProse`) — verified in-process to return the correct $79.23 (SDB) and $77.82 (BE) against live Firecrawl markdown.

## Vendor impact analysis

| Vendor          | JSON-LD path? | Impact of fix    |
| --------------- | ------------- | ---------------- |
| sdbullion       | Phase 0       | **Fixed** ✓      |
| bullionexchanges| Phase 2 (CF)  | **Fixed** ✓      |
| jmbullion       | Phase 0       | Unchanged (uses tiered `priceSpecification`, still wins) |
| summitmetals    | Phase 0       | Unchanged (no JSON-LD price, falls through to "Regular price" prose) |
| apmex, monumentmetals, herobullion, gainesvillecoins | Firecrawl-only | Unchanged (don't hit `extractJsonLdPrice` for price) |

## Tests

Added 6 regression assertions in `devops/pollers/shared/price-extract-jsonld.test.mjs`:

- Bare `offer.price` skipped for `sdbullion` (verbatim live JSON-LD payload as fixture)
- Bare `offer.price` skipped for `bullionexchanges`
- Bare `offer.price` still honored for non-denied vendors (`jmbullion`)
- Tiered `priceSpecification` still honored even for denied vendor
- Zero-price OOS sentinel still returned for denied vendor
- Empty `providerId` (legacy callers) keeps old behavior

```
25 tests: 25 passed, 0 failed
```

## Post-deploy verification

After this lands and the home poller redeploys:

```sql
SELECT vendor, coin_slug, price, source, scraped_at
FROM price_snapshots
WHERE vendor IN ('sdbullion','bullionexchanges')
  AND coin_slug LIKE '%maple%'
ORDER BY scraped_at DESC LIMIT 6;
```

Expect: `source` shifts from `*:jsonLd` to `*:tableFirstRow` or `*:firstInRangeProse`; prices match the 1-unit Check/Wire row on the live page. Spot-check SDB gold maple (was $4580.63 via JSON-LD — likely also under-reported by same mechanism).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pricing data extraction for specific bullion vendors by improving how fallback price sources are handled, ensuring correct pricing is displayed when tiered pricing information is unavailable.

* **Tests**
  * Added test cases covering vendor-specific pricing scenarios to validate the pricing extraction improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->