### PR TITLE
feat(STRK-141): migrate market histories to IndexedDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.35.3] - 2026-06-04
+
+### Changed — STRK-141: Migrate market histories to IndexedDB
+
+- **Storage**: Spot and retail price history now live in a dedicated IndexedDB store (`StakTrakrHistory`) instead of localStorage, permanently removing the storage-quota ceiling. Existing history migrates automatically and losslessly on first load, with a localStorage fallback when IndexedDB is unavailable (STRK-141).
+- **Item price history**: Now bounded by a silent retention cap (365-day age cutoff plus 1000 entries per item) so the one remaining localStorage history key can no longer re-trigger a quota error (STRK-141).
+- **Backups**: Manual encrypted vault and ZIP backups no longer carry the reproducible spot/retail caches; item price history remains included, and older backups containing spot/retail history restore cleanly by ignoring those entries (STRK-141).
+
+---
+
 ## [3.35.2] - 2026-06-03
 
 ### Fixed — STRK-144: Summit Metals false-OOS + wrong (bulk) price tier

--- a/index.html
+++ b/index.html
@@ -8526,6 +8526,7 @@
     <script defer src="./js/image-processor.js"></script>
     <script defer src="./js/image-cache.js"></script>
     <script defer src="./js/attachment-manager.js"></script>
+    <script defer src="./js/history-store.js"></script>
     <script defer src="./js/attachment-ui.js"></script>
     <script defer src="./js/bulk-image-cache.js"></script>
     <script defer src="./js/image-cache-modal.js"></script>

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.35.3 &ndash; Market history storage</strong>: Spot &amp; retail price history moved to IndexedDB, permanently clearing the storage-quota ceiling; existing history migrates automatically with no loss, and item price history is now capped so it can&rsquo;t refill the quota (STRK-141).</li>
     <li><strong>v3.35.2 &ndash; Summit Metals accuracy</strong>: Summit Metals listings no longer show a false &ldquo;out of stock&rdquo; badge, and pricing now reflects the single-unit tier instead of the 100&plus; bulk price (STRK-144).</li>
     <li><strong>v3.35.2 &ndash; Metal-neutral purity labels</strong>: Fineness options no longer name a metal, so selecting .900 on a gold item no longer reads &ldquo;90&percnt; Silver&rdquo; (STRK-145).</li>
     <li><strong>v3.35.1 &ndash; Storage quota fix</strong>: Market price history is now compressed (lz-string), clearing the &ldquo;storage quota exceeded&rdquo; error and freeing roughly 80&percnt; of its storage footprint &mdash; existing data is upgraded automatically with no loss (STRK-140).</li>
@@ -146,7 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.35.0 &ndash; Cloud sync hardening</strong>: Tag merge on sync, conflict-loop fix after accepting remote changes, Bullion Exchanges content-quality retry (STRK-106, STRK-107, STRK-108).</li>
     <li><strong>v3.35.0 &ndash; Retail &amp; autocomplete fixes</strong>: SDB/BE spot-ticker sidebar leak patched, autocomplete field name casing corrected (STRK-99, STRK-114).</li>
     <li><strong>v3.35.0 &ndash; Test infrastructure</strong>: Full Playwright suite consolidation &mdash; 7 batches reorganized scattered specs into compact domain suites with archived historical coverage (STRK-97 &ndash; STRK-122).</li>
-    <li><strong>v3.34.85 &ndash; Memorial Day release</strong>: Mobile bulk editor, gold-api.com provider, retail accuracy fixes, Goldback premium ticker, Numista tag chips, oklch theme system, and cloud sync reliability (STRK-91, STRK-89, STRK-99, STRK-85, STRK-84, STRK-25, STRK-101).</li>
   `;
 };
 

--- a/js/api.js
+++ b/js/api.js
@@ -1039,7 +1039,9 @@ const renderApiHistoryTable = () => {
 const showApiHistoryModal = () => {
   const modal = document.getElementById("apiHistoryModal");
   if (!modal) return;
-  loadSpotHistory();
+  // STRK-141: spotHistory is the boot-hydrated, always-current in-memory source of
+  // truth (saveSpotHistory assigns it before the async IDB write). The former sync
+  // loadSpotHistory() reload is now async and vestigial — read the global directly.
   apiHistoryEntries = spotHistory.filter(
     (e) =>
       e.source === "api" ||
@@ -2840,7 +2842,8 @@ ${
  * Exports all spot history data as a CSV file
  */
 const exportSpotHistory = () => {
-  loadSpotHistory();
+  // STRK-141: read the always-current in-memory spotHistory global (the former sync
+  // reload is now async; the global is maintained on every save).
   if (!spotHistory.length) {
     appAlert("No spot history to export.");
     return;
@@ -2859,7 +2862,7 @@ const exportSpotHistory = () => {
  */
 const importSpotHistory = (file) => {
   const reader = new FileReader();
-  reader.onload = (e) => {
+  reader.onload = async (e) => {
     let entries = [];
     try {
       if (file.name.endsWith(".json")) {
@@ -2888,7 +2891,8 @@ const importSpotHistory = (file) => {
       return;
     }
 
-    loadSpotHistory();
+    // STRK-141: await the now-async reload so recordSpot appends onto a fresh base.
+    await loadSpotHistory();
     let imported = 0;
     entries.forEach((entry) => {
       recordSpot(
@@ -2936,7 +2940,8 @@ const restoreHistoricalSpotData = async () => {
   }
 
   try {
-    loadSpotHistory();
+    // STRK-141: await the now-async reload so the dedup base is fresh.
+    await loadSpotHistory();
     const existing = Array.isArray(spotHistory) ? spotHistory : [];
 
     // Build dedup Set from existing entries — these always win

--- a/js/constants.js
+++ b/js/constants.js
@@ -1012,6 +1012,7 @@ const ALLOWED_STORAGE_KEYS = [
   "migration_hourlySource", // one-time migration flag: re-tag StakTrakr hourly entries
   "migration_seedHistoryMerge", // one-time migration flag: skip redundant seed-history merge writes
   "migration_cmp2_compression", // one-time migration flag: re-encode CMP1/large keys to CMP2 (STRK-140)
+  "migration_idb_history_v1", // one-time migration flag: market histories moved to IndexedDB (STRK-141)
   "numistaLookupRules", // custom Numista search lookup rules (JSON array)
   "numistaViewFields", // view modal Numista field visibility config (JSON object)
   TIMEZONE_KEY, // string: "auto" | "UTC" | IANA zone (STACK-63)
@@ -1117,6 +1118,24 @@ const VAULT_SETTINGS_DIFF_SKIP = [
   LAST_CACHE_REFRESH_KEY,
   LAST_API_SYNC_KEY,
 ];
+
+/**
+ * Market-history localStorage keys now owned by IndexedDB (STRK-141).
+ * Skipped by backup/restore so the IDB store remains the single source of
+ * truth for these histories.
+ * @constant {string[]}
+ */
+const HISTORY_IDB_KEYS = [
+  SPOT_HISTORY_KEY,
+  "v2RetailHistory", // nosemgrep: codacy.javascript.security.hard-coded-password
+  RETAIL_PRICE_HISTORY_KEY,
+];
+
+/** @constant {number} ITEM_PRICE_HISTORY_MAX_DAYS - Retention window (days) for per-item price history (STRK-141) */
+const ITEM_PRICE_HISTORY_MAX_DAYS = 365;
+
+/** @constant {number} ITEM_PRICE_HISTORY_MAX_ENTRIES - Max retained entries for per-item price history (STRK-141) */
+const ITEM_PRICE_HISTORY_MAX_ENTRIES = 1000;
 
 // =============================================================================
 // INLINE CHIP CONFIG — controls which chips appear in the Name cell and order
@@ -1937,6 +1956,10 @@ if (typeof window !== "undefined") {
   window.SYNC_SCOPE_KEYS = SYNC_SCOPE_KEYS;
   window.VAULT_EXCLUDE_KEYS = VAULT_EXCLUDE_KEYS;
   window.VAULT_SETTINGS_DIFF_SKIP = VAULT_SETTINGS_DIFF_SKIP;
+  // STRK-141: market histories migrated to IndexedDB
+  window.HISTORY_IDB_KEYS = HISTORY_IDB_KEYS;
+  window.ITEM_PRICE_HISTORY_MAX_DAYS = ITEM_PRICE_HISTORY_MAX_DAYS;
+  window.ITEM_PRICE_HISTORY_MAX_ENTRIES = ITEM_PRICE_HISTORY_MAX_ENTRIES;
   window.CERT_LOOKUP_URLS = CERT_LOOKUP_URLS;
   // Inline chip config
   window.INLINE_CHIP_DEFAULTS = INLINE_CHIP_DEFAULTS;

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.35.2";
+const APP_VERSION = "3.35.3";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/history-store.js
+++ b/js/history-store.js
@@ -1,0 +1,433 @@
+// HISTORY STORE — IndexedDB storage for market histories (STRK-141)
+// =============================================================================
+
+/**
+ * HistoryStore provides persistent IndexedDB storage for the API-reproducible
+ * market-history caches (spot price history, retail price history) that
+ * previously lived in localStorage and pushed it past its ~5–10 MB ceiling.
+ *
+ * Records are coarse-grained: one record per logical history key, storing the
+ * whole history as UNCOMPRESSED JSON (LZ compression was a localStorage-ceiling
+ * workaround — pointless at IndexedDB's ~4 GB headroom).
+ *
+ * Schema:
+ *   DB: StakTrakrHistory v1
+ *   Store "histories" — keyPath: "key"
+ *     Record: { key: string, data: any, updatedAt: number }
+ *
+ * Backend-only: knows nothing about spot/retail semantics, performs no
+ * rendering, and makes no top-level DOM access (load-order-safe).
+ *
+ * Mirrors the established IndexedDB pattern in ImageCache / AttachmentManager.
+ *
+ * @class
+ */
+class HistoryStore {
+  constructor() {
+    /** @type {IDBDatabase|null} */
+    this._db = null;
+    /** @type {boolean} */
+    this._available = false;
+    /** @type {number} Default storage quota estimate in bytes (updated async) */
+    this._quotaBytes = 4 * 1024 * 1024 * 1024; // 4 GB default; updated async
+    /** @type {string} */
+    this._dbName = "StakTrakrHistory";
+    /** @type {string} */
+    this._storeName = "histories";
+    /** @type {Array<string>} Logical keys eligible for the boot migration */
+    this._migrationKeys = ["metalSpotHistory", "v2RetailHistory"];
+    /** @type {string} */
+    this._migrationFlag = "migration_idb_history_v1";
+  }
+
+  async _initQuota() {
+    try {
+      if (!navigator?.storage?.estimate) return;
+      const { quota = 0, usage = 0 } = await navigator.storage.estimate();
+      const available = quota - usage;
+      if (available <= 0) return; // file:// or estimate unavailable
+      this._quotaBytes = Math.min(
+        Math.max(available * 0.6, Math.min(available, 500 * 1024 * 1024)),
+        4 * 1024 * 1024 * 1024
+      );
+    } catch {
+      // Leave at 4 GB default
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Open (or create) the IndexedDB database. Safe to call multiple times.
+   * @returns {Promise<boolean>} true if DB opened successfully
+   */
+  async init() {
+    if (this._db) return true;
+
+    if (typeof indexedDB === "undefined") {
+      console.warn("HistoryStore: IndexedDB not available");
+      this._available = false;
+      return false;
+    }
+
+    try {
+      this._db = await new Promise((resolve, reject) => {
+        const req = indexedDB.open(this._dbName, 1);
+
+        req.onupgradeneeded = (e) => {
+          const db = e.target.result;
+          if (!db.objectStoreNames.contains("histories")) {
+            db.createObjectStore("histories", { keyPath: "key" });
+          }
+        };
+
+        req.onsuccess = (e) => resolve(e.target.result);
+        req.onerror = (e) => reject(e.target.error);
+      });
+
+      // Detect browser-initiated connection closure
+      this._db.onclose = () => {
+        console.warn("HistoryStore: DB connection closed by browser");
+        this._db = null;
+        this._available = false;
+      };
+
+      this._available = true;
+      this._initQuota(); // non-blocking, updates _quotaBytes async
+      this._requestStoragePersistOnce(); // one-time persistent-storage request
+      return true;
+    } catch (err) {
+      console.warn("HistoryStore: failed to open DB", err);
+      this._available = false;
+      return false;
+    }
+  }
+
+  /**
+   * Whether IndexedDB opened successfully.
+   * @returns {boolean}
+   */
+  isAvailable() {
+    return this._available;
+  }
+
+  /**
+   * Ensure the DB connection is alive, reconnecting if stale.
+   * Call before every public operation to guard against browser-initiated
+   * connection closures (storage pressure, tab backgrounding, etc.).
+   * @returns {Promise<boolean>}
+   */
+  async _ensureDb() {
+    if (this._db) {
+      try {
+        // Lightweight probe — creating a transaction throws if the conn is dead
+        this._db.transaction("histories", "readonly");
+        return true;
+      } catch {
+        console.warn("HistoryStore: DB connection stale, reconnecting...");
+        this._db = null;
+        this._available = false;
+      }
+    }
+    return this.init();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Read the `data` field of the record stored under a logical key.
+   * @param {string} key - logical history key (e.g. "metalSpotHistory")
+   * @returns {Promise<any|null>} the stored data, or null if absent/unavailable
+   */
+  async get(key) {
+    if (!key || !(await this._ensureDb())) return null;
+    const rec = await this._get("histories", key);
+    return rec ? rec.data : null;
+  }
+
+  /**
+   * Write a history blob under a logical key as { key, data, updatedAt }.
+   * Stores UNCOMPRESSED JSON. Catches QuotaExceededError /
+   * NS_ERROR_DOM_INDEXEDDB_QUOTA_ERR and returns false instead of throwing,
+   * so callers can fall back to localStorage without their in-memory copy
+   * being disturbed.
+   * @param {string} key
+   * @param {any} data
+   * @returns {Promise<boolean>} true if the write was confirmed
+   */
+  async put(key, data) {
+    if (!key || !(await this._ensureDb())) return false;
+
+    const record = { key, data, updatedAt: Date.now() };
+
+    try {
+      const tx = this._db.transaction("histories", "readwrite");
+      tx.objectStore("histories").put(record);
+      await this._txComplete(tx);
+      return true;
+    } catch (err) {
+      if (err?.name === "QuotaExceededError" || err?.name === "NS_ERROR_DOM_INDEXEDDB_QUOTA_ERR") {
+        console.warn("HistoryStore: quota exceeded, history not stored", key);
+      } else {
+        console.warn("HistoryStore: put failed", key, err);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Remove the record for a logical key.
+   * @param {string} key
+   * @returns {Promise<boolean>}
+   */
+  async remove(key) {
+    if (!key || !(await this._ensureDb())) return false;
+    return this._delete("histories", key);
+  }
+
+  /**
+   * Report history storage usage for the settings panel.
+   * @returns {Promise<{count: number, bytesEstimate: number}>}
+   */
+  async getUsage() {
+    const result = { count: 0, bytesEstimate: 0 };
+    if (!(await this._ensureDb())) return result;
+
+    try {
+      await this._iterate("histories", (rec) => {
+        result.count++;
+        try {
+          result.bytesEstimate += JSON.stringify(rec.data).length;
+        } catch {
+          // Non-serializable record — skip its byte contribution.
+        }
+      });
+    } catch (err) {
+      console.warn("HistoryStore: getUsage iterate failed", err);
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Migration (one-time, idempotent — modeled on __migrateCompressionV2)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * One-time, idempotent boot migration of legacy localStorage history payloads
+   * into IndexedDB. Safe-by-construction:
+   *   - Guarded by the "migration_idb_history_v1" localStorage flag — a no-op
+   *     once set.
+   *   - For each logical key: decode (CMP2:/CMP1: aware) → JSON.parse →
+   *     shape-guard. On parse error / wrong shape, the key is DEFERRED (its
+   *     localStorage copy is left untouched) and the flag is NOT set.
+   *   - A legacy localStorage copy is deleted ONLY after its put() is confirmed
+   *     (returns true). A failed/false put DEFERS the key and keeps the LS copy.
+   *   - The flag is set ONLY when every present key migrated with no deferrals,
+   *     so a partial failure retries on the next boot.
+   *
+   * @returns {Promise<{migrated: string[], deferred: string[]}>}
+   */
+  async migrate() {
+    const migrated = [];
+    const deferred = [];
+
+    // Guard: never run if the idempotency flag is set.
+    try {
+      if (typeof localStorage === "undefined") return { migrated, deferred };
+      if (localStorage.getItem(this._migrationFlag) === "true") {
+        return { migrated, deferred };
+      }
+    } catch {
+      return { migrated, deferred };
+    }
+
+    // Without a working IDB backend there is no destination — defer everything,
+    // leave every LS copy, and do not set the flag (retry next boot). (R3)
+    if (!(await this._ensureDb())) {
+      return { migrated, deferred };
+    }
+
+    for (const key of this._migrationKeys) {
+      let raw;
+      try {
+        raw = localStorage.getItem(key);
+      } catch {
+        continue; // unreadable — treat as absent
+      }
+      if (raw === null || typeof raw !== "string") continue; // absent — skip
+
+      // Decode any Phase-1 CMP2:/CMP1: payload, then parse + shape-guard.
+      let parsed;
+      try {
+        const decoded =
+          typeof __decompressIfNeeded === "function" ? __decompressIfNeeded(raw) : raw;
+        parsed = JSON.parse(decoded);
+      } catch {
+        deferred.push(key); // corrupt/unparseable — keep LS copy, don't flag
+        continue;
+      }
+
+      if (!this._isValidShape(key, parsed)) {
+        deferred.push(key); // wrong shape — keep LS copy, don't flag
+        continue;
+      }
+
+      // Write to IDB; only delete the legacy LS copy on a CONFIRMED put.
+      const ok = await this.put(key, parsed);
+      if (!ok) {
+        deferred.push(key); // write not confirmed — keep LS copy, don't flag
+        continue;
+      }
+
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // The data is durable in IDB; a failed removeItem is non-fatal and is
+        // harmless to retry (next boot's flag guard short-circuits the rest).
+      }
+      migrated.push(key);
+    }
+
+    // Set the idempotency flag ONLY when nothing was deferred.
+    if (deferred.length === 0) {
+      try {
+        localStorage.setItem(this._migrationFlag, "true");
+      } catch {
+        /* ignore */
+      }
+    }
+
+    return { migrated, deferred };
+  }
+
+  /**
+   * Shape guard for a migrated payload (matches the existing load-path type
+   * guards): spot history must be an Array; retail history must be a non-array
+   * object.
+   * @param {string} key
+   * @param {any} parsed
+   * @returns {boolean}
+   */
+  _isValidShape(key, parsed) {
+    if (key === "metalSpotHistory") {
+      return Array.isArray(parsed);
+    }
+    if (key === "v2RetailHistory") {
+      return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+    }
+    // Unknown key — accept any defined value.
+    return parsed !== null && parsed !== undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // IndexedDB helpers (private)
+  // ---------------------------------------------------------------------------
+
+  /** @returns {Promise<Object|null>} */
+  _get(storeName, key) {
+    return new Promise((resolve) => {
+      try {
+        const tx = this._db.transaction(storeName, "readonly");
+        const req = tx.objectStore(storeName).get(key);
+        req.onsuccess = () => resolve(req.result || null);
+        req.onerror = () => resolve(null);
+      } catch {
+        resolve(null);
+      }
+    });
+  }
+
+  /**
+   * Iterate over all records in a store using a cursor (O(1) heap).
+   * @param {string} storeName
+   * @param {function(any): void} callback
+   * @returns {Promise<void>}
+   */
+  _iterate(storeName, callback) {
+    return new Promise((resolve, reject) => {
+      try {
+        const tx = this._db.transaction(storeName, "readonly");
+        const req = tx.objectStore(storeName).openCursor();
+        req.onsuccess = (e) => {
+          const cursor = e.target.result;
+          if (cursor) {
+            callback(cursor.value);
+            cursor.continue();
+          } else {
+            resolve();
+          }
+        };
+        req.onerror = () => reject(req.error);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  /** @returns {Promise<boolean>} */
+  async _delete(storeName, key) {
+    try {
+      const tx = this._db.transaction(storeName, "readwrite");
+      tx.objectStore(storeName).delete(key);
+      await this._txComplete(tx);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Wait for a transaction to complete. */
+  _txComplete(tx) {
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /** Request persistent storage once per device (same gate as the image/attachment paths). */
+  _requestStoragePersistOnce() {
+    const key =
+      typeof STORAGE_PERSIST_GRANTED_KEY !== "undefined"
+        ? STORAGE_PERSIST_GRANTED_KEY
+        : "storagePersistGranted";
+    try {
+      if (localStorage.getItem(key) !== null) return;
+    } catch {
+      return;
+    }
+    if (!navigator?.storage?.persist) {
+      try {
+        localStorage.setItem(key, "false");
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    navigator.storage
+      .persist()
+      .then((granted) => localStorage.setItem(key, granted ? "true" : "false"))
+      .catch(() => {
+        try {
+          localStorage.setItem(key, "false");
+        } catch {
+          /* ignore */
+        }
+      });
+  }
+}
+
+// Singleton instance exposed globally
+const historyStore = new HistoryStore();
+if (typeof window !== "undefined") {
+  window.historyStore = historyStore;
+}

--- a/js/init.js
+++ b/js/init.js
@@ -586,7 +586,32 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     inventory.forEach((i) => addCompositionOption(i.composition || i.metal));
     refreshCompositionOptions();
-    loadSpotHistory();
+
+    // STRK-141: Initialize the market-history IndexedDB store and run the
+    // one-time, idempotent localStorage→IndexedDB migration BEFORE hydrating
+    // the spot/retail globals, so loadSpotHistory()/initRetailPrices() read
+    // from the store (not the localStorage fallback). Both calls swallow their
+    // own failures and return safely if IndexedDB is unavailable — the spot/
+    // retail wrappers then transparently fall back to localStorage. This must
+    // complete before the Phase 13 first render so history-dependent views
+    // (spot table, sparklines, retail charts) render hydrated (R4), and the
+    // migration runs exactly once, awaited (R2). Do NOT wrap in try/catch that
+    // blocks boot — graceful degradation (R3) is handled inside the store.
+    if (typeof historyStore !== "undefined") {
+      await historyStore.init();
+      await historyStore.migrate();
+      debugLog("HistoryStore available:", historyStore.isAvailable());
+    }
+
+    // Hydrate spot history from the store (awaited, before render — R4)
+    await loadSpotHistory();
+
+    // Roll legacy hourly spot source into the loaded history. Previously called
+    // at parse time in spot.js; moved here so it runs AFTER spot history loads
+    // and the store is ready (STRK-141).
+    if (typeof migrateHourlySource === "function") {
+      await migrateHourlySource();
+    }
 
     // Load per-item price history (STACK-43)
     if (typeof loadItemPriceHistory === "function") {
@@ -615,8 +640,11 @@ document.addEventListener("DOMContentLoaded", async () => {
       );
     }
 
-    // Load retail market prices and start background auto-sync
-    if (typeof initRetailPrices === "function") initRetailPrices();
+    // Load retail market prices and start background auto-sync.
+    // STRK-141: initRetailPrices() is async and awaits _loadV2RetailHistory()
+    // internally, so awaiting it here hydrates retailPriceHistory from the
+    // store before the Phase 13 render (R4). Single load path — no double-load.
+    if (typeof initRetailPrices === "function") await initRetailPrices();
     if (typeof startRetailBackgroundSync === "function") startRetailBackgroundSync();
 
     // Load display currency preference and cached exchange rates (STACK-50)

--- a/js/inventory-backup.js
+++ b/js/inventory-backup.js
@@ -107,22 +107,29 @@
       };
       zip.file("settings.json", JSON.stringify(settings, null, 2));
 
-      // 3. Add spot price history
-      const spotHistoryData = {
-        version: APP_VERSION,
-        exportDate: new Date().toISOString(),
-        history: spotHistory,
-      };
-      zip.file("spot_price_history.json", JSON.stringify(spotHistoryData, null, 2));
+      // 3. Add spot price history — skipped when owned by IndexedDB (STRK-141, R7.2).
+      // Spot history is reproducible from the API and is never written to a backup.
+      if (!HISTORY_IDB_KEYS.includes(SPOT_HISTORY_KEY)) {
+        const spotHistoryData = {
+          version: APP_VERSION,
+          exportDate: new Date().toISOString(),
+          history: spotHistory,
+        };
+        zip.file("spot_price_history.json", JSON.stringify(spotHistoryData, null, 2));
+      }
 
-      // 3a-retail. Add retail market prices (STAK-217)
+      // 3a-retail. Add retail market prices (STAK-217).
+      // Retail history is skipped when owned by IndexedDB (STRK-141, R7.2); current
+      // retail prices (a separate, non-history key) are still exported.
       const retailPricesData = loadDataSync(RETAIL_PRICES_KEY) || null;
-      const retailHistoryData = loadDataSync(RETAIL_PRICE_HISTORY_KEY) || {};
       if (retailPricesData) {
         zip.file("retail_prices.json", JSON.stringify(retailPricesData, null, 2));
       }
-      if (Object.keys(retailHistoryData).length > 0) {
-        zip.file("retail_price_history.json", JSON.stringify(retailHistoryData, null, 2));
+      if (!HISTORY_IDB_KEYS.includes(RETAIL_PRICE_HISTORY_KEY)) {
+        const retailHistoryData = loadDataSync(RETAIL_PRICE_HISTORY_KEY) || {};
+        if (Object.keys(retailHistoryData).length > 0) {
+          zip.file("retail_price_history.json", JSON.stringify(retailHistoryData, null, 2));
+        }
       }
 
       // 3b. Add per-item price history (STACK-43)
@@ -482,10 +489,10 @@
         }
       }
 
-      // 1d. Pre-parse ancillary data (applied after user accepts DiffModal)
+      // 1d. Pre-parse ancillary data (applied after user accepts DiffModal).
+      // Spot + retail price history are intentionally not parsed/restored from older
+      // backups — they are reproducible from the API and now owned by IndexedDB (STRK-141, R7.3).
       const ancillary = {};
-      const historyStr = await zip.file("spot_price_history.json")?.async("string");
-      if (historyStr) ancillary.spotHistory = JSON.parse(historyStr).history || [];
 
       const itemHistoryStr = await zip.file("item_price_history.json")?.async("string");
       if (itemHistoryStr) ancillary.itemPriceHistory = JSON.parse(itemHistoryStr).history || {};
@@ -496,15 +503,6 @@
           ancillary.retailPrices = JSON.parse(retailPricesStr);
         } catch (e) {
           debugWarn("restoreBackupZip: retail_prices.json parse error", e);
-        }
-      }
-      const retailHistoryStr = await zip.file("retail_price_history.json")?.async("string");
-      if (retailHistoryStr) {
-        try {
-          const rh = JSON.parse(retailHistoryStr);
-          if (!Array.isArray(rh) && typeof rh === "object") ancillary.retailHistory = rh;
-        } catch (e) {
-          debugWarn("restoreBackupZip: retail_price_history.json parse error", e);
         }
       }
 
@@ -540,10 +538,8 @@
           catalogManager.importMappings(settingsObj.catalogMappings, false);
         }
 
-        if (ancillary.spotHistory) {
-          saveDataSync(SPOT_HISTORY_KEY, ancillary.spotHistory);
-          loadSpotHistory();
-        }
+        // Spot price history from older backups is intentionally NOT restored —
+        // it is reproducible from the API and now owned by IndexedDB (STRK-141, R7.3).
 
         if (ancillary.itemPriceHistory && typeof mergeItemPriceHistory === "function") {
           mergeItemPriceHistory(ancillary.itemPriceHistory);
@@ -555,10 +551,8 @@
           saveDataSync(RETAIL_PRICES_KEY, ancillary.retailPrices);
           if (typeof loadRetailPrices === "function") loadRetailPrices();
         }
-        if (ancillary.retailHistory) {
-          saveDataSync(RETAIL_PRICE_HISTORY_KEY, ancillary.retailHistory);
-          if (typeof loadRetailPriceHistory === "function") loadRetailPriceHistory();
-        }
+        // Retail price history from older backups is intentionally NOT restored —
+        // reproducible from the API and now owned by IndexedDB (STRK-141, R7.3).
 
         // Restore cached coin images (STACK-88)
         if (window.imageCache?.isAvailable()) {

--- a/js/priceHistory.js
+++ b/js/priceHistory.js
@@ -6,10 +6,51 @@
 // =============================================================================
 
 /**
+ * Applies the silent item-price retention cap to a history object (STRK-141, R6).
+ * Pure helper — operates on the passed object in place and returns it:
+ *   (a) drops entries older than ITEM_PRICE_HISTORY_MAX_DAYS (reuses
+ *       purgeItemPriceHistory's age-cutoff logic), and
+ *   (b) for any item whose entry array exceeds ITEM_PRICE_HISTORY_MAX_ENTRIES,
+ *       keeps only the newest ITEM_PRICE_HISTORY_MAX_ENTRIES (drops oldest).
+ *
+ * No UI control, setting, or toggle is exposed — the cap is silent (R6.3).
+ *
+ * @param {Object} history - Item price history object keyed by UUID
+ * @returns {Object} The same history object, with retention applied
+ */
+const applyItemPriceRetention = (history) => {
+  if (!history || typeof history !== "object" || Array.isArray(history)) return history;
+
+  const cutoff = Date.now() - ITEM_PRICE_HISTORY_MAX_DAYS * 24 * 60 * 60 * 1000;
+
+  for (const uuid of Object.keys(history)) {
+    let entries = Array.isArray(history[uuid]) ? history[uuid] : [];
+
+    // (a) Age cutoff — drop entries older than the retention window.
+    entries = entries.filter((e) => e && e.ts >= cutoff);
+
+    // (b) Per-item backstop — keep only the newest N entries (drop oldest).
+    if (entries.length > ITEM_PRICE_HISTORY_MAX_ENTRIES) {
+      entries = entries.slice(entries.length - ITEM_PRICE_HISTORY_MAX_ENTRIES);
+    }
+
+    if (entries.length === 0) {
+      delete history[uuid];
+    } else {
+      history[uuid] = entries;
+    }
+  }
+
+  return history;
+};
+
+/**
  * Saves item price history to localStorage.
+ * Enforces the silent retention cap (STRK-141) before every write.
  */
 const saveItemPriceHistory = () => {
   try {
+    applyItemPriceRetention(itemPriceHistory);
     saveDataSync(ITEM_PRICE_HISTORY_KEY, itemPriceHistory);
   } catch (error) {
     console.error("Error saving item price history:", error);
@@ -520,6 +561,7 @@ const deleteItemPriceEntry = (uuid, timestamp) => {
 };
 
 // Ensure global availability
+window.applyItemPriceRetention = applyItemPriceRetention;
 window.renderItemPriceHistoryTable = renderItemPriceHistoryTable;
 window.filterItemPriceHistoryTable = filterItemPriceHistoryTable;
 window.clearItemPriceHistory = clearItemPriceHistory;

--- a/js/retail-view-modal.js
+++ b/js/retail-view-modal.js
@@ -858,7 +858,13 @@ const openRetailViewModal = (slug) => {
           if (Array.isArray(hist) && typeof retailPriceHistory !== "undefined") {
             anySuccess = true;
             retailPriceHistory[slug] = hist;
-            if (typeof saveRetailPriceHistory === "function") saveRetailPriceHistory();
+            // STRK-141: persist through the canonical v2 store (IndexedDB-backed)
+            // instead of the retired legacy `retailPriceHistory` localStorage key.
+            if (typeof _saveV2RetailHistory === "function") {
+              _saveV2RetailHistory();
+            } else if (typeof saveRetailPriceHistory === "function") {
+              saveRetailPriceHistory();
+            }
           }
         }
         // Show staleness warning if both fetches failed

--- a/js/retail.js
+++ b/js/retail.js
@@ -362,27 +362,15 @@ const saveRetailPrices = () => {
   }
 };
 
-const loadRetailPriceHistory = () => {
-  try {
-    const loaded = loadDataSync(RETAIL_PRICE_HISTORY_KEY);
-    // Guard: stored value must be a plain object; arrays (corrupt/legacy data) are discarded.
-    retailPriceHistory =
-      loaded && !Array.isArray(loaded) && typeof loaded === "object" ? loaded : {};
-  } catch (err) {
-    console.error("[retail] Failed to load retail price history:", err);
-    retailPriceHistory = {};
-  }
-  // Re-export so window.retailPriceHistory reflects the new reference after reassignment.
-  if (typeof window !== "undefined") window.retailPriceHistory = retailPriceHistory;
-};
+// STRK-141: the legacy `retailPriceHistory` localStorage key is retired.
+// These functions are now thin aliases that route through the canonical v2
+// store (`_loadV2RetailHistory` / `_saveV2RetailHistory`), so the live writer
+// (the retail-view-modal edit) persists to IndexedDB instead of the legacy LS
+// key. No new key is introduced. (NOTE: _loadV2RetailHistory is async; await it
+// at call sites that need the load to complete before reading.)
+const loadRetailPriceHistory = () => _loadV2RetailHistory();
 
-const saveRetailPriceHistory = () => {
-  try {
-    saveDataSync(RETAIL_PRICE_HISTORY_KEY, retailPriceHistory);
-  } catch (err) {
-    _handleSaveError("retail price history", err);
-  }
-};
+const saveRetailPriceHistory = () => _saveV2RetailHistory();
 
 const loadRetailIntradayData = () => {
   try {
@@ -536,23 +524,44 @@ const _loadV2RetailIntraday = () => {
   if (typeof window !== "undefined") window.retailIntradayData = retailIntradayData;
 };
 
+// STRK-141: retail history is IndexedDB-backed via historyStore (with a
+// synchronous localStorage fallback when IndexedDB is unavailable). The
+// in-memory retailPriceHistory global stays the synchronous source of truth
+// for all render/chart reads; storage is async only at boot hydration (awaited)
+// and persistence (fire-and-forget after the global is already updated).
 const _saveV2RetailHistory = () => {
   try {
-    saveDataSync(_V2_RETAIL_HISTORY_KEY, retailPriceHistory);
+    // Update the in-memory global FIRST so synchronous readers/renderers see the
+    // current value immediately, then schedule the durable write.
+    if (typeof window !== "undefined") window.retailPriceHistory = retailPriceHistory;
+    const store = typeof historyStore !== "undefined" ? historyStore : window?.historyStore;
+    if (store && store.isAvailable()) {
+      // Fire-and-forget IDB write — do NOT await. Reads already see the global.
+      void store.put(_V2_RETAIL_HISTORY_KEY, retailPriceHistory);
+    } else {
+      saveDataSync(_V2_RETAIL_HISTORY_KEY, retailPriceHistory);
+    }
   } catch (err) {
     _handleSaveError("v2 retail history", err);
   }
 };
 
-const _loadV2RetailHistory = () => {
+const _loadV2RetailHistory = async () => {
   try {
-    const loaded = loadDataSync(_V2_RETAIL_HISTORY_KEY);
+    const store = typeof historyStore !== "undefined" ? historyStore : window?.historyStore;
+    const loaded =
+      store && store.isAvailable()
+        ? await store.get(_V2_RETAIL_HISTORY_KEY)
+        : loadDataSync(_V2_RETAIL_HISTORY_KEY);
+    // Preserve the existing type guard: retail history must be a non-array object.
     retailPriceHistory =
       loaded && !Array.isArray(loaded) && typeof loaded === "object" ? loaded : {};
   } catch (e) {
     retailPriceHistory = {};
     debugLog("Failed to load v2 retail history: " + e.message, "warn");
   }
+  // MANDATORY re-export after the `let` reassignment — without it readers keep a
+  // stale binding (silent data loss).
   if (typeof window !== "undefined") window.retailPriceHistory = retailPriceHistory;
 };
 
@@ -1308,7 +1317,7 @@ const renderRetailHistoryTable = () => {
 // Initializer
 // ---------------------------------------------------------------------------
 
-const initRetailPrices = () => {
+const initRetailPrices = async () => {
   // Restore manifest slug list from localStorage (so we don't fall back to 12-item RETAIL_SLUGS)
   try {
     const cached = localStorage.getItem(RETAIL_MANIFEST_SLUGS_KEY);
@@ -1360,7 +1369,9 @@ const initRetailPrices = () => {
     }
   }
   _loadV2RetailPrices();
-  _loadV2RetailHistory();
+  // STRK-141: history load is async (IndexedDB-backed) — await so the global is
+  // hydrated before first render. init.js (task 7) awaits initRetailPrices().
+  await _loadV2RetailHistory();
   _loadV2RetailIntraday();
   loadRetailProviders();
   loadRetailAvailability();

--- a/js/settings.js
+++ b/js/settings.js
@@ -3442,7 +3442,21 @@ const STORAGE_KEY_LABELS = {
   catalogMap: { label: "Catalog Map", icon: "🗂", category: "Inventory" },
   itemTags: { label: "Item Tags", icon: "🏷", category: "Inventory" },
   changeLog: { label: "Change Log", icon: "📝", category: "Inventory" },
-  metalSpotHistory: { label: "Spot Price History", icon: "📈", category: "Prices" },
+  metalSpotHistory: {
+    label: "Spot Price History (IndexedDB — localStorage fallback)",
+    icon: "📈",
+    category: "Prices",
+  },
+  v2RetailHistory: {
+    label: "Retail Price History (IndexedDB — localStorage fallback)",
+    icon: "📈",
+    category: "Prices",
+  },
+  retailPriceHistory: {
+    label: "Retail Price History (legacy — IndexedDB)",
+    icon: "📈",
+    category: "Prices",
+  },
   "item-price-history": { label: "Item Price History", icon: "💰", category: "Prices" },
   "goldback-prices": { label: "Goldback Prices", icon: "🥇", category: "Prices" },
   "goldback-price-history": { label: "Goldback Price History", icon: "🥇", category: "Prices" },
@@ -3607,8 +3621,20 @@ const renderStorageSection = async (silent = false) => {
     }
   }
 
+  // Spot + retail price history live in the StakTrakrHistory IndexedDB store
+  // (migrated out of localStorage — STRK-141). Surface it like the image stores.
+  let historyStats = null;
+  if (typeof historyStore !== "undefined" && historyStore.isAvailable()) {
+    try {
+      historyStats = await historyStore.getUsage();
+    } catch (e) {
+      /* unavailable */
+    }
+  }
+
   const attachTotalKB = attachStats ? attachStats.totalBytes / 1024 : 0;
-  const idbTotalKB = (idbStats ? idbStats.totalBytes / 1024 : 0) + attachTotalKB;
+  const historyTotalKB = historyStats ? historyStats.bytesEstimate / 1024 : 0;
+  const idbTotalKB = (idbStats ? idbStats.totalBytes / 1024 : 0) + attachTotalKB + historyTotalKB;
   const idbLimitKB = idbStats ? idbStats.limitBytes / 1024 : 50 * 1024;
   const lsLimitKB = 5 * 1024;
   const combinedKB = lsTotalKB + idbTotalKB;
@@ -3642,7 +3668,7 @@ const renderStorageSection = async (silent = false) => {
     "storageStat_idb",
     fmt(idbTotalKB),
     idbTotalKB > 0
-      ? `Images: ~${fmt(idbTotalKB - attachTotalKB)} · Attachments: ${fmt(attachTotalKB)}`
+      ? `Images: ~${fmt(idbTotalKB - attachTotalKB - historyTotalKB)} · Attachments: ${fmt(attachTotalKB)} · History: ${fmt(historyTotalKB)}`
       : "No IndexedDB data",
     "storageStatBar_idb",
     pct(idbTotalKB, idbLimitKB),
@@ -3705,21 +3731,23 @@ const renderStorageSection = async (silent = false) => {
 
   // ── 5. Render IndexedDB table ─────────────────────────────────────────────
   if (idbTable) {
-    if (!idbStats) {
+    if (!idbStats && !attachStats && !historyStats) {
       idbTable.innerHTML = '<p class="settings-subtext">IndexedDB unavailable in this browser.</p>';
     } else {
       const imagesTotalKB = idbStats ? idbStats.totalBytes / 1024 : 0;
-      const idbRows = [
-        { label: "Coin Images", icon: "🖼", count: idbStats.numistaCount, sizeKB: null },
-        { label: "User Images", icon: "📷", count: idbStats.userImageCount, sizeKB: null },
-        {
-          label: "Pattern Images",
-          icon: "🎨",
-          count: idbStats.patternImageCount || 0,
-          sizeKB: null,
-        },
-        { label: "Coin Metadata", icon: "📄", count: idbStats.metadataCount, sizeKB: null },
-      ];
+      const idbRows = idbStats
+        ? [
+            { label: "Coin Images", icon: "🖼", count: idbStats.numistaCount, sizeKB: null },
+            { label: "User Images", icon: "📷", count: idbStats.userImageCount, sizeKB: null },
+            {
+              label: "Pattern Images",
+              icon: "🎨",
+              count: idbStats.patternImageCount || 0,
+              sizeKB: null,
+            },
+            { label: "Coin Metadata", icon: "📄", count: idbStats.metadataCount, sizeKB: null },
+          ]
+        : [];
       // Estimate image row sizes by proportion of images total (exact per-store breakdown unavailable)
       const idbImageCount = idbRows.reduce((s, r) => s + r.count, 0) || 1;
       idbRows.forEach((r) => {
@@ -3735,13 +3763,24 @@ const renderStorageSection = async (silent = false) => {
           exact: true,
         });
       }
+      // Spot + retail history row uses exact bytes from historyStore.getUsage() (STRK-141)
+      if (historyStats !== null) {
+        idbRows.push({
+          label: "Spot/Retail History",
+          icon: "📈",
+          count: historyStats.count,
+          sizeKB: historyTotalKB,
+          dbName: "StakTrakrHistory",
+          exact: true,
+        });
+      }
 
       const idbRowsHtml = idbRows
         .map((r) => {
           const barPct = idbTotalKB > 0 ? Math.min((r.sizeKB / idbTotalKB) * 100, 100) : 0;
           const sizeStr =
             r.sizeKB >= 1024 ? `${(r.sizeKB / 1024).toFixed(1)} MB` : `${r.sizeKB.toFixed(1)} KB`;
-          const dbName = r.exact ? "StakTrakrAttachments" : "StakTrakrImages";
+          const dbName = r.dbName || (r.exact ? "StakTrakrAttachments" : "StakTrakrImages");
           return `<tr class="storage-key-row">
           <td class="storage-key-icon">${r.icon}</td>
           <td class="storage-key-label">${r.label}<span class="storage-key-raw">${dbName}</span></td>

--- a/js/spot.js
+++ b/js/spot.js
@@ -1280,7 +1280,8 @@ const renderSpotHistoryTable = () => {
   const table = document.getElementById("settingsSpotHistoryTable");
   if (!table) return;
 
-  loadSpotHistory();
+  // STRK-141: spotHistory is the boot-hydrated, always-current global; the former
+  // sync loadSpotHistory() reload is now async and vestigial — read the global.
   let data = [...spotHistory];
 
   // Sort

--- a/js/spot.js
+++ b/js/spot.js
@@ -82,6 +82,12 @@ const getPersistedSpotHistorySnapshot = (entries) => {
   };
 };
 
+// STRK-141: Synchronous facade over an async IndexedDB tail.
+// The in-memory `spotHistory` global is updated FIRST so render/chart reads and
+// every existing synchronous caller stay current, then the durable write is
+// fire-and-forget: historyStore.put when IndexedDB is available (it swallows its
+// own quota failures by returning false — the in-memory copy is already current),
+// otherwise the synchronous localStorage fallback. Callers must NOT await this.
 const saveSpotHistory = () => {
   try {
     const snapshot = getPersistedSpotHistorySnapshot(spotHistory);
@@ -104,24 +110,41 @@ const saveSpotHistory = () => {
           ")"
       );
     }
-    saveDataSync(SPOT_HISTORY_KEY, snapshot.entries, { quietQuotaToast: true });
+    // Assign the in-memory global FIRST so readers/renderers are immediately current.
+    spotHistory = snapshot.entries;
+    if (typeof historyStore !== "undefined" && historyStore.isAvailable()) {
+      // Fire-and-forget: do NOT await. put() returns false on quota without throwing,
+      // and the in-memory copy above is already authoritative for all readers.
+      void historyStore.put("metalSpotHistory", snapshot.entries);
+    } else {
+      saveDataSync(SPOT_HISTORY_KEY, snapshot.entries, { quietQuotaToast: true });
+    }
   } catch (error) {
     console.warn("Spot history save skipped:", error);
   }
 };
 
 /**
- * Loads spot history from localStorage
+ * Loads spot history into the in-memory `spotHistory` global.
+ * STRK-141: reads from IndexedDB (historyStore) when available, otherwise the
+ * synchronous localStorage fallback, then runs the existing trim/dedup snapshot.
+ * Async because the IndexedDB read is async; init.js (task 7) awaits this during
+ * boot before the first render.
  */
-const loadSpotHistory = () => {
+const loadSpotHistory = async () => {
   try {
-    const data = loadDataSync(SPOT_HISTORY_KEY, []);
+    const data =
+      typeof historyStore !== "undefined" && historyStore.isAvailable()
+        ? await historyStore.get("metalSpotHistory")
+        : loadDataSync(SPOT_HISTORY_KEY, []);
     const snapshot = getPersistedSpotHistorySnapshot(Array.isArray(data) ? data : []);
     spotHistory = snapshot.entries;
 
     if (snapshot.changed) {
       try {
-        saveDataSync(SPOT_HISTORY_KEY, snapshot.entries, { quietQuotaToast: true });
+        // Re-persist the sanitized snapshot through the sync facade (routes to
+        // IndexedDB or localStorage as appropriate); spotHistory is already set.
+        saveSpotHistory();
         if (typeof debugLog === "function" && snapshot.trimmedSeedEntries > 0) {
           debugLog(
             "Spot history: migrated persisted storage to trimmed runtime snapshot (" +
@@ -148,11 +171,15 @@ const loadSpotHistory = () => {
  * source is "api", and timestamp lands exactly on the hour (:00:00).
  * Regular syncs never produce on-the-hour timestamps.
  */
-const migrateHourlySource = () => {
+// STRK-141: async because it awaits loadSpotHistory (now async). No longer runs
+// at module parse time — init.js (task 7) invokes `await migrateHourlySource()`
+// inside the awaited boot sequence AFTER historyStore.init()/migrate() so spot
+// history loads from the ready store before re-tagging.
+const migrateHourlySource = async () => {
   const FLAG = "migration_hourlySource";
   try {
     if (localStorage.getItem(FLAG)) return;
-    loadSpotHistory();
+    await loadSpotHistory();
     let changed = 0;
     spotHistory.forEach((e) => {
       if (
@@ -175,8 +202,9 @@ const migrateHourlySource = () => {
   }
 };
 
-// Run migration on script load
-migrateHourlySource();
+// STRK-141: NOT called at parse time anymore. Task 7 (init.js boot wiring) calls
+// `await migrateHourlySource()` during the awaited boot, after the history store
+// is initialized/migrated. Exposed on window below for the boot sequence.
 
 /**
  * Removes spot history entries older than the specified number of days
@@ -1604,10 +1632,23 @@ window.renderSpotHistoryTable = renderSpotHistoryTable;
 window.renderLbmaHistoryTable = renderLbmaHistoryTable;
 window.clearSpotHistory = clearSpotHistory;
 window.saveSpotHistory = saveSpotHistory;
+// STRK-141: expose async load + the relocated boot migration so init.js (task 7)
+// can await them in the boot sequence after historyStore.init()/migrate().
+window.loadSpotHistory = loadSpotHistory;
+window.migrateHourlySource = migrateHourlySource;
 window.getHistoricalSparklineData = getHistoricalSparklineData;
 window.getRequiredYears = getRequiredYears;
 window.fetchYearFile = fetchYearFile;
 window.lookupHistoricalSpot = lookupHistoricalSpot;
 window.historicalDataCache = historicalDataCache;
-// STAK-222: Expose spotHistory via getter so window.spotHistory always reflects current array
-Object.defineProperty(window, "spotHistory", { get: () => spotHistory, configurable: true });
+// STAK-222: Expose spotHistory via getter so window.spotHistory always reflects current array.
+// STRK-141: add a setter (mirroring inventory/changeLog in state.js) so window.spotHistory is
+// assignable — required by the quota-safety test and good state-exposure hygiene. The `spotHistory`
+// binding lives in state.js but is a shared script-tag global, so this setter reassigns it.
+Object.defineProperty(window, "spotHistory", {
+  get: () => spotHistory,
+  set: (val) => {
+    spotHistory = val;
+  },
+  configurable: true,
+});

--- a/js/vault.js
+++ b/js/vault.js
@@ -327,6 +327,15 @@ function collectVaultData(scope) {
 
   for (var i = 0; i < keysToCollect.length; i++) {
     var key = keysToCollect[i];
+    // Skip market histories now owned by IndexedDB — never written to a backup (STRK-141, R7.2).
+    // item-price-history is not in this set, so it is still exported (R7.1).
+    if (
+      typeof HISTORY_IDB_KEYS !== "undefined" &&
+      Array.isArray(HISTORY_IDB_KEYS) &&
+      HISTORY_IDB_KEYS.indexOf(key) !== -1
+    ) {
+      continue;
+    }
     // Skip credentials and device-specific state in portable full exports
     if (
       scope === "full" &&
@@ -383,6 +392,15 @@ async function restoreVaultData(payload) {
   var keys = Object.keys(data);
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
+    // Ignore market histories from older backups — they are reproducible from the
+    // API and now owned by IndexedDB; write to neither localStorage nor IDB (STRK-141, R7.3).
+    if (
+      typeof HISTORY_IDB_KEYS !== "undefined" &&
+      Array.isArray(HISTORY_IDB_KEYS) &&
+      HISTORY_IDB_KEYS.indexOf(key) !== -1
+    ) {
+      continue;
+    }
     // Only restore recognized keys
     if (ALLOWED_STORAGE_KEYS.indexOf(key) !== -1) {
       try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.35.2",
+  "version": "3.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.35.2",
+      "version": "3.35.3",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.35.2",
+  "version": "3.35.3",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.2-b1780605937";
+const CACHE_NAME = "staktrakr-v3.35.3-b1780613809";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.2-b1780534784";
+const CACHE_NAME = "staktrakr-v3.35.2-b1780605937";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =
@@ -39,6 +39,7 @@ const CORE_ASSETS = [
   "./js/bulk-image-cache.js",
   "./js/image-cache-modal.js",
   "./js/attachment-manager.js",
+  "./js/history-store.js",
   "./js/attachment-ui.js",
   "./js/fuzzy-search.js",
   "./js/autocomplete.js",

--- a/tests/playwright/core/history-store-migration.spec.js
+++ b/tests/playwright/core/history-store-migration.spec.js
@@ -1,0 +1,938 @@
+// STRK-141 Phase 2 — Migrate market histories to IndexedDB.
+//
+// TDD RED-PHASE SPEC (Phase 0, task 0.3). These tests are written BEFORE the
+// feature exists and MUST FAIL against the current build:
+//   - window.historyStore (the new HistoryStore singleton) does not exist yet
+//   - the boot localStorage->IndexedDB migration does not exist yet
+//   - the item-price-history retention cap (applyItemPriceRetention) does not exist yet
+//   - the backup export/restore exclusion of spot/retail history does not exist yet
+//
+// They turn green only after the STRK-141 implementation lands. Each test maps to
+// one or more acceptance criteria from
+//   DocVault/specflow/StakTrakr/specs/STRK-141-migrate-market-histories-to-indexeddb/
+//   {requirements.md, design.md (Testing Strategy)}.
+//
+// Conventions (StakTrakr Playwright gotchas):
+//   - IndexedDB is asserted by driving window.historyStore via page.evaluate.
+//   - The IDB-unavailable path is forced by stubbing window.indexedDB in an
+//     addInitScript that runs BEFORE the app scripts load.
+//   - Dates use toLocaleDateString('en-CA'), never toISOString().slice(0,10).
+
+import { test, expect } from "../helpers/mocks/extended-test.js";
+
+// --- Logical history keys (match constants.js literals) ---------------------
+const SPOT_KEY = "metalSpotHistory";
+const RETAIL_KEY = "v2RetailHistory";
+const LEGACY_RETAIL_KEY = "retailPriceHistory";
+const ITEM_PRICE_KEY = "item-price-history";
+const MIGRATION_FLAG = "migration_idb_history_v1";
+const HISTORY_DB = "StakTrakrHistory";
+const HISTORY_STORE = "histories";
+
+// Use recent timestamps so getPersistedSpotHistorySnapshot's 180-day seed trim
+// never drops the seeded points out from under the assertions.
+const NOW = Date.now();
+const DAY = 24 * 60 * 60 * 1000;
+
+// Real spot-history entries carry STRING timestamps in the exact format
+// `js/spot.js` writes: `new Date(t).toISOString().replace("T", " ").slice(0, 19)`
+// → "YYYY-MM-DD HH:MM:SS" (space-separated, no trailing Z). Numeric timestamps
+// fail getPersistedSpotHistorySnapshot's `typeof entry.timestamp === "string"`
+// guard (js/spot.js:46) and get silently dropped, so loadSpotHistory hydrates
+// empty. Mint matching string timestamps here.
+const spotStamp = (ms) => new Date(ms).toISOString().replace("T", " ").slice(0, 19);
+
+// Declaration order matches ascending timestamp order so the snapshot's
+// localeCompare sort (js/spot.js:71) leaves the array unchanged and the
+// `toEqual(SPOT_HISTORY)` assertions hold. Distinct second-resolution stamps
+// avoid the `${timestamp}|${metal}` dedup collapsing entries.
+const SPOT_HISTORY = [
+  {
+    timestamp: spotStamp(NOW - 2 * DAY),
+    metal: "silver",
+    spot: 31.11,
+    source: "api",
+    provider: "MetalsDev",
+  },
+  {
+    timestamp: spotStamp(NOW - 1 * DAY - 60 * 1000),
+    metal: "silver",
+    spot: 31.42,
+    source: "api",
+    provider: "MetalsDev",
+  },
+  {
+    timestamp: spotStamp(NOW - 1 * DAY),
+    metal: "gold",
+    spot: 2410.5,
+    source: "api",
+    provider: "MetalsDev",
+  },
+];
+
+// A larger spot-history payload whose JSON exceeds the 4096-char compression
+// threshold, so __compressIfNeeded actually emits a CMP2 blob (exercises R2.2,
+// the decompress-on-migration path). String timestamps inside the 180-day
+// runtime window, source:"api" (NOT "seed") so the seed-cutoff trim in
+// getPersistedSpotHistorySnapshot keeps every entry.
+const LARGE_SPOT_HISTORY = (() => {
+  const metals = ["silver", "gold", "platinum", "palladium"];
+  const out = [];
+  for (let i = 0; i < 140; i++) {
+    out.push({
+      timestamp: spotStamp(NOW - (i + 1) * 60 * 60 * 1000),
+      metal: metals[i % metals.length],
+      spot: 30 + i * 0.137,
+      source: "api",
+      provider: "MetalsDev",
+    });
+  }
+  return out;
+})();
+
+const RETAIL_HISTORY = {
+  "silver-eagle": [
+    { timestamp: spotStamp(NOW - 2 * DAY), price: 38.5, dealer: "apmex" },
+    { timestamp: spotStamp(NOW - 1 * DAY), price: 39.1, dealer: "apmex" },
+  ],
+  "gold-eagle": [{ timestamp: spotStamp(NOW - 1 * DAY), price: 2620, dealer: "jmbullion" }],
+};
+
+// Suppress the What's New popup at boot (matches helpers/seed.js).
+async function suppressWhatsNew(page) {
+  await page.addInitScript(() => {
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        if (typeof APP_VERSION !== "undefined") localStorage.setItem("ackVersion", APP_VERSION);
+      },
+      { once: true }
+    );
+  });
+}
+
+// Seed legacy market histories into localStorage BEFORE the app boots.
+async function seedLegacyHistory(page, { spot = SPOT_HISTORY, retail = RETAIL_HISTORY } = {}) {
+  await page.addInitScript(
+    ({ spotKey, retailKey, spotData, retailData }) => {
+      if (spotData) localStorage.setItem(spotKey, JSON.stringify(spotData));
+      if (retailData) localStorage.setItem(retailKey, JSON.stringify(retailData));
+    },
+    { spotKey: SPOT_KEY, retailKey: RETAIL_KEY, spotData: spot, retailData: retail }
+  );
+}
+
+// Stub indexedDB unavailable BEFORE app scripts load (R3 graceful degradation).
+async function stubIndexedDbUnavailable(page) {
+  await page.addInitScript(() => {
+    try {
+      Object.defineProperty(window, "indexedDB", {
+        configurable: true,
+        get() {
+          return undefined;
+        },
+      });
+    } catch {
+      // Fallback for engines that reject the redefine: blank the open() entry.
+      try {
+        window.indexedDB = undefined;
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+}
+
+async function gotoApp(page) {
+  await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+}
+
+// Delete the StakTrakrHistory IndexedDB database and clear LS/SS for the current
+// origin. Requires the page to already be on an origin that can reach
+// indexedDB/localStorage (call AFTER a gotoApp, or in afterEach). Used both for
+// cross-test isolation (no IDB bleed into other core specs — workers:1 shares
+// the browser) and mid-test, between the migration test's compressor-priming
+// boot and its real migration boot, so the boot migration is not pre-flagged.
+async function clearHistoryState(page) {
+  await page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        try {
+          localStorage.clear();
+          sessionStorage.clear();
+        } catch {
+          /* ignore */
+        }
+        if (!window.indexedDB || typeof window.indexedDB.deleteDatabase !== "function") {
+          resolve();
+          return;
+        }
+        // The app's HistoryStore singleton holds an OPEN connection to
+        // StakTrakrHistory for the lifetime of the page. With that connection
+        // live, deleteDatabase() fires `onblocked` — NOT `onsuccess` — so the
+        // database is NEVER actually deleted, only the resolve() fires. Because
+        // Playwright reuses the same browser context (and IndexedDB) across tests
+        // in a worker (workers:1), the populated spot-history DB would otherwise
+        // survive into later core specs. Close the app's connection first so the
+        // delete completes cleanly and this spec leaves a truly empty IndexedDB.
+        try {
+          if (window.historyStore && window.historyStore._db) {
+            window.historyStore._db.close();
+            window.historyStore._db = null;
+            window.historyStore._available = false;
+          }
+        } catch {
+          /* ignore */
+        }
+        const req = window.indexedDB.deleteDatabase("StakTrakrHistory");
+        req.onsuccess = req.onerror = req.onblocked = () => resolve();
+      })
+  );
+}
+
+// Wait for the new store singleton to come up. (RED: never appears today.)
+async function waitForHistoryStore(page) {
+  await page.waitForFunction(() => typeof window.historyStore !== "undefined", null, {
+    timeout: 8000,
+  });
+}
+
+// Read a record's `data` field straight from the raw IndexedDB store, so the
+// assertion does not depend on historyStore's own getter behaving correctly.
+async function readIdbRecord(page, key) {
+  return page.evaluate(
+    ({ dbName, storeName, recordKey }) =>
+      new Promise((resolve, reject) => {
+        if (!window.indexedDB) {
+          resolve({ __noIdb: true });
+          return;
+        }
+        const open = window.indexedDB.open(dbName);
+        open.onerror = () => reject(open.error);
+        open.onsuccess = () => {
+          const db = open.result;
+          if (!db.objectStoreNames.contains(storeName)) {
+            db.close();
+            resolve(null);
+            return;
+          }
+          const tx = db.transaction(storeName, "readonly");
+          const req = tx.objectStore(storeName).get(recordKey);
+          req.onerror = () => reject(req.error);
+          req.onsuccess = () => {
+            const rec = req.result;
+            db.close();
+            resolve(rec ? rec.data : null);
+          };
+        };
+      }),
+    { dbName: HISTORY_DB, storeName: HISTORY_STORE, recordKey: key }
+  );
+}
+
+test.describe("core/history-store-migration (STRK-141)", () => {
+  // Isolation: this spec creates and populates the StakTrakrHistory IndexedDB on
+  // boot. With workers:1 the browser process is shared, so a leaked DB bleeds
+  // into later core specs (e.g. retail-market.spec.js). Start each test from a
+  // clean origin (no DB, no LS/SS) and leave none behind.
+  test.beforeEach(async ({ page }) => {
+    // Land on the app origin once with no seeding so storage is reachable, let
+    // the async fire-and-forget boot migration + seed bundle SETTLE (otherwise a
+    // late write can land in IndexedDB after we wipe it — a race that re-seeds
+    // the DB and re-sets the migration flag), then wipe everything. Individual
+    // tests re-seed via addInitScript + their own gotoApp from this clean slate.
+    await page.goto("/index.html", { waitUntil: "domcontentloaded" });
+    await page
+      .waitForFunction(() => localStorage.getItem("migration_idb_history_v1") === "true", null, {
+        timeout: 8000,
+      })
+      .catch(() => {});
+    await clearHistoryState(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearHistoryState(page);
+  });
+
+  // -- Migration (R2.1, R2.2, R2.3) -----------------------------------------
+  test("migrates compressed spot + plain retail history to IndexedDB and removes legacy LS keys", async ({
+    page,
+  }) => {
+    await suppressWhatsNew(page);
+    // First boot purely to obtain the app's real CMP2 compressor, so we can seed
+    // a genuine Phase-1-compressed metalSpotHistory payload (R2.2).
+    await gotoApp(page);
+    await page.waitForFunction(() => typeof window.__compressIfNeeded === "function");
+    const compressedSpot = await page.evaluate(
+      (data) => window.__compressIfNeeded(JSON.stringify(data)),
+      LARGE_SPOT_HISTORY
+    );
+    // Sanity guard: ensure we actually seeded a Phase-1 CMP2 blob (the whole
+    // point of this test is the decompress-on-migration path).
+    expect(compressedSpot.startsWith("CMP2:")).toBe(true);
+
+    // The priming boot above already ran the boot migration (setting the
+    // migration_idb_history_v1 flag) and seeded the LBMA bundle into the store.
+    // Wipe that state so the upcoming boot performs a REAL migration of the
+    // compressed LS payload instead of short-circuiting on the already-set flag.
+    await clearHistoryState(page);
+
+    // Re-seed LS with the compressed spot payload + plain retail, then re-boot.
+    await page.addInitScript(
+      ({ spotKey, retailKey, spotBlob, retailData }) => {
+        localStorage.setItem(spotKey, spotBlob);
+        localStorage.setItem(retailKey, JSON.stringify(retailData));
+      },
+      {
+        spotKey: SPOT_KEY,
+        retailKey: RETAIL_KEY,
+        spotBlob: compressedSpot,
+        retailData: RETAIL_HISTORY,
+      }
+    );
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    // Let the awaited boot migration settle.
+    await page.waitForFunction(() => localStorage.getItem("migration_idb_history_v1") === "true", {
+      timeout: 8000,
+    });
+
+    const idbSpot = await readIdbRecord(page, SPOT_KEY);
+    const idbRetail = await readIdbRecord(page, RETAIL_KEY);
+    const lsState = await page.evaluate(
+      ({ spotKey, retailKey, flag }) => ({
+        spotLs: localStorage.getItem(spotKey),
+        retailLs: localStorage.getItem(retailKey),
+        flag: localStorage.getItem(flag),
+      }),
+      { spotKey: SPOT_KEY, retailKey: RETAIL_KEY, flag: MIGRATION_FLAG }
+    );
+
+    // Decompressed, every data point preserved (R2.1, R2.2). Boot may also
+    // fire-and-forget the LBMA spot seed bundle into the store, so the spot
+    // record can be a SUPERSET of the migrated payload rather than exactly equal.
+    // Assert containment: every migrated data point is present in the store (the
+    // AC is "preserving every data point", not "the store equals only the seed").
+    expect(Array.isArray(idbSpot)).toBe(true);
+    for (const entry of LARGE_SPOT_HISTORY) {
+      expect(idbSpot).toContainEqual(entry);
+    }
+    // Retail history is not seeded at boot, so it round-trips exactly.
+    expect(idbRetail).toEqual(RETAIL_HISTORY);
+    // Legacy LS copies reclaimed (R2.3).
+    expect(lsState.spotLs).toBeNull();
+    expect(lsState.retailLs).toBeNull();
+    // Idempotency flag set (R2.4).
+    expect(lsState.flag).toBe("true");
+  });
+
+  // -- Idempotency (R2.4, R2.5) ---------------------------------------------
+  test("second boot performs no migration and leaves migrated data unchanged", async ({ page }) => {
+    await suppressWhatsNew(page);
+    await seedLegacyHistory(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    await page.waitForFunction(() => localStorage.getItem("migration_idb_history_v1") === "true", {
+      timeout: 8000,
+    });
+
+    // Boot fetches live spot prices (mocked) and appends them, so the migrated
+    // record is a SUPERSET of the seeded payload. Assert containment of every
+    // migrated data point (R2.1) rather than exact equality.
+    const firstSpot = await readIdbRecord(page, SPOT_KEY);
+    expect(Array.isArray(firstSpot)).toBe(true);
+    for (const entry of SPOT_HISTORY) {
+      expect(firstSpot).toContainEqual(entry);
+    }
+
+    // Mutate the IDB record directly with a sentinel marker, then re-boot. A
+    // re-run migration would overwrite it from a (now-absent) LS copy; an
+    // idempotent boot must not. The marker carries a VALID recent STRING
+    // timestamp so getPersistedSpotHistorySnapshot keeps it (a numeric timestamp
+    // would be filtered out, emptying spotHistory and triggering the first-time
+    // seed merge, which would overwrite the record — masking the idempotency
+    // check). source "marker" + a unique metal make it unambiguous.
+    const marker = {
+      timestamp: spotStamp(NOW - 3 * 60 * 60 * 1000),
+      metal: "marker",
+      spot: 1,
+      source: "marker",
+    };
+    await page.evaluate(
+      ({ dbName, storeName, recordKey, markerEntry }) =>
+        new Promise((resolve, reject) => {
+          const open = window.indexedDB.open(dbName);
+          open.onsuccess = () => {
+            const db = open.result;
+            const tx = db.transaction(storeName, "readwrite");
+            tx.objectStore(storeName).put({
+              key: recordKey,
+              data: [markerEntry],
+              updatedAt: Date.now(),
+            });
+            tx.oncomplete = () => {
+              db.close();
+              resolve();
+            };
+            tx.onerror = () => reject(tx.error);
+          };
+          open.onerror = () => reject(open.error);
+        }),
+      { dbName: HISTORY_DB, storeName: HISTORY_STORE, recordKey: SPOT_KEY, markerEntry: marker }
+    );
+
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    await page.waitForTimeout(500);
+
+    const secondSpot = await readIdbRecord(page, SPOT_KEY);
+    // Marker survived => migration did NOT re-run (R2.5). Boot's live-spot fetch
+    // may append entries, so assert the marker is still PRESENT (containment)
+    // rather than that it is the sole record; the seeded SPOT_HISTORY must NOT
+    // have been re-migrated back in (the LS copies were reclaimed on first boot).
+    expect(Array.isArray(secondSpot)).toBe(true);
+    expect(secondSpot).toContainEqual(marker);
+    for (const entry of SPOT_HISTORY) {
+      expect(secondSpot).not.toContainEqual(entry);
+    }
+  });
+
+  // -- Graceful degradation (R3.1, R3.2, R3.3) ------------------------------
+  test("with indexedDB unavailable, spot/retail load+save via localStorage, legacy keys kept, boot completes", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await stubIndexedDbUnavailable(page);
+    await suppressWhatsNew(page);
+    await seedLegacyHistory(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+
+    const result = await page.evaluate(
+      ({ spotKey, retailKey, flag, seeded }) => {
+        const mem = Array.isArray(window.spotHistory) ? window.spotHistory : null;
+        return {
+          idbAbsent: !window.indexedDB,
+          available: window.historyStore.isAvailable(),
+          // Boot must have hydrated the in-memory globals from the LS fallback.
+          // Boot also fetches live spot prices (mocked) and appends them, so the
+          // global is a SUPERSET of the seeded LS entries — assert containment of
+          // every seeded entry, not an exact count.
+          spotMemArray: Array.isArray(mem),
+          spotMemHasAllSeeded:
+            mem &&
+            seeded.every((s) =>
+              mem.some(
+                (e) => e.timestamp === s.timestamp && e.metal === s.metal && e.spot === s.spot
+              )
+            ),
+          // Legacy LS copies must remain (R3.2 — never destroy the source of truth).
+          spotLs: localStorage.getItem(spotKey),
+          retailLs: localStorage.getItem(retailKey),
+          // Migration flag must NOT be set when migration could not run (R3.1).
+          flag: localStorage.getItem(flag),
+        };
+      },
+      { spotKey: SPOT_KEY, retailKey: RETAIL_KEY, flag: MIGRATION_FLAG, seeded: SPOT_HISTORY }
+    );
+
+    expect(result.idbAbsent).toBe(true);
+    expect(result.available).toBe(false);
+    expect(result.spotMemArray).toBe(true);
+    expect(result.spotMemHasAllSeeded).toBe(true);
+    expect(result.spotLs).not.toBeNull();
+    expect(result.retailLs).not.toBeNull();
+    expect(result.flag).toBeNull();
+
+    // A save in IDB-unavailable mode must still persist to localStorage (R3.1).
+    // The entry needs a STRING timestamp or getPersistedSpotHistorySnapshot drops
+    // it (typeof check) and an empty array would be persisted instead.
+    const saved = await page.evaluate(
+      ({ spotKey, stamp }) => {
+        window.spotHistory = [{ timestamp: stamp, metal: "platinum", spot: 980, source: "api" }];
+        window.saveSpotHistory();
+        return localStorage.getItem(spotKey);
+      },
+      { spotKey: SPOT_KEY, stamp: spotStamp(NOW) }
+    );
+    expect(saved).not.toBeNull();
+    expect(saved).toContain("platinum");
+
+    // No unhandled error and boot completed (R3.3).
+    expect(pageErrors).toEqual([]);
+  });
+
+  // -- Cleanup safety (R2/R3, design-review finding 1) ----------------------
+  test("cleanupStorage keeps spot/retail history keys and migration flag when IDB is unavailable", async ({
+    page,
+  }) => {
+    await stubIndexedDbUnavailable(page);
+    await suppressWhatsNew(page);
+    await seedLegacyHistory(page);
+    // Also pre-seed the migration flag to prove it is allowlisted, not purged.
+    await page.addInitScript((flag) => localStorage.setItem(flag, "true"), MIGRATION_FLAG);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    await page.waitForFunction(() => typeof window.cleanupStorage === "function", null, {
+      timeout: 8000,
+    });
+
+    const state = await page.evaluate(
+      ({ spotKey, retailKey, flag }) => {
+        // Run the boot cleanup explicitly so the assertion is deterministic.
+        window.cleanupStorage();
+        return {
+          spotLs: localStorage.getItem(spotKey),
+          retailLs: localStorage.getItem(retailKey),
+          flag: localStorage.getItem(flag),
+          spotAllowed:
+            window.ALLOWED_STORAGE_KEYS instanceof Set
+              ? window.ALLOWED_STORAGE_KEYS.has(spotKey)
+              : window.ALLOWED_STORAGE_KEYS.includes(spotKey),
+          flagAllowed:
+            window.ALLOWED_STORAGE_KEYS instanceof Set
+              ? window.ALLOWED_STORAGE_KEYS.has(flag)
+              : window.ALLOWED_STORAGE_KEYS.includes(flag),
+        };
+      },
+      { spotKey: SPOT_KEY, retailKey: RETAIL_KEY, flag: MIGRATION_FLAG }
+    );
+
+    expect(state.spotLs).not.toBeNull();
+    expect(state.retailLs).not.toBeNull();
+    expect(state.flag).toBe("true");
+    expect(state.spotAllowed).toBe(true);
+    expect(state.flagAllowed).toBe(true);
+  });
+
+  // -- No blank charts (R4) -------------------------------------------------
+  test("first render of the spot history table shows data hydrated from IndexedDB (no empty flash)", async ({
+    page,
+  }) => {
+    await suppressWhatsNew(page);
+    // Seed the data ONLY into IndexedDB (no localStorage copy). If the render
+    // path still reads localStorage synchronously, the table will be empty —
+    // proving the boot hydration into the in-memory global is required (R4).
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    // Boot is a first-time user here, so it fire-and-forgets the LBMA seed bundle
+    // into spotHistory + the store. Wait for that async seed merge to SETTLE
+    // (it sets migration_seedHistoryMerge) before we overwrite the record.
+    await page
+      .waitForFunction(() => localStorage.getItem("migration_seedHistoryMerge") === "1", null, {
+        timeout: 8000,
+      })
+      .catch(() => {});
+    // PUT our payload, then re-hydrate + render — all in ONE evaluate so a
+    // pending seed write cannot sneak into the gap between put and load.
+    // saveSpotHistory's IDB write is fire-and-forget: gate first on the store
+    // record being STABLE (two equal reads) so the one-shot seed write has
+    // flushed, then put our 3-entry payload and confirm the read-back before
+    // loading. This closes the race deterministically without weakening R4.
+    const rendered = await page.evaluate(
+      async ({ key, data }) => {
+        await window.historyStore.init();
+        localStorage.removeItem(key); // IndexedDB is the only source.
+
+        // Wait until the boot seed's one-shot write has flushed (stable record).
+        let prev = JSON.stringify(await window.historyStore.get(key));
+        for (let i = 0; i < 40; i++) {
+          await new Promise((r) => setTimeout(r, 40));
+          const cur = JSON.stringify(await window.historyStore.get(key));
+          if (cur === prev) break;
+          prev = cur;
+        }
+
+        // Overwrite with exactly our payload; confirm the read-back matches.
+        for (let attempt = 0; attempt < 25; attempt++) {
+          await window.historyStore.put(key, data);
+          const back = await window.historyStore.get(key);
+          if (Array.isArray(back) && back.length === data.length) break;
+          await new Promise((r) => setTimeout(r, 50));
+        }
+
+        // Re-hydrate from the store the way boot does, then render once.
+        if (typeof window.loadSpotHistory === "function") await window.loadSpotHistory();
+        window.renderSpotHistoryTable();
+        const tbody = document.querySelector("#settingsSpotHistoryTable tbody");
+        return {
+          rowCount: tbody ? tbody.querySelectorAll("tr").length : -1,
+          isEmptyState: tbody ? /No spot price history/i.test(tbody.textContent || "") : true,
+          inMemory: Array.isArray(window.spotHistory) ? window.spotHistory.length : -1,
+        };
+      },
+      { key: SPOT_KEY, data: SPOT_HISTORY }
+    );
+
+    expect(rendered.inMemory).toBe(SPOT_HISTORY.length);
+    expect(rendered.isEmptyState).toBe(false);
+    expect(rendered.rowCount).toBe(SPOT_HISTORY.length);
+  });
+
+  // -- Quota safety (R1.3) --------------------------------------------------
+  test("a historyStore.put rejecting with QuotaExceededError falls back without throwing or corrupting memory", async ({
+    page,
+  }) => {
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+
+    const result = await page.evaluate(async () => {
+      await window.historyStore.init();
+      // Force the underlying IDB write to reject with a quota error.
+      const quotaErr =
+        typeof DOMException === "function"
+          ? new DOMException("quota", "QuotaExceededError")
+          : Object.assign(new Error("quota"), { name: "QuotaExceededError" });
+
+      const stored = [{ timestamp: Date.now(), metal: "gold", spot: 2400, source: "api" }];
+      window.spotHistory = stored.slice();
+
+      // historyStore.put MUST swallow the quota rejection and return false.
+      // Force the real IDB write to reject with a quota error by stubbing
+      // IDBObjectStore.prototype.put — this exercises put()'s catch path
+      // through the genuine IndexedDB call, with no production test hook.
+      let threw = false;
+      let putResult;
+      const origIdbPut = IDBObjectStore.prototype.put;
+      IDBObjectStore.prototype.put = function () {
+        throw quotaErr;
+      };
+      try {
+        putResult = await window.historyStore.put("metalSpotHistory", stored);
+      } catch {
+        threw = true;
+      } finally {
+        IDBObjectStore.prototype.put = origIdbPut;
+      }
+
+      return {
+        threw,
+        putResult,
+        // In-memory global must be intact after a failed write.
+        inMemoryIntact: JSON.stringify(window.spotHistory) === JSON.stringify(stored),
+      };
+    });
+
+    expect(result.threw).toBe(false);
+    expect(result.putResult).toBe(false);
+    expect(result.inMemoryIntact).toBe(true);
+  });
+
+  // -- Retention cap (R6) ---------------------------------------------------
+  test("item-price retention cap drops oldest beyond age cutoff and per-item limit while keeping newest", async ({
+    page,
+  }) => {
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await page.waitForFunction(() => typeof window.applyItemPriceRetention === "function", null, {
+      timeout: 8000,
+    });
+
+    const result = await page.evaluate(() => {
+      const now = Date.now();
+      const day = 24 * 60 * 60 * 1000;
+      // Item A: one entry just inside 365d, one well past it (must be dropped).
+      // Item B: 1200 entries (must be capped to the newest 1000).
+      const recent = { ts: now - 10 * day, itemName: "A", retail: 30, spot: 28, melt: 25 };
+      const ancient = { ts: now - 400 * day, itemName: "A", retail: 20, spot: 18, melt: 16 };
+      const itemB = [];
+      for (let i = 0; i < 1200; i++) {
+        itemB.push({ ts: now - (1200 - i) * 1000, itemName: "B", retail: i, spot: i, melt: i });
+      }
+
+      const history = { A: [ancient, recent], B: itemB };
+      const capped = window.applyItemPriceRetention(history);
+
+      const noControl =
+        !document.querySelector('[data-setting="itemPriceRetention"]') &&
+        !document.getElementById("itemPriceRetentionSetting") &&
+        !document.getElementById("itemPriceHistoryRetentionInput");
+
+      return {
+        aLen: capped.A ? capped.A.length : 0,
+        aKeptRecent: capped.A ? capped.A.some((e) => e.ts === recent.ts) : false,
+        aDroppedAncient: capped.A ? !capped.A.some((e) => e.ts === ancient.ts) : true,
+        bLen: capped.B ? capped.B.length : 0,
+        // The newest of item B (retail 1199) must survive; the oldest (0) must go.
+        bKeptNewest: capped.B ? capped.B.some((e) => e.retail === 1199) : false,
+        bDroppedOldest: capped.B ? !capped.B.some((e) => e.retail === 0) : true,
+        noControl,
+      };
+    });
+
+    expect(result.aLen).toBe(1);
+    expect(result.aKeptRecent).toBe(true);
+    expect(result.aDroppedAncient).toBe(true);
+    expect(result.bLen).toBe(1000);
+    expect(result.bKeptNewest).toBe(true);
+    expect(result.bDroppedOldest).toBe(true);
+    expect(result.noControl).toBe(true);
+  });
+
+  // -- Backup surfaces: export (R7.1, R7.2) ---------------------------------
+  test("ZIP and vault export exclude spot + retail history and include item-price history", async ({
+    page,
+  }) => {
+    await suppressWhatsNew(page);
+    await seedLegacyHistory(page);
+    await page.addInitScript(
+      ({ itemKey, legacyRetailKey }) => {
+        localStorage.setItem(
+          itemKey,
+          JSON.stringify({ "uuid-1": [{ ts: Date.now(), itemName: "Eagle", retail: 35 }] })
+        );
+        // Legacy retail key also present so old export code paths are exercised.
+        localStorage.setItem(legacyRetailKey, JSON.stringify({ "silver-eagle": [{ price: 38 }] }));
+      },
+      { itemKey: ITEM_PRICE_KEY, legacyRetailKey: LEGACY_RETAIL_KEY }
+    );
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    await page.waitForFunction(
+      () =>
+        typeof window.createBackupZip === "function" &&
+        typeof window.collectVaultData === "function"
+    );
+
+    // --- ZIP export ---
+    const zipResult = await page.evaluate(async () => {
+      const blob = await window.createBackupZip();
+      const zip = await window.JSZip.loadAsync(await blob.arrayBuffer());
+      const names = Object.keys(zip.files);
+      return {
+        hasSpotFile: names.includes("spot_price_history.json"),
+        hasRetailFile: names.includes("retail_price_history.json"),
+        hasItemFile: names.includes("item_price_history.json"),
+      };
+    });
+    expect(zipResult.hasSpotFile).toBe(false);
+    expect(zipResult.hasRetailFile).toBe(false);
+    expect(zipResult.hasItemFile).toBe(true);
+
+    // --- Vault export ---
+    const vaultResult = await page.evaluate(
+      ({ spotKey, retailKey, legacyRetailKey, itemKey }) => {
+        const payload = window.collectVaultData("full");
+        const data = (payload && payload.data) || {};
+        return {
+          hasSpot: Object.prototype.hasOwnProperty.call(data, spotKey),
+          hasRetail: Object.prototype.hasOwnProperty.call(data, retailKey),
+          hasLegacyRetail: Object.prototype.hasOwnProperty.call(data, legacyRetailKey),
+          hasItem: Object.prototype.hasOwnProperty.call(data, itemKey),
+        };
+      },
+      {
+        spotKey: SPOT_KEY,
+        retailKey: RETAIL_KEY,
+        legacyRetailKey: LEGACY_RETAIL_KEY,
+        itemKey: ITEM_PRICE_KEY,
+      }
+    );
+    expect(vaultResult.hasSpot).toBe(false);
+    expect(vaultResult.hasRetail).toBe(false);
+    expect(vaultResult.hasLegacyRetail).toBe(false);
+    expect(vaultResult.hasItem).toBe(true);
+  });
+
+  // -- Old-backup restore (R7.3, design-review finding 2) -------------------
+  test("restoring a vault containing spot+retail history ignores them (no LS, no IDB) but restores item-price", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    await page.waitForFunction(() => typeof window.restoreVaultData === "function", null, {
+      timeout: 8000,
+    });
+    // First-time-user boot fire-and-forgets the LBMA seed bundle into the store.
+    // Wait for that async seed merge to SETTLE (sets migration_seedHistoryMerge)
+    // so the spot/retail IDB snapshot captured below is stable and not racing a
+    // late seed write — otherwise before/after would differ for a reason other
+    // than restore.
+    await page
+      .waitForFunction(() => localStorage.getItem("migration_seedHistoryMerge") === "1", null, {
+        timeout: 8000,
+      })
+      .catch(() => {});
+
+    const result = await page.evaluate(
+      async ({ spotKey, retailKey, legacyRetailKey, itemKey, dbName, storeName }) => {
+        // Start LS clean (item-price target must not pre-exist).
+        localStorage.removeItem(spotKey);
+        localStorage.removeItem(retailKey);
+        localStorage.removeItem(legacyRetailKey);
+        localStorage.removeItem(itemKey);
+
+        // Read a record's `data` straight from the raw IDB store.
+        function idbData(recordKey) {
+          if (!window.indexedDB) return Promise.resolve(null);
+          return new Promise((resolve) => {
+            const open = window.indexedDB.open(dbName);
+            open.onerror = () => resolve(null);
+            open.onsuccess = () => {
+              const db = open.result;
+              if (!db.objectStoreNames.contains(storeName)) {
+                db.close();
+                resolve(null);
+                return;
+              }
+              const tx = db.transaction(storeName, "readonly");
+              const req = tx.objectStore(storeName).get(recordKey);
+              req.onsuccess = () => {
+                db.close();
+                resolve(req.result ? req.result.data : null);
+              };
+              req.onerror = () => {
+                db.close();
+                resolve(null);
+              };
+            };
+          });
+        }
+
+        // Boot legitimately fire-and-forgets the LBMA spot seed bundle into the
+        // store, so the spot/retail IDB records are NOT empty before restore.
+        // The seed's IDB write is itself fire-and-forget, so poll each record
+        // until two successive reads match (stable) before snapshotting — this
+        // guarantees the before/after comparison isolates the restore's effect,
+        // not a late seed write landing mid-test.
+        async function stableIdb(recordKey) {
+          let prev = JSON.stringify(await idbData(recordKey));
+          for (let i = 0; i < 25; i++) {
+            await new Promise((r) => setTimeout(r, 40));
+            const cur = JSON.stringify(await idbData(recordKey));
+            if (cur === prev) return JSON.parse(cur);
+            prev = cur;
+          }
+          return JSON.parse(prev);
+        }
+        const spotIdbBefore = await stableIdb(spotKey);
+        const retailIdbBefore = await stableIdb(retailKey);
+
+        const itemHistory = { "uuid-7": [{ ts: Date.now(), itemName: "Maple", retail: 41 }] };
+        // An OLD backup payload that still carries spot + retail history. Its
+        // spot/retail entries are distinctive (provider "OLDBACKUP") so we can
+        // detect if restore ever wrote them into the store.
+        const payload = {
+          _meta: { appVersion: "old", scope: "full" },
+          data: {
+            [spotKey]: JSON.stringify([
+              {
+                timestamp: "2020-01-01 00:00:00",
+                metal: "silver",
+                spot: 30,
+                source: "api",
+                provider: "OLDBACKUP",
+              },
+            ]),
+            [retailKey]: JSON.stringify({ "oldbackup-slug": [{ price: 38 }] }),
+            [legacyRetailKey]: JSON.stringify({ "oldbackup-slug": [{ price: 38 }] }),
+            [itemKey]: JSON.stringify(itemHistory),
+          },
+        };
+
+        let threw = false;
+        try {
+          await window.restoreVaultData(payload);
+        } catch {
+          threw = true;
+        }
+
+        const spotIdbAfter = await idbData(spotKey);
+        const retailIdbAfter = await idbData(retailKey);
+
+        const containsOldBackupSpot = Array.isArray(spotIdbAfter)
+          ? spotIdbAfter.some((e) => e && e.provider === "OLDBACKUP")
+          : false;
+        const containsOldBackupRetail =
+          retailIdbAfter && typeof retailIdbAfter === "object"
+            ? Object.prototype.hasOwnProperty.call(retailIdbAfter, "oldbackup-slug")
+            : false;
+
+        return {
+          threw,
+          spotLs: localStorage.getItem(spotKey),
+          retailLs: localStorage.getItem(retailKey),
+          legacyRetailLs: localStorage.getItem(legacyRetailKey),
+          itemLs: localStorage.getItem(itemKey),
+          // IDB spot/retail unchanged by restore (deep-equal before vs after).
+          spotIdbUnchanged: JSON.stringify(spotIdbBefore) === JSON.stringify(spotIdbAfter),
+          retailIdbUnchanged: JSON.stringify(retailIdbBefore) === JSON.stringify(retailIdbAfter),
+          // And the old-backup spot/retail payloads were NOT written into IDB.
+          containsOldBackupSpot,
+          containsOldBackupRetail,
+        };
+      },
+      {
+        spotKey: SPOT_KEY,
+        retailKey: RETAIL_KEY,
+        legacyRetailKey: LEGACY_RETAIL_KEY,
+        itemKey: ITEM_PRICE_KEY,
+        dbName: HISTORY_DB,
+        storeName: HISTORY_STORE,
+      }
+    );
+
+    // No error raised (R7.3).
+    expect(result.threw).toBe(false);
+    expect(pageErrors).toEqual([]);
+    // Spot/retail from the old backup written to NEITHER localStorage NOR IDB:
+    // the LS keys stay null and the IDB records are byte-for-byte the same as the
+    // boot-seeded state captured before restore (restore ignored them).
+    expect(result.spotLs).toBeNull();
+    expect(result.retailLs).toBeNull();
+    expect(result.legacyRetailLs).toBeNull();
+    expect(result.spotIdbUnchanged).toBe(true);
+    expect(result.retailIdbUnchanged).toBe(true);
+    expect(result.containsOldBackupSpot).toBe(false);
+    expect(result.containsOldBackupRetail).toBe(false);
+    // Item-price history IS restored.
+    expect(result.itemLs).not.toBeNull();
+    expect(result.itemLs).toContain("Maple");
+  });
+
+  // -- Sync scope unchanged (R5.1, R5.2) ------------------------------------
+  test("no market-history key is in the cloud auto-sync scope", async ({ page }) => {
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await page.waitForFunction(() => typeof window.SYNC_SCOPE_KEYS !== "undefined", null, {
+      timeout: 8000,
+    });
+
+    const scope = await page.evaluate(
+      ({ spotKey, retailKey, legacyRetailKey, itemKey }) => {
+        const keys = Array.isArray(window.SYNC_SCOPE_KEYS)
+          ? window.SYNC_SCOPE_KEYS
+          : Array.from(window.SYNC_SCOPE_KEYS || []);
+        return {
+          keys,
+          hasSpot: keys.includes(spotKey),
+          hasRetail: keys.includes(retailKey),
+          hasLegacyRetail: keys.includes(legacyRetailKey),
+          hasItem: keys.includes(itemKey),
+          hasHistoryFlag: keys.includes("migration_idb_history_v1"),
+        };
+      },
+      {
+        spotKey: SPOT_KEY,
+        retailKey: RETAIL_KEY,
+        legacyRetailKey: LEGACY_RETAIL_KEY,
+        itemKey: ITEM_PRICE_KEY,
+      }
+    );
+
+    expect(scope.hasSpot).toBe(false);
+    expect(scope.hasRetail).toBe(false);
+    expect(scope.hasLegacyRetail).toBe(false);
+    expect(scope.hasItem).toBe(false);
+    expect(scope.hasHistoryFlag).toBe(false);
+  });
+});

--- a/tests/playwright/core/history-store-migration.spec.js
+++ b/tests/playwright/core/history-store-migration.spec.js
@@ -1,14 +1,14 @@
 // STRK-141 Phase 2 — Migrate market histories to IndexedDB.
 //
-// TDD RED-PHASE SPEC (Phase 0, task 0.3). These tests are written BEFORE the
-// feature exists and MUST FAIL against the current build:
-//   - window.historyStore (the new HistoryStore singleton) does not exist yet
-//   - the boot localStorage->IndexedDB migration does not exist yet
-//   - the item-price-history retention cap (applyItemPriceRetention) does not exist yet
-//   - the backup export/restore exclusion of spot/retail history does not exist yet
+// REGRESSION SPEC. Originally authored as the TDD red-phase suite (Phase 0,
+// task 0.3) before the feature existed; now that the STRK-141 implementation has
+// landed these tests pass and guard against regressions. Coverage:
+//   - window.historyStore (the HistoryStore singleton) lifecycle
+//   - the boot localStorage->IndexedDB migration (idempotent, decompress-aware)
+//   - the item-price-history retention cap (applyItemPriceRetention)
+//   - the backup export/restore exclusion of spot/retail history
 //
-// They turn green only after the STRK-141 implementation lands. Each test maps to
-// one or more acceptance criteria from
+// Each test maps to one or more acceptance criteria from
 //   DocVault/specflow/StakTrakr/specs/STRK-141-migrate-market-histories-to-indexeddb/
 //   {requirements.md, design.md (Testing Strategy)}.
 //

--- a/tests/playwright/core/retail-market.spec.js
+++ b/tests/playwright/core/retail-market.spec.js
@@ -322,6 +322,15 @@ async function setupRetailFixture(page, options = {}) {
       typeof window.refreshMarketData === "function" &&
       typeof window.showSettingsModal === "function"
   );
+  // STRK-148 de-flake: boot's awaited loadSeedSpotHistory() pushes the seed
+  // bundle's gold spot (~$4456) into spotPrices.gold AFTER the function-existence
+  // wait above, via fetchSpotPrice(). Wait for that boot seed write to land
+  // BEFORE the override below, so the override is the last writer and isn't
+  // clobbered before refreshMarketData() reads it. (Latent race surfaced by
+  // STRK-141's awaited boot-hydration timing; not a product bug — see STRK-148.)
+  await page.waitForFunction(
+    () => typeof spotPrices !== "undefined" && Number(spotPrices.gold) > 0
+  );
   await page.evaluate(async () => {
     if (typeof spotPrices !== "undefined") {
       spotPrices.gold = 2000;

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.35.2",
-  "releaseDate": "2026-06-03",
+  "version": "3.35.3",
+  "releaseDate": "2026-06-04",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

Phase 2 of epic **STRK-139** (market-history storage migration). Moves the reproducible market-history caches off the localStorage budget permanently, removing the `QuotaExceededError` failure mode that Phase 1 (STRK-140) only deferred.

- **New `js/history-store.js`** — `HistoryStore` class backed by a dedicated `StakTrakrHistory` IndexedDB database (single `histories` store), mirroring the existing `ImageCache`/`AttachmentManager` pattern. Quota-safe `put()` (catches `QuotaExceededError` → returns `false`, never throws).
- **Spot + retail history → IndexedDB.** `metalSpotHistory` and `v2RetailHistory` leave localStorage entirely. An idempotent one-time migration (`migration_idb_history_v1` flag) decompresses Phase-1 LZ payloads and copies them into IDB, deleting the legacy LS copy **only after a confirmed write** (hard data-loss guard). Falls back to localStorage when IndexedDB is unavailable.
- **Item price history stays in localStorage** (the only user-authored, non-reproducible key) and gains a silent retention cap (365-day age cutoff + 1000 entries/item) so it can't re-trigger the quota.
- **Boot hydration:** `init.js` awaits `historyStore.init() → migrate() → loadSpotHistory() → retail load` before first render — no blank charts (R4).
- **Backup scope:** spot/retail history excluded from manual vault + ZIP export/restore; item-price-history still included. **Cloud auto-sync scope unchanged** (no history key added to `SYNC_SCOPE_KEYS`).

## Linked issue

- Closes **STRK-141** (Phase 2: Migrate market histories to IndexedDB) — currently *In Review*; moves to Done on merge.
- Parent epic: **STRK-139**.
- Follow-up hardening tracked in **STRK-149** (read-path edge cases; all self-healing via the API-reproducible design).

## Version

**3.35.3** (3.35.2 was already released on `dev` for STRK-144/145/142). All 6 release files bumped; `sw.js` cache stamped `staktrakr-v3.35.3`. Spot bundle current (1968→2026-06-04).

## Tests

- New suite `tests/playwright/core/history-store-migration.spec.js` — **10/10 passing** (migration, idempotency, IDB-unavailable fallback, cleanup-safety, first-render hydration, quota-safe put, retention cap, backup exclusion, old-backup restore, cloud-sync scope).
- **Core suite: 156/156** · **Extended: 10/10** — zero regressions.

## Review

- **Codacy CLI + CodeRabbit** (parallel): CLEAN, zero Critical/High. Optional hardening waived → STRK-149.
- **Independent peer review** (pr-review-toolkit): one Important finding — `loadSpotHistory` sync→async contract gap in 5 callers (4 in `api.js`) — **fixed in this PR** (await at write/dedup sites, drop vestigial reload at display sites), suites re-run green.

🤖 Generated via /spec workflow.