### PR TITLE
chore: add explicit CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+  schedule:
+    - cron: "37 8 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ No application build step is required.
 - Framework: Playwright (`@playwright/test`), configured in `playwright.config.js`.
 - Place specs under `tests/playwright/<area>/` and name files `*.spec.js`.
 - Use stable, user-visible assertions and keep fixtures in `tests/fixtures/`.
+- In Codex sandboxed sessions on macOS, Playwright/Chromium may fail with
+  `bootstrap_check_in ... MachPortRendezvousServer ... Permission denied (1100)`;
+  rerun the same Playwright command with sandbox escalation instead of retrying
+  inside the sandbox.
 - For quick local checks, run a focused file:
   - `npx playwright test tests/playwright/01-page-load/page-load.spec.js`
 
@@ -192,6 +196,8 @@ Playwright and browser-heavy tasks open many file descriptors through Chromium,
 Node, pipes, logs, and MCP/runtime streams. To avoid `Too many open files
 (os error 24)` during spec or review work:
 
+- If Chromium launch fails with the macOS Mach port permission error, treat it
+  as a sandbox boundary and rerun the exact Playwright command with escalation.
 - Run no more than 2 subagents in parallel when any active task runs Playwright,
   starts a browser, inspects browser output, or reviews Playwright artifacts.
 - Prefer serial review after Playwright runs when the task already launched


### PR DESCRIPTION
## Summary
- add an explicit CodeQL advanced-setup workflow that loads .github/codeql/codeql-config.yml
- keep CodeQL focused on JavaScript/TypeScript so existing paths-ignore rules exclude tests, vendor, devops, wiki, and playground
- document the Codex macOS Playwright sandbox escalation pattern in AGENTS.md

## Validation
- ruby YAML parse for .github/workflows/codeql.yml
- npm_config_cache=/private/tmp/specflow-npm-cache npm run lint:md:all
- git diff --check

## Notes
This branch is cut from origin/main and cherry-picks only the tooling commit, so it does not pull the broader dev branch into main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for Playwright on macOS, including instructions for resolving sandbox permission errors and escalation conditions for concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->