### PR TITLE
fix(STRK-149): localStorage fallback for deferred history keys (finding #1)

### DIFF
--- a/js/retail.js
+++ b/js/retail.js
@@ -549,10 +549,17 @@ const _saveV2RetailHistory = () => {
 const _loadV2RetailHistory = async () => {
   try {
     const store = typeof historyStore !== "undefined" ? historyStore : window?.historyStore;
-    const loaded =
-      store && store.isAvailable()
-        ? await store.get(_V2_RETAIL_HISTORY_KEY)
-        : loadDataSync(_V2_RETAIL_HISTORY_KEY);
+    let loaded;
+    if (store && store.isAvailable()) {
+      // IDB available: prefer it, but fall back to the localStorage copy when
+      // get() returns null for a DEFERRED key — migrate() keeps an unconfirmed
+      // or wrong-shape payload in localStorage WITHOUT writing it to IDB, so the
+      // LS copy is still the source of truth (R3.1, STRK-149 finding #1).
+      const idb = await store.get(_V2_RETAIL_HISTORY_KEY);
+      loaded = idb !== null ? idb : loadDataSync(_V2_RETAIL_HISTORY_KEY);
+    } else {
+      loaded = loadDataSync(_V2_RETAIL_HISTORY_KEY);
+    }
     // Preserve the existing type guard: retail history must be a non-array object.
     retailPriceHistory =
       loaded && !Array.isArray(loaded) && typeof loaded === "object" ? loaded : {};

--- a/js/retail.js
+++ b/js/retail.js
@@ -555,8 +555,10 @@ const _loadV2RetailHistory = async () => {
       // get() returns null for a DEFERRED key — migrate() keeps an unconfirmed
       // or wrong-shape payload in localStorage WITHOUT writing it to IDB, so the
       // LS copy is still the source of truth (R3.1, STRK-149 finding #1).
+      // `??` (not `!== null`) so the fallback also fires if get() ever returns
+      // undefined.
       const idb = await store.get(_V2_RETAIL_HISTORY_KEY);
-      loaded = idb !== null ? idb : loadDataSync(_V2_RETAIL_HISTORY_KEY);
+      loaded = idb ?? loadDataSync(_V2_RETAIL_HISTORY_KEY);
     } else {
       loaded = loadDataSync(_V2_RETAIL_HISTORY_KEY);
     }

--- a/js/spot.js
+++ b/js/spot.js
@@ -139,8 +139,11 @@ const loadSpotHistory = async () => {
       // get() returns null for a DEFERRED key — migrate() keeps an unconfirmed
       // or wrong-shape payload in localStorage WITHOUT writing it to IDB, so the
       // LS copy is still the source of truth (R3.1, STRK-149 finding #1).
-      const idb = await historyStore.get("metalSpotHistory");
-      data = idb !== null ? idb : loadDataSync(SPOT_HISTORY_KEY, []);
+      // `??` (not `!== null`) so the fallback also fires if get() ever returns
+      // undefined; use SPOT_HISTORY_KEY so the IDB read and the LS fallback
+      // resolve the same key.
+      const idb = await historyStore.get(SPOT_HISTORY_KEY);
+      data = idb ?? loadDataSync(SPOT_HISTORY_KEY, []);
     } else {
       data = loadDataSync(SPOT_HISTORY_KEY, []);
     }

--- a/js/spot.js
+++ b/js/spot.js
@@ -133,10 +133,17 @@ const saveSpotHistory = () => {
  */
 const loadSpotHistory = async () => {
   try {
-    const data =
-      typeof historyStore !== "undefined" && historyStore.isAvailable()
-        ? await historyStore.get("metalSpotHistory")
-        : loadDataSync(SPOT_HISTORY_KEY, []);
+    let data;
+    if (typeof historyStore !== "undefined" && historyStore.isAvailable()) {
+      // IDB available: prefer it, but fall back to the localStorage copy when
+      // get() returns null for a DEFERRED key — migrate() keeps an unconfirmed
+      // or wrong-shape payload in localStorage WITHOUT writing it to IDB, so the
+      // LS copy is still the source of truth (R3.1, STRK-149 finding #1).
+      const idb = await historyStore.get("metalSpotHistory");
+      data = idb !== null ? idb : loadDataSync(SPOT_HISTORY_KEY, []);
+    } else {
+      data = loadDataSync(SPOT_HISTORY_KEY, []);
+    }
     const snapshot = getPersistedSpotHistorySnapshot(Array.isArray(data) ? data : []);
     spotHistory = snapshot.entries;
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780642045";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780673350";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780673350";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780675639";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/core/history-store-migration.spec.js
+++ b/tests/playwright/core/history-store-migration.spec.js
@@ -466,6 +466,98 @@ test.describe("core/history-store-migration (STRK-141)", () => {
     expect(pageErrors).toEqual([]);
   });
 
+  // -- Deferred-key fallback (R3.1, STRK-149 finding #1) ---------------------
+  // The test above covers IDB *fully* unavailable. This covers the gap migrate()
+  // can leave behind: IndexedDB IS available, but get() returns null for a key
+  // that migrate() *deferred* (corrupt / wrong-shape / write-not-confirmed
+  // payload kept in localStorage, NOT written to IDB). R3.1: "...OR a migration
+  // write cannot be confirmed THEN continue reading from localStorage." The load
+  // path must fall back to the LS copy instead of hydrating empty.
+  test("deferred key (IDB available, get() null) hydrates spot+retail from the localStorage fallback", async ({
+    page,
+  }) => {
+    await suppressWhatsNew(page);
+    await gotoApp(page);
+    await waitForHistoryStore(page);
+    // Gate on the first-time boot's LBMA seed merge having COMPLETED before the
+    // in-evaluate drain. Without this, under full-suite load the drain can observe
+    // a premature "stable empty" store (boot has not written yet), break early,
+    // and a late seed write then lands AFTER our remove() — repopulating the key.
+    // (Same completion gate the R4 test below uses.)
+    await page
+      .waitForFunction(() => localStorage.getItem("migration_seedHistoryMerge") === "1", null, {
+        timeout: 8000,
+      })
+      .catch(() => {});
+    // Then drain + engineer the deferred state in ONE evaluate (no Playwright
+    // gap). Boot also fire-and-forgets saveSpotHistory() IDB writes from its live
+    // spot fetch; under workers:1 (shared browser/IDB) one can land AFTER our
+    // remove() and defeat the null-state the test needs. Poll until the spot
+    // record is STABLE across two reads (same technique as the R4 test) BEFORE
+    // removing it, so get() deterministically returns null for the deferred key.
+    const result = await page.evaluate(
+      async ({ spotKey, retailKey, spotData, retailData }) => {
+        const store = window.historyStore;
+        await store.init();
+
+        // Drain: wait until boot's fire-and-forget writes have flushed (the spot
+        // record stops changing between reads).
+        let prev = JSON.stringify(await store.get(spotKey));
+        for (let i = 0; i < 50; i++) {
+          await new Promise((r) => setTimeout(r, 40));
+          const cur = JSON.stringify(await store.get(spotKey));
+          if (cur === prev) break;
+          prev = cur;
+        }
+
+        // Engineer the deferred state: IDB available, NO record for either key,
+        // but a localStorage copy present — exactly what migrate() leaves when it
+        // defers an unconfirmed payload.
+        await store.remove(spotKey);
+        await store.remove(retailKey);
+        localStorage.setItem(spotKey, JSON.stringify(spotData));
+        localStorage.setItem(retailKey, JSON.stringify(retailData));
+
+        // Self-validation: confirm the precondition the fix hinges on — get()
+        // returns null while the LS copy exists. If a leak made get() non-null,
+        // this fails clearly instead of producing a confusing hydration mismatch.
+        const getSpotNull = (await store.get(spotKey)) === null;
+        const getRetailNull = (await store.get(retailKey)) === null;
+
+        await window.loadSpotHistory();
+        await window.loadRetailPriceHistory();
+
+        return {
+          available: store.isAvailable(),
+          getSpotNull,
+          getRetailNull,
+          spotMem: window.spotHistory,
+          retailMem: window.retailPriceHistory,
+        };
+      },
+      {
+        spotKey: SPOT_KEY,
+        retailKey: RETAIL_KEY,
+        spotData: SPOT_HISTORY,
+        retailData: RETAIL_HISTORY,
+      }
+    );
+
+    // Genuinely the IDB-AVAILABLE path with a null get() (deferred key), NOT the
+    // IDB-unavailable path the test above already covers.
+    expect(result.available).toBe(true);
+    expect(result.getSpotNull).toBe(true);
+    expect(result.getRetailNull).toBe(true);
+    // Spot: every seeded LS entry hydrated the in-memory global via the fallback
+    // (without the fix, get()===null makes spotHistory hydrate as []).
+    expect(Array.isArray(result.spotMem)).toBe(true);
+    for (const entry of SPOT_HISTORY) {
+      expect(result.spotMem).toContainEqual(entry);
+    }
+    // Retail: the LS copy hydrated the global (without the fix it would be {}).
+    expect(result.retailMem).toEqual(RETAIL_HISTORY);
+  });
+
   // -- Cleanup safety (R2/R3, design-review finding 1) ----------------------
   test("cleanupStorage keeps spot/retail history keys and migration flag when IDB is unavailable", async ({
     page,


### PR DESCRIPTION
## STRK-149 finding #1 — IDB-null → localStorage fallback

Closes the Medium hardening finding from the STRK-141 task-12 security review (parent epic STRK-139).

### Problem
`loadSpotHistory` (`js/spot.js`) and `_loadV2RetailHistory` (`js/retail.js`) used `historyStore.isAvailable() ? get() : loadDataSync()`. When IDB is **available** but `get()` returns `null` for a **deferred** key — a corrupt / wrong-shape / write-not-confirmed payload that `migrate()` intentionally keeps in localStorage and does *not* write to IDB — the load path silently hydrated empty (`[]` / `{}`) instead of reading the localStorage copy. This grazes **R3.1**: *"…OR a migration write cannot be confirmed THEN continue reading from localStorage."*

### Fix
Both load paths now fall back to `loadDataSync` when the IDB read returns `null`, preserving the existing IDB-unavailable and IDB-present behaviors. Three cases:

| Case | Behavior |
|---|---|
| IDB unavailable | `loadDataSync` (unchanged) |
| IDB available, `get()` non-null | use IDB (unchanged) |
| IDB available, `get()` null (deferred key) | **fall back to `loadDataSync`** (fix) |

### Test
Adds a regression test for the deferred-key-with-IDB-available path — the existing suite only covered IDB *fully* unavailable. The test engineers the deferred state (`remove()` + LS copy) and is made deterministic under `workers:1` (shared browser/IDB) via the boot seed-merge completion gate + an in-`evaluate` stable-read drain (same pattern as the R4 test).

### Verification
- Red → green: test fails without the fix, passes with it.
- **6 clean full core-suite runs** (180/180 each) — the new test is not flaky in-suite.
- `npm run lint` clean on changed files.

### Out of scope (left tracked in STRK-149)
Findings #2–#5 (legacy `retailPriceHistory` carry-over, `typeof` guard, ts-sort before slice, stale backup README copy) — Low/Nit/Cosmetic, all self-healing via the API-reproducible design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)