### PR TITLE
chore: document Plane Epic state convention in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No application build step is required.
 
 Every **runtime code** change requires:
 
-1. A Plane issue in the StakTrakr project with a `STRK-###` ID. The ID goes into the commit message, PR body, and version lock claim. Legacy `STAK-###` (StakTrakr pre-Plane issue identifier) references are historical only.
+1. A Plane issue in the StakTrakr project with a `STRK-###` ID. The ID goes into the commit message, PR body, and version lock claim. Legacy `STAK-###` (StakTrakr pre-Plane issue identifier) references are historical only. Parent epics use the **Epic** Plane state (`0d1317b4-883f-44f0-b277-8f1f7f0388c0`); child issues use the standard states (Todo → In Progress → In Review → Done). Full state UUID table in `CLAUDE.md` under Issue Tracking.
 2. A git worktree at `.worktrees/patch-<VERSION>/` on branch `patch/<VERSION>`. All edits/commits happen inside the worktree. Zero edits on `dev`.
 3. A version lock claim in `devops/version.lock` (gitignored — edit directly, never commit). Format and lifecycle in the Release Workflow doc below.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,20 @@ Tier 2: 11 deep-dive docs at `Foundation/Deep Dives/`. Authoritative cron/config
 
 Prefix `STRK`. Plane: `https://plane.lbruton.cc/lbruton/projects/026dbe54-fe52-4a9f-9f1b-7edcb9bbdceb/`. Pre-migration `STAK-*` archived at `DocVault/Archive/Issues-Pre-Plane/StakTrakr/`. Create via `/issue` or `mcp__plane__create_issue`.
 
+**Plane state conventions:**
+
+| State       | UUID (re-fetch if stale)                         | Use for                                               |
+| ----------- | ------------------------------------------------ | ----------------------------------------------------- |
+| Epic        | `0d1317b4-883f-44f0-b277-8f1f7f0388c0`           | Parent epic issues — appears in its own Kanban column |
+| Todo        | `6f8780df-5ca8-4dc1-9951-fd96e9886647` (default) | Normal child issues not yet started                   |
+| In Progress | `36cd8909-caa7-48ca-aeab-9f6cd4913740`           | Actively being worked                                 |
+| In Review   | `1a90f64f-be80-42ae-aa82-dd8d3f28db88`           | Complete, awaiting review                             |
+| Done        | `b6039898-c1c1-46ea-8396-1ae8b52f0692`           | Merged / closed                                       |
+| Backlog     | `fc9a6f2f-7152-43ee-8f8d-95a05d9b2480`           | Parked, not yet scheduled                             |
+| Cancelled   | `7645f387-5f01-4395-9f40-03d75fda6fda`           | Won't fix                                             |
+
+When creating an epic → set state to **Epic**. Child issues inherit the standard states (Todo → In Progress → In Review → Done). UUIDs are convenience references — re-fetch via `mcp__plane__list_states` if a session boundary or compaction may have introduced drift.
+
 ## Git Topology
 
 - Branch model: `feature/* → dev → main`. Runtime code changes require worktree → PR → dev. `main` is fully protected (PR required). `dev` allows direct push for config/tooling only (instruction files, `.claude/`, `.gitignore`, skill files, devops config). Runtime code (`js/`, `css/`, `index.html`, `data/`, `pollers/`, tests) still requires PR discipline.


### PR DESCRIPTION
## Summary
- Adds a full Plane state reference table (all 7 states with UUIDs) to `CLAUDE.md` under Issue Tracking
- Adds a one-line Epic state note to `AGENTS.md` pointing back to the table
- Establishes the convention: parent epics → **Epic** state; child issues → standard Todo/In Progress/In Review/Done flow

## Test plan
- [ ] Markdown linting passes (instruction files only, no runtime code changed)