### PR TITLE
v3.34.88 — STRK-108: cloud sync tag merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.88] - 2026-05-25
+
+### Fixed — STRK-108: Cloud sync tag merge
+
+- **Cloud sync tags**: Selective cloud sync now carries per-item tags,
+  removed-tag opt-outs, and per-UUID tag timestamps through the encrypted sync
+  payload, using last-writer-wins merge semantics and refreshing in-memory tag
+  state after pulls. (STRK-108)
+- **Tag-only pulls**: Manifest-first sync now detects tag-only remote changes
+  and routes version-upgrade tag keys through dedicated merge logic instead of
+  generic settings writes. (STRK-108)
+
+---
+
 ## [3.34.87] - 2026-05-25
 
 ### Changed — STRK-107: Cloud sync conflict loop after accepting remote changes

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.88 &ndash; STRK-108: Cloud sync tag merge</strong>: Cloud sync now preserves item tags, removed-tag opt-outs, and per-item tag timestamps across devices during selective sync merges (STRK-108).</li>
     <li><strong>v3.34.87 &ndash; STRK-107: Cloud sync conflict loop fix</strong>: Accepting remote item changes now neutralizes superseded local changelog entries at the acceptance cutoff, preserving Activity Log history while preventing stale conflicts from reappearing on the next sync (STRK-107).</li>
     <li><strong>v3.34.86 &ndash; STRK-106: Bullion Exchanges gold reliability</strong>: Byparr scrape now retries on pre-hydration shells (the React price grid loads after Playwright&rsquo;s &lsquo;load&rsquo; event, causing ~26% of gold pages to snapshot empty); content-quality check + bounded retry restore gold price coverage (STRK-106).</li>
     <li><strong>v3.34.85 &ndash; Memorial Day public release</strong>: First full public release since v3.34.38 (April 30) &mdash; 47 patches across 111 issues over 24 days. Highlights below; see the full <a href="https://github.com/lbruton/StakTrakr/blob/main/CHANGELOG.md">CHANGELOG</a> for everything.</li>

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -4592,7 +4592,9 @@ window.syncRestoreOverrideBackup = syncRestoreOverrideBackup;
 window.changeVaultPassword = changeVaultPassword;
 window.syncGetLastPush = syncGetLastPush;
 window._syncRelativeTime = _syncRelativeTime;
-window.CloudSyncTest = window.CloudSyncTest || {};
-window.CloudSyncTest.hasTagChanges = _hasTagChanges;
-window.CloudSyncTest.mergeTagData = _mergeTagData;
-window.CloudSyncTest.mergeOneSidedTagSettings = _mergeOneSidedTagSettings;
+if (window.location && /^(localhost|127\.0\.0\.1)$/.test(window.location.hostname)) {
+  window.CloudSyncTest = window.CloudSyncTest || {};
+  window.CloudSyncTest.hasTagChanges = _hasTagChanges;
+  window.CloudSyncTest.mergeTagData = _mergeTagData;
+  window.CloudSyncTest.mergeOneSidedTagSettings = _mergeOneSidedTagSettings;
+}

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2665,6 +2665,178 @@ async function pullSyncVault(remoteMeta) {
 // Restore preview (Layer 5 — REQ-5)
 // ---------------------------------------------------------------------------
 
+function _tagSyncKeys() {
+  return [
+    typeof ITEM_TAGS_KEY !== "undefined" ? ITEM_TAGS_KEY : "itemTags",
+    typeof ITEM_REMOVED_TAGS_KEY !== "undefined" ? ITEM_REMOVED_TAGS_KEY : "itemRemovedTags",
+    typeof ITEM_TAGS_LAST_MODIFIED_KEY !== "undefined"
+      ? ITEM_TAGS_LAST_MODIFIED_KEY
+      : "itemTagsLastModified",
+  ];
+}
+
+function _isTagSyncKey(key) {
+  return _tagSyncKeys().indexOf(key) !== -1;
+}
+
+function _normalizeRawStorageValue(value) {
+  if (value === undefined || value === null) return null;
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function _parseTagStore(rawValue, fallback) {
+  if (rawValue === undefined || rawValue === null) return fallback || {};
+  try {
+    var raw = typeof rawValue === "string" ? rawValue : JSON.stringify(rawValue);
+    var decoded = typeof __decompressIfNeeded === "function" ? __decompressIfNeeded(raw) : raw;
+    var parsed = typeof decoded === "string" ? JSON.parse(decoded) : decoded;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed
+      : fallback || {};
+  } catch (_e) {
+    return fallback || {};
+  }
+}
+
+function _extractRemoteTagData(remoteSettings) {
+  remoteSettings = remoteSettings || {};
+  return {
+    itemTags: remoteSettings[_tagSyncKeys()[0]],
+    itemRemovedTags: remoteSettings[_tagSyncKeys()[1]],
+    itemTagsLastModified: remoteSettings[_tagSyncKeys()[2]],
+  };
+}
+
+function _hasTagChanges(remoteSettings) {
+  if (!remoteSettings) return false;
+  var keys = _tagSyncKeys();
+  for (var i = 0; i < keys.length; i++) {
+    var localVal = typeof localStorage !== "undefined" ? localStorage.getItem(keys[i]) : null;
+    var remoteVal = _normalizeRawStorageValue(remoteSettings[keys[i]]);
+    if (localVal !== remoteVal) return true;
+  }
+  return false;
+}
+
+function _restoreRawStorageValues(priorValues) {
+  if (!priorValues || typeof localStorage === "undefined") return;
+  var keys = Object.keys(priorValues);
+  for (var i = 0; i < keys.length; i++) {
+    if (priorValues[keys[i]] === null) localStorage.removeItem(keys[i]);
+    else localStorage.setItem(keys[i], priorValues[keys[i]]);
+  }
+}
+
+function _mergeTagData(remoteTagData) {
+  var keys = _tagSyncKeys();
+  remoteTagData = remoteTagData || {};
+
+  var localTags =
+    typeof loadDataSync === "function" ? loadDataSync(keys[0], {}) : _parseTagStore(null, {});
+  var localRemoved =
+    typeof loadDataSync === "function" ? loadDataSync(keys[1], {}) : _parseTagStore(null, {});
+  var localTimestamps =
+    typeof loadTagTimestamps === "function"
+      ? loadTagTimestamps()
+      : typeof loadDataSync === "function"
+        ? loadDataSync(keys[2], {})
+        : {};
+
+  var remoteTags = _parseTagStore(remoteTagData.itemTags, {});
+  var remoteRemoved = _parseTagStore(remoteTagData.itemRemovedTags, {});
+  var remoteTimestamps = _parseTagStore(remoteTagData.itemTagsLastModified, {});
+
+  localTags =
+    typeof localTags === "object" && localTags !== null && !Array.isArray(localTags)
+      ? localTags
+      : {};
+  localRemoved =
+    typeof localRemoved === "object" && localRemoved !== null && !Array.isArray(localRemoved)
+      ? localRemoved
+      : {};
+  localTimestamps =
+    typeof localTimestamps === "object" &&
+    localTimestamps !== null &&
+    !Array.isArray(localTimestamps)
+      ? localTimestamps
+      : {};
+
+  var mergedTags = Object.assign({}, localTags);
+  var mergedRemoved = Object.assign({}, localRemoved);
+  var mergedTimestamps = Object.assign({}, localTimestamps);
+  var uuidSet = new Set();
+  [localTags, localRemoved, localTimestamps, remoteTags, remoteRemoved, remoteTimestamps].forEach(
+    function (store) {
+      Object.keys(store || {}).forEach(function (uuid) {
+        uuidSet.add(uuid);
+      });
+    }
+  );
+
+  var updated = 0;
+  uuidSet.forEach(function (uuid) {
+    var localTs = Number(localTimestamps[uuid] || 0);
+    var remoteTs = Number(remoteTimestamps[uuid] || 0);
+    if (remoteTs > localTs) {
+      if (Array.isArray(remoteTags[uuid]) && remoteTags[uuid].length > 0) {
+        mergedTags[uuid] = remoteTags[uuid].slice();
+      } else {
+        delete mergedTags[uuid];
+      }
+      if (Array.isArray(remoteRemoved[uuid]) && remoteRemoved[uuid].length > 0) {
+        mergedRemoved[uuid] = remoteRemoved[uuid].slice();
+      } else {
+        delete mergedRemoved[uuid];
+      }
+      mergedTimestamps[uuid] = remoteTs;
+      updated++;
+    }
+  });
+
+  Object.keys(mergedTags).forEach(function (uuid) {
+    if (!Array.isArray(mergedTags[uuid]) || mergedTags[uuid].length === 0) {
+      delete mergedTags[uuid];
+      return;
+    }
+    if (!Array.isArray(mergedRemoved[uuid])) return;
+    var presentTags = new Set(
+      mergedTags[uuid].map(function (tag) {
+        return String(tag).toLowerCase();
+      })
+    );
+    mergedRemoved[uuid] = mergedRemoved[uuid].filter(function (tag) {
+      return !presentTags.has(String(tag).toLowerCase());
+    });
+    if (mergedRemoved[uuid].length === 0) delete mergedRemoved[uuid];
+  });
+
+  if (typeof saveDataSync === "function") {
+    saveDataSync(keys[0], mergedTags);
+    saveDataSync(keys[1], mergedRemoved);
+    saveDataSync(keys[2], mergedTimestamps);
+  } else if (typeof localStorage !== "undefined") {
+    localStorage.setItem(keys[0], JSON.stringify(mergedTags));
+    localStorage.setItem(keys[1], JSON.stringify(mergedRemoved));
+    localStorage.setItem(keys[2], JSON.stringify(mergedTimestamps));
+  }
+
+  if (typeof loadItemTags === "function") loadItemTags();
+  return { merged: true, uuidsUpdated: updated };
+}
+
+function _mergeOneSidedTagSettings(remoteSettings) {
+  var tagKeysMerged = 0;
+  var tagData = _extractRemoteTagData(remoteSettings);
+  Object.keys(tagData).forEach(function (key) {
+    if (tagData[key] !== undefined && tagData[key] !== null) tagKeysMerged++;
+  });
+  if (tagKeysMerged === 0) return { tagKeysMerged: 0, mergeResult: null };
+  return {
+    tagKeysMerged: tagKeysMerged,
+    mergeResult: _mergeTagData(tagData),
+  };
+}
+
 /**
  * Consolidated post-apply sequence for sync and vault restore paths.
  * Handles backup, inventory assignment, settings application, save/render,
@@ -2682,6 +2854,7 @@ async function pullSyncVault(remoteMeta) {
  * @param {string} [options.source='sync'] - 'sync' or 'vault' — controls toast prefix
  * @param {boolean} [options.showToast=true] - Whether to show the summary toast
  * @param {boolean} [options.broadcastPull=true] - Whether to broadcast pull-complete to other tabs
+ * @param {object} [options.remoteTagData] - Raw remote tag stores from sync payload
  */
 function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remoteMeta, options) {
   var acceptanceCutoff = Date.now();
@@ -2691,6 +2864,7 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
   var source = opts.source || "sync";
   var shouldToast = opts.showToast !== false;
   var shouldBroadcast = opts.broadcastPull !== false;
+  var tagPriorValues = null;
 
   // 1. Pre-apply backup
   if (typeof syncSaveOverrideBackup === "function") {
@@ -2704,6 +2878,33 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
   var _prevInventory = inventory;
   if (typeof newInventory !== "undefined" && newInventory !== null) {
     inventory = newInventory;
+  }
+
+  if (opts.remoteTagData) {
+    var tagKeys = _tagSyncKeys();
+    tagPriorValues = {};
+    for (var tk = 0; tk < tagKeys.length; tk++) {
+      tagPriorValues[tagKeys[tk]] =
+        typeof localStorage !== "undefined" ? localStorage.getItem(tagKeys[tk]) : null;
+    }
+    try {
+      _mergeTagData(opts.remoteTagData);
+    } catch (tagErr) {
+      inventory = _prevInventory;
+      _restoreRawStorageValues(tagPriorValues);
+      console.warn("[CloudSync] Tag merge failed — rolling back pull:", tagErr);
+      logCloudSyncActivity(
+        "cloud_sync_pull",
+        "partial",
+        { failedCount: 1, failedKeys: tagKeys },
+        null
+      );
+      if (typeof updateSyncStatusIndicator === "function") {
+        updateSyncStatusIndicator("error", "rollback");
+      }
+      if (typeof refreshSyncUI === "function") refreshSyncUI();
+      return;
+    }
   }
 
   // 3. Apply settings changes.
@@ -2748,6 +2949,7 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
     }
     if (_failedCount > 0) {
       inventory = _prevInventory;
+      _restoreRawStorageValues(tagPriorValues);
       for (var r = 0; r < _appliedKeys.length; r++) {
         try {
           var prior = _priorValues[_appliedKeys[r]];
@@ -2944,6 +3146,10 @@ function showRestorePreviewModal(diffResult, settingsDiff, remotePayload, remote
             // Delegate everything to _applyAndFinalize (backup, save, render, toast, status, broadcast)
             _applyAndFinalize(newInv, selectedChanges, settingsChanges, remoteMeta, {
               source: "sync",
+              remoteTagData:
+                remotePayload && remotePayload.data
+                  ? _extractRemoteTagData(remotePayload.data)
+                  : null,
             });
             debugLog("[CloudSync] Restore preview: applied selected changes via DiffEngine");
             p = Promise.resolve();
@@ -3133,7 +3339,7 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
             for (var _dvs = 0; _dvs < SYNC_SCOPE_KEYS.length; _dvs++) {
               if (
                 SYNC_SCOPE_KEYS[_dvs] === "metalInventory" ||
-                SYNC_SCOPE_KEYS[_dvs] === "itemTags"
+                _isTagSyncKey(SYNC_SCOPE_KEYS[_dvs])
               )
                 continue;
               var _dvlv =
@@ -3152,6 +3358,7 @@ async function _deferredVaultRestore(token, password, remoteMeta, selectedChange
           }
           _applyAndFinalize(newInv, selectedChanges, _dvSettingsChanges, remoteMeta, {
             source: "sync",
+            remoteTagData: _extractRemoteTagData(payload.data),
           });
           debugLog(
             "[CloudSync] Deferred vault restore complete (selective apply, settings:",
@@ -3323,7 +3530,7 @@ async function pullWithPreview(remoteMeta) {
             var _mLocalSettings = {};
             if (typeof SYNC_SCOPE_KEYS !== "undefined" && typeof localStorage !== "undefined") {
               for (var ms = 0; ms < SYNC_SCOPE_KEYS.length; ms++) {
-                if (SYNC_SCOPE_KEYS[ms] === "metalInventory" || SYNC_SCOPE_KEYS[ms] === "itemTags")
+                if (SYNC_SCOPE_KEYS[ms] === "metalInventory" || _isTagSyncKey(SYNC_SCOPE_KEYS[ms]))
                   continue;
                 var msv = localStorage.getItem(SYNC_SCOPE_KEYS[ms]);
                 if (msv !== null) _mLocalSettings[SYNC_SCOPE_KEYS[ms]] = msv;
@@ -3342,7 +3549,8 @@ async function pullWithPreview(remoteMeta) {
             !manifestSettingsDiff ||
             !manifestSettingsDiff.changed ||
             manifestSettingsDiff.changed.length === 0;
-          if (_mNoChanges && _mNoSettingsChanges) {
+          var _mHasTagChanges = _hasTagChanges(manifest.settings);
+          if (_mNoChanges && _mNoSettingsChanges && !_mHasTagChanges) {
             // STAK-387: Silent return — no vault download needed when manifest confirms no changes
             var _silentPullMeta = {
               syncId: remoteMeta ? remoteMeta.syncId : null,
@@ -3411,6 +3619,20 @@ async function pullWithPreview(remoteMeta) {
             return;
           }
 
+          if (_mNoChanges && _mNoSettingsChanges && _mHasTagChanges) {
+            _applyAndFinalize(inventory, [], null, remoteMeta, {
+              source: "sync",
+              showToast: false,
+              remoteTagData: _extractRemoteTagData(manifest.settings),
+            });
+            logCloudSyncActivity(
+              "auto_sync_pull",
+              "success",
+              "Tag-only changes merged silently (manifest)"
+            );
+            return;
+          }
+
           // STAK-402 + STAK-412: Verify the manifest diff is complete by checking
           // whether the expected post-apply count matches the remote item count.
           // The manifest changelog only records changes the pushing device made — it
@@ -3452,8 +3674,17 @@ async function pullWithPreview(remoteMeta) {
             if (_allOneSided) {
               var _appliedCount = 0;
               var _failedCount = 0;
+              try {
+                var _tagMerge = _mergeOneSidedTagSettings(manifest.settings || {});
+                _appliedCount += _tagMerge.tagKeysMerged;
+              } catch (_tagMergeErr) {
+                _failedCount++;
+              }
               for (var _si = 0; _si < manifestSettingsDiff.changed.length; _si++) {
                 var _sc = manifestSettingsDiff.changed[_si];
+                if (_isTagSyncKey(_sc.key)) {
+                  continue;
+                }
                 // Guard: only apply keys in the ALLOWED_STORAGE_KEYS allowlist
                 if (
                   typeof ALLOWED_STORAGE_KEYS !== "undefined" &&
@@ -3769,14 +4000,14 @@ async function pullWithPreview(remoteMeta) {
       if (remotePayload.data) {
         var _rsKeys = Object.keys(remotePayload.data);
         for (var rs = 0; rs < _rsKeys.length; rs++) {
-          if (_rsKeys[rs] !== "metalInventory" && _rsKeys[rs] !== "itemTags") {
+          if (_rsKeys[rs] !== "metalInventory" && !_isTagSyncKey(_rsKeys[rs])) {
             remoteSettings[_rsKeys[rs]] = remotePayload.data[_rsKeys[rs]];
           }
         }
       }
       if (typeof SYNC_SCOPE_KEYS !== "undefined") {
         for (var i = 0; i < SYNC_SCOPE_KEYS.length; i++) {
-          if (SYNC_SCOPE_KEYS[i] === "metalInventory" || SYNC_SCOPE_KEYS[i] === "itemTags")
+          if (SYNC_SCOPE_KEYS[i] === "metalInventory" || _isTagSyncKey(SYNC_SCOPE_KEYS[i]))
             continue;
           // STAK-497: Use raw localStorage.getItem to match vault payload format.
           // loadDataSync JSON-parses values, which fails for scalar settings
@@ -4361,3 +4592,7 @@ window.syncRestoreOverrideBackup = syncRestoreOverrideBackup;
 window.changeVaultPassword = changeVaultPassword;
 window.syncGetLastPush = syncGetLastPush;
 window._syncRelativeTime = _syncRelativeTime;
+window.CloudSyncTest = window.CloudSyncTest || {};
+window.CloudSyncTest.hasTagChanges = _hasTagChanges;
+window.CloudSyncTest.mergeTagData = _mergeTagData;
+window.CloudSyncTest.mergeOneSidedTagSettings = _mergeOneSidedTagSettings;

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.87";
+const APP_VERSION = "3.34.88";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/constants.js
+++ b/js/constants.js
@@ -629,6 +629,12 @@ const TYPE_METAL_FILTER = {
 /** @constant {string} ITEM_TAGS_KEY - LocalStorage key for item tags mapping (STAK-126) */
 const ITEM_TAGS_KEY = "itemTags"; // nosemgrep: codacy.javascript.security.hard-coded-password
 
+/** @constant {string} ITEM_REMOVED_TAGS_KEY - LocalStorage key for removed per-item tags (STAK-556) */
+const ITEM_REMOVED_TAGS_KEY = "itemRemovedTags"; // nosemgrep: codacy.javascript.security.hard-coded-password
+
+/** @constant {string} ITEM_TAGS_LAST_MODIFIED_KEY - LocalStorage key for per-item tag timestamps (STRK-108) */
+const ITEM_TAGS_LAST_MODIFIED_KEY = "itemTagsLastModified"; // nosemgrep: codacy.javascript.security.hard-coded-password
+
 /** @constant {number} MAX_TAGS_PER_ITEM - Maximum number of tags allowed per item (STAK-126) */
 const MAX_TAGS_PER_ITEM = 20;
 
@@ -853,6 +859,8 @@ const SYNC_SCOPE_KEYS = [
   // ── Core data ──
   "metalInventory", // LS_KEY — inventory items
   "itemTags", // ITEM_TAGS_KEY — per-item tags
+  "itemRemovedTags", // ITEM_REMOVED_TAGS_KEY — removed per-item tags
+  "itemTagsLastModified", // ITEM_TAGS_LAST_MODIFIED_KEY — per-item tag timestamps
 
   // ── Display preferences ──
   "displayCurrency", // DISPLAY_CURRENCY_KEY — active display currency
@@ -1016,6 +1024,8 @@ const ALLOWED_STORAGE_KEYS = [
   SHOW_REALIZED_KEY, // boolean string: "true"/"false" — show realized G/L in summary cards (STAK-72)
   METAL_ORDER_KEY, // JSON array: metal order/visibility config
   ITEM_TAGS_KEY, // JSON object: per-item tags keyed by UUID (STAK-126)
+  ITEM_REMOVED_TAGS_KEY, // JSON object: per-item removed Numista tags keyed by UUID (STAK-556)
+  ITEM_TAGS_LAST_MODIFIED_KEY, // JSON object: per-item tag timestamps keyed by UUID (STRK-108)
   "seedImagesVer", // string: current seed images version for cache invalidation
   "cloud_token_dropbox", // JSON: Dropbox OAuth token data
   "cloud_token_pcloud", // JSON: pCloud OAuth token data
@@ -1055,7 +1065,6 @@ const ALLOWED_STORAGE_KEYS = [
   // STAK-504: Market data module keys
   "vendorPricesActiveTab", // string: active metal tab in vendor prices section
   "v2SpotHistoryTs", // string: ISO timestamp of cached v2 spot history
-  "itemRemovedTags", // JSON object: per-item removed Numista tags keyed by UUID (STAK-556)
   "inventorySeedApplied", // STRK-13: ISO timestamp string, sentinel proving seed has been applied (or migration ran)
   "staktrakr.bootDiagnostics", // STRK-13: JSON array, 10-entry ring buffer of boot classifications
   // STRK-45: per-item attachments
@@ -1969,6 +1978,8 @@ if (typeof window !== "undefined") {
   window.saveNumistaViewFieldConfig = saveNumistaViewFieldConfig;
   // Item tags (STAK-126)
   window.ITEM_TAGS_KEY = ITEM_TAGS_KEY;
+  window.ITEM_REMOVED_TAGS_KEY = ITEM_REMOVED_TAGS_KEY;
+  window.ITEM_TAGS_LAST_MODIFIED_KEY = ITEM_TAGS_LAST_MODIFIED_KEY;
   window.MAX_TAGS_PER_ITEM = MAX_TAGS_PER_ITEM;
   window.MAX_TAG_LENGTH = MAX_TAG_LENGTH;
   // Multi-currency support (STACK-50)

--- a/js/events.js
+++ b/js/events.js
@@ -2025,7 +2025,13 @@ const commitItemToInventory = (f, isEditing, editIdx) => {
       typeof addItemTag === "function" &&
       typeof saveItemTags === "function"
     ) {
-      pendingTags.forEach((tag) => addItemTag(addedItem.uuid, tag, false));
+      let addedTags = false;
+      pendingTags.forEach((tag) => {
+        if (addItemTag(addedItem.uuid, tag, false)) addedTags = true;
+      });
+      if (addedTags && typeof stampTagTimestamp === "function") {
+        stampTagTimestamp([addedItem.uuid]);
+      }
       saveItemTags();
       window.pendingAddItemTags = [];
     }
@@ -2299,7 +2305,13 @@ const setupItemFormListeners = () => {
               typeof isCloneFieldChecked === "function" &&
               isCloneFieldChecked("tags")
             ) {
-              sourceTags.forEach((tag) => addItemTag(newItem.uuid, tag, false));
+              let addedTags = false;
+              sourceTags.forEach((tag) => {
+                if (addItemTag(newItem.uuid, tag, false)) addedTags = true;
+              });
+              if (addedTags && typeof stampTagTimestamp === "function") {
+                stampTagTimestamp([newItem.uuid]);
+              }
               saveItemTags();
             }
           }

--- a/js/inventory-import.js
+++ b/js/inventory-import.js
@@ -37,6 +37,7 @@
   const _postImportCleanup = (newItems, pendingTagsByUuid) => {
     // Apply deferred tags if needed (keyed by DiffEngine.computeItemKey)
     if (pendingTagsByUuid && typeof addItemTag === "function") {
+      const stampedUuids = new Set();
       for (const item of newItems) {
         const itemKey =
           typeof DiffEngine !== "undefined"
@@ -44,8 +45,13 @@
             : item.uuid || item.serial || "";
         const tags = pendingTagsByUuid.get(itemKey);
         if (tags && tags.length) {
-          tags.forEach((tag) => addItemTag(item.uuid, tag, false));
+          tags.forEach((tag) => {
+            if (addItemTag(item.uuid, tag, false)) stampedUuids.add(item.uuid);
+          });
         }
+      }
+      if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
+        stampTagTimestamp(Array.from(stampedUuids));
       }
       if (typeof saveItemTags === "function") saveItemTags();
     }
@@ -156,6 +162,7 @@
           const tagEligible = selectedChanges.filter(function (c) {
             return c.type === "add" || c.type === "modify";
           });
+          const stampedUuids = new Set();
           for (const change of tagEligible) {
             if (change.item && change.item.uuid) {
               const tagKey =
@@ -165,10 +172,15 @@
               const tags = options.pendingTagsByUuid.get(tagKey);
               if (tags && tags.length) {
                 tags.forEach(function (tag) {
-                  addItemTag(change.item.uuid, tag, false);
+                  if (addItemTag(change.item.uuid, tag, false)) {
+                    stampedUuids.add(change.item.uuid);
+                  }
                 });
               }
             }
+          }
+          if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
+            stampTagTimestamp(Array.from(stampedUuids));
           }
           if (typeof saveItemTags === "function") saveItemTags();
         }
@@ -551,6 +563,7 @@
             saveInventory();
             // STAK-424: Apply deferred tags after override confirmation
             if (pendingTagsByUuid.size > 0 && typeof addItemTag === "function") {
+              const stampedUuids = new Set();
               for (const item of imported) {
                 const itemKey =
                   typeof DiffEngine !== "undefined"
@@ -558,8 +571,13 @@
                     : item.uuid || item.serial || "";
                 const tags = pendingTagsByUuid.get(itemKey);
                 if (tags && tags.length) {
-                  tags.forEach((tag) => addItemTag(item.uuid, tag, false));
+                  tags.forEach((tag) => {
+                    if (addItemTag(item.uuid, tag, false)) stampedUuids.add(item.uuid);
+                  });
                 }
+              }
+              if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
+                stampTagTimestamp(Array.from(stampedUuids));
               }
               if (typeof saveItemTags === "function") saveItemTags();
             }
@@ -1438,11 +1456,17 @@
         // ── Override path: skip DiffEngine, import all directly ──
         if (override) {
           if (typeof addItemTag === "function") {
+            const stampedUuids = new Set();
             for (const item of imported) {
               const pendingTags = pendingTagsByUuid.get(item.uuid);
               if (pendingTags && pendingTags.length) {
-                pendingTags.forEach((tag) => addItemTag(item.uuid, tag, false));
+                pendingTags.forEach((tag) => {
+                  if (addItemTag(item.uuid, tag, false)) stampedUuids.add(item.uuid);
+                });
               }
+            }
+            if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
+              stampTagTimestamp(Array.from(stampedUuids));
             }
             if (typeof saveItemTags === "function") saveItemTags();
           }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1250,7 +1250,12 @@ const splitInventoryItem = async (originalIdx, disposedQty, dispositionInput) =>
   // 7. Copy tags (non-blocking — tag loss is acceptable)
   try {
     if (typeof getItemTags === "function" && typeof addItemTag === "function") {
-      getItemTags(original.uuid).forEach((tag) => addItemTag(clone.uuid, tag, false));
+      const copiedTags = getItemTags(original.uuid);
+      let addedTags = false;
+      copiedTags.forEach((tag) => {
+        if (addItemTag(clone.uuid, tag, false)) addedTags = true;
+      });
+      if (addedTags && typeof stampTagTimestamp === "function") stampTagTimestamp([clone.uuid]);
       if (typeof saveItemTags === "function") saveItemTags();
     }
   } catch (e) {
@@ -1814,7 +1819,11 @@ const editItem = (idx, logIdx = null) => {
       const addHandler = () => {
         const val = elements.newTagInput.value.trim();
         if (val && typeof addItemTag === "function") {
-          parseTagInput(val).forEach((t) => addItemTag(item.uuid, t, false));
+          let addedTags = false;
+          parseTagInput(val).forEach((t) => {
+            if (addItemTag(item.uuid, t, false)) addedTags = true;
+          });
+          if (addedTags && typeof stampTagTimestamp === "function") stampTagTimestamp([item.uuid]);
           if (typeof saveItemTags === "function") saveItemTags();
           elements.newTagInput.value = "";
           renderEditTags();

--- a/js/tags.js
+++ b/js/tags.js
@@ -58,6 +58,49 @@ const saveItemTags = () => {
 };
 
 /**
+ * Load per-item tag modification timestamps.
+ * @returns {Object<string, number>} Timestamp map keyed by item UUID
+ */
+const loadTagTimestamps = () => {
+  const key =
+    typeof ITEM_TAGS_LAST_MODIFIED_KEY !== "undefined"
+      ? ITEM_TAGS_LAST_MODIFIED_KEY
+      : "itemTagsLastModified";
+  const loaded = loadDataSync(key, {});
+  return typeof loaded === "object" && loaded !== null && !Array.isArray(loaded) ? loaded : {};
+};
+
+/**
+ * Save per-item tag modification timestamps without scheduling a sync push.
+ * @param {Object<string, number>} map - Timestamp map keyed by item UUID
+ */
+const saveTagTimestampsDirect = (map) => {
+  const key =
+    typeof ITEM_TAGS_LAST_MODIFIED_KEY !== "undefined"
+      ? ITEM_TAGS_LAST_MODIFIED_KEY
+      : "itemTagsLastModified";
+  const safeMap = typeof map === "object" && map !== null && !Array.isArray(map) ? map : {};
+  saveDataSync(key, safeMap);
+};
+
+/**
+ * Stamp tag modification timestamps for one or more item UUIDs.
+ * @param {string|string[]} uuids - Item UUID or UUID array
+ */
+const stampTagTimestamp = (uuids) => {
+  const list = Array.isArray(uuids) ? uuids : [uuids];
+  const filtered = list.filter((uuid) => typeof uuid === "string" && uuid.trim().length > 0);
+  if (filtered.length === 0) return;
+
+  const timestamps = loadTagTimestamps();
+  const now = Date.now();
+  filtered.forEach((uuid) => {
+    timestamps[uuid] = now;
+  });
+  saveTagTimestampsDirect(timestamps);
+};
+
+/**
  * Helper to find an inventory item by UUID for cache invalidation.
  * @param {string} uuid - The item UUID
  * @returns {Object|null} The inventory item or null
@@ -83,7 +126,8 @@ const getItemTags = (uuid) => {
  * Add a tag to an item. Prevents duplicates and enforces limits.
  * @param {string} uuid - Item UUID
  * @param {string} tag - Tag name
- * @param {boolean} [persist=true] - Whether to save to localStorage immediately
+ * @param {boolean} [persist=true] - Whether to stamp and save to localStorage immediately.
+ *   Callers using persist=false must stamp after their batch and before saveItemTags().
  * @returns {boolean} True if tag was added
  */
 const addItemTag = (uuid, tag, persist = true) => {
@@ -103,14 +147,17 @@ const addItemTag = (uuid, tag, persist = true) => {
 
   itemTags[uuid].push(trimmed);
 
-  if (persist) saveItemTags();
+  if (persist) {
+    stampTagTimestamp([uuid]);
+    clearRemovedTag(uuid, trimmed);
+    saveItemTags();
+  }
 
   if (typeof window.invalidateSearchCache === "function") {
     const item = findItemByUuid(uuid);
     if (item) window.invalidateSearchCache(item);
   }
 
-  if (persist) clearRemovedTag(uuid, trimmed);
   return true;
 };
 
@@ -128,6 +175,7 @@ const removeItemTag = (uuid, tag) => {
 
   itemTags[uuid].splice(idx, 1);
   addRemovedTag(uuid, tag);
+  stampTagTimestamp([uuid]);
 
   // Clean up empty arrays
   if (itemTags[uuid].length === 0) {
@@ -150,11 +198,17 @@ const removeItemTag = (uuid, tag) => {
  */
 const deleteItemTags = (uuid) => {
   if (!uuid) return;
+  let changed = false;
+  const removedTagsBeforeDelete = loadRemovedTags(uuid);
   if (itemTags[uuid]) {
     delete itemTags[uuid];
-    saveItemTags();
+    changed = true;
   }
   clearAllRemovedTags(uuid);
+  if (changed || removedTagsBeforeDelete.length > 0) {
+    stampTagTimestamp([uuid]);
+    saveItemTags();
+  }
 
   if (typeof window.invalidateSearchCache === "function") {
     const item = findItemByUuid(uuid);
@@ -186,6 +240,7 @@ const renameTag = (oldName, newName) => {
   if (trimmed.length === 0 || trimmed.length > MAX_TAG_LENGTH) return 0;
 
   let affected = 0;
+  const affectedUuids = [];
   for (const [uuid, tags] of Object.entries(itemTags)) {
     const idx = tags.indexOf(oldName);
     if (idx !== -1) {
@@ -198,10 +253,12 @@ const renameTag = (oldName, newName) => {
         tags[idx] = trimmed;
       }
       affected++;
+      affectedUuids.push(uuid);
       if (tags.length === 0) delete itemTags[uuid];
     }
   }
   if (affected > 0) {
+    stampTagTimestamp(affectedUuids);
     saveItemTags();
     if (typeof window.resetSearchCache === "function") {
       window.resetSearchCache();
@@ -229,7 +286,7 @@ const deleteTagGlobal = (tag) => {
     }
   }
   if (affected > 0) {
-    saveItemTags();
+    stampTagTimestamp(affectedUuids);
     // Record removals so respectEdits sync won't re-add
     const raw = loadDataSync("itemRemovedTags", {});
     const map = Object.assign(Object.create(null), raw);
@@ -241,6 +298,7 @@ const deleteTagGlobal = (tag) => {
       }
     }
     saveDataSync("itemRemovedTags", map);
+    saveItemTags();
     if (typeof window.resetSearchCache === "function") {
       window.resetSearchCache();
     }
@@ -402,7 +460,7 @@ const applyNumistaTags = (
     }
   }
   if (persist && added > 0) {
-    saveItemTags();
+    stampTagTimestamp([uuid]);
     // Batch-clear removal tracking for re-imported tags
     const raw = loadDataSync("itemRemovedTags", {});
     const map = Object.assign(Object.create(null), raw);
@@ -412,6 +470,7 @@ const applyNumistaTags = (
       if (map[uuid].length === 0) delete map[uuid];
       saveDataSync("itemRemovedTags", map);
     }
+    saveItemTags();
   }
 
   return { added, skippedEdits };
@@ -560,7 +619,11 @@ const showTagInput = (container, uuid, renderTags, onChanged) => {
   const commitTag = () => {
     const val = input.value.trim();
     if (val) {
-      parseTagInput(val).forEach((t) => addItemTag(uuid, t, false));
+      let addedTags = false;
+      parseTagInput(val).forEach((t) => {
+        if (addItemTag(uuid, t, false)) addedTags = true;
+      });
+      if (addedTags && typeof stampTagTimestamp === "function") stampTagTimestamp([uuid]);
       if (typeof saveItemTags === "function") saveItemTags();
     }
     renderTags();
@@ -601,6 +664,9 @@ const showTagInput = (container, uuid, renderTags, onChanged) => {
 // Expose globally
 window.loadItemTags = loadItemTags;
 window.saveItemTags = saveItemTags;
+window.loadTagTimestamps = loadTagTimestamps;
+window.saveTagTimestampsDirect = saveTagTimestampsDirect;
+window.stampTagTimestamp = stampTagTimestamp;
 window.getItemTags = getItemTags;
 window.addItemTag = addItemTag;
 window.removeItemTag = removeItemTag;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.87",
+  "version": "3.34.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.87",
+      "version": "3.34.88",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.87",
+  "version": "3.34.88",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.87-b1779690156";
+const CACHE_NAME = "staktrakr-v3.34.87-b1779746621";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.87-b1779746621";
+const CACHE_NAME = "staktrakr-v3.34.87-b1779747648";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.88-b1779748693";
+const CACHE_NAME = "staktrakr-v3.34.88-b1779748906";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.87-b1779747648";
+const CACHE_NAME = "staktrakr-v3.34.88-b1779748693";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/04-cloud-sync/cloud-sync-tags.spec.js
+++ b/tests/playwright/04-cloud-sync/cloud-sync-tags.spec.js
@@ -1,0 +1,183 @@
+import { test, expect } from "../helpers/mocks/extended-test.js";
+
+async function gotoApp(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("ackVersion", "9.9.9");
+    localStorage.setItem("cloud_sync_enabled", "false");
+  });
+  await page.goto("/index.html");
+}
+
+async function seedTagState(page, { itemTags = {}, removedTags = {}, timestamps = {} } = {}) {
+  await page.evaluate(
+    (state) => {
+      localStorage.setItem("itemTags", JSON.stringify(state.itemTags));
+      localStorage.setItem("itemRemovedTags", JSON.stringify(state.removedTags));
+      localStorage.setItem("itemTagsLastModified", JSON.stringify(state.timestamps));
+      if (typeof window.loadItemTags === "function") window.loadItemTags();
+    },
+    { itemTags, removedTags, timestamps }
+  );
+}
+
+function remoteTagData({ itemTags = {}, removedTags = {}, timestamps = {} } = {}) {
+  return {
+    itemTags: JSON.stringify(itemTags),
+    itemRemovedTags: JSON.stringify(removedTags),
+    itemTagsLastModified: JSON.stringify(timestamps),
+  };
+}
+
+async function mergeTags(page, remote) {
+  return page.evaluate((remoteData) => {
+    if (!window.CloudSyncTest || typeof window.CloudSyncTest.mergeTagData !== "function") {
+      throw new Error("CloudSyncTest.mergeTagData is not available");
+    }
+    return window.CloudSyncTest.mergeTagData(remoteData);
+  }, remote);
+}
+
+test.describe("cloud sync tag merge", () => {
+  test("AC-1 — selective merge applies remote item tags", async ({ page }) => {
+    await gotoApp(page);
+    await seedTagState(page, {
+      itemTags: { "item-1": [] },
+      timestamps: { "item-1": 100 },
+    });
+
+    await mergeTags(
+      page,
+      remoteTagData({
+        itemTags: { "item-1": ["Other animal", "Toy or game"] },
+        timestamps: { "item-1": 200 },
+      })
+    );
+
+    const tags = await page.evaluate(() => JSON.parse(localStorage.getItem("itemTags")));
+    expect(tags["item-1"]).toEqual(["Other animal", "Toy or game"]);
+  });
+
+  test("AC-2 — per-UUID last-writer-wins preserves newer local tags", async ({ page }) => {
+    await gotoApp(page);
+    await seedTagState(page, {
+      itemTags: {
+        "remote-wins": ["Local old"],
+        "local-wins": ["Local new"],
+      },
+      timestamps: {
+        "remote-wins": 100,
+        "local-wins": 300,
+      },
+    });
+
+    await mergeTags(
+      page,
+      remoteTagData({
+        itemTags: {
+          "remote-wins": ["Remote new"],
+          "local-wins": ["Remote old"],
+        },
+        timestamps: {
+          "remote-wins": 200,
+          "local-wins": 250,
+        },
+      })
+    );
+
+    const tags = await page.evaluate(() => JSON.parse(localStorage.getItem("itemTags")));
+    expect(tags["remote-wins"]).toEqual(["Remote new"]);
+    expect(tags["local-wins"]).toEqual(["Local new"]);
+  });
+
+  test("AC-3 — merge refreshes in-memory itemTags", async ({ page }) => {
+    await gotoApp(page);
+    await seedTagState(page, {
+      itemTags: { "item-1": ["Old"] },
+      timestamps: { "item-1": 100 },
+    });
+
+    await mergeTags(
+      page,
+      remoteTagData({
+        itemTags: { "item-1": ["Fresh"] },
+        timestamps: { "item-1": 200 },
+      })
+    );
+
+    const memoryTags = await page.evaluate(() => window.getItemTags("item-1"));
+    expect(memoryTags).toEqual(["Fresh"]);
+  });
+
+  test("AC-4 — removed tags merge and re-add wins over removal", async ({ page }) => {
+    await gotoApp(page);
+    await seedTagState(page, {
+      itemTags: { "item-1": ["Local"] },
+      removedTags: { "item-1": ["Remote new"] },
+      timestamps: { "item-1": 100 },
+    });
+
+    await mergeTags(
+      page,
+      remoteTagData({
+        itemTags: { "item-1": ["Remote new"] },
+        removedTags: { "item-1": ["Remote new", "Still removed"] },
+        timestamps: { "item-1": 200 },
+      })
+    );
+
+    const state = await page.evaluate(() => ({
+      tags: JSON.parse(localStorage.getItem("itemTags")),
+      removed: JSON.parse(localStorage.getItem("itemRemovedTags")),
+    }));
+    expect(state.tags["item-1"]).toEqual(["Remote new"]);
+    expect(state.removed["item-1"]).toEqual(["Still removed"]);
+  });
+
+  test("AC-5 — tag-only remote changes are detected before silent pull", async ({ page }) => {
+    await gotoApp(page);
+    await seedTagState(page, {
+      itemTags: { "item-1": ["Local"] },
+      removedTags: {},
+      timestamps: { "item-1": 100 },
+    });
+
+    const hasChanges = await page.evaluate(
+      (remoteSettings) => {
+        if (!window.CloudSyncTest || typeof window.CloudSyncTest.hasTagChanges !== "function") {
+          throw new Error("CloudSyncTest.hasTagChanges is not available");
+        }
+        return window.CloudSyncTest.hasTagChanges(remoteSettings);
+      },
+      remoteTagData({ itemTags: { "item-1": ["Remote"] }, timestamps: { "item-1": 200 } })
+    );
+
+    expect(hasChanges).toBe(true);
+  });
+
+  test("STAK-470 — one-sided settings auto-merge routes tag keys through merge logic", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+    await seedTagState(page, {
+      itemTags: { "item-1": ["Local old"] },
+      timestamps: { "item-1": 100 },
+    });
+
+    const result = await page.evaluate(
+      (remoteSettings) => {
+        if (
+          !window.CloudSyncTest ||
+          typeof window.CloudSyncTest.mergeOneSidedTagSettings !== "function"
+        ) {
+          throw new Error("CloudSyncTest.mergeOneSidedTagSettings is not available");
+        }
+        return window.CloudSyncTest.mergeOneSidedTagSettings(remoteSettings);
+      },
+      remoteTagData({ itemTags: { "item-1": ["Remote new"] }, timestamps: { "item-1": 200 } })
+    );
+
+    const tags = await page.evaluate(() => JSON.parse(localStorage.getItem("itemTags")));
+    expect(result.tagKeysMerged).toBeGreaterThan(0);
+    expect(tags["item-1"]).toEqual(["Remote new"]);
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.87",
+  "version": "3.34.88",
   "releaseDate": "2026-05-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- Add sync-scoped tag timestamp and tombstone stores so tag edits merge per item instead of overwriting whole tag state.
- Route tag scope keys through dedicated cloud sync merge logic for manifest, vault, and one-sided settings paths.
- Add Playwright coverage for AC-1 through AC-5 plus the STAK-470 tag-key route.
- Bump release artifacts to v3.34.88.

Issue: STRK-108
Sketch: DocVault/Projects/StakTrakr/sketches/STRK-108-cloud-sync-tags/
DocVault: cad10be

## Test Plan
- [x] AC-1 — selective merge applies remote item tags
- [x] AC-2 — per-UUID last-writer-wins preserves newer local tags
- [x] AC-3 — merge refreshes in-memory itemTags
- [x] AC-4 — removed tags merge and re-add wins over removal
- [x] AC-5 — tag-only remote changes are detected before silent pull
- [x] STAK-470 — one-sided settings auto-merge routes tag keys through merge logic
- [x] npm run lint
- [x] npm test
- [x] Codacy CLI: OpenGrep 0 findings; Trivy reported two medium dependency findings outside the changed surface (python-dotenv/requests in devops poller requirements)