### PR TITLE
v3.34.89 — STRK-110: fix consistent return findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.89] - 2026-05-25
+
+### Fixed — STRK-110: Consistent return cleanup
+
+- **Code quality**: Normalized `updateManualSpot()` and `openRetailViewModal()`
+  to return `undefined` explicitly without leaking helper return values, clearing
+  PMD ConsistentReturn findings while preserving existing UI behavior. (STRK-110)
+
+---
+
 ## [3.34.88] - 2026-05-25
 
 ### Fixed — STRK-108: Cloud sync tag merge

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.89 &ndash; STRK-110: Consistent return cleanup</strong>: Manual spot entry and retail detail modal open paths now return undefined consistently, clearing PMD ConsistentReturn findings without changing user-facing behavior (STRK-110).</li>
     <li><strong>v3.34.88 &ndash; STRK-108: Cloud sync tag merge</strong>: Cloud sync now preserves item tags, removed-tag opt-outs, and per-item tag timestamps across devices during selective sync merges (STRK-108).</li>
     <li><strong>v3.34.87 &ndash; STRK-107: Cloud sync conflict loop fix</strong>: Accepting remote item changes now neutralizes superseded local changelog entries at the acceptance cutoff, preserving Activity Log history while preventing stale conflicts from reappearing on the next sync (STRK-107).</li>
     <li><strong>v3.34.86 &ndash; STRK-106: Bullion Exchanges gold reliability</strong>: Byparr scrape now retries on pre-hydration shells (the React price grid loads after Playwright&rsquo;s &lsquo;load&rsquo; event, causing ~26% of gold pages to snapshot empty); content-quality check + bounded retry restore gold price coverage (STRK-106).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.81 &ndash; Mobile parity</strong>: Bulk editor now usable on phones with sticky identity columns and 44px tap targets; nested-path fields (shape, capsule, capsule notes) bulk-edit correctly; modal action buttons safe-area aware on notched devices; chart viewports scale properly on small screens (STRK-91, STRK-42, STAK-578).</li>
     <li><strong>v3.34.80 &ndash; Goldback expansion</strong>: New &frac14; Goldback (Idaho, g0.25) denomination; ticker now shows G1-rate-based premium % with three-tier color coding (low &lt;2%, mid 2&ndash;5%, high &ge;5%) across ticker, vendor matrix, and detail modal; daily retail charts fixed; goldback purchase-price lookup repaired (STRK-66, STRK-85, STRK-69, STRK-77).</li>
     <li><strong>v3.34.78 &ndash; Retail accuracy + new spot provider</strong>: SD Bullion and Bullion Exchanges scrape now lands on the correct 1-unit Check/Wire price instead of bulk-tier values; 90-day Market History &ldquo;All&rdquo; view carries per-vendor data across the full window; gold-api.com added as a first-class spot provider; header Spot button no longer fires four redundant per-metal syncs (STRK-99, STRK-92, STRK-89, STRK-93).</li>
-    <li><strong>v3.34.71 &ndash; Workflow, catalog & reliability</strong>: Direct Print button for inventory; partial-stack disposition with constrained quantity selector; per-side image override (obverse + reverse independently); structured Capsule field with notes; new metallic dark theme on an oklch token system; service-worker cache recovery; manifest-first cloud sync now preserves item field edits (STRK-49, STRK-44, STRK-53, STRK-67, STRK-46, STRK-25, STRK-56, STRK-101).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.88";
+const APP_VERSION = "3.34.89";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -669,7 +669,7 @@ const _buildIntradayChart = (slug) => {
  */
 const openRetailViewModal = (slug) => {
   const meta = RETAIL_COIN_META[slug];
-  if (!meta) return;
+  if (!meta) return undefined;
 
   const titleEl = safeGetElement("retailViewCoinName");
   const subtitleEl = safeGetElement("retailViewModalSubtitle");
@@ -879,6 +879,8 @@ const openRetailViewModal = (slug) => {
         debugLog(`[retail-view-modal] Background refresh failed: ${err.message}`, "warn");
       });
   }
+
+  return undefined;
 };
 
 const closeRetailViewModal = () => {

--- a/js/spot.js
+++ b/js/spot.js
@@ -464,16 +464,18 @@ const fetchSpotPrice = () => {
  */
 const updateManualSpot = (metalKey) => {
   const metalConfig = Object.values(METALS).find((m) => m.key === metalKey);
-  if (!metalConfig) return;
+  if (!metalConfig) return undefined;
 
   const input = elements.userSpotPriceInput[metalKey];
   const value = input.value;
 
-  if (!value) return;
+  if (!value) return undefined;
 
   const num = parseFloat(value);
-  if (isNaN(num) || num <= 0)
-    return appAlert(`Invalid ${metalConfig.name.toLowerCase()} spot price.`);
+  if (isNaN(num) || num <= 0) {
+    appAlert(`Invalid ${metalConfig.name.toLowerCase()} spot price.`);
+    return undefined;
+  }
 
   localStorage.setItem(metalConfig.localStorageKey, num);
   spotPrices[metalKey] = num;
@@ -507,6 +509,8 @@ const updateManualSpot = (metalKey) => {
   if (typeof hideManualInput === "function") {
     hideManualInput(metalConfig.name);
   }
+
+  return undefined;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.88",
+  "version": "3.34.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.88",
+      "version": "3.34.89",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.88",
+  "version": "3.34.89",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.88-b1779748906";
+const CACHE_NAME = "staktrakr-v3.34.89-b1779751621";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.88",
+  "version": "3.34.89",
   "releaseDate": "2026-05-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary
- Normalize `updateManualSpot()` return paths so invalid input alerts do not leak helper return values.
- Normalize `openRetailViewModal()` early/terminal return paths to explicit `undefined`.
- Bump StakTrakr release artifacts to `3.34.89`; `sw.js` was stamped by the pre-commit hook.

## Issue
- STRK-110 — [Sweep] Fix ConsistentReturn — mixed return statements in 2 functions

## Validation
- `node --check js/spot.js && node --check js/retail-view-modal.js && node --check js/about.js && node --check js/constants.js`
- `bash devops/hooks/check-release-sync.sh`
- `npm run lint` — passed with 0 errors and 2 existing warnings in `js/diff-engine.js` and `js/diff-modal.js`
- `npm run test:unit` — 26 passed
- `git diff --check`
- `npm run test:offline` — 766 passed, 1 skipped

## Notes
- Local Codacy CLI ESLint was attempted, but it ignored the repo ESLint browser/global setup and produced broad pre-existing `no-undef` noise; the temporary SARIF output was removed and `.codacy/codacy.yaml` churn was restored. Dashboard PMD re-analysis should confirm the ConsistentReturn findings after branch analysis.