### PR TITLE
chore: update Codacy exclusions for instruction files (STRK-113)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -3,7 +3,11 @@
 # Local CLI exclusions live per-tool in .codacy/tools-configs/.
 ---
 exclude_paths:
+  - "AGENTS.md"
+  - "CLAUDE.md"
+  - "GEMINI.md"
   - ".agents/**"
+  - ".Codex/**"
   - ".codacy/**"
   - ".claude/**"
   - ".gemini/**"


### PR DESCRIPTION
## Summary
- Exclude top-level agent instruction files from Codacy dashboard scans.
- Exclude local Codex scaffolding from Codacy dashboard scans.
- Preserve runtime scanning for sw-router.js despite the reviewed false positive.

## Rationale
STRK-113 reviewed false positives from Codacy SRM and Agentlinter. The instruction-file findings are configuration noise across intentionally duplicated agent guardrails, while .Codex hook findings target local agent tooling rather than deployed StakTrakr runtime code.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".codacy.yml"); puts "codacy yaml ok"'\n- git diff --check -- .codacy.yml\n- pre-commit hooks during commit\n\n## Issue\nSTRK-113