### PR TITLE
chore(deps): patch playwright SSL bypass + ws memory disclosure (security)

### DIFF
--- a/devops/pollers/shared/package-lock.json
+++ b/devops/pollers/shared/package-lock.json
@@ -11,8 +11,8 @@
         "@libsql/client": "^0.14.0",
         "better-sqlite3": "^11.0.0",
         "dotenv": "^16.4.0",
-        "playwright": "1.49.0",
-        "playwright-core": "1.49.0"
+        "playwright": "1.55.1",
+        "playwright-core": "1.55.1"
       }
     },
     "node_modules/@libsql/client": {
@@ -563,12 +563,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.55.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -827,9 +827,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/devops/pollers/shared/package.json
+++ b/devops/pollers/shared/package.json
@@ -8,7 +8,10 @@
     "@libsql/client": "^0.14.0",
     "better-sqlite3": "^11.0.0",
     "dotenv": "^16.4.0",
-    "playwright": "1.49.0",
-    "playwright-core": "1.49.0"
+    "playwright": "1.55.1",
+    "playwright-core": "1.55.1"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

Manual security patch for the 2 Dependabot alerts that fired against main after v3.34.85 shipped. Both are in the production poller workspace (\`devops/pollers/shared/\`).

## Vulnerabilities resolved

| Severity | Package | Current → Fixed | Advisory |
|---|---|---|---|
| 🔴 **HIGH** | playwright | 1.49.0 → **1.55.1** | SSL cert verification bypass on browser downloads (exploitable during \`playwright install\`) |
| 🟡 medium | ws | 8.19.0 → **8.20.1** | Uninitialized memory disclosure in packet handling |

## Approach

- **playwright + playwright-core** pinned to exact \`1.55.1\` (matches existing exact-version convention)
- **ws** pinned via \`overrides\` block since it's transitive through \`@libsql/isomorphic-ws@^8.13.0\` — libsql doesn't release fast enough to pull the fix on its own

## Why manual instead of Dependabot

1. Dependabot was misconfigured to target main (fixed in [\`6d4eb4d9\`](https://github.com/lbruton/StakTrakr/commit/6d4eb4d9) on dev — \`target-branch: \"dev\"\` added)
2. The 8 main-targeted PRs (#1155–#1162) were closed; reopen cycle on dev takes hours
3. Production workspace — no reason to leave vulnerable longer

## Real-world exposure (already mitigated by deploy posture)

- **Playwright HIGH** only triggers during \`playwright install\`. The home poller installs once at Docker build time; no active exposure until next container rebuild. Patching closes the window.
- **ws MEDIUM** affects WebSocket packet handling. The libsql client uses ws for the sqld connection (Tailscale-only, single-tenant) so attacker control of input is constrained.

## Lockfile regen

Generated with \`npm install --ignore-scripts\` because \`better-sqlite3\` needs Xcode CLT to compile native bindings (not installed on this dev machine). Production Docker runner handles the rebuild cleanly during image build.

## Test plan

- [x] Pre-commit hooks passed (gitleaks, signing key, prettier)
- [ ] CI green
- [ ] Codacy clean
- [ ] Dependabot security alerts close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)