### PR TITLE
v3.34.91 — STRK-111+112: sweep cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.34.91] - 2026-05-25
+
+### Changed — STRK-111+112: Sweep cleanup
+
+- **Dead code**: Removed unused `cacheFirst()` strategy function from service worker (STRK-111)
+- **Dependencies**: Bumped `flatted`, `ajv`, and `brace-expansion` to fix 3 npm audit vulnerabilities (1 high, 2 moderate) (STRK-112)
+
+---
+
 ## [3.34.90] - 2026-05-25
 
 ### Fixed — STRK-114: Autocomplete field name casing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.34.91] - 2026-05-25
 
-### Changed — STRK-111+112: Sweep cleanup
+### Changed — STRK-111: Sweep cleanup
 
 - **Dead code**: Removed unused `cacheFirst()` strategy function from service worker (STRK-111)
 - **Dependencies**: Bumped `flatted`, `ajv`, and `brace-expansion` to fix 3 npm audit vulnerabilities (1 high, 2 moderate) (STRK-112)

--- a/js/about.js
+++ b/js/about.js
@@ -139,7 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
-    <li><strong>v3.34.91 &ndash; STRK-111+112: Sweep cleanup</strong>: Removed unused cacheFirst() service worker strategy and bumped 3 transitive dependencies to resolve npm audit vulnerabilities (STRK-111, STRK-112).</li>
+    <li><strong>v3.34.91 &ndash; STRK-111: Sweep cleanup</strong>: Removed unused cacheFirst() service worker strategy and bumped 3 transitive dependencies to resolve npm audit vulnerabilities (STRK-111, STRK-112).</li>
     <li><strong>v3.34.90 &ndash; STRK-114: Autocomplete field name fix</strong>: Purchase Location and Storage Location suggestions now remember your past entries instead of only showing generic defaults (STRK-114).</li>
     <li><strong>v3.34.89 &ndash; STRK-110: Consistent return cleanup</strong>: Manual spot entry and retail detail modal open paths now return undefined consistently, clearing PMD ConsistentReturn findings without changing user-facing behavior (STRK-110).</li>
     <li><strong>v3.34.88 &ndash; STRK-108: Cloud sync tag merge</strong>: Cloud sync now preserves item tags, removed-tag opt-outs, and per-item tag timestamps across devices during selective sync merges (STRK-108).</li>

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.34.91 &ndash; STRK-111+112: Sweep cleanup</strong>: Removed unused cacheFirst() service worker strategy and bumped 3 transitive dependencies to resolve npm audit vulnerabilities (STRK-111, STRK-112).</li>
     <li><strong>v3.34.90 &ndash; STRK-114: Autocomplete field name fix</strong>: Purchase Location and Storage Location suggestions now remember your past entries instead of only showing generic defaults (STRK-114).</li>
     <li><strong>v3.34.89 &ndash; STRK-110: Consistent return cleanup</strong>: Manual spot entry and retail detail modal open paths now return undefined consistently, clearing PMD ConsistentReturn findings without changing user-facing behavior (STRK-110).</li>
     <li><strong>v3.34.88 &ndash; STRK-108: Cloud sync tag merge</strong>: Cloud sync now preserves item tags, removed-tag opt-outs, and per-item tag timestamps across devices during selective sync merges (STRK-108).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.34.86 &ndash; STRK-106: Bullion Exchanges gold reliability</strong>: Byparr scrape now retries on pre-hydration shells (the React price grid loads after Playwright&rsquo;s &lsquo;load&rsquo; event, causing ~26% of gold pages to snapshot empty); content-quality check + bounded retry restore gold price coverage (STRK-106).</li>
     <li><strong>v3.34.85 &ndash; Memorial Day public release</strong>: First full public release since v3.34.38 (April 30) &mdash; 47 patches across 111 issues over 24 days. Highlights below; see the full <a href="https://github.com/lbruton/StakTrakr/blob/main/CHANGELOG.md">CHANGELOG</a> for everything.</li>
     <li><strong>v3.34.81 &ndash; Mobile parity</strong>: Bulk editor now usable on phones with sticky identity columns and 44px tap targets; nested-path fields (shape, capsule, capsule notes) bulk-edit correctly; modal action buttons safe-area aware on notched devices; chart viewports scale properly on small screens (STRK-91, STRK-42, STAK-578).</li>
-    <li><strong>v3.34.80 &ndash; Goldback expansion</strong>: New &frac14; Goldback (Idaho, g0.25) denomination; ticker now shows G1-rate-based premium % with three-tier color coding (low &lt;2%, mid 2&ndash;5%, high &ge;5%) across ticker, vendor matrix, and detail modal; daily retail charts fixed; goldback purchase-price lookup repaired (STRK-66, STRK-85, STRK-69, STRK-77).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.34.90";
+const APP_VERSION = "3.34.91";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.34.90",
+  "version": "3.34.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.34.90",
+      "version": "3.34.91",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -341,9 +341,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -755,9 +755,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.34.90",
+  "version": "3.34.91",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.91-b1779771008";
+const CACHE_NAME = "staktrakr-v3.34.91-b1779771467";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.34.90-b1779769740";
+const CACHE_NAME = "staktrakr-v3.34.91-b1779771008";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =
@@ -256,19 +256,6 @@ function respondWithCacheFallback(request, response) {
 // Guarantee a Response for respondWith() — catch undefined and rejections
 function ensureResponse(promise) {
   return promise.then((response) => response || Response.error()).catch(() => Response.error());
-}
-
-// Strategy: cache-first with network fallback
-function cacheFirst(request) {
-  return ensureResponse(
-    caches
-      .match(request)
-      .then(
-        (cached) =>
-          cached ||
-          fetchAndCache(request).then((response) => respondWithCacheFallback(request, response))
-      )
-  );
 }
 
 // Strategy: network-first with cache fallback

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.34.90",
+  "version": "3.34.91",
   "releaseDate": "2026-05-25",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

- **Dead code removal** (STRK-111): Removed unused `cacheFirst()` strategy function from `sw.js` — defined but never called, flagged by ESLint `no-unused-vars`
- **Dependency bumps** (STRK-112): `npm audit fix` resolved 3 transitive vulnerabilities:
  - `flatted` <=3.4.1 (high — unbounded recursion DoS + prototype pollution)
  - `ajv` <6.14.0 (moderate — ReDoS with `$data` option)
  - `brace-expansion` <1.1.13 (moderate — zero-step sequence hang)

## Test plan

- [ ] `npm audit` reports 0 vulnerabilities
- [ ] `npx eslint sw.js` passes clean
- [ ] Service worker strategies (`networkFirst`, `staleWhileRevalidate`) still referenced and functional
- [ ] `npm test` passes (no runtime changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 3.34.91
  * Updated dependencies (flatted, ajv, brace-expansion) to address npm audit vulnerabilities
  * Cleaned up service worker by removing unused optimization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lbruton/StakTrakr/pull/1173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->