### PR TITLE
patch/3.35.7 — STRK-154: Cloud Sync Convergence & Auto-Healing

### DIFF
--- a/.context/cloud-sync-convergence.md
+++ b/.context/cloud-sync-convergence.md
@@ -1,0 +1,68 @@
+# Cloud-Sync Convergence Invariant (STRK-154)
+
+Authoritative design note for the StakTrakr cloud-sync compare/merge/hash surfaces.
+Read this before adding a `SYNC_SCOPE_KEYS` entry or touching any sync comparison.
+
+## The invariant
+
+> Every cloud-sync **compare**, **merge**, and **hash** operates on **normalized
+> logical content** — never raw serialization — and every **merge** is
+> **commutative / convergent on ties**.
+
+Two consequences follow, and both are mandatory:
+
+1. **Logical, not raw.** Decompress (`__decompressIfNeeded`) and canonicalize
+   (sorted object keys, order-preserved arrays, scalar-as-JSON normalized to its
+   logical value) before comparing or hashing. Identical logical content must
+   compare/hash equal regardless of: lz-string `CMP2:` compression vs plain
+   (raw length `> 4096` compresses on one device, not the other — STRK-140),
+   scalar stored as JSON (`"dark"`) vs raw (`dark`), object key insertion order,
+   or date-time serialization variant.
+2. **Commutative merge.** `merge(A, B)` must equal `merge(B, A)`, **including on a
+   timestamp tie**. A last-write-wins no-op on a tie is non-commutative and freezes
+   two diverged devices in a permanent "Review Sync Changes" loop. Resolve ties by
+   a deterministic union (or another commutative rule), and only bump the
+   modification timestamp when content actually changes (so the merge stays
+   idempotent once both sides agree).
+
+The fixes are **self-healing**: existing diverged installs reconcile on the next
+sync with no user action. The one exception is data that cannot round-trip
+(`[object Object]` corruption), which a one-time idempotent boot-repair clears.
+
+## Surface matrix
+
+| Surface                       | Location                                                               | Compares / merges on                                                                                 | Guarantee                | Issue          |
+| ----------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------ | -------------- |
+| Per-item tag merge            | `cloud-sync.js` `_mergeTagData` / `_unionTags`                         | parsed+decompressed tag stores; sorted, case-insensitive union on tie                                | commutative + convergent | STRK-155       |
+| Tag-change gate               | `cloud-sync.js` `_hasTagChanges`                                       | canonicalized logical content                                                                        | logical equality         | STRK-159       |
+| Settings hash                 | `cloud-sync.js` `computeSettingsHash` / `_canonicalizeSettingValue`    | decompressed, JSON-parsed, sorted-key canonical form (push and poll)                                 | logical equality         | STRK-156       |
+| Settings apply                | `cloud-sync.js` `_applyAndFinalize` / `_safeSettingWriteValue`         | rejects `[object Object]` before persisting                                                          | integrity guard          | STRK-157       |
+| Boot repair                   | `cloud-sync.js` `syncBootRepairCorruptSettings`                        | removes un-round-trippable corruption                                                                | idempotent self-heal     | STRK-157       |
+| `.stvault` snapshot / restore | `cloud-sync.js` `syncSaveOverrideBackup` / `syncRestoreOverrideBackup` | raw strings for backup, but skips corruption; restore drift is invisible because the hash is logical | byte-stable round-trip   | STRK-157 / 159 |
+| Inventory hash                | `cloud-sync.js` `computeInventoryHash`                                 | item key + content fingerprint; `disposition` canonicalized                                          | logical equality         | STRK-159       |
+| Inventory item diff           | `diff-engine.js` `compareItems` / `_valuesEqual`                       | logical; instant-aware for `lastModified` (`INSTANT_FIELDS`)                                         | logical equality         | STRK-158       |
+| Attachments diff              | `diff-engine.js` `_diffAttachments`                                    | UUID / fileName keyed (order-independent); pill count reconciled with rendered rows                  | order-independent        | STRK-158       |
+| Settings diff (modal)         | `diff-engine.js` `compareSettings` / `_settingsValuesEqual`            | type-coerced + sorted-key stringify                                                                  | logical equality         | pre-existing   |
+
+## Adding a new `SYNC_SCOPE_KEYS` entry
+
+1. **Scalar string preference** (theme, currency): no special handling — store the
+   raw string; `_canonicalizeSettingValue` parses-or-keeps it.
+2. **Object / array config**: always write with `JSON.stringify`; never let an
+   object reach `localStorage.setItem` un-stringified (that is the `[object Object]`
+   corruption). Object key order does not matter (the hash canonicalizes), but
+   **array element order is meaningful** and is preserved (e.g. `headerBtnOrder`).
+3. **Per-item map merged across devices** (like tags): give it a commutative merge
+   and reconcile ties by union, mirroring `_mergeTagData`. Do not add a raw
+   last-write-wins compare.
+4. **Date-time field** compared in the item diff: add it to `INSTANT_FIELDS` in
+   `diff-engine.js` so serialization variants are not phantom conflicts.
+
+## Tests
+
+Each merged/hashed store has a unit test under `tests/unit/`:
+`cloud-sync-tag-merge.test.js` (commutativity), `cloud-sync-settings-hash.test.js`
+(logical equality, compressed-vs-plain), `cloud-sync-boot-repair.test.js`
+(corruption guard + idempotent repair), `diff-engine-normalization.test.js`
+(instant-aware + attachments), and `cloud-sync-convergence-audit.test.js`
+(inventory-hash canonicalization + logical tag-change gate).

--- a/.context/cloud-sync-convergence.md
+++ b/.context/cloud-sync-convergence.md
@@ -26,8 +26,20 @@ Two consequences follow, and both are mandatory:
    idempotent once both sides agree).
 
 The fixes are **self-healing**: existing diverged installs reconcile on the next
-sync with no user action. The one exception is data that cannot round-trip
-(`[object Object]` corruption), which a one-time idempotent boot-repair clears.
+sync with no user action — including tags that diverged with **no
+`itemTagsLastModified` entry** (legacy installs, or Numista batch writes via
+`applyNumistaTags(persist=false)`), which the tie-union converges by content
+presence, not just by an equal timestamp. The one exception is data that cannot
+round-trip (`[object Object]` corruption), which a one-time idempotent boot-repair
+clears.
+
+**Corruption sentinel is exact-match.** `_isCorruptObjectString` matches the
+**entire** value being the `String(obj)` coercion artifact (`[object Object]` or
+comma-joined repeats), never a substring. A free-text scope key (`itemTags`,
+`tagBlacklist`, `chipCustomGroups`, …) may legitimately hold a user-entered tag or
+label named `[object Object]` embedded in valid JSON; that must be preserved and
+synced. Detecting the artifact as a substring would let boot-repair delete the
+whole store, wiping every tag/group (STRK-157 review finding).
 
 ## Surface matrix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.35.7] - 2026-06-05
+
+### Changed — STRK-154: Cloud Sync Convergence & Auto-Healing
+
+- **Cloud sync**: Fixed a permanent "Review Sync Changes" loop between two devices — per-item tag merges now converge deterministically (commutative union on a timestamp tie) and auto-heal diverged tags on the next sync with no user action (STRK-155).
+- **Cloud sync**: Settings compare by logical content instead of raw storage, so a value compressed on one device and plain on another (or stored in a different key order) no longer triggers an endless sync (STRK-156).
+- **Cloud sync**: Added apply/restore integrity guards and a one-time boot-repair that clears unrecoverable `[object Object]` corruption without touching valid data (STRK-157).
+- **Cloud sync**: The Review Sync Changes modal no longer shows phantom conflicts — timestamps differing only in format and reordered attachments are recognized as unchanged (STRK-158).
+- **Cloud sync**: Audited and hardened every sync compare/merge/hash surface for convergence and documented the invariant (STRK-159).
+
+---
+
 ## [3.35.6] - 2026-06-05
 
 ### Changed — STRK-32: Isolate price extractor Vendor modules

--- a/js/about.js
+++ b/js/about.js
@@ -139,6 +139,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.35.7 &ndash; Cloud sync convergence</strong>: Fixed the permanent &ldquo;Review Sync Changes&rdquo; loop between devices &mdash; tag merges now converge and auto-heal, settings compare by logical content instead of raw storage, and phantom timestamp/attachment conflicts in the review modal are gone (STRK-154).</li>
     <li><strong>v3.35.6 &ndash; Vendor module isolation</strong>: Retail price extraction now routes migrated Vendors through isolated modules, keeps dashboard single-Vendor retry import-safe, and packages the new modules for poller deploys (STRK-32).</li>
     <li><strong>v3.35.5 &ndash; Goldback import &amp; Type-drives-Metal</strong>: Selecting a Goldback/Silverback Numista result now auto-fills Type, Metal, and weight (including fractional denominations), and choosing a Goldback type in the form sets its metal automatically (STRK-138).</li>
     <li><strong>v3.35.3 &ndash; Market history storage</strong>: Spot &amp; retail price history moved to IndexedDB, permanently clearing the storage-quota ceiling; existing history migrates automatically with no loss, and item price history is now capped so it can&rsquo;t refill the quota (STRK-141).</li>
@@ -146,8 +147,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.35.2 &ndash; Metal-neutral purity labels</strong>: Fineness options no longer name a metal, so selecting .900 on a gold item no longer reads &ldquo;90&percnt; Silver&rdquo; (STRK-145).</li>
     <li><strong>v3.35.1 &ndash; Storage quota fix</strong>: Market price history is now compressed (lz-string), clearing the &ldquo;storage quota exceeded&rdquo; error and freeing roughly 80&percnt; of its storage footprint &mdash; existing data is upgraded automatically with no loss (STRK-140).</li>
     <li><strong>v3.35.0 &ndash; Trade linking</strong>: Bidirectional trade links between disposed traded items and received inventory, with editable provenance, spot-derived trade values, backup/export coverage, and cloud-sync visibility (STRK-123).</li>
-    <li><strong>v3.35.0 &ndash; Cloud sync hardening</strong>: Tag merge on sync, conflict-loop fix after accepting remote changes, Bullion Exchanges content-quality retry (STRK-106, STRK-107, STRK-108).</li>
-    <li><strong>v3.35.0 &ndash; Retail &amp; autocomplete fixes</strong>: SDB/BE spot-ticker sidebar leak patched, autocomplete field name casing corrected (STRK-99, STRK-114).</li>
   `;
 };
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -133,7 +133,9 @@ async function computeInventoryHash(items) {
         "|" +
         (item.tradedFromUuid || "") +
         "|" +
-        (item.disposition ? JSON.stringify(item.disposition) : "");
+        // STRK-159: canonicalize disposition (sorted keys) so a different key
+        // insertion order of the same object is not a false inventory mismatch.
+        (item.disposition ? _stableCanonicalString(item.disposition) : "");
       keys.push(itemKey + "::" + contentSample);
     }
     keys.sort();
@@ -2820,11 +2822,6 @@ function _isTagSyncKey(key) {
   return _tagSyncKeys().indexOf(key) !== -1;
 }
 
-function _normalizeRawStorageValue(value) {
-  if (value === undefined || value === null) return null;
-  return typeof value === "string" ? value : JSON.stringify(value);
-}
-
 function _parseTagStore(rawValue, fallback) {
   if (rawValue === undefined || rawValue === null) return fallback || {};
   try {
@@ -2852,9 +2849,14 @@ function _hasTagChanges(remoteSettings) {
   if (!remoteSettings) return false;
   var keys = _tagSyncKeys();
   for (var i = 0; i < keys.length; i++) {
-    var localVal = typeof localStorage !== "undefined" ? localStorage.getItem(keys[i]) : null;
-    var remoteVal = _normalizeRawStorageValue(remoteSettings[keys[i]]);
-    if (localVal !== remoteVal) return true;
+    // STRK-159: compare LOGICAL content, not raw serialization. _parseTagStore
+    // decompresses + JSON-parses each tag store and _stableCanonicalString sorts
+    // its keys, so a compressed-vs-plain (or key-order) variant of identical tags
+    // is no longer a false "changed" signal that triggers a needless merge.
+    var localRaw = typeof localStorage !== "undefined" ? localStorage.getItem(keys[i]) : null;
+    var localCanon = _stableCanonicalString(_parseTagStore(localRaw, {}));
+    var remoteCanon = _stableCanonicalString(_parseTagStore(remoteSettings[keys[i]], {}));
+    if (localCanon !== remoteCanon) return true;
   }
   return false;
 }

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -2744,6 +2744,37 @@ function _restoreRawStorageValues(priorValues) {
   return { failed: failed, total: keys.length };
 }
 
+/**
+ * STRK-155: Deterministic, commutative union of two tag arrays.
+ * Dedups case-insensitively (matching addItemTag's case-insensitive dedup in
+ * tags.js), picks the lexicographically-smallest original string as the
+ * representative so merge(A,B) and merge(B,A) yield byte-identical output, and
+ * returns the result sorted by lowercased key. Trims and drops blank/non-string
+ * entries. Commutativity is the whole point: it is what lets two diverged
+ * devices converge to the same superset on a timestamp tie.
+ * @param {string[]} a
+ * @param {string[]} b
+ * @returns {string[]}
+ */
+function _unionTags(a, b) {
+  var byLower = {};
+  var all = (Array.isArray(a) ? a : []).concat(Array.isArray(b) ? b : []);
+  for (var i = 0; i < all.length; i++) {
+    if (typeof all[i] !== "string") continue;
+    var trimmed = all[i].trim();
+    if (!trimmed) continue;
+    var key = trimmed.toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(byLower, key) || trimmed < byLower[key]) {
+      byLower[key] = trimmed;
+    }
+  }
+  return Object.keys(byLower)
+    .sort()
+    .map(function (k) {
+      return byLower[k];
+    });
+}
+
 function _mergeTagData(remoteTagData) {
   var keys = _tagSyncKeys();
   remoteTagData = remoteTagData || {};
@@ -2807,6 +2838,35 @@ function _mergeTagData(remoteTagData) {
       }
       mergedTimestamps[uuid] = remoteTs;
       updated++;
+    } else if (
+      remoteTs === localTs &&
+      Object.prototype.hasOwnProperty.call(remoteTimestamps, uuid) &&
+      Object.prototype.hasOwnProperty.call(localTimestamps, uuid)
+    ) {
+      // STRK-155: timestamp tie with potentially divergent content. A plain
+      // last-write-wins no-op here is non-commutative and freezes two diverged
+      // devices in a permanent "Review Sync Changes" loop. Take the deterministic
+      // union of both sides instead — union is commutative, so both devices
+      // converge to the same superset within one round-trip. Only the side(s)
+      // whose content actually changes bump the timestamp, so once both agree the
+      // merge is idempotent. Known trade-off (confirmed): a tag removed on one
+      // device without bumping its timestamp can reappear (data-loss-averse).
+      var unionedTags = _unionTags(localTags[uuid], remoteTags[uuid]);
+      var unionedRemoved = _unionTags(localRemoved[uuid], remoteRemoved[uuid]);
+      var canonicalLocalTags = _unionTags(localTags[uuid], []);
+      var canonicalLocalRemoved = _unionTags(localRemoved[uuid], []);
+      var tagsChanged = unionedTags.join(" ") !== canonicalLocalTags.join(" ");
+      var removedChanged = unionedRemoved.join(" ") !== canonicalLocalRemoved.join(" ");
+
+      if (unionedTags.length > 0) mergedTags[uuid] = unionedTags;
+      else delete mergedTags[uuid];
+      if (unionedRemoved.length > 0) mergedRemoved[uuid] = unionedRemoved;
+      else delete mergedRemoved[uuid];
+
+      if (tagsChanged || removedChanged) {
+        mergedTimestamps[uuid] = Date.now();
+        updated++;
+      }
     }
   });
 

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -421,6 +421,68 @@ function syncIsEnabled() {
 }
 
 // ---------------------------------------------------------------------------
+// Settings serialization integrity + boot-repair (STRK-157)
+// ---------------------------------------------------------------------------
+
+/**
+ * STRK-157: Corruption sentinel. An object/array written to localStorage via
+ * String()/coercion instead of JSON.stringify becomes the literal "[object Object]"
+ * (or "[object Object],[object Object]" for arrays). No legitimate settings value
+ * contains this substring, so it is a safe marker for un-round-trippable corruption.
+ * @param {*} value
+ * @returns {boolean}
+ */
+function _isCorruptObjectString(value) {
+  return typeof value === "string" && value.indexOf("[object Object]") !== -1;
+}
+
+/**
+ * STRK-157: Compute the string to persist for a synced setting, rejecting values
+ * that cannot round-trip. Returns the clean string to write, or null when the
+ * value is "[object Object]"-corrupt and must be skipped — so a corrupt remote can
+ * never overwrite a good local value or re-stick itself on every pull.
+ * @param {*} remoteVal
+ * @returns {string|null}
+ */
+function _safeSettingWriteValue(remoteVal) {
+  var str = typeof remoteVal === "string" ? remoteVal : JSON.stringify(remoteVal);
+  if (_isCorruptObjectString(str)) return null;
+  return str;
+}
+
+/**
+ * STRK-157: One-time, idempotent boot repair. Scans SYNC_SCOPE_KEYS for values
+ * corrupted into "[object Object]" form (an object written without JSON.stringify).
+ * The load paths parse-fail and fall back to defaults in memory, but the corrupt
+ * string never leaves localStorage, so it perpetually diverges the settings hash —
+ * the one value class that cannot self-heal via convergent compare. Removes each
+ * corrupt key so its load path uses defaults. Idempotent: a second run finds nothing.
+ * @returns {string[]} keys that were repaired
+ */
+function syncBootRepairCorruptSettings() {
+  var repaired = [];
+  try {
+    if (typeof localStorage === "undefined") return repaired;
+    var keys = typeof SYNC_SCOPE_KEYS !== "undefined" ? SYNC_SCOPE_KEYS : [];
+    for (var i = 0; i < keys.length; i++) {
+      var raw = localStorage.getItem(keys[i]);
+      if (raw === null) continue;
+      var decoded = typeof __decompressIfNeeded === "function" ? __decompressIfNeeded(raw) : raw;
+      if (_isCorruptObjectString(decoded)) {
+        localStorage.removeItem(keys[i]);
+        repaired.push(keys[i]);
+      }
+    }
+    if (repaired.length > 0) {
+      debugLog("[CloudSync] STRK-157 boot-repair removed corrupt keys:", repaired.join(", "));
+    }
+  } catch (e) {
+    debugLog("[CloudSync] syncBootRepairCorruptSettings failed:", e.message);
+  }
+  return repaired;
+}
+
+// ---------------------------------------------------------------------------
 // Override backup — snapshot local data before a remote pull overwrites it
 // ---------------------------------------------------------------------------
 
@@ -434,7 +496,13 @@ function syncSaveOverrideBackup() {
     var data = {};
     for (var i = 0; i < keys.length; i++) {
       var raw = localStorage.getItem(keys[i]);
-      if (raw !== null) data[keys[i]] = raw;
+      if (raw === null) continue;
+      // STRK-157: never snapshot a corrupt "[object Object]" value — restore would
+      // reintroduce it. Skip it so restore falls back to the load-path default.
+      var decodedSnap =
+        typeof __decompressIfNeeded === "function" ? __decompressIfNeeded(raw) : raw;
+      if (_isCorruptObjectString(decodedSnap)) continue;
+      data[keys[i]] = raw;
     }
     var backup = {
       timestamp: Date.now(),
@@ -497,7 +565,14 @@ async function syncRestoreOverrideBackup() {
         typeof ALLOWED_STORAGE_KEYS !== "undefined" &&
         ALLOWED_STORAGE_KEYS.indexOf(bkeys[j]) !== -1
       ) {
-        localStorage.setItem(bkeys[j], backup.data[bkeys[j]]);
+        // STRK-157: don't reintroduce "[object Object]" corruption on restore.
+        var restoreVal = backup.data[bkeys[j]];
+        var restoreDecoded =
+          typeof __decompressIfNeeded === "function"
+            ? __decompressIfNeeded(restoreVal)
+            : restoreVal;
+        if (_isCorruptObjectString(restoreDecoded)) continue;
+        localStorage.setItem(bkeys[j], restoreVal);
       }
     }
     if (typeof loadItemTags === "function") loadItemTags();
@@ -3076,12 +3151,17 @@ function _applyAndFinalize(newInventory, selectedChanges, settingsChanges, remot
         sc.remoteVal !== undefined &&
         typeof localStorage !== "undefined"
       ) {
+        // STRK-157: reject "[object Object]" corruption — never persist a value
+        // that cannot round-trip and would re-stick on every pull. Skip it and
+        // leave the good local value intact (not counted as a write failure).
+        var writeVal = _safeSettingWriteValue(sc.remoteVal);
+        if (writeVal === null) {
+          debugLog("[CloudSync] STRK-157: skipped corrupt settings value for key:", sc.key);
+          continue;
+        }
         _priorValues[sc.key] = localStorage.getItem(sc.key);
         try {
-          localStorage.setItem(
-            sc.key,
-            typeof sc.remoteVal === "string" ? sc.remoteVal : JSON.stringify(sc.remoteVal)
-          );
+          localStorage.setItem(sc.key, writeVal);
           _appliedKeys.push(sc.key);
         } catch (_e) {
           _failedCount++;
@@ -4581,6 +4661,12 @@ function initCloudSync() {
     console.warn("[CloudSync] Skipping init — app initialization failed");
     return;
   }
+  // STRK-157: repair any "[object Object]"-corrupt scope keys before sync compares
+  // hashes — this corruption can't self-heal via convergent compare, so clear it
+  // once at boot (idempotent). Runs even when sync is disabled so a later enable
+  // starts clean.
+  syncBootRepairCorruptSettings();
+
   // Initialize multi-tab coordination (Layer 7)
   initSyncTabCoordination();
 
@@ -4746,6 +4832,7 @@ window.getSyncPasswordSilent = getSyncPasswordSilent;
 window.syncIsEnabled = syncIsEnabled;
 window.syncSaveOverrideBackup = syncSaveOverrideBackup;
 window.syncRestoreOverrideBackup = syncRestoreOverrideBackup;
+window.syncBootRepairCorruptSettings = syncBootRepairCorruptSettings;
 window.changeVaultPassword = changeVaultPassword;
 window.syncGetLastPush = syncGetLastPush;
 window._syncRelativeTime = _syncRelativeTime;

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -179,7 +179,67 @@ function computeTotalWeight(items) {
 }
 
 /**
+ * STRK-156: Recursively stable-stringify a logical value. Sorts plain-object
+ * keys at every depth so key-insertion-order variants collapse to one form;
+ * PRESERVES array element order (array order is meaningful for settings like
+ * headerBtnOrder, so a genuine reorder must remain a real difference); and
+ * normalizes undefined/empty-string to null. The output is a canonical string
+ * suitable for hashing, not a re-parseable JSON document.
+ * @param {*} val
+ * @returns {string}
+ */
+function _stableCanonicalString(val) {
+  if (val === null || val === undefined || val === "") return "null";
+  if (typeof val !== "object") return JSON.stringify(val);
+  if (Array.isArray(val)) {
+    return "[" + val.map(_stableCanonicalString).join(",") + "]";
+  }
+  var keys = Object.keys(val).sort();
+  return (
+    "{" +
+    keys
+      .map(function (k) {
+        return JSON.stringify(k) + ":" + _stableCanonicalString(val[k]);
+      })
+      .join(",") +
+    "}"
+  );
+}
+
+/**
+ * STRK-156: Normalize a raw localStorage settings string into canonical logical
+ * content for hashing. Decompresses CMP2/CMP1 bodies (so a value compressed on
+ * one device hashes the same as its plain twin on another — the STAK-497 hazard
+ * resurfaced through lz-string, STRK-140), then JSON-parses — falling back to the
+ * raw string for scalar prefs stored without quotes (e.g. appTheme "dark") so
+ * they match a JSON-quoted twin — then canonicalizes via _stableCanonicalString.
+ * @param {string} rawValue
+ * @returns {string} canonical string of the logical value
+ */
+function _canonicalizeSettingValue(rawValue) {
+  if (rawValue === null || rawValue === undefined) return "null";
+  var decoded =
+    typeof __decompressIfNeeded === "function" ? __decompressIfNeeded(rawValue) : rawValue;
+  if (typeof decoded !== "string") decoded = String(decoded);
+  var parsed;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch (_e) {
+    parsed = decoded;
+  }
+  return _stableCanonicalString(parsed);
+}
+
+/**
  * Compute SHA-256 hash of sync-scoped settings (non-inventory localStorage keys).
+ * Hashes NORMALIZED logical content (decompressed, JSON-parsed, key-sorted) via
+ * _canonicalizeSettingValue rather than the raw localStorage strings, so two
+ * devices holding identical logical settings — one CMP2-compressed, one plain;
+ * scalar-as-JSON vs raw; differing object key-order — compute the SAME hash and
+ * stop looping (STRK-156). Both the push (manifest) and poll sides call this one
+ * function, so they stay consistent by construction.
+ * Rollout note: an old-build device (raw hash) and a new-build device (logical
+ * hash) mismatch once; both converge after both update.
  * Returns hex string or null if hashing is unavailable.
  * @returns {Promise<string|null>}
  */
@@ -190,16 +250,20 @@ async function computeSettingsHash() {
     var settings = {};
     for (var i = 0; i < keys.length; i++) {
       if (keys[i] === "metalInventory") continue; // skip inventory — covered by inventoryHash
-      // STAK-497: Use raw localStorage.getItem to match the manifest snapshot
-      // format. loadDataSync JSON-parses the value, which fails for scalar
-      // settings stored as raw strings (e.g. "dark" instead of '"dark"'),
-      // producing a different hash from the manifest and triggering infinite
-      // sync loops.
       var val = localStorage.getItem(keys[i]);
-      if (val !== null) settings[keys[i]] = val;
+      if (val !== null) settings[keys[i]] = _canonicalizeSettingValue(val);
     }
-    var sorted = JSON.stringify(settings, Object.keys(settings).sort());
-    var encoded = new TextEncoder().encode(sorted);
+    var sortedKeys = Object.keys(settings).sort();
+    var canonical =
+      "{" +
+      sortedKeys
+        .map(function (k) {
+          // settings[k] is already a canonical string from _canonicalizeSettingValue
+          return JSON.stringify(k) + ":" + settings[k];
+        })
+        .join(",") +
+      "}";
+    var encoded = new TextEncoder().encode(canonical);
     var hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
     return sha256BufferToHex(hashBuffer);
   } catch (e) {

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -435,7 +435,15 @@ function syncIsEnabled() {
  * @returns {boolean}
  */
 function _isCorruptObjectString(value) {
-  return typeof value === "string" && value.indexOf("[object Object]") !== -1;
+  if (typeof value !== "string") return false;
+  // Genuine corruption is the ENTIRE value being the String(obj)/String(arr)
+  // coercion artifact — "[object Object]" for an object, or comma-joined repeats
+  // for an array of objects. Match the whole value EXACTLY, never as a substring:
+  // free-text scope keys (itemTags, tagBlacklist, chipCustomGroups, ...) can
+  // legitimately hold a user-entered tag/label named "[object Object]" embedded in
+  // valid JSON, and a substring match would let boot-repair wipe the entire store
+  // (STRK-157 review finding). A coercion artifact never appears inside valid JSON.
+  return /^\[object Object\](\s*,\s*\[object Object\])*$/.test(value.trim());
 }
 
 /**
@@ -2981,8 +2989,20 @@ function _mergeTagData(remoteTagData) {
       updated++;
     } else if (
       remoteTs === localTs &&
-      Object.prototype.hasOwnProperty.call(remoteTimestamps, uuid) &&
-      Object.prototype.hasOwnProperty.call(localTimestamps, uuid)
+      // Fire the tie-union when both sides agree on the timestamp AND either both
+      // have a timestamp entry, OR the tag/removed CONTENT is present on both sides.
+      // The content-presence arm converges legacy / Numista-batch tags that have no
+      // itemTagsLastModified entry (both coerce to ts=0) — without it those diverged
+      // untimestamped tags never reach the union and re-trigger a silent tag-only
+      // merge every poll (STRK-155 review finding). One-sided uuids are excluded by
+      // requiring presence on BOTH sides, so a remote-only untimestamped tag is not
+      // spuriously adopted here.
+      ((Object.prototype.hasOwnProperty.call(remoteTimestamps, uuid) &&
+        Object.prototype.hasOwnProperty.call(localTimestamps, uuid)) ||
+        (Object.prototype.hasOwnProperty.call(localTags, uuid) &&
+          Object.prototype.hasOwnProperty.call(remoteTags, uuid)) ||
+        (Object.prototype.hasOwnProperty.call(localRemoved, uuid) &&
+          Object.prototype.hasOwnProperty.call(remoteRemoved, uuid)))
     ) {
       // STRK-155: timestamp tie with potentially divergent content. A plain
       // last-write-wins no-op here is non-commutative and freezes two diverged

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.35.6";
+const APP_VERSION = "3.35.7";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-engine.js
+++ b/js/diff-engine.js
@@ -94,21 +94,61 @@ const DIFF_FIELDS = [
 // ---------------------------------------------------------------------------
 
 /**
+ * STRK-158: Fields whose values are date-time INSTANTS and must compare by epoch,
+ * not by raw string. lastModified is stored in two ISO serializations of the same
+ * instant (compact "20260603T061930904Z" vs extended "2026-06-03T06:19:30.904Z"),
+ * so a raw === reports a phantom conflict the user can never clear.
+ */
+const INSTANT_FIELDS = new Set(["lastModified"]);
+
+/**
+ * STRK-158: Parse an ISO instant to epoch milliseconds, accepting both the compact
+ * form (YYYYMMDDTHHmmssSSSZ, with optional millis) actually stored by some writers
+ * and the extended form Date.parse handles natively. Returns null when the value
+ * is not a parseable instant (so callers fall back to raw comparison).
+ * @param {*} val
+ * @returns {number|null}
+ */
+function _parseInstant(val) {
+  if (typeof val === "number") return Number.isFinite(val) ? val : null;
+  if (typeof val !== "string") return null;
+  let s = val.trim();
+  const compact = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(\d{3})?Z?$/.exec(s);
+  if (compact) {
+    s =
+      `${compact[1]}-${compact[2]}-${compact[3]}T${compact[4]}:${compact[5]}:${compact[6]}` +
+      (compact[7] ? `.${compact[7]}` : "") +
+      "Z";
+  }
+  const t = Date.parse(s);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
  * Returns true when two values are considered equal for diff purposes.
  * Uses strict equality after normalising undefined, null, and empty strings
  * to null so that a missing field, an explicit null, and an empty string
- * are all treated identically.
+ * are all treated identically. For INSTANT_FIELDS (e.g. lastModified) it compares
+ * by epoch ms so two serializations of the same instant are equal (STRK-158).
  *
  * @param {*} a
  * @param {*} b
+ * @param {string} [field] - the field name being compared (enables instant-aware compare)
  * @returns {boolean}
  */
-function _valuesEqual(a, b) {
+function _valuesEqual(a, b, field) {
   const norm = (v) => (v === undefined || v === "" ? null : v);
   a = norm(a);
   b = norm(b);
   if (a === b) return true;
   if (a === null || b === null) return false;
+  // STRK-158: instant-aware compare for date-time fields. Same instant, different
+  // ISO serialization (compact vs extended) must not be a phantom conflict.
+  if (field && INSTANT_FIELDS.has(field) && typeof a !== "object" && typeof b !== "object") {
+    const ta = _parseInstant(a);
+    const tb = _parseInstant(b);
+    if (ta !== null && tb !== null) return ta === tb;
+  }
   // Deep compare for objects (e.g. disposition) — recursive stable stringify
   if (typeof a === "object" && typeof b === "object") {
     return _stableStringify(a) === _stableStringify(b);
@@ -468,7 +508,24 @@ const DiffEngine = {
       const changes = [];
 
       for (const field of DIFF_FIELDS) {
-        if (!_valuesEqual(local[field], remote[field])) {
+        if (field === "attachments") {
+          // STRK-158: reconcile the count pill with the rendered per-entry rows.
+          // _valuesEqual on the raw arrays is order-sensitive (_stableStringify),
+          // so a pure reorder of the same UUIDs falsely counted as "1 field changed"
+          // while _diffAttachments (UUID/fileName-keyed, order-independent) rendered
+          // zero rows. Use _diffAttachments as the source of truth: no per-entry
+          // diff -> not a changed field.
+          const attDiff = _diffAttachments(local.attachments, remote.attachments);
+          if (attDiff.length > 0) {
+            changes.push({
+              field,
+              localVal: local.attachments !== undefined ? local.attachments : null,
+              remoteVal: remote.attachments !== undefined ? remote.attachments : null,
+            });
+          }
+          continue;
+        }
+        if (!_valuesEqual(local[field], remote[field], field)) {
           changes.push({
             field,
             localVal: local[field] !== undefined ? local[field] : null,
@@ -557,8 +614,9 @@ const DiffEngine = {
       const lookupKey = `${localChange.itemKey}|${localChange.field}`;
       if (remoteIndex.has(lookupKey)) {
         const remoteChange = remoteIndex.get(lookupKey);
-        // Only a conflict if the resolved values differ
-        if (!_valuesEqual(localChange.remoteVal, remoteChange.remoteVal)) {
+        // Only a conflict if the resolved values differ (STRK-158: instant-aware
+        // for lastModified so an ISO-serialization variant isn't a phantom conflict)
+        if (!_valuesEqual(localChange.remoteVal, remoteChange.remoteVal, localChange.field)) {
           conflicts.push({
             itemKey: localChange.itemKey,
             field: localChange.field,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.35.6",
+  "version": "3.35.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.35.6",
+      "version": "3.35.7",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.35.6",
+  "version": "3.35.7",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780690362";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780690691";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780690691";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780691004";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780691665";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780693112";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780693112";
+const CACHE_NAME = "staktrakr-v3.35.7-b1780693300";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780691262";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780691665";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780691004";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780691262";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.6-b1780675639";
+const CACHE_NAME = "staktrakr-v3.35.6-b1780690362";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/cloud-sync-boot-repair.test.js
+++ b/tests/unit/cloud-sync-boot-repair.test.js
@@ -1,0 +1,125 @@
+// Unit tests for settings apply/restore integrity + boot-repair (STRK-157, parent STRK-154).
+//
+// Object-valued SYNC_SCOPE_KEYS were observed stored as the literal string
+// "[object Object],[object Object]" — an array/object written without JSON.stringify.
+// The sync apply path (_applyAndFinalize) wrote `typeof remoteVal === 'string'
+// ? remoteVal : JSON.stringify(remoteVal)`, so a pre-coerced "[object Object]" string
+// was written verbatim and re-applied every pull (sticky). Load paths JSON.parse +
+// fall back to defaults, so the UI survives but the value never round-trips ->
+// permanent settings-hash divergence.
+//
+// Fix (this file's unit surface):
+//   _isCorruptObjectString  — corruption sentinel ("[object Object]" substring)
+//   _safeSettingWriteValue  — compute the write string, or null to skip corruption
+//   syncBootRepairCorruptSettings — one-time, idempotent removal of corrupt keys
+//
+// Loaded via slice-and-eval (mirrors storage-compression.test.js) with mock storage.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("../../js/cloud-sync.js", import.meta.url), "utf-8");
+const start = src.indexOf("function _isCorruptObjectString");
+const end = src.indexOf("function syncSaveOverrideBackup");
+assert.ok(
+  start !== -1 && end !== -1 && end > start,
+  "could not locate boot-repair helper block in cloud-sync.js"
+);
+const block = src.slice(start, end);
+
+function makeSandbox(seed, decompressFn) {
+  const map = new Map(Object.entries(seed || {}));
+  const localStorageMock = {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+  };
+  const SYNC_SCOPE_KEYS = [
+    "metalInventory",
+    "appTheme",
+    "viewModalSectionConfig",
+    "chipCustomGroups",
+    "numistaViewFields",
+  ];
+  const __decompressIfNeeded = decompressFn || ((s) => s);
+  const debugLog = () => {};
+  const factory = new Function(
+    "localStorage",
+    "SYNC_SCOPE_KEYS",
+    "__decompressIfNeeded",
+    "debugLog",
+    block +
+      "\nreturn { _isCorruptObjectString, _safeSettingWriteValue, syncBootRepairCorruptSettings };"
+  );
+  const api = factory(localStorageMock, SYNC_SCOPE_KEYS, __decompressIfNeeded, debugLog);
+  return { map, ...api };
+}
+
+describe("STRK-157 apply-path corruption guard", () => {
+  test("_safeSettingWriteValue returns null for [object Object] corruption (skip, don't persist)", () => {
+    const { _safeSettingWriteValue } = makeSandbox();
+    assert.equal(_safeSettingWriteValue("[object Object]"), null);
+    assert.equal(_safeSettingWriteValue("[object Object],[object Object]"), null);
+  });
+
+  test("_safeSettingWriteValue passes clean scalars and JSON through unchanged", () => {
+    const { _safeSettingWriteValue } = makeSandbox();
+    assert.equal(_safeSettingWriteValue("dark"), "dark");
+    assert.equal(_safeSettingWriteValue('"dark"'), '"dark"');
+    assert.equal(_safeSettingWriteValue('{"a":1}'), '{"a":1}');
+  });
+
+  test("_safeSettingWriteValue JSON-stringifies non-string objects/arrays", () => {
+    const { _safeSettingWriteValue } = makeSandbox();
+    assert.equal(_safeSettingWriteValue({ a: 1 }), '{"a":1}');
+    assert.equal(_safeSettingWriteValue([{ a: 1 }, { b: 2 }]), '[{"a":1},{"b":2}]');
+  });
+});
+
+describe("STRK-157 boot-repair for corrupt object-valued keys", () => {
+  test("removes corrupt keys, leaves clean keys intact, reports what it repaired", () => {
+    const sb = makeSandbox({
+      appTheme: "dark",
+      viewModalSectionConfig: "[object Object],[object Object]",
+      chipCustomGroups: '{"valid":true}',
+      numistaViewFields: "[object Object]",
+    });
+    const repaired = sb.syncBootRepairCorruptSettings();
+    assert.deepEqual(
+      repaired.slice().sort(),
+      ["numistaViewFields", "viewModalSectionConfig"],
+      "both corrupt keys reported"
+    );
+    assert.equal(sb.map.has("viewModalSectionConfig"), false, "corrupt key removed");
+    assert.equal(sb.map.has("numistaViewFields"), false, "corrupt key removed");
+    assert.equal(sb.map.get("appTheme"), "dark", "clean scalar untouched");
+    assert.equal(sb.map.get("chipCustomGroups"), '{"valid":true}', "clean object untouched");
+  });
+
+  test("is idempotent: a second run finds nothing and is a no-op", () => {
+    const sb = makeSandbox({
+      appTheme: "dark",
+      viewModalSectionConfig: "[object Object]",
+    });
+    const first = sb.syncBootRepairCorruptSettings();
+    assert.deepEqual(first, ["viewModalSectionConfig"]);
+    const second = sb.syncBootRepairCorruptSettings();
+    assert.deepEqual(second, [], "no-op on second run");
+    assert.equal(sb.map.get("appTheme"), "dark");
+  });
+
+  test("detects corruption hidden behind a compression marker (decompress first)", () => {
+    const decompress = (s) => (s === "CMP2:corrupt" ? "[object Object]" : s);
+    const sb = makeSandbox({ chipCustomGroups: "CMP2:corrupt", appTheme: "dark" }, decompress);
+    const repaired = sb.syncBootRepairCorruptSettings();
+    assert.deepEqual(repaired, ["chipCustomGroups"]);
+    assert.equal(sb.map.has("chipCustomGroups"), false);
+  });
+
+  test("no corruption present -> empty result, nothing removed", () => {
+    const sb = makeSandbox({ appTheme: "dark", chipCustomGroups: '{"ok":1}' });
+    assert.deepEqual(sb.syncBootRepairCorruptSettings(), []);
+    assert.equal(sb.map.size, 2);
+  });
+});

--- a/tests/unit/cloud-sync-boot-repair.test.js
+++ b/tests/unit/cloud-sync-boot-repair.test.js
@@ -9,7 +9,7 @@
 // permanent settings-hash divergence.
 //
 // Fix (this file's unit surface):
-//   _isCorruptObjectString  — corruption sentinel ("[object Object]" substring)
+//   _isCorruptObjectString  — corruption sentinel (EXACT match of the coercion artifact)
 //   _safeSettingWriteValue  — compute the write string, or null to skip corruption
 //   syncBootRepairCorruptSettings — one-time, idempotent removal of corrupt keys
 //
@@ -41,6 +41,8 @@ function makeSandbox(seed, decompressFn) {
     "viewModalSectionConfig",
     "chipCustomGroups",
     "numistaViewFields",
+    "itemTags",
+    "tagBlacklist",
   ];
   const __decompressIfNeeded = decompressFn || ((s) => s);
   const debugLog = () => {};
@@ -121,5 +123,48 @@ describe("STRK-157 boot-repair for corrupt object-valued keys", () => {
     const sb = makeSandbox({ appTheme: "dark", chipCustomGroups: '{"ok":1}' });
     assert.deepEqual(sb.syncBootRepairCorruptSettings(), []);
     assert.equal(sb.map.size, 2);
+  });
+});
+
+// STRK-157 review finding (major): the corruption sentinel must match the ENTIRE
+// value being the String(obj) coercion artifact, NOT merely contain the substring —
+// otherwise a user-entered free-text tag/chip named "[object Object]" (valid JSON,
+// under the 50-char tag limit) would make boot-repair delete the ENTIRE itemTags /
+// chipCustomGroups store, wiping all tags/groups for all items.
+describe("STRK-157 corruption sentinel is exact-match, not substring (free-text safety)", () => {
+  test("a legitimate tag literally named [object Object] does NOT wipe the itemTags store", () => {
+    const legit = JSON.stringify({ u1: ["silver", "[object Object]", "1oz"], u2: ["proof"] });
+    const sb = makeSandbox({
+      appTheme: "dark",
+      itemTags: legit,
+      chipCustomGroups: "[object Object],[object Object]", // genuinely coerced
+    });
+    const repaired = sb.syncBootRepairCorruptSettings();
+    assert.deepEqual(
+      repaired,
+      ["chipCustomGroups"],
+      "only the genuinely-coerced store is repaired"
+    );
+    assert.equal(
+      sb.map.get("itemTags"),
+      legit,
+      "free-text store with embedded substring preserved intact"
+    );
+    assert.equal(sb.map.has("chipCustomGroups"), false, "the bare-artifact store is still removed");
+  });
+
+  test("tagBlacklist containing a [object Object] entry inside valid JSON is preserved", () => {
+    const legit = JSON.stringify(["junk", "[object Object]"]);
+    const sb = makeSandbox({ tagBlacklist: legit });
+    assert.deepEqual(sb.syncBootRepairCorruptSettings(), []);
+    assert.equal(sb.map.get("tagBlacklist"), legit);
+  });
+
+  test("_safeSettingWriteValue persists valid JSON that merely contains the substring", () => {
+    const { _safeSettingWriteValue } = makeSandbox();
+    const legit = '{"u1":["[object Object]"]}';
+    assert.equal(_safeSettingWriteValue(legit), legit, "must not refuse to sync a legit tag");
+    // but the bare artifact is still rejected
+    assert.equal(_safeSettingWriteValue("[object Object]"), null);
   });
 });

--- a/tests/unit/cloud-sync-convergence-audit.test.js
+++ b/tests/unit/cloud-sync-convergence-audit.test.js
@@ -1,0 +1,133 @@
+// Unit tests for the convergence audit fixes (STRK-159, parent STRK-154).
+//
+// STRK-159 generalizes the convergence invariant ("compare/merge/hash on logical
+// content, never raw serialization") across the remaining sync surfaces:
+//   1. computeInventoryHash canonicalizes item.disposition (sorted keys) so a
+//      key-order variant of the same object is not a false inventory mismatch.
+//   2. _hasTagChanges compares decompressed, canonicalized tag content so a
+//      compressed-vs-plain (or key-order) variant of identical tags is not a
+//      false "changed" signal that triggers a needless merge.
+//
+// Loaded via slice-and-eval with the real vendored lz-string engine.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// --- Real lz-string + __decompressIfNeeded (for genuine compressed-vs-plain) ---
+const lzCode = readFileSync(new URL("../../vendor/lz-string.min.js", import.meta.url), "utf-8");
+const _lzModule = { exports: {} };
+new Function("module", "exports", "window", lzCode)(_lzModule, _lzModule.exports, undefined);
+const LZString = _lzModule.exports;
+const utilsSrc = readFileSync(new URL("../../js/utils.js", import.meta.url), "utf-8");
+const compFactory = new Function(
+  "__LZ",
+  "__LZ_REAL",
+  utilsSrc.slice(
+    utilsSrc.indexOf("const __ST_COMP_PREFIX"),
+    utilsSrc.indexOf("function getContrastColor")
+  ) + "\nreturn { __decompressIfNeeded };"
+);
+const { __decompressIfNeeded } = compFactory(LZString, true);
+
+const src = readFileSync(new URL("../../js/cloud-sync.js", import.meta.url), "utf-8");
+
+function slice(from, to) {
+  const a = src.indexOf(from);
+  const b = src.indexOf(to);
+  assert.ok(a !== -1 && b !== -1 && b > a, `could not locate block ${from} .. ${to}`);
+  return src.slice(a, b);
+}
+
+// Extract the real _stableCanonicalString once and reuse it as an injected dep.
+const _stableCanonicalString = new Function(
+  slice("function _stableCanonicalString", "function _canonicalizeSettingValue") +
+    "\nreturn _stableCanonicalString;"
+)();
+
+// NOTE: include the `async` keyword — computeInventoryHash awaits crypto.subtle,
+// so a slice that drops `async` yields "await in non-async function" SyntaxError.
+const invBlock = slice("async function computeInventoryHash", "function summarizeMetals");
+const tagBlock = slice("function _tagSyncKeys()", "function _unionTags");
+
+function sha256BufferToHex(buffer) {
+  const a = new Uint8Array(buffer);
+  let hex = "";
+  for (let j = 0; j < a.length; j++) hex += ("0" + a[j].toString(16)).slice(-2);
+  return hex;
+}
+
+function inventoryHash(items) {
+  const factory = new Function(
+    "crypto",
+    "DiffEngine",
+    "TextEncoder",
+    "sha256BufferToHex",
+    "_stableCanonicalString",
+    "debugLog",
+    invBlock + "\nreturn computeInventoryHash;"
+  );
+  const fn = factory(
+    globalThis.crypto,
+    { computeItemKey: (it) => String(it.uuid) },
+    TextEncoder,
+    sha256BufferToHex,
+    _stableCanonicalString,
+    () => {}
+  );
+  return fn(items);
+}
+
+function makeHasTagChanges(store, decompress) {
+  const localStorageMock = { getItem: (k) => (k in store ? store[k] : null) };
+  const factory = new Function(
+    "localStorage",
+    "__decompressIfNeeded",
+    "_stableCanonicalString",
+    "console",
+    tagBlock + "\nreturn _hasTagChanges;"
+  );
+  return factory(localStorageMock, decompress || ((s) => s), _stableCanonicalString, console);
+}
+
+describe("STRK-159 computeInventoryHash canonicalizes disposition", () => {
+  test("disposition key-order variance hashes EQUAL", async () => {
+    const h1 = await inventoryHash([
+      { uuid: "x", disposition: { soldDate: "2026-01-01", soldPrice: 100 } },
+    ]);
+    const h2 = await inventoryHash([
+      { uuid: "x", disposition: { soldPrice: 100, soldDate: "2026-01-01" } },
+    ]);
+    assert.equal(h1, h2, "same disposition, different key order, must hash equal");
+  });
+
+  test("a genuine disposition value change DOES change the hash", async () => {
+    const h1 = await inventoryHash([{ uuid: "x", disposition: { soldPrice: 100 } }]);
+    const h2 = await inventoryHash([{ uuid: "x", disposition: { soldPrice: 200 } }]);
+    assert.notEqual(h1, h2, "different disposition value must hash differently");
+  });
+});
+
+describe("STRK-159 _hasTagChanges compares logical content", () => {
+  const plain = JSON.stringify({ u1: ["a", "b"] });
+
+  test("compressed (CMP2) vs plain of identical tags -> NOT changed", () => {
+    const compressed = "CMP2:" + LZString.compressToUTF16(plain);
+    const hasChanges = makeHasTagChanges({ itemTags: plain }, __decompressIfNeeded);
+    assert.equal(
+      hasChanges({ itemTags: compressed }),
+      false,
+      "compressed twin of identical tags must not be a change"
+    );
+  });
+
+  test("tag-store key-order variance -> NOT changed", () => {
+    const hasChanges = makeHasTagChanges({ itemTags: JSON.stringify({ u1: ["a"], u2: ["b"] }) });
+    assert.equal(hasChanges({ itemTags: JSON.stringify({ u2: ["b"], u1: ["a"] }) }), false);
+  });
+
+  test("genuinely different tag content -> changed", () => {
+    const hasChanges = makeHasTagChanges({ itemTags: plain });
+    assert.equal(hasChanges({ itemTags: JSON.stringify({ u1: ["a", "c"] }) }), true);
+  });
+});

--- a/tests/unit/cloud-sync-settings-hash.test.js
+++ b/tests/unit/cloud-sync-settings-hash.test.js
@@ -1,0 +1,129 @@
+// Unit tests for computeSettingsHash logical-content hashing (STRK-156, parent STRK-154).
+//
+// computeSettingsHash() used to hash the RAW localStorage string for each
+// SYNC_SCOPE_KEYS entry. Raw strings differ for identical logical content when:
+//   - lz-string CMP2-compressed (raw > 4096) on one device vs plain on the other
+//   - a scalar stored as JSON ("\"dark\"") vs raw (dark)
+//   - object key-order differs
+// Any of these produced a false settings:false -> infinite pull loop. The live
+// incident had the divergent itemTags compressed (CMP2) on one device and plain
+// on the other, guaranteeing a hash mismatch even for identical content.
+//
+// Fix: hash NORMALIZED logical content (decompress, JSON-parse with raw-scalar
+// fallback, sort object keys, preserve array order). These tests load the REAL
+// computeSettingsHash block from js/cloud-sync.js and the REAL compression helpers
+// from js/utils.js (slice-and-eval, mirrors storage-compression.test.js), with the
+// real vendored lz-string engine, so compressed-vs-plain is exercised end-to-end.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// --- Real lz-string engine (UMD assigns IIFE to module.exports) ---
+const lzCode = readFileSync(new URL("../../vendor/lz-string.min.js", import.meta.url), "utf-8");
+const _lzModule = { exports: {} };
+new Function("module", "exports", "window", lzCode)(_lzModule, _lzModule.exports, undefined);
+const LZString = _lzModule.exports;
+
+// --- Real __compressIfNeeded / __decompressIfNeeded from utils.js ---
+const utilsSrc = readFileSync(new URL("../../js/utils.js", import.meta.url), "utf-8");
+const cStart = utilsSrc.indexOf("const __ST_COMP_PREFIX");
+const cEnd = utilsSrc.indexOf("function getContrastColor");
+assert.ok(
+  cStart !== -1 && cEnd !== -1 && cEnd > cStart,
+  "could not locate compression block in utils.js"
+);
+const compFactory = new Function(
+  "__LZ",
+  "__LZ_REAL",
+  utilsSrc.slice(cStart, cEnd) + "\nreturn { __compressIfNeeded, __decompressIfNeeded };"
+);
+const { __compressIfNeeded, __decompressIfNeeded } = compFactory(LZString, true);
+
+// --- Real computeSettingsHash block from cloud-sync.js ---
+const src = readFileSync(new URL("../../js/cloud-sync.js", import.meta.url), "utf-8");
+const start = src.indexOf("function _stableCanonicalString");
+const end = src.indexOf("function initSyncTabCoordination");
+assert.ok(
+  start !== -1 && end !== -1 && end > start,
+  "could not locate settings-hash block in cloud-sync.js"
+);
+const block = src.slice(start, end);
+
+const SCOPE = ["metalInventory", "appTheme", "itemTags", "objConfig", "arrConfig"];
+
+function sha256BufferToHex(buffer) {
+  const a = new Uint8Array(buffer);
+  let hex = "";
+  for (let j = 0; j < a.length; j++) hex += ("0" + a[j].toString(16)).slice(-2);
+  return hex;
+}
+
+// Compute the settings hash over a given localStorage map.
+function hashOf(store) {
+  const localStorageMock = { getItem: (k) => (k in store ? store[k] : null) };
+  const factory = new Function(
+    "crypto",
+    "localStorage",
+    "SYNC_SCOPE_KEYS",
+    "__decompressIfNeeded",
+    "TextEncoder",
+    "sha256BufferToHex",
+    "debugLog",
+    block + "\nreturn computeSettingsHash;"
+  );
+  const computeSettingsHash = factory(
+    globalThis.crypto,
+    localStorageMock,
+    SCOPE,
+    __decompressIfNeeded,
+    TextEncoder,
+    sha256BufferToHex,
+    () => {}
+  );
+  return computeSettingsHash();
+}
+
+describe("STRK-156 computeSettingsHash hashes logical content", () => {
+  test("compressed (CMP2) vs plain value of identical content hash EQUAL", async () => {
+    // Build a value large enough that __compressIfNeeded emits a CMP2 body.
+    const big = JSON.stringify({ u1: Array.from({ length: 600 }, (_, i) => "tag-" + i) });
+    const compressed = __compressIfNeeded(big);
+    assert.ok(compressed.startsWith("CMP2:"), "test precondition: value must compress to CMP2");
+    assert.notEqual(compressed, big, "compressed form must differ from plain form");
+
+    const hPlain = await hashOf({ appTheme: "dark", itemTags: big });
+    const hComp = await hashOf({ appTheme: "dark", itemTags: compressed });
+    assert.equal(hPlain, hComp, "compressed and plain twins must hash equal");
+  });
+
+  test("scalar stored as raw vs JSON-quoted hash EQUAL", async () => {
+    const hRaw = await hashOf({ appTheme: "dark" }); // raw scalar (no quotes)
+    const hJson = await hashOf({ appTheme: '"dark"' }); // JSON-quoted string
+    assert.equal(hRaw, hJson, "raw scalar and JSON-quoted twin must hash equal");
+  });
+
+  test("object key-order variance hashes EQUAL", async () => {
+    const h1 = await hashOf({ objConfig: '{"a":1,"b":2}' });
+    const h2 = await hashOf({ objConfig: '{"b":2,"a":1}' });
+    assert.equal(h1, h2, "key-order must not change the hash");
+  });
+
+  test("a genuine value change DOES change the hash", async () => {
+    const h1 = await hashOf({ appTheme: "dark" });
+    const h2 = await hashOf({ appTheme: "light" });
+    assert.notEqual(h1, h2, "different logical content must hash differently");
+  });
+
+  test("array reorder DOES change the hash (array order is meaningful)", async () => {
+    const h1 = await hashOf({ arrConfig: '["a","b","c"]' });
+    const h2 = await hashOf({ arrConfig: '["c","b","a"]' });
+    assert.notEqual(h1, h2, "array element order must remain significant");
+  });
+
+  test("metalInventory key is excluded from the settings hash", async () => {
+    const h1 = await hashOf({ appTheme: "dark", metalInventory: "[{}]" });
+    const h2 = await hashOf({ appTheme: "dark", metalInventory: "[{},{}]" });
+    assert.equal(h1, h2, "inventory must not influence the settings hash");
+  });
+});

--- a/tests/unit/cloud-sync-tag-merge.test.js
+++ b/tests/unit/cloud-sync-tag-merge.test.js
@@ -214,4 +214,81 @@ describe("STRK-155 convergent per-item tag merge", () => {
     assert.deepEqual(r.itemTags.u1, ["alpha", "beta"]);
     assert.equal(r.itemRemovedTags.u1, undefined, "present tag must not remain in removed list");
   });
+
+  // STRK-155 review finding: legacy / Numista-batch tags (applyNumistaTags persist=false,
+  // pre-timestamp installs) have tag content but NO itemTagsLastModified entry, so both
+  // sides coerce to ts=0. The original tie-gate required a timestamp entry on both sides,
+  // leaving these divergent-but-untimestamped tags non-convergent AND re-triggering a
+  // silent tag-only merge every poll. The gate must also fire on equal timestamps when the
+  // tag content is present on BOTH sides.
+  test("untimestamped tags present on both sides still converge to the union", () => {
+    const A = {
+      itemTags: { u1: ["alpha", "beta"] },
+      itemRemovedTags: {},
+      itemTagsLastModified: {},
+    };
+    const B = {
+      itemTags: { u1: ["beta", "gamma"] },
+      itemRemovedTags: {},
+      itemTagsLastModified: {},
+    };
+    const r1 = runMerge(A, {
+      itemTags: B.itemTags,
+      itemRemovedTags: B.itemRemovedTags,
+      itemTagsLastModified: B.itemTagsLastModified,
+    });
+    const r2 = runMerge(B, {
+      itemTags: A.itemTags,
+      itemRemovedTags: A.itemRemovedTags,
+      itemTagsLastModified: A.itemTagsLastModified,
+    });
+    assert.deepEqual(
+      r1.itemTags.u1,
+      ["alpha", "beta", "gamma"],
+      "untimestamped tie converges to union"
+    );
+    assert.deepEqual(r1, r2, "commutative for the untimestamped case too");
+    // content changed -> a timestamp is now stamped, ending the per-poll busy-loop
+    assert.equal(r1.itemTagsLastModified.u1, FIXED_NOW);
+  });
+
+  test("untimestamped union is idempotent: re-merging the converged superset is a no-op", () => {
+    // After convergence the uuid HAS a (bumped) timestamp; a stale untimestamped remote
+    // must not clobber it, and identical content must not re-bump.
+    const r = runMerge(
+      {
+        itemTags: { u1: ["alpha", "beta", "gamma"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: FIXED_NOW },
+      },
+      {
+        itemTags: { u1: ["alpha", "beta", "gamma"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: {},
+      }
+    );
+    assert.deepEqual(r.itemTags.u1, ["alpha", "beta", "gamma"]);
+    assert.equal(
+      r.itemTagsLastModified.u1,
+      FIXED_NOW,
+      "local stamped value wins over untimestamped remote"
+    );
+  });
+
+  test("one-sided untimestamped uuid is NOT spuriously adopted (no false tie)", () => {
+    // u2 exists only on the remote with no timestamp — must not be force-unioned into local.
+    const r = runMerge(
+      { itemTags: { u1: ["a"] }, itemRemovedTags: {}, itemTagsLastModified: {} },
+      {
+        itemTags: { u1: ["a"], u2: ["remote-only"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: {},
+      }
+    );
+    assert.equal(
+      r.itemTags.u2,
+      undefined,
+      "remote-only untimestamped uuid is not adopted via the tie path"
+    );
+  });
 });

--- a/tests/unit/cloud-sync-tag-merge.test.js
+++ b/tests/unit/cloud-sync-tag-merge.test.js
@@ -1,0 +1,217 @@
+// Unit tests for the convergent per-item tag merge (STRK-155, parent STRK-154).
+//
+// The cloud-sync tag merge (_mergeTagData in js/cloud-sync.js) was last-write-wins
+// keyed on itemTagsLastModified. On a timestamp TIE with differing content it
+// no-op'd and kept local — making it non-commutative: merge(A,B) != merge(B,A).
+// Two devices whose itemTags/itemRemovedTags diverged while sharing an identical
+// itemTagsLastModified map could therefore never reconcile, and computeSettingsHash
+// looped forever.
+//
+// Fix: on a timestamp tie where content differs, take the deterministic UNION of
+// both sides' tags (case-insensitive dedup, deterministic representative, sorted),
+// and bump the timestamp when content changes. Union is commutative -> both devices
+// converge to the same superset.
+//
+// These tests load the REAL _mergeTagData block from js/cloud-sync.js via the
+// slice-and-eval pattern (mirrors storage-compression.test.js) with mock storage
+// and a stubbed clock injected, so the merge is a pure data transformation.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("../../js/cloud-sync.js", import.meta.url), "utf-8");
+const start = src.indexOf("function _tagSyncKeys()");
+const end = src.indexOf("function _mergeOneSidedTagSettings");
+assert.ok(
+  start !== -1 && end !== -1 && end > start,
+  "could not locate tag-merge block in cloud-sync.js"
+);
+const block = src.slice(start, end);
+
+const FIXED_NOW = 9_999_000;
+
+// Build a fresh sandbox (mock storage + stubbed deps) and return _mergeTagData bound to it.
+function makeMerge(seed) {
+  const store = JSON.parse(JSON.stringify(seed || {}));
+  const loadDataSync = (key, def) => (key in store ? store[key] : def);
+  const saveDataSync = (key, data) => {
+    store[key] = data;
+  };
+  const loadTagTimestamps = () => store.itemTagsLastModified || {};
+  const loadItemTags = () => {};
+  const localStorageMock = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  const __decompressIfNeeded = (s) => s;
+  function MockDate() {}
+  MockDate.now = () => FIXED_NOW;
+
+  const factory = new Function(
+    "localStorage",
+    "loadDataSync",
+    "saveDataSync",
+    "loadTagTimestamps",
+    "loadItemTags",
+    "__decompressIfNeeded",
+    "Date",
+    block + "\nreturn { _mergeTagData: _mergeTagData };"
+  );
+  const { _mergeTagData } = factory(
+    localStorageMock,
+    loadDataSync,
+    saveDataSync,
+    loadTagTimestamps,
+    loadItemTags,
+    __decompressIfNeeded,
+    MockDate
+  );
+  return { store, _mergeTagData };
+}
+
+// Run a merge: seed local state, apply a remote tag payload, return resulting stores.
+function runMerge(localSeed, remote) {
+  const { store, _mergeTagData } = makeMerge(localSeed);
+  _mergeTagData(remote);
+  return {
+    itemTags: store.itemTags || {},
+    itemRemovedTags: store.itemRemovedTags || {},
+    itemTagsLastModified: store.itemTagsLastModified || {},
+  };
+}
+
+describe("STRK-155 convergent per-item tag merge", () => {
+  test("commutativity: divergent tags with EQUAL timestamps converge identically in both directions", () => {
+    const A = {
+      itemTags: { u1: ["alpha", "beta"] },
+      itemRemovedTags: {},
+      itemTagsLastModified: { u1: 1000 },
+    };
+    const B = {
+      itemTags: { u1: ["beta", "gamma"] },
+      itemRemovedTags: {},
+      itemTagsLastModified: { u1: 1000 },
+    };
+
+    const r1 = runMerge(A, {
+      itemTags: B.itemTags,
+      itemRemovedTags: B.itemRemovedTags,
+      itemTagsLastModified: B.itemTagsLastModified,
+    });
+    const r2 = runMerge(B, {
+      itemTags: A.itemTags,
+      itemRemovedTags: A.itemRemovedTags,
+      itemTagsLastModified: A.itemTagsLastModified,
+    });
+
+    // merge(A,B) === merge(B,A) — byte-identical including timestamps
+    assert.deepEqual(r1, r2, "merge must be commutative on a timestamp tie");
+    // Converged to the sorted union superset
+    assert.deepEqual(r1.itemTags.u1, ["alpha", "beta", "gamma"]);
+    // Content changed on the tie -> timestamp bumped to the stubbed clock
+    assert.equal(r1.itemTagsLastModified.u1, FIXED_NOW);
+  });
+
+  test("commutativity is case-insensitive: 'Gold' and 'gold' dedup to one deterministic representative", () => {
+    const A = {
+      itemTags: { u1: ["Gold", "silver"] },
+      itemRemovedTags: {},
+      itemTagsLastModified: { u1: 5000 },
+    };
+    const B = {
+      itemTags: { u1: ["gold", "Silver", "copper"] },
+      itemRemovedTags: {},
+      itemTagsLastModified: { u1: 5000 },
+    };
+
+    const r1 = runMerge(A, {
+      itemTags: B.itemTags,
+      itemRemovedTags: B.itemRemovedTags,
+      itemTagsLastModified: B.itemTagsLastModified,
+    });
+    const r2 = runMerge(B, {
+      itemTags: A.itemTags,
+      itemRemovedTags: A.itemRemovedTags,
+      itemTagsLastModified: A.itemTagsLastModified,
+    });
+
+    assert.deepEqual(r1, r2, "case-variant union must be commutative");
+    // One entry per lowercased tag; both directions pick the same representative
+    const tags = r1.itemTags.u1;
+    const lowered = tags.map((t) => t.toLowerCase());
+    assert.deepEqual([...new Set(lowered)].sort(), ["copper", "gold", "silver"]);
+    assert.equal(lowered.length, 3, "no case-duplicate tags survive");
+  });
+
+  test("regression: a genuinely newer remote timestamp still wins (LWW preserved when NOT tied)", () => {
+    const r = runMerge(
+      {
+        itemTags: { u1: ["old"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 1000 },
+      },
+      {
+        itemTags: { u1: ["fresh"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 2000 },
+      }
+    );
+    assert.deepEqual(r.itemTags.u1, ["fresh"]);
+    assert.equal(r.itemTagsLastModified.u1, 2000);
+  });
+
+  test("regression: a genuinely newer LOCAL timestamp still wins (no remote clobber)", () => {
+    const r = runMerge(
+      {
+        itemTags: { u1: ["local-new"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 3000 },
+      },
+      {
+        itemTags: { u1: ["remote-old"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 1000 },
+      }
+    );
+    assert.deepEqual(r.itemTags.u1, ["local-new"]);
+    assert.equal(r.itemTagsLastModified.u1, 3000);
+  });
+
+  test("idempotency: merging identical content on a tie does NOT bump the timestamp", () => {
+    const r = runMerge(
+      {
+        itemTags: { u1: ["a", "b"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 1000 },
+      },
+      {
+        itemTags: { u1: ["a", "b"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 1000 },
+      }
+    );
+    assert.deepEqual(r.itemTags.u1, ["a", "b"]);
+    assert.equal(r.itemTagsLastModified.u1, 1000, "no content change -> no timestamp bump");
+  });
+
+  test("removed-tags reconcile via present-vs-removed post-pass after union", () => {
+    // u1: local removed 'beta'; remote still has 'beta' present, equal timestamps.
+    // Union of present tags includes 'beta' -> it must be dropped from removed.
+    const r = runMerge(
+      {
+        itemTags: { u1: ["alpha"] },
+        itemRemovedTags: { u1: ["beta"] },
+        itemTagsLastModified: { u1: 1000 },
+      },
+      {
+        itemTags: { u1: ["alpha", "beta"] },
+        itemRemovedTags: {},
+        itemTagsLastModified: { u1: 1000 },
+      }
+    );
+    assert.deepEqual(r.itemTags.u1, ["alpha", "beta"]);
+    assert.equal(r.itemRemovedTags.u1, undefined, "present tag must not remain in removed list");
+  });
+});

--- a/tests/unit/diff-engine-normalization.test.js
+++ b/tests/unit/diff-engine-normalization.test.js
@@ -1,0 +1,105 @@
+// Unit tests for DiffEngine normalization (STRK-158, parent STRK-154).
+//
+// Problem A — lastModified format: _valuesEqual compared scalars with raw ===.
+// lastModified is stored in two ISO serializations of the SAME instant — compact
+// "20260603T061930904Z" vs extended "2026-06-03T06:19:30.904Z" — so it reported a
+// phantom conflict in the Review Sync Changes modal that no resolution cleared.
+//
+// Problem B — attachments "1 field changed" with an empty body: _valuesEqual flagged
+// the attachments array as changed via order-sensitive _stableStringify, but
+// _diffAttachments (UUID/fileName-keyed, order-independent) returned zero per-entry
+// rows. The pill showed >=1 change while the body rendered nothing.
+//
+// These tests drive the PUBLIC DiffEngine.compareItems (the acceptance surface).
+// diff-engine.js is pure data with `window.DiffEngine = DiffEngine`, so the whole
+// file is evaluated with a mock window — no slicing needed.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("../../js/diff-engine.js", import.meta.url), "utf-8");
+const win = {};
+new Function("window", src)(win);
+const DiffEngine = win.DiffEngine;
+assert.ok(
+  DiffEngine && typeof DiffEngine.compareItems === "function",
+  "DiffEngine.compareItems must load"
+);
+
+const base = { uuid: "item-1", name: "Silver Eagle", metal: "Silver" };
+
+describe("STRK-158 Problem A — lastModified instant-awareness", () => {
+  test("compact vs extended ISO of the SAME instant is NOT a conflict", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, lastModified: "20260603T061930904Z" }],
+      [{ ...base, lastModified: "2026-06-03T06:19:30.904Z" }]
+    );
+    assert.equal(res.modified.length, 0, "same instant must not be reported as modified");
+    assert.equal(res.unchanged.length, 1);
+  });
+
+  test("compact vs extended ISO without milliseconds also compares equal", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, lastModified: "20260603T061930Z" }],
+      [{ ...base, lastModified: "2026-06-03T06:19:30Z" }]
+    );
+    assert.equal(res.modified.length, 0);
+  });
+
+  test("a genuinely different timestamp IS still a conflict", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, lastModified: "2026-06-03T06:19:30.904Z" }],
+      [{ ...base, lastModified: "2026-06-03T07:00:00.000Z" }]
+    );
+    assert.equal(res.modified.length, 1, "different instants must still be reported");
+    assert.ok(
+      res.modified[0].changes.some((c) => c.field === "lastModified"),
+      "lastModified must be the changed field"
+    );
+  });
+});
+
+describe("STRK-158 Problem B — attachments phantom conflict", () => {
+  const a1 = { attachmentUuid: "att-1", fileName: "receipt.pdf" };
+  const a2 = { attachmentUuid: "att-2", fileName: "cert.pdf" };
+
+  test("reordered attachments (same UUIDs) are NOT reported as a conflict", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, attachments: [a1, a2] }],
+      [{ ...base, attachments: [a2, a1] }]
+    );
+    assert.equal(res.modified.length, 0, "a pure reorder must not count as a change");
+    assert.equal(res.unchanged.length, 1);
+  });
+
+  test("a genuine attachment addition IS reported", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, attachments: [a1] }],
+      [{ ...base, attachments: [a1, a2] }]
+    );
+    assert.equal(res.modified.length, 1);
+    assert.ok(
+      res.modified[0].changes.some((c) => c.field === "attachments"),
+      "attachments must be flagged on a real add"
+    );
+  });
+
+  test("a genuine attachment removal IS reported", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, attachments: [a1, a2] }],
+      [{ ...base, attachments: [a1] }]
+    );
+    assert.equal(res.modified.length, 1);
+    assert.ok(res.modified[0].changes.some((c) => c.field === "attachments"));
+  });
+
+  test("identical attachments in identical order are unchanged", () => {
+    const res = DiffEngine.compareItems(
+      [{ ...base, attachments: [a1, a2] }],
+      [{ ...base, attachments: [a1, a2] }]
+    );
+    assert.equal(res.modified.length, 0);
+    assert.equal(res.unchanged.length, 1);
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.35.6",
+  "version": "3.35.7",
   "releaseDate": "2026-06-05",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## STRK-154 — Cloud Sync Convergence & Auto-Healing (patch 3.35.7)

Fixes the permanent **"Review Sync Changes" loop** between two devices and makes every cloud-sync compare/merge/hash operate on **normalized logical content** with **commutative, convergent** merges. The fixes are self-healing — existing diverged installs reconcile on the next sync with no user action.

Closes the five children of epic **STRK-154**.

### What changed (per child issue)

| Issue | Fix |
|-------|-----|
| **STRK-155** | `_mergeTagData`: deterministic, case-insensitive **union on a timestamp tie** (commutative) instead of a non-commutative last-write-wins no-op. The loop-breaker + auto-heal. |
| **STRK-156** | `computeSettingsHash`: hashes **normalized logical content** (decompress + canonical-stringify), so CMP2-compressed-vs-plain, scalar-as-JSON-vs-raw, and key-order variants of identical content hash equal. Push and poll share the one function. |
| **STRK-157** | Apply-path rejects `[object Object]` corruption; one-time idempotent **boot-repair** clears unrecoverable corruption; snapshot/restore guarded. |
| **STRK-158** | `DiffEngine`: instant-aware `lastModified` compare (no phantom conflict from ISO-format variance) + attachments count reconciled with `_diffAttachments` (no "1 field changed, empty body"). |
| **STRK-159** | Convergence audit: `computeInventoryHash` canonicalizes `disposition`; `_hasTagChanges` compares logical content. Invariant + full surface matrix documented in `.context/cloud-sync-convergence.md`. |

### Adversarial review (pre-PR)

A multi-agent adversarial review of the diff surfaced and I fixed two confirmed findings (commit `fd4650e9`):

- **(major)** the corruption sentinel used a *substring* match on the whole store — a user-entered tag/chip named literally `[object Object]` would make boot-repair wipe the entire `itemTags`/`chipCustomGroups` store. Now an **exact** full-value match; free-text values containing the substring are preserved.
- **(minor)** legacy / Numista-batch tags written without a timestamp entry never converged and re-triggered a silent merge each poll. The tie-union now also fires on equal timestamps when tag **content** is present on both sides.

### Testing

- **168 unit tests** pass (`npm run test:unit`) — 39 new across 5 files (`cloud-sync-tag-merge`, `cloud-sync-settings-hash`, `cloud-sync-boot-repair`, `diff-engine-normalization`, `cloud-sync-convergence-audit`), each written TDD red→green: commutativity, logical-equality, compressed-vs-plain, corruption guard + idempotent repair, instant-aware diff, free-text safety, untimestamped convergence.
- **Core Playwright** (`npm test`): 179/180; the lone failure is `retail-market.spec.js:435` (Goldback premium rendering), a known full-suite-ordering flake (STRK-143 lineage) — passes in isolation (1.9s) and in-file (6/6), and is causally unrelated to these cloud-sync changes.
- `/update-spot-bundle` run (bundle already current); version bumped to 3.35.7 across all 6 release-bearing files; `check-release-sync` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
