### PR TITLE
fix: STRK-144 Summit Metals false-OOS + bulk-price-tier

### DIFF
--- a/devops/pollers/shared/price-extract-summit-oos.test.mjs
+++ b/devops/pollers/shared/price-extract-summit-oos.test.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for STRK-144 — Summit Metals false-OOS + bulk-price-tier fixes.
+ *
+ * Two bugs, both in devops/pollers/shared/price-extract.js:
+ *   1. Every Summit product page embeds a static FAQ whose answer text contains
+ *      the literal "...or marked as 'Out of stock.'". That trips
+ *      OUT_OF_STOCK_PATTERNS in detectStockStatus(), false-flagging EVERY Summit
+ *      item OOS. Fix: a MARKDOWN_CUTOFF_PATTERNS.summitmetals entry trims the
+ *      description/reviews/FAQ tail before stock + price detection.
+ *   2. The summit branch of extractPrice() read the "Regular price" mini-cards,
+ *      which carry the 100+ BULK price ($77.78) instead of the 1-9 single-unit
+ *      price ($79.22). Fix: prefer firstTableRowFirstPrice() / tierAnchoredPrice()
+ *      (first qty tier) before falling back to the "Regular price" cards.
+ *
+ * price-extract.js auto-runs main() on import and exports nothing, so — per the
+ * convention of the sibling price-extract-*.test.mjs files — this test inlines a
+ * replica of the relevant logic. Keep the replica in sync with the source when
+ * the regexes change. A structural assertion at the end guards the real config
+ * against silent removal.
+ *
+ * Run with:
+ *   node devops/pollers/shared/price-extract-summit-oos.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// --- Replica of source logic (keep in sync with price-extract.js) -----------
+
+const OUT_OF_STOCK_PATTERNS = [
+  /out of stock/i,
+  /sold out/i,
+  /currently unavailable/i,
+  /notify me when available/i,
+  /email when in stock/i,
+  /temporarily out of stock/i,
+  /back ?order/i,
+  /pre-?order/i,
+  /^\s*unavailable\s*$/im,
+];
+
+const MARKDOWN_CUTOFF_PATTERNS = {
+  summitmetals: [
+    /^Description Shipping & Returns\s*$/im,
+    /^#{0,6}\s*What Our Clients/im,
+    /^Faq'?s\s*$/im,
+  ],
+};
+
+function applyCutoff(markdown, providerId) {
+  const patterns = MARKDOWN_CUTOFF_PATTERNS[providerId];
+  if (!patterns) return markdown;
+  let cutIndex = markdown.length;
+  for (const pattern of patterns) {
+    const match = markdown.search(pattern);
+    if (match !== -1 && match < cutIndex) cutIndex = match;
+  }
+  return markdown.slice(0, cutIndex);
+}
+
+function isOutOfStock(markdown) {
+  return OUT_OF_STOCK_PATTERNS.some((p) => p.test(markdown));
+}
+
+// inRange for 1 oz silver (METAL_PRICE_RANGE_PER_OZ.silver = {min:40,max:200}).
+function inRange(p) {
+  return p >= 40 && p <= 200;
+}
+
+function firstTableRowFirstPrice(markdown) {
+  for (const line of markdown.split("\n")) {
+    if (!line.startsWith("|")) continue;
+    if (/^\|\s*[-:]+/.test(line)) continue;
+    const prices = [];
+    for (const m of line.matchAll(/\|\s*\*{0,2}\$?([\d,]+\.\d{2})\*{0,2}\s*(?:\|)/g)) {
+      const p = parseFloat(m[1].replace(/,/g, ""));
+      if (inRange(p)) prices.push(p);
+    }
+    if (prices.length > 0) return prices[0];
+  }
+  return null;
+}
+
+function tierAnchoredPrice(markdown) {
+  const pattern = /\b(?:\d{1,3}\s*-\s*\d{1,5}|\d{1,3}\+)\s+\$\s*([\d,]+\.\d{2})/g;
+  for (const m of markdown.matchAll(pattern)) {
+    const p = parseFloat(m[1].replace(/,/g, ""));
+    if (inRange(p)) return p;
+  }
+  return null;
+}
+
+function regularPricePrices(markdown) {
+  const prices = [];
+  let m;
+  const pat = /(?:Regular|Sale)\s+price\s+\$?([\d,]+\.\d{2})/g;
+  while ((m = pat.exec(markdown)) !== null) {
+    const p = parseFloat(m[1].replace(/,/g, ""));
+    if (inRange(p)) prices.push(p);
+  }
+  return prices;
+}
+
+function summitPrice(markdown) {
+  const tblFirst = firstTableRowFirstPrice(markdown);
+  if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
+  const tier = tierAnchoredPrice(markdown);
+  if (tier !== null) return { price: tier, matchedBy: "tierAnchored" };
+  const reg = regularPricePrices(markdown);
+  if (reg.length > 0) return { price: Math.min(...reg), matchedBy: "regularPrice" };
+  return null;
+}
+
+// --- Fixtures (faithful to the real Summit ASE page ordering) ---------------
+
+// Firecrawl path: pipe table preserved.
+const SUMMIT_PIPE = `Live Spot Prices:
+Ag $75.46
+
+1 oz American Silver Eagle BU (Random Year)
+===========================================
+
+$79.22
+
+| Quantity | Check / Wire / Zelle | CC / PayPal / Crypto |
+| --- | --- | --- |
+| 1-9 | $79.22 | $82.55 |
+| 10-19 | $78.83 | $82.14 |
+| 100+ | $77.78 | $81.05 |
+
+In Stock, Ready to Ship
+
+### Top Off to FedEx Shipping
+
+Regular price $77.78
+Regular price ~$0.00~Sale price $77.78
+ Add to cart
+
+Description Shipping & Returns
+
+### Description
+
+Some product copy here.
+
+What Our ClientsSay
+-------------------
+
+Faq's
+-----
+
+Is the product I'm looking for in stock and available?
+------------------------------------------------------
+
+The status will be clearly displayed, indicating whether the item is in stock,
+showing the exact quantity, or marked as "Out of stock." This ensures you're
+always informed.
+`;
+
+// phase0 Playwright innerText path: pipe table flattened to prose.
+const SUMMIT_PROSE = `Live Spot Prices: Ag $75.46
+
+1 oz American Silver Eagle BU (Random Year)
+
+$79.22
+
+Quantity Check / Wire / Zelle CC / PayPal / Crypto
+1-9 $79.22 $82.55
+10-19 $78.83 $82.14
+100+ $77.78 $81.05
+
+In Stock, Ready to Ship
+
+Regular price $77.78 Sale price $77.78 Add to cart
+
+Description Shipping & Returns
+
+What Our ClientsSay
+
+Faq's
+
+Is the product I'm looking for in stock and available? The status will be
+clearly displayed, indicating whether the item is in stock, showing the exact
+quantity, or marked as "Out of stock." This ensures you're always informed.
+`;
+
+// --- Tests ------------------------------------------------------------------
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+test("BUG REPRO: raw page (FAQ included) false-flags OOS", () => {
+  // Documents the bug: without the cutoff, the FAQ "Out of stock" trips detection.
+  assert.equal(isOutOfStock(SUMMIT_PIPE), true);
+  assert.equal(isOutOfStock(SUMMIT_PROSE), true);
+});
+
+test("cutoff removes the FAQ tail → not OOS (pipe path)", () => {
+  const cleaned = applyCutoff(SUMMIT_PIPE, "summitmetals");
+  assert.equal(/out of stock/i.test(cleaned), false);
+  assert.equal(isOutOfStock(cleaned), false);
+});
+
+test("cutoff removes the FAQ tail → not OOS (prose path)", () => {
+  const cleaned = applyCutoff(SUMMIT_PROSE, "summitmetals");
+  assert.equal(/out of stock/i.test(cleaned), false);
+  assert.equal(isOutOfStock(cleaned), false);
+});
+
+test("cutoff preserves the in-stock badge and price table", () => {
+  const cleaned = applyCutoff(SUMMIT_PIPE, "summitmetals");
+  assert.match(cleaned, /In Stock, Ready to Ship/);
+  assert.match(cleaned, /1-9/);
+});
+
+test("price = 1-9 single-unit Check/Wire ($79.22), not 100+ bulk (pipe path)", () => {
+  const cleaned = applyCutoff(SUMMIT_PIPE, "summitmetals");
+  const result = summitPrice(cleaned);
+  assert.equal(result.price, 79.22);
+  assert.equal(result.matchedBy, "tableFirstRow");
+});
+
+test("price = 1-9 single-unit Check/Wire ($79.22), not 100+ bulk (prose path)", () => {
+  const cleaned = applyCutoff(SUMMIT_PROSE, "summitmetals");
+  const result = summitPrice(cleaned);
+  assert.equal(result.price, 79.22);
+  assert.equal(result.matchedBy, "tierAnchored");
+});
+
+test("old behavior would have returned the bulk $77.78 (regression guard)", () => {
+  // The pre-fix summit branch read regularPricePrices() first → Math.min → 77.78.
+  const cleaned = applyCutoff(SUMMIT_PIPE, "summitmetals");
+  const bulk = Math.min(...regularPricePrices(cleaned));
+  assert.equal(bulk, 77.78);
+  // The fix must NOT return that value.
+  assert.notEqual(summitPrice(cleaned).price, bulk);
+});
+
+test("STRUCTURAL: real source has summitmetals cutoff + table-first extraction", () => {
+  const src = readFileSync(join(__dirname, "price-extract.js"), "utf8");
+  // Cutoff config present.
+  assert.match(src, /summitmetals:\s*\[/, "MARKDOWN_CUTOFF_PATTERNS.summitmetals missing");
+  assert.match(src, /Description Shipping & Returns/, "summit cutoff anchor missing");
+  // Summit price branch prefers qty-tier extractors over the bulk cards.
+  const branch = src.slice(src.indexOf('if (providerId === "summitmetals")'));
+  const tblIdx = branch.indexOf("firstTableRowFirstPrice()");
+  const tierIdx = branch.indexOf("tierAnchoredPrice()");
+  const regIdx = branch.indexOf("regularPricePrices()");
+  assert.ok(tblIdx !== -1 && tierIdx !== -1 && regIdx !== -1, "expected all three extractors in summit branch");
+  assert.ok(tblIdx < regIdx && tierIdx < regIdx, "qty-tier extractors must precede the bulk regularPricePrices fallback");
+});
+
+let passed = 0;
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/devops/pollers/shared/price-extract-summit-oos.test.mjs
+++ b/devops/pollers/shared/price-extract-summit-oos.test.mjs
@@ -46,9 +46,9 @@ const OUT_OF_STOCK_PATTERNS = [
 
 const MARKDOWN_CUTOFF_PATTERNS = {
   summitmetals: [
-    /^Description Shipping & Returns\s*$/im,
+    /^\s*Description Shipping & Returns\s*$/im,
     /^#{0,6}\s*What Our Clients/im,
-    /^Faq'?s\s*$/im,
+    /^#{0,6}\s*Faq'?s\s*$/im,
   ],
 };
 
@@ -246,7 +246,9 @@ test("STRUCTURAL: real source has summitmetals cutoff + table-first extraction",
   assert.match(src, /summitmetals:\s*\[/, "MARKDOWN_CUTOFF_PATTERNS.summitmetals missing");
   assert.match(src, /Description Shipping & Returns/, "summit cutoff anchor missing");
   // Summit price branch prefers qty-tier extractors over the bulk cards.
-  const branch = src.slice(src.indexOf('if (providerId === "summitmetals")'));
+  const startIdx = src.indexOf('if (providerId === "summitmetals")');
+  assert.notEqual(startIdx, -1, "summit branch not found in source");
+  const branch = src.slice(startIdx);
   const tblIdx = branch.indexOf("firstTableRowFirstPrice()");
   const tierIdx = branch.indexOf("tierAnchoredPrice()");
   const regIdx = branch.indexOf("regularPricePrices()");

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -195,6 +195,20 @@ const MARKDOWN_CUTOFF_PATTERNS = {
     /[\d,]+\s+Reviews?\b/i, // Playwright plain-text (innerText has no href)
     /\bSuggested Products\b/i, // "Suggested Products" section after reviews
   ],
+  // Summit Metals (Shopify) embeds an identical static FAQ accordion on every
+  // product page. One answer contains the literal phrase "...or marked as
+  // 'Out of stock.'", which trips OUT_OF_STOCK_PATTERNS in detectStockStatus()
+  // and false-flags EVERY Summit item OOS — even though the real status badge
+  // ("In Stock, Ready to Ship") appears higher up the page. Cut the
+  // description/reviews/FAQ tail before stock + price detection. The product's
+  // own pricing table and "Regular price" cards sit ABOVE "Description Shipping
+  // & Returns", so price extraction is unaffected. (Same failure class as the
+  // monumentmetals review-block fix above.)
+  summitmetals: [
+    /^Description Shipping & Returns\s*$/im, // product tab bar — tail begins here
+    /^#{0,6}\s*What Our Clients/im, // reviews section heading (fallback)
+    /^Faq'?s\s*$/im, // FAQ section heading (final guard before "Out of stock")
+  ],
 };
 
 // Patterns that match the START of the actual product content, used to strip
@@ -708,10 +722,18 @@ function extractPrice(markdown, metal, weightOz = 1, providerId = "") {
   }
 
   if (providerId === "summitmetals") {
-    const reg = regularPricePrices();
+    // Summit's pricing grid lists tiers 1-9 → 100+ with columns Check/Wire |
+    // Card. The 1-9 Check/Wire price is the single-unit comparison point, matching
+    // every other vendor. Firecrawl renders it as a pipe table; phase0 Playwright
+    // innerText flattens it to prose ("1-9 $79.22 $82.55"). Target the FIRST qty
+    // tier on both paths. The "Regular price" mini-cards carry the 100+ BULK price
+    // (≈0.3% lower), so they are the last-resort fallback, never the primary read.
+    const tblFirst = firstTableRowFirstPrice(); // Firecrawl pipe-table path
+    if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
+    const tier = tierAnchoredPrice(); // phase0 innerText prose path
+    if (tier !== null) return { price: tier, matchedBy: "tierAnchored" };
+    const reg = regularPricePrices(); // fallback: bulk "Regular price" cards
     if (reg.length > 0) return { price: Math.min(...reg), matchedBy: "regularPrice" };
-    const tbl = tablePrices();
-    if (tbl.length > 0) return { price: Math.min(...tbl), matchedBy: "tablePrices" };
     return null;
   }
 

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -205,9 +205,9 @@ const MARKDOWN_CUTOFF_PATTERNS = {
   // & Returns", so price extraction is unaffected. (Same failure class as the
   // monumentmetals review-block fix above.)
   summitmetals: [
-    /^Description Shipping & Returns\s*$/im, // product tab bar — tail begins here
+    /^\s*Description Shipping & Returns\s*$/im, // product tab bar — tail begins here
     /^#{0,6}\s*What Our Clients/im, // reviews section heading (fallback)
-    /^Faq'?s\s*$/im, // FAQ section heading (final guard before "Out of stock")
+    /^#{0,6}\s*Faq'?s\s*$/im, // FAQ section heading (final guard before "Out of stock")
   ],
 };
 


### PR DESCRIPTION
## Summary

Fixes [STRK-144]. Every Summit Metals item in the retail table was showing **OOS** while the product pages were in stock.

**Root cause (proven against live pages + live API):** Each Summit product page embeds an identical static FAQ accordion whose answer contains the literal `...or marked as "Out of stock."`. That string matches `OUT_OF_STOCK_PATTERNS[0]` (`/out of stock/i`) in `detectStockStatus()`, so **every** Summit item false-flags OOS — even though the real badge `In Stock, Ready to Ship` appears higher on the page. Same failure class as the Monument Metals embedded-review-prose bug, which was fixed with a `MARKDOWN_CUTOFF_PATTERNS` entry.

Fingerprint confirming it's a stock-detector bug (not price/404): live `ase/latest.json` returned `summitmetals { price: 77.87, in_stock: false }` — a valid price with a false OOS flag.

## Changes

1. **OOS false-positive** — add `MARKDOWN_CUTOFF_PATTERNS.summitmetals` to trim the description/reviews/FAQ tail before stock + price detection. The product's price table and cards sit above the `Description Shipping & Returns` cut anchor, so price extraction is unaffected.
2. **Wrong price tier (folded in)** — the `summitmetals` branch of `extractPrice()` read the mini-cart "Regular price" cards, which carry the **100+ bulk** price ($77.78) rather than the **1-9 single-unit** Check/Wire price ($79.22). Now prefers `firstTableRowFirstPrice()` (Firecrawl pipe-table path) → `tierAnchoredPrice()` (phase0 innerText prose path) → `regularPricePrices()` fallback. Mirrors the `UNTRUSTED_OFFER_PRICE_VENDORS` branch.
3. **Regression test** — `price-extract-summit-oos.test.mjs` (inline-replica convention, since `price-extract.js` auto-runs `main()` on import). Covers both scrape paths, the bug repro, the in-stock/price assertions, and a structural guard on the real source.

## Verification

- New test: 8/8 pass. All 7 sibling `price-extract-*.test.mjs` suites pass (no regression).
- `node --check` clean; prettier clean.
- **End-to-end against real scraped markdown** (live ASE page): raw → OOS flagged `true` (reproduces bug); after cutoff → OOS `false`, `In Stock, Ready to Ship` preserved, price resolves to **$79.22** (single-unit), not $77.78 (bulk).

## Out of scope (flagged in the issue)

- Live feed showed gold `age` with `price=None` despite a valid in-range page price — likely phase0 Playwright `networkidle` render-timing flakiness; watch after this lands.
- `dashboard.js` retry path calls `m.extractPrice(url, slug, vid, vendor)` on a module with no exports — pre-existing dead/broken code.

## Deploy note

Poller-only change (`devops/pollers/shared/`). No app-bundle version bump. Home poller picks it up on image rebuild; Fly on next `fly deploy -a staktrakr`.