### PR TITLE
chore(deps): bump spot-poller python deps to patch CVEs

### DIFF
--- a/devops/pollers/shared/spot-poller/requirements.txt
+++ b/devops/pollers/shared/spot-poller/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.32.4
-python-dotenv>=1.0.0
+requests>=2.33.0
+python-dotenv>=1.2.2


### PR DESCRIPTION
## Summary

Bumps the two `spot-poller` Python dependency floors flagged by the Codacy **trivy SCA** scan to their fixed versions.

| Package | Before | After | CVE |
| --- | --- | --- | --- |
| `requests` | `>=2.32.4` | `>=2.33.0` | CVE-2026-25645 |
| `python-dotenv` | `>=1.0.0` | `>=1.2.2` | CVE-2026-28684 |

The pins use `>=`, so trivy resolved each finding against the floor; raising the floor to the patched release clears it. Only one git-tracked `requirements.txt` pins these packages (`devops/pollers/shared/spot-poller/requirements.txt`) — verified via repo-wide grep.

## Verification

Installed the bumped `requirements.txt` in a clean venv (mirrors the Docker image's `pip install -r requirements.txt`):

- Resolved `requests 2.34.2` (≥ 2.33.0) and `python-dotenv 1.2.2` (≥ 1.2.2) — both clear the CVE floors.
- `import requests` / `from dotenv import load_dotenv` succeed.
- `py_compile` passes for both `poller.py` and `update-seed-data.py`.

## Scope

Standalone dependency-bump chore. **Unrelated to STRK-141** (that PR touches no `requirements.txt`).