### PR TITLE
hotfix(.github/dependabot.yml): target dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,23 @@
 # Dependabot config — supply-chain hardening (DEVS-10 / DEVS-12)
 #
 # Release-age enforcement is handled by `min-release-age=3` in the `.npmrc`
-# files at each workspace root (./.npmrc, ./devops/.npmrc,
-# ./devops/pollers/shared/.npmrc). Dependabot itself has no native cooldown
-# primitive, so the quarantine window is enforced at install time by npm.
+# files at each workspace root (./.npmrc, ./devops/pollers/shared/.npmrc).
+# Dependabot itself has no native cooldown primitive, so the quarantine
+# window is enforced at install time by npm.
 #
 # Security alerts (dependabot security updates) bypass the release-age floor
 # by design and continue to flow normally.
+#
+# target-branch: "dev" — bumps land on the integration branch first, get
+# tested with the rest of dev, and ship to main with the next release.
+# Production poller deps (under /devops/pollers/shared/) especially want
+# the dev runway before reaching main.
 
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -23,6 +29,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/devops/pollers/shared"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

GitHub reads \`dependabot.yml\` from the **default branch (main)**. The \`target-branch: \"dev\"\` fix that landed on dev as [\`6d4eb4d9\`](https://github.com/lbruton/StakTrakr/commit/6d4eb4d9) won't take effect until main has it too — otherwise Dependabot keeps opening PRs against main on every scan cycle.

Observed: the 8 PRs ([#1155](https://github.com/lbruton/StakTrakr/pull/1155)–[#1162](https://github.com/lbruton/StakTrakr/pull/1162)) that fired against main right after v3.34.85 shipped. Those were closed with explanation but Dependabot will re-fire them against main until this hotfix lands.

## What

Sync main's \`.github/dependabot.yml\` with dev's. Pure config, no code or runtime changes:

- Add \`target-branch: \"dev\"\` to both npm ecosystem entries
- Tighten comment header (drop stale \`devops/.npmrc\` reference)
- Document the target-branch rationale inline

Functionally identical to dev's current state after [\`6d4eb4d9\`](https://github.com/lbruton/StakTrakr/commit/6d4eb4d9).

## After merge

- Future Dependabot scans see main's new config → all bump PRs go to dev
- Production poller deps land on dev runway before shipping to main with next release
- Routes around the squash-merge divergence pattern that would otherwise re-introduce drift between branches' dependabot.yml each release

## Related

- [PR #1163](https://github.com/lbruton/StakTrakr/pull/1163) — manual security patch on dev (playwright SSL + ws memory disclosure) for the 2 alerts that fired alongside the original 8 misrouted PRs
- Closed PRs: #1155, #1156, #1157, #1158, #1159, #1160, #1161, #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)