### PR TITLE
chore(#1189): best-effort rollback + tag cache reload in cloud-sync

### DIFF
--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2724,8 +2724,12 @@ function _restoreRawStorageValues(priorValues) {
   if (!priorValues || typeof localStorage === "undefined") return;
   var keys = Object.keys(priorValues);
   for (var i = 0; i < keys.length; i++) {
-    if (priorValues[keys[i]] === null) localStorage.removeItem(keys[i]);
-    else localStorage.setItem(keys[i], priorValues[keys[i]]);
+    try {
+      if (priorValues[keys[i]] === null) localStorage.removeItem(keys[i]);
+      else localStorage.setItem(keys[i], priorValues[keys[i]]);
+    } catch (_e) {
+      /* best-effort — swallow quota errors during rollback */
+    }
   }
 }
 
@@ -2894,6 +2898,7 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
     } catch (tagErr) {
       inventory = _prevInventory;
       _restoreRawStorageValues(tagPriorValues);
+      if (typeof loadItemTags === "function") loadItemTags();
       console.warn("[CloudSync] Tag merge failed — rolling back pull:", tagErr);
       logCloudSyncActivity(
         "cloud_sync_pull",
@@ -2952,6 +2957,7 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
     if (_failedCount > 0) {
       inventory = _prevInventory;
       _restoreRawStorageValues(tagPriorValues);
+      if (typeof loadItemTags === "function") loadItemTags();
       for (var r = 0; r < _appliedKeys.length; r++) {
         try {
           var prior = _priorValues[_appliedKeys[r]];

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.0-b1779894425";
+const CACHE_NAME = "staktrakr-v3.35.0-b1779901087";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary
- Wrap `localStorage.removeItem`/`setItem` calls in `_restoreRawStorageValues()` with individual `try/catch` blocks so quota errors during rollback don't abort the restore loop (matches the existing pattern at the settings rollback site)
- Call `loadItemTags()` after both tag-rollback paths in `_applyAndFinalize()` so the in-memory tag cache resyncs with the restored localStorage values

## Context
Follows up on [PR #1188 review comment](https://github.com/lbruton/StakTrakr/pull/1188#discussion_r3312063960). Without the `loadItemTags()` call, a failed sync rollback leaves phantom merged tags in memory that don't match what's actually in storage.

Closes #1189

## Test plan
- [x] ESLint — 0 errors (2 pre-existing warnings)
- [x] Unit tests — 120/120 pass
- [ ] Core Playwright suite