### PR TITLE
fix(STRK-58): poll goldback hourly + fix dashboard timestamp

### DIFF
--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -2255,7 +2255,7 @@ function renderApiHealthPage(v2, failureCount, vendorMetalAvgs) {
   let goldbackHtml = '<span style="color:var(--red);">Endpoint 404 — scraper needs deploy</span>';
   if (v2.goldback?.ok) {
     const gb = v2.goldback.data.data;
-    goldbackHtml = `<span style="color:var(--green);font-weight:600;">$${gb.g1_usd}</span> <span style="color:var(--muted);font-size:11px;">(${gb.date})</span>`;
+    goldbackHtml = `<span style="color:var(--green);font-weight:600;">$${gb.g1_usd}</span> <span style="color:var(--muted);font-size:11px;">(${gb.t ? gb.t.slice(0, 16).replace("T", " ") + " UTC" : "—"})</span>`;
   }
 
   return `<!DOCTYPE html>

--- a/devops/pollers/home-poller/docker-entrypoint.sh
+++ b/devops/pollers/home-poller/docker-entrypoint.sh
@@ -20,7 +20,7 @@ mkdir -p /data/retail /data/api /data/hourly /data/logs
 # Home poller cron schedule (STAK-478: home is sole retail+goldback scraper):
 #   Retail:  :30 (home only — Fly.io does NOT scrape retail)
 #   Spot:    :15,:45 (staggered from Fly.io spot at :00,:30)
-#   Goldback: 16:05 UTC daily (11:05 AM EST — goldback.com updates once/day)
+#   Goldback: :05 hourly (CurrencyLayer-backed rate shifts intraday — STRK-58)
 #   Provider export: every 5 min (same as Fly.io)
 #   Fly.io health check: every 5 min
 echo "[entrypoint] Writing cron schedule..."
@@ -28,7 +28,7 @@ cat > /etc/cron.d/home-poller << 'CRON'
 # StakTrakr home poller cron jobs
 30 * * * * root . /etc/environment; /app/run-home.sh >> /data/logs/retail-poller.log 2>&1
 15,45 * * * * root . /etc/environment; POLLER_ID=home-spot METAL_PRICE_API_KEY=$METAL_PRICE_API_KEY DATA_DIR=/data SQLD_URL=$SQLD_URL SQLD_AUTH_TOKEN=$SQLD_AUTH_TOKEN TURSO_DATABASE_URL=$TURSO_DATABASE_URL TURSO_AUTH_TOKEN=$TURSO_AUTH_TOKEN node /app/spot-extract.js >> /data/logs/spot-poller.log 2>&1
-5 16 * * * root . /etc/environment; cd /app && node goldback-scraper.js >> /data/logs/goldback-poller.log 2>&1
+5 * * * * root . /etc/environment; cd /app && node goldback-scraper.js >> /data/logs/goldback-poller.log 2>&1
 */5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /data/logs/provider-export.log 2>&1
 */5 * * * * root . /etc/environment; /app/check-flyio.sh >> /data/logs/flyio-check.log 2>&1
 0 3 * * * root . /etc/environment; node /app/turso-backup-sync.js >> /data/logs/turso-sync.log 2>&1

--- a/devops/pollers/shared/goldback-scraper.js
+++ b/devops/pollers/shared/goldback-scraper.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * StakTrakr Goldback Daily Rate Scraper
+ * StakTrakr Goldback Rate Scraper
  * =======================================
  * Fetches the G1 USD exchange rate from goldback.com's JSON API.
- * Runs once daily at 11:05 AM EST (16:05 UTC) — goldback.com updates once/day.
+ * Runs hourly at :05 — the rate is CurrencyLayer-backed and shifts intraday (STRK-58).
  *
  * Primary source:  GET https://www.goldback.com/gb-proxy.php
  *   → { success: true, quotes: { USDUSD: 8.89 } }
@@ -15,8 +15,8 @@
  *
  * Writes:
  *   sqld price_snapshots table        -- coin_slug="goldback-g1", vendor="goldback"
- *   DATA_DIR/api/goldback-spot.json   -- latest rate (local backup, overwritten each day)
- *   DATA_DIR/goldback-{YYYY}.json     -- rolling daily log (local backup, appended)
+ *   DATA_DIR/api/goldback-spot.json   -- latest rate (local backup, overwritten each run)
+ *   DATA_DIR/goldback-{YYYY}.json     -- rolling log, one entry per day (last run of the day wins)
  *
  * Usage:
  *   DATA_DIR=/path/to/data node goldback-scraper.js


### PR DESCRIPTION
## STRK-58 — Goldback scraper: increase poll frequency to match retail cadence

The goldback.com G1 rate is **CurrencyLayer-backed and shifts intraday** as gold spot moves — not a single daily publish. Polling once daily let the StakTrakr rate drift from goldback.com's live rate by up to ~$0.05 within hours (observed $9.47 vs $9.42 on 2026-05-08).

### Changes
- **`docker-entrypoint.sh`** — goldback cron `5 16 * * *` (16:05 UTC daily) → `5 * * * *` (hourly at `:05`). Kept off the `:15/:30/:45` spot/retail slots to avoid stacking Node processes. Comment block updated.
- **`goldback-scraper.js`** — header comment retitled and frequency note corrected (daily → hourly, with intraday rationale).
- **`dashboard.js`** (bonus fix) — the V2 API payload exposes the rate time as `gb.t` (ISO), not `gb.date`, so the poller dashboard rendered `(undefined)` next to the G1 rate. Now reads `gb.t` and formats it as `YYYY-MM-DD HH:MM UTC`.

### Verification
- Live V2 endpoint (`api.staktrakr.com/data/v2/goldback/latest.json`) confirmed to expose `t` + `ts`, no `date` field.
- `node --check` on both JS files + `bash -n` on the entrypoint — all pass.

### ⚠️ Post-merge action required
The cron is written at **container startup** (`cat > /etc/cron.d/home-poller`). Merging does **not** change the live cadence — the **home-poller stack must be redeployed/restarted** to pick up the new schedule. Run `/deploy-verify` (Portainer) after merge.

### Notes
- No version bump — devops/poller config, rolls into next release.
- GSD session (below `/spec` threshold; issue fully pre-scoped).