### PR TITLE
fix(test): STRK-142 freeze clock in retail-market fixture to defuse time-bomb

### DIFF
--- a/tests/playwright/core/retail-market.spec.js
+++ b/tests/playwright/core/retail-market.spec.js
@@ -307,9 +307,12 @@ async function setupRetailFixture(page, options = {}) {
     await route.fulfill({ status: 503, contentType: "application/json", body: "{}" });
   });
 
-  // Freeze Date so the market-history 7-day window is deterministic across the
-  // seeded RECENT_DATE fixtures. setFixedTime (not install) keeps timers running
-  // so app boot / chart / exchange-rate logic is unaffected.
+  // Freeze Date for the market-history 7-day window across the seeded
+  // RECENT_DATE fixtures. setFixedTime pins Date.now()/new Date() at FIXED_NOW
+  // permanently (install()/setSystemTime() would let it tick forward from the
+  // seed instead). Playwright still installs faked timers but drives them in
+  // real time, so setTimeout/requestAnimationFrame keep firing and app boot /
+  // chart / exchange-rate logic runs normally — we pin the clock, not pause it.
   await page.clock.setFixedTime(FIXED_NOW);
 
   await page.goto("/index.html", { waitUntil: "domcontentloaded" });

--- a/tests/playwright/core/retail-market.spec.js
+++ b/tests/playwright/core/retail-market.spec.js
@@ -6,6 +6,14 @@ const GOLDBACK_G1_RATE = 4.25;
 const GENERATED_AT = "2026-05-26T12:00:00.000Z";
 const RECENT_DATE = "2026-05-24";
 const RECENT_TS = Math.floor(new Date(`${RECENT_DATE}T18:00:00Z`).getTime() / 1000);
+// Pin the browser clock so wall-clock-relative filters (e.g. the market-history
+// 7-day timeframe window in renderVendorPrices) always include the seeded
+// RECENT_DATE rows. Without this the test rots into a time-bomb: once real
+// "today" drifts >7 days past RECENT_DATE, the default history view filters out
+// every seeded row and #retailHistoryTableBody renders the empty placeholder.
+// Anchored just after GENERATED_AT so all seeded data (manifest generated_at,
+// prices lastSync) sits in the past while RECENT_DATE stays inside the window.
+const FIXED_NOW = new Date("2026-05-26T18:00:00.000Z");
 const CURRENCY_DISCLAIMER =
   "Currency conversion is for convenience only — vendors are US-based and may not accept your selected currency at checkout.";
 
@@ -298,6 +306,11 @@ async function setupRetailFixture(page, options = {}) {
   await page.route("https://api2.staktrakr.com/data/v2/**", async (route) => {
     await route.fulfill({ status: 503, contentType: "application/json", body: "{}" });
   });
+
+  // Freeze Date so the market-history 7-day window is deterministic across the
+  // seeded RECENT_DATE fixtures. setFixedTime (not install) keeps timers running
+  // so app boot / chart / exchange-rate logic is unaffected.
+  await page.clock.setFixedTime(FIXED_NOW);
 
   await page.goto("/index.html", { waitUntil: "domcontentloaded" });
   await page.waitForFunction(


### PR DESCRIPTION
## Summary

Fixes a **wall-clock time-bomb** in `tests/playwright/core/retail-market.spec.js` — the test *"retail ticker, matrix, history, and detail modal follow display currency changes"* fails on a clean `dev` checkout (reproduces independent of the STRK-140 compression merge).

**Plane:** STRK-142

## Root cause

The fixture seeds market history at a hardcoded `RECENT_DATE = "2026-05-24"`. The market-history changelog tab defaults to the **7-day** timeframe, and `renderVendorPrices` (`js/retail.js` ~L1264) filters rows against the *real* clock:

```js
const cutoff = new Date();                            // real today
cutoff.setDate(cutoff.getDate() - 7);
const cutoffStr = cutoff.toISOString().slice(0, 10);
return allHistory.filter((entry) => entry.date >= cutoffStr);
```

Once real "today" drifts >7 days past `RECENT_DATE`, every seeded row is filtered out and `#retailHistoryTableBody` renders *"No history yet — sync from the Market Prices section."* The matrix `$38.00` assertion passes throughout because the matrix view does not apply the date-window filter — that divergence over the same seeded store is the smoking gun (rules out seeding/shape/overwrite causes).

## Fix

Pin the browser clock in the shared `setupRetailFixture`:

- `FIXED_NOW = new Date("2026-05-26T18:00:00.000Z")` — just after `GENERATED_AT`, so all seeded data sits in the past while `RECENT_DATE` stays inside the 7-day window.
- `await page.clock.setFixedTime(FIXED_NOW)` immediately before `page.goto`. `setFixedTime` (not `install`) pins `Date` but leaves `setTimeout`/`requestAnimationFrame` running, so app boot / chart / exchange-rate logic is unaffected.

Scope is one spec file — no app code or shared helper touched.

## Verification

- Target test passes.
- All 6 tests in `retail-market.spec.js` pass (x2 full-file runs).
- Full core gate `npm test` — **146 passed** against current `dev` HEAD (`67f83f4a`, post lz-string compression merge).

## Note (out of scope)

Observed a one-off flake in `matrix defaults to All…` (L361) during one full-file run — passed in isolation and on two subsequent full-file runs. Pre-existing, non-deterministic, unrelated to this fixture change; not addressed here.