### PR TITLE
v3.34.86 — STRK-106: BE Byparr content-quality retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.86] - 2026-05-24
+
+### Fixed — STRK-106: Bullion Exchanges gold scrape failures
+
+- **Byparr content-quality retry**: The cf-clearance sidecar client now inspects
+  Byparr's returned HTML for price-token density and retries up to 3 attempts
+  when the response looks like a pre-hydration shell (BE's React price grid
+  hydrates asynchronously after Playwright's `load` event, causing ~26% of
+  gold-page scrapes to snapshot before the price table renders). Retry threshold,
+  attempt cap, and backoff are tunable via `CF_CLEARANCE_MIN_DOLLARS`,
+  `CF_CLEARANCE_MAX_ATTEMPTS`, and `CF_CLEARANCE_RETRY_DELAY_MS` env vars.
+  Network/HTTP errors are not retried here — the caller's existing fallback
+  chain handles those. (STRK-106)
+
+---
+
 ## [3.34.85] - 2026-05-24
 
 ### Fixed — STRK-96: Playwright suite failures

--- a/devops/pollers/shared/cf-clearance.js
+++ b/devops/pollers/shared/cf-clearance.js
@@ -22,8 +22,81 @@ const CF_CLEARANCE_SIDECAR_URL =
 const CF_CLEARANCE_ENABLED = process.env.CF_CLEARANCE_ENABLED ?? "1";
 const CF_CLEARANCE_TIMEOUT_MS = process.env.CF_CLEARANCE_TIMEOUT_MS ?? "30000";
 
+// STRK-106: Byparr returns Playwright's HTML at the `load` event, before React
+// hydration finishes. Heavier vendor pages (Bullion Exchanges gold in particular)
+// frequently snapshot a 25–54KB shell missing the price grid — ~60% of attempts
+// in burst testing, ~26% in production — versus the ~92KB hydrated page.
+// Byparr reports HTTP 200 every time, so the only signal of a thin response is
+// inspecting the HTML.
+//
+// Heuristic: count dollar amounts in the HTML. Full BE product pages contain
+// 9+ price tokens (single-unit + tier pricing); shells contain 0–4 (mostly
+// header tickers). When below threshold, retry the Byparr call. This is
+// vendor-agnostic — other Byparr-protected vendors with the same hydration
+// race benefit too.
+const CF_CLEARANCE_MAX_ATTEMPTS = Number(process.env.CF_CLEARANCE_MAX_ATTEMPTS ?? "3");
+const CF_CLEARANCE_MIN_DOLLARS = Number(process.env.CF_CLEARANCE_MIN_DOLLARS ?? "6");
+const CF_CLEARANCE_RETRY_DELAY_MS = Number(process.env.CF_CLEARANCE_RETRY_DELAY_MS ?? "1000");
+
+// Match $NNN.NN price tokens with optional thousands separators (e.g. $1,234.56).
+// Allows whitespace between `$` and digits to catch inline HTML where currency
+// and amount are split into separate spans.
+const DOLLAR_TOKEN_RE = /\$\s*[0-9]{1,5}(?:,[0-9]{3})*\.[0-9]{2}/g;
+
+function countDollarTokens(html) {
+  if (!html) return 0;
+  const matches = html.match(DOLLAR_TOKEN_RE);
+  return matches ? matches.length : 0;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Single Byparr fetch attempt. Returns { ok, data, errorMsg } so the retry
+ * loop can branch cleanly without nesting try/catch per iteration.
+ */
+async function fetchByparrOnce(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${CF_CLEARANCE_SIDECAR_URL}/v1`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cmd: "request.get", url, maxTimeout: timeoutMs }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      return {
+        ok: false,
+        errorMsg: `HTTP ${response.status}: ${text.slice(0, 120)}`,
+      };
+    }
+    const data = await response.json();
+    if (data.status !== "ok" || !data.solution) {
+      return {
+        ok: false,
+        errorMsg: `unexpected response shape: ${JSON.stringify(data).slice(0, 200)}`,
+      };
+    }
+    return { ok: true, data };
+  } catch (err) {
+    return { ok: false, errorMsg: err.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
  * Harvest a cf_clearance cookie (and pre-fetched HTML) from the Byparr sidecar.
+ *
+ * Retries up to CF_CLEARANCE_MAX_ATTEMPTS times when Byparr returns thin HTML
+ * (fewer than CF_CLEARANCE_MIN_DOLLARS dollar tokens) — symptomatic of the
+ * React hydration race documented in STRK-106. Network errors and HTTP
+ * failures are NOT retried here; the caller's existing fallback chain handles
+ * those.
  *
  * @param {string} url - Vendor product URL to solve CF challenge for
  * @returns {Promise<{ cfClearance: string|null, userAgent: string, responseHtml: string|null } | null>}
@@ -37,53 +110,70 @@ export async function getCFClearanceCookie(url) {
   }
 
   const timeoutMs = Number(CF_CLEARANCE_TIMEOUT_MS);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let lastResult = null;
 
-  try {
-    const response = await fetch(`${CF_CLEARANCE_SIDECAR_URL}/v1`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ cmd: "request.get", url, maxTimeout: timeoutMs }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      throw new Error(`HTTP ${response.status}: ${text.slice(0, 120)}`);
-    }
-
-    const data = await response.json();
-    if (data.status !== "ok" || !data.solution) {
-      console.warn("[cf-clearance] unexpected response shape:", JSON.stringify(data).slice(0, 200));
+  for (let attempt = 1; attempt <= CF_CLEARANCE_MAX_ATTEMPTS; attempt++) {
+    const { ok, data, errorMsg } = await fetchByparrOnce(url, timeoutMs);
+    if (!ok) {
+      console.warn(`[cf-clearance] sidecar error (attempt ${attempt}): ${errorMsg}`);
+      // Network / shape failures don't benefit from immediate retry — return
+      // null so the caller falls through to its existing fallback chain.
       return null;
     }
 
     const cfCookie = data.solution.cookies?.find((c) => c.name === "cf_clearance");
-    if (!cfCookie?.value) {
-      // Cloudflare may not set a cookie (managed challenge / Turnstile), but
-      // Byparr still fetched the page — return the HTML so the caller can
-      // extract prices directly without needing a cookie+Playwright round-trip.
-      if (data.solution.response) {
-        console.log(
-          "[cf-clearance] no cookie, but have response HTML — returning for direct extraction"
-        );
-      } else {
-        console.warn("[cf-clearance] no cf_clearance cookie and no response HTML");
-        return null;
-      }
-    }
+    const responseHtml = data.solution.response ?? null;
+    const dollarCount = countDollarTokens(responseHtml);
 
-    return {
+    lastResult = {
       cfClearance: cfCookie?.value ?? null,
       userAgent: data.solution.userAgent,
       // HTML Byparr already fetched — lets caller skip a second browser request
-      responseHtml: data.solution.response ?? null,
+      responseHtml,
     };
-  } catch (err) {
-    console.warn("[cf-clearance] sidecar error: " + err.message);
-    return null;
-  } finally {
-    clearTimeout(timer);
+
+    // Quality check: is the rendered HTML usable, or did we snapshot before
+    // hydration finished? Retry up to MAX_ATTEMPTS on thin HTML.
+    if (dollarCount >= CF_CLEARANCE_MIN_DOLLARS) {
+      if (attempt > 1) {
+        console.log(
+          `[cf-clearance] attempt ${attempt}/${CF_CLEARANCE_MAX_ATTEMPTS}: ` +
+            `usable HTML (${dollarCount} price tokens, len=${responseHtml?.length ?? 0})`
+        );
+      }
+      break;
+    }
+
+    if (attempt < CF_CLEARANCE_MAX_ATTEMPTS) {
+      console.warn(
+        `[cf-clearance] attempt ${attempt}/${CF_CLEARANCE_MAX_ATTEMPTS}: ` +
+          `thin HTML (${dollarCount} price tokens, len=${responseHtml?.length ?? 0}) — ` +
+          `retrying after ${CF_CLEARANCE_RETRY_DELAY_MS}ms`
+      );
+      await sleep(CF_CLEARANCE_RETRY_DELAY_MS);
+    } else {
+      console.warn(
+        `[cf-clearance] all ${CF_CLEARANCE_MAX_ATTEMPTS} attempts returned ` +
+          `thin HTML (${dollarCount} price tokens) — returning best-effort response`
+      );
+    }
   }
+
+  // Even if the final attempt was thin, return what we have — the caller may
+  // still extract a price via JSON-LD, or its own fallback chain handles the
+  // miss. Pre-retry behavior was to return a thin response without inspection.
+  if (!lastResult) return null;
+
+  if (!lastResult.cfClearance) {
+    if (lastResult.responseHtml) {
+      console.log(
+        "[cf-clearance] no cookie, but have response HTML — returning for direct extraction"
+      );
+    } else {
+      console.warn("[cf-clearance] no cf_clearance cookie and no response HTML");
+      return null;
+    }
+  }
+
+  return lastResult;
 }

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.86 &ndash; STRK-106: Bullion Exchanges gold reliability</strong>: Byparr scrape now retries on pre-hydration shells (the React price grid loads after Playwright&rsquo;s &lsquo;load&rsquo; event, causing ~26% of gold pages to snapshot empty); content-quality check + bounded retry restore gold price coverage (STRK-106).</li>
     <li><strong>v3.34.85 &ndash; Memorial Day public release</strong>: First full public release since v3.34.38 (April 30) &mdash; 47 patches across 111 issues over 24 days. Highlights below; see the full <a href="https://github.com/lbruton/StakTrakr/blob/main/CHANGELOG.md">CHANGELOG</a> for everything.</li>
     <li><strong>v3.34.81 &ndash; Mobile parity</strong>: Bulk editor now usable on phones with sticky identity columns and 44px tap targets; nested-path fields (shape, capsule, capsule notes) bulk-edit correctly; modal action buttons safe-area aware on notched devices; chart viewports scale properly on small screens (STRK-91, STRK-42, STAK-578).</li>
     <li><strong>v3.34.80 &ndash; Goldback expansion</strong>: New &frac14; Goldback (Idaho, g0.25) denomination; ticker now shows G1-rate-based premium % with three-tier color coding (low &lt;2%, mid 2&ndash;5%, high &ge;5%) across ticker, vendor matrix, and detail modal; daily retail charts fixed; goldback purchase-price lookup repaired (STRK-66, STRK-85, STRK-69, STRK-77).</li>

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.85";
+const APP_VERSION = "3.34.86";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.85",
+  "version": "3.34.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.85",
+      "version": "3.34.86",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.85",
+  "version": "3.34.86",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.85-b1779641287";
+const CACHE_NAME = "staktrakr-v3.34.86-b1779653223";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.85",
+  "version": "3.34.86",
   "releaseDate": "2026-05-24",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

Fixes [STRK-106](https://plane.lbruton.cc/lbruton/browse/STRK-106/) — Bullion Exchanges gold scrape failures (~26% of cycles).

### Root cause

Byparr returns Playwright's HTML snapshot at the `load` event, but BE's React price grid hydrates asynchronously after `load`. Gold product pages are heavier (more cross-sell, more JSON-LD) and frequently snapshot a 25–54KB shell missing the price grid — **~60% of attempts in burst testing, ~26% in production** — versus the ~92KB hydrated page. Byparr reports HTTP 200 every time, so there's no upstream error signal.

### Fix

`devops/pollers/shared/cf-clearance.js` now inspects the returned HTML and retries up to `CF_CLEARANCE_MAX_ATTEMPTS` (default 3) when the dollar-token count falls below `CF_CLEARANCE_MIN_DOLLARS` (default 6), with `CF_CLEARANCE_RETRY_DELAY_MS` backoff (default 1000ms). Vendor-agnostic — any Byparr-protected vendor with the same hydration race benefits.

Network/HTTP errors are NOT retried here; the caller's existing fallback chain handles those. The function still returns a best-effort result if all attempts come back thin, preserving pre-retry semantics for the worst case.

### Empirical baseline (from STRK-106 investigation)

| Attempt | HTML size | $ amounts | Price grid? |
|---|---|---|---|
| 1 | 54.6 KB | 0 | NO |
| 2 | 25.1 KB | 4 | NO |
| 3 | **92.8 KB** | **9** | YES |
| 4 | 92.8 KB | 9 | YES |
| 5 | 54.7 KB | 4 | NO |

With ~40% per-attempt success: 3 attempts → ~78%, 4 attempts → ~87%.

## Test plan

- [ ] CI: lint + Playwright suite pass
- [ ] After merge: monitor next 2–3 hourly retail polls on home LXC for BE gold success rate via sqld `price_snapshots` query (compare 24h before vs. 24h after for `vendor='bullionexchanges'`, gold coins, `is_failed` count)
- [ ] Spot-check `docker logs staktrakr-home-poller --tail 200 | grep cf-clearance` for new `attempt N/3` log lines
- [ ] Optional: `docker exec staktrakr-home-poller bash -c 'DATA_DIR=/data FIRECRAWL_BASE_URL=http://firecrawl-api:3002 PLAYWRIGHT_LAUNCH=1 COINS=age,buffalo,krugerrand-gold,maple-gold PROVIDERS=bullionexchanges DRY_RUN=1 node devops/pollers/shared/price-extract.js'` to validate gold scrapes before counting on cron

## Risk

- Failed scrapes add up to ~5–20s of latency (3 attempts × ~5s + 2 × 1s backoff). Successful scrapes are unchanged.
- Threshold `CF_CLEARANCE_MIN_DOLLARS=6` is empirically calibrated against BE; if another Byparr-protected vendor genuinely renders fewer price tokens on a real product page, it would over-retry. Mitigation: env-tunable, no code change required.
- Behavior change is **caller-transparent** — same return shape, same null-on-error semantics.

## Issues

- [STRK-106](https://plane.lbruton.cc/lbruton/browse/STRK-106/): Bullion Exchanges — gold scrape failures (~26% of cycles): Byparr cf-clearance degrading, Firecrawl fallback CF-blocked

## Out of scope (deferred from STRK-106 fix-options list)

- Option 2: patching Byparr to expose a `waitFor` / `waitUntil` param (architectural, requires container rebuild)
- Option 3: making Firecrawl fallback CF-aware (independent improvement, separate ticket if needed)
- Option 4: direct Playwright with `waitForSelector` on the price grid (selector-maintenance burden)