### PR TITLE
fix+refactor(STRK-160): fix Summit bulk-price root cause (JSON-LD untrusted) + isolate per-vendor cutoff/strategy

### DIFF
--- a/devops/pollers/shared/price-extract-provider-config.js
+++ b/devops/pollers/shared/price-extract-provider-config.js
@@ -78,12 +78,9 @@ const LEGACY_PROVIDER_OVERRIDES = {
     phase: "firecrawl", // Phase 0 Playwright direct always times out
     waitFor: 3_000,
   },
-  summitmetals: {
-    // defaults are fine: phase0 + networkidle
-  },
-  goldback: {
-    // defaults are fine: phase0 + networkidle
-  },
+  // NOTE: apmex, goldback, and summitmetals are MIGRATED — their config lives in
+  // their own price-extract-vendor-*.js modules, not here. Only not-yet-migrated
+  // vendors remain in this transitional map (STRK-32 / STRK-150/151/152).
 };
 
 export function mergeProviderConfig(...configs) {

--- a/devops/pollers/shared/price-extract-shared.js
+++ b/devops/pollers/shared/price-extract-shared.js
@@ -7,6 +7,7 @@
  */
 
 import { isFractionalExemptProvider } from "./price-extract-provider-config.js";
+import { getVendorModule } from "./price-extract-vendors.js";
 
 // Per-oz price ranges by metal type.
 // Multiplied by weight_oz to get the expected price range for each coin.
@@ -23,7 +24,8 @@ const METAL_PRICE_RANGE_PER_OZ = {
 // UPDATE 2026-02-21: Monument Metals DOES have a pricing table (1-24 row with eCheck/Wire column).
 // "As Low As" is bulk discount (500+) — use table-first extraction like all other vendors.
 // Empty set = all vendors now use table-first strategy.
-const USES_AS_LOW_AS = new Set([]);
+// TRANSITIONAL — see the legacy per-vendor block below.
+const LEGACY_USES_AS_LOW_AS = new Set([]);
 
 const OUT_OF_STOCK_PATTERNS = [
   /out of stock/i,
@@ -53,11 +55,27 @@ const SOFT_404_PATTERNS = [
   /has\s+been\s+(removed|discontinued)/i,
 ];
 
+// ---------------------------------------------------------------------------
+// TRANSITIONAL per-vendor data for NOT-YET-MIGRATED vendors (STRK-32 / STRK-104).
+//
+// Migrated vendors own these on their price-extract-vendor-*.js module:
+//   cutoffPatterns, headerSkipPattern, preorderTolerant, untrustedOfferPrice,
+//   usesAsLowAs.
+// The resolver helpers below read the vendor MODULE first (getVendorModule) and
+// fall back to these maps only for vendors that have not migrated yet. When you
+// migrate a vendor, MOVE its entries out of here and into its module so a change
+// to one vendor's data can never touch another's. Do NOT add new vendors here.
+// ---------------------------------------------------------------------------
+
 // Providers whose "Pre-Order" / "Presale" items still show live purchasable prices.
 // For these, skip the pre-?order OOS pattern — treat presale as in-stock.
-const PREORDER_TOLERANT_PROVIDERS = new Set(["jmbullion", "monumentmetals"]);
+const LEGACY_PREORDER_TOLERANT_PROVIDERS = new Set(["jmbullion", "monumentmetals"]);
 
-const MARKDOWN_CUTOFF_PATTERNS = {
+// Providers whose JSON-LD/offer.price is the CC price (untrusted as the wire price);
+// extract the qty-tier table price instead.
+const LEGACY_UNTRUSTED_OFFER_PRICE_VENDORS = new Set(["sdbullion", "bullionexchanges"]);
+
+const LEGACY_MARKDOWN_CUTOFF_PATTERNS = {
   sdbullion: [
     /^\*\*Add on Items\*\*/im,
     /^Add on Items\s*$/im,
@@ -72,24 +90,53 @@ const MARKDOWN_CUTOFF_PATTERNS = {
     /[\d,]+\s+Reviews?\b/i,
     /\bSuggested Products\b/i,
   ],
-  summitmetals: [
-    /^\s*Description Shipping & Returns\s*$/im,
-    /^#{0,6}\s*What Our Clients/im,
-    /^#{0,6}\s*Faq'?s\s*$/im,
-  ],
+  // summitmetals — MIGRATED to price-extract-vendor-summit.js (cutoffPatterns).
 };
 
-const MARKDOWN_HEADER_SKIP_PATTERNS = {
+const LEGACY_MARKDOWN_HEADER_SKIP_PATTERNS = {
   jmbullion:
     /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2},\s+\d{4}\s+at\s+\d{1,2}:\d{2}\s+[A-Z]{2,4}/,
   monumentmetals: /(?:Home\s*>|Bullion\s*>|Coins?\s*>)/,
 };
 
+// --- Per-vendor flag resolvers: migrated module first, legacy map fallback. ---
+// A migrated vendor declares the flag (even `false`/`null`/`[]`) on its module,
+// which wins; a not-yet-migrated vendor (legacy adapter) returns `undefined` for
+// the flag, so we fall back to the transitional maps above.
+function resolvePreorderTolerant(providerId) {
+  const v = getVendorModule(providerId);
+  return v.preorderTolerant !== undefined
+    ? v.preorderTolerant
+    : LEGACY_PREORDER_TOLERANT_PROVIDERS.has(providerId);
+}
+
+function resolveUntrustedOfferPrice(providerId) {
+  const v = getVendorModule(providerId);
+  return v.untrustedOfferPrice !== undefined
+    ? v.untrustedOfferPrice
+    : LEGACY_UNTRUSTED_OFFER_PRICE_VENDORS.has(providerId);
+}
+
+function resolveUsesAsLowAs(providerId) {
+  const v = getVendorModule(providerId);
+  return v.usesAsLowAs !== undefined ? v.usesAsLowAs : LEGACY_USES_AS_LOW_AS.has(providerId);
+}
+
+function resolveFractionalExempt(providerId) {
+  const fromModule = getVendorModule(providerId).config?.fractionalExempt;
+  return fromModule !== undefined ? fromModule : isFractionalExemptProvider(providerId);
+}
+
 export function preprocessMarkdown(markdown, providerId) {
   if (!markdown) return "";
   let result = markdown;
 
-  const headerPattern = MARKDOWN_HEADER_SKIP_PATTERNS[providerId];
+  const vendorModule = getVendorModule(providerId);
+
+  const headerPattern =
+    vendorModule.headerSkipPattern !== undefined
+      ? vendorModule.headerSkipPattern
+      : LEGACY_MARKDOWN_HEADER_SKIP_PATTERNS[providerId];
   if (headerPattern) {
     const headerMatch = result.search(headerPattern);
     if (headerMatch !== -1) {
@@ -98,8 +145,11 @@ export function preprocessMarkdown(markdown, providerId) {
     }
   }
 
-  const patterns = MARKDOWN_CUTOFF_PATTERNS[providerId];
-  if (patterns) {
+  const patterns =
+    vendorModule.cutoffPatterns !== undefined
+      ? vendorModule.cutoffPatterns
+      : LEGACY_MARKDOWN_CUTOFF_PATTERNS[providerId];
+  if (patterns && patterns.length) {
     let cutIndex = result.length;
     for (const pattern of patterns) {
       const match = result.search(pattern);
@@ -127,7 +177,7 @@ export function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "
     }
   }
 
-  const toleratesPreorder = PREORDER_TOLERANT_PROVIDERS.has(providerId);
+  const toleratesPreorder = resolvePreorderTolerant(providerId);
   for (const pattern of OUT_OF_STOCK_PATTERNS) {
     if (toleratesPreorder && /pre-?order/i.source === pattern.source) continue;
     const match = markdown.match(pattern);
@@ -140,7 +190,7 @@ export function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "
     }
   }
 
-  if (expectedWeightOz >= 1 && !isFractionalExemptProvider(providerId)) {
+  if (expectedWeightOz >= 1 && !resolveFractionalExempt(providerId)) {
     const headingMatch = markdown.match(/^#{1,2}\s+(.+)$/m);
     const titleArea = headingMatch ? headingMatch[1] : markdown.slice(0, 500);
 
@@ -170,8 +220,6 @@ export function detectStockStatus(markdown, expectedWeightOz = 1, providerId = "
 // Sentinel returned by extractJsonLdPrice when JSON-LD has a valid Product
 // with price=0 — signals "real product page, no price (OOS)".
 export const JSONLD_ZERO_PRICE = Symbol("jsonld-zero-price");
-
-const UNTRUSTED_OFFER_PRICE_VENDORS = new Set(["sdbullion", "bullionexchanges"]);
 
 export function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerId = "") {
   if (!jsonLdScripts || jsonLdScripts.length === 0) return null;
@@ -232,7 +280,7 @@ export function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerI
 
           const price = parseFloat(String(offer.price ?? "").replace(/,/g, ""));
           if (!isNaN(price) && price === 0) return JSONLD_ZERO_PRICE;
-          if (UNTRUSTED_OFFER_PRICE_VENDORS.has(providerId)) continue;
+          if (resolveUntrustedOfferPrice(providerId)) continue;
           if (inRange(price)) return price;
         }
       }
@@ -432,29 +480,40 @@ export function extractMarkdownPrice(markdown, metal, weightOz = 1, providerId =
     return prices;
   }
 
-  if (providerId === "summitmetals") {
-    const tblFirst = firstTableRowFirstPrice();
-    if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
-    const tier = tierAnchoredPrice();
-    if (tier !== null) return { price: tier, matchedBy: "tierAnchored" };
-    const reg = regularPricePrices();
-    if (reg.length > 0) return { price: Math.min(...reg), matchedBy: "regularPrice" };
-    return null;
+  // Shared, vendor-agnostic extraction toolkit. A migrated vendor's extractPrice
+  // composes these; the default strategy below uses them for legacy vendors.
+  const helpers = {
+    inRange,
+    tablePrices,
+    firstTableRowFirstPrice,
+    tierAnchoredPrice,
+    firstInRangePriceProse,
+    regularPricePrices,
+    asLowAsPrices,
+    jmPriceFromProseTable,
+    jmPriceFromPipeTable,
+  };
+
+  // Migrated vendors own their price strategy on their module (e.g. summitmetals).
+  const vendorModule = getVendorModule(providerId);
+  if (typeof vendorModule.extractPrice === "function") {
+    return vendorModule.extractPrice(helpers, { markdown, metal, weightOz, providerId });
   }
 
+  // Default + transitional per-provider strategies for not-yet-migrated vendors.
   if (providerId === "jmbullion") {
     const proseTbl = jmPriceFromProseTable();
     if (proseTbl !== null) return { price: proseTbl, matchedBy: "jmProseTable" };
     const pipeTbl = jmPriceFromPipeTable();
     if (pipeTbl !== null) return { price: pipeTbl, matchedBy: "jmPipeTable" };
     return null;
-  } else if (UNTRUSTED_OFFER_PRICE_VENDORS.has(providerId)) {
+  } else if (resolveUntrustedOfferPrice(providerId)) {
     const tblFirst = firstTableRowFirstPrice();
     if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
     const tier = tierAnchoredPrice();
     if (tier !== null) return { price: tier, matchedBy: "tierAnchored" };
     return null;
-  } else if (USES_AS_LOW_AS.has(providerId)) {
+  } else if (resolveUsesAsLowAs(providerId)) {
     const ala = asLowAsPrices();
     if (ala.length > 0) return { price: Math.min(...ala), matchedBy: "asLowAs" };
     const tbl = tablePrices();

--- a/devops/pollers/shared/price-extract-shared.js
+++ b/devops/pollers/shared/price-extract-shared.js
@@ -60,7 +60,7 @@ const SOFT_404_PATTERNS = [
 //
 // Migrated vendors own these on their price-extract-vendor-*.js module:
 //   cutoffPatterns, headerSkipPattern, preorderTolerant, untrustedOfferPrice,
-//   usesAsLowAs.
+//   usesAsLowAs, and fractionalExempt (via the module's config).
 // The resolver helpers below read the vendor MODULE first (getVendorModule) and
 // fall back to these maps only for vendors that have not migrated yet. When you
 // migrate a vendor, MOVE its entries out of here and into its module so a change
@@ -245,6 +245,9 @@ export function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerI
     return false;
   }
 
+  // Constant for the whole call — resolve once, not per offer in the nested loops.
+  const offerPriceUntrusted = resolveUntrustedOfferPrice(providerId);
+
   for (const script of jsonLdScripts) {
     try {
       const data = JSON.parse(script);
@@ -280,7 +283,7 @@ export function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerI
 
           const price = parseFloat(String(offer.price ?? "").replace(/,/g, ""));
           if (!isNaN(price) && price === 0) return JSONLD_ZERO_PRICE;
-          if (resolveUntrustedOfferPrice(providerId)) continue;
+          if (offerPriceUntrusted) continue;
           if (inRange(price)) return price;
         }
       }

--- a/devops/pollers/shared/price-extract-summit-oos.test.mjs
+++ b/devops/pollers/shared/price-extract-summit-oos.test.mjs
@@ -2,20 +2,24 @@
 /**
  * Unit tests for STRK-144 — Summit Metals false-OOS + bulk-price-tier fixes.
  *
- * Two bugs, both now owned by devops/pollers/shared/price-extract-shared.js:
+ * As of STRK-32/STRK-160 both fixes are owned by the Summit Vendor module,
+ * devops/pollers/shared/price-extract-vendor-summit.js (cutoffPatterns +
+ * extractPrice), resolved at runtime through the shared parser via the Vendor
+ * registry. The two bugs the fix prevents:
  *   1. Every Summit product page embeds a static FAQ whose answer text contains
  *      the literal "...or marked as 'Out of stock.'". That trips
  *      OUT_OF_STOCK_PATTERNS in detectStockStatus(), false-flagging EVERY Summit
- *      item OOS. Fix: a MARKDOWN_CUTOFF_PATTERNS.summitmetals entry trims the
+ *      item OOS. Fix: the Summit module's cutoffPatterns trim the
  *      description/reviews/FAQ tail before stock + price detection.
- *   2. The summit branch of extractMarkdownPrice() read the "Regular price" mini-cards,
+ *   2. The summit extractPrice strategy used to read the "Regular price" mini-cards,
  *      which carry the 100+ BULK price ($77.78) instead of the 1-9 single-unit
  *      price ($79.22). Fix: prefer firstTableRowFirstPrice() / tierAnchoredPrice()
  *      (first qty tier) before falling back to the "Regular price" cards.
  *
  * The shared helpers are importable, so this test exercises the real parser and
- * OOS helpers. A structural assertion at the end guards the real config against
- * silent removal.
+ * OOS helpers end-to-end (registry → Summit module → shared toolkit). A
+ * structural assertion at the end guards the module config against silent
+ * removal AND that it no longer lives in the shared file.
  *
  * Run with:
  *   node devops/pollers/shared/price-extract-summit-oos.test.mjs
@@ -175,20 +179,40 @@ test("old behavior would have returned the bulk $77.78 (regression guard)", () =
   assert.notEqual(extractMarkdownPrice(cleaned, "silver", 1, "summitmetals").price, bulk);
 });
 
-test("STRUCTURAL: real source has summitmetals cutoff + table-first extraction", () => {
-  const src = readFileSync(join(__dirname, "price-extract-shared.js"), "utf8");
-  // Cutoff config present.
-  assert.match(src, /summitmetals:\s*\[/, "MARKDOWN_CUTOFF_PATTERNS.summitmetals missing");
-  assert.match(src, /Description Shipping & Returns/, "summit cutoff anchor missing");
-  // Summit price branch prefers qty-tier extractors over the bulk cards.
-  const startIdx = src.indexOf('if (providerId === "summitmetals")');
-  assert.notEqual(startIdx, -1, "summit branch not found in source");
-  const branch = src.slice(startIdx);
-  const tblIdx = branch.indexOf("firstTableRowFirstPrice()");
-  const tierIdx = branch.indexOf("tierAnchoredPrice()");
-  const regIdx = branch.indexOf("regularPricePrices()");
-  assert.ok(tblIdx !== -1 && tierIdx !== -1 && regIdx !== -1, "expected all three extractors in summit branch");
-  assert.ok(tblIdx < regIdx && tierIdx < regIdx, "qty-tier extractors must precede the bulk regularPricePrices fallback");
+test("STRUCTURAL: Summit cutoff + table-first strategy live in the Vendor module", () => {
+  const moduleSrc = readFileSync(join(__dirname, "price-extract-vendor-summit.js"), "utf8");
+  // Cutoff config present in the module.
+  assert.match(moduleSrc, /cutoffPatterns:\s*\[/, "summit module cutoffPatterns missing");
+  assert.match(moduleSrc, /Description Shipping & Returns/, "summit cutoff anchor missing");
+  // extractPrice prefers qty-tier extractors over the bulk "Regular price" cards.
+  const startIdx = moduleSrc.indexOf("extractPrice(");
+  assert.notEqual(startIdx, -1, "summit extractPrice strategy not found in module");
+  const strategy = moduleSrc.slice(startIdx);
+  const tblIdx = strategy.indexOf("firstTableRowFirstPrice()");
+  const tierIdx = strategy.indexOf("tierAnchoredPrice()");
+  const regIdx = strategy.indexOf("regularPricePrices()");
+  assert.ok(
+    tblIdx !== -1 && tierIdx !== -1 && regIdx !== -1,
+    "expected all three extractors in summit extractPrice",
+  );
+  assert.ok(
+    tblIdx < regIdx && tierIdx < regIdx,
+    "qty-tier extractors must precede the bulk regularPricePrices fallback",
+  );
+});
+
+test("STRUCTURAL: shared.js no longer owns Summit-specific data (isolation guarantee)", () => {
+  const sharedSrc = readFileSync(join(__dirname, "price-extract-shared.js"), "utf8");
+  assert.equal(
+    sharedSrc.includes("Description Shipping & Returns"),
+    false,
+    "summit cutoff anchor must not live in shared.js — it belongs to the Vendor module",
+  );
+  assert.equal(
+    sharedSrc.includes('providerId === "summitmetals"'),
+    false,
+    "summit price branch must not live in shared.js — it belongs to the Vendor module",
+  );
 });
 
 let passed = 0;

--- a/devops/pollers/shared/price-extract-summit-oos.test.mjs
+++ b/devops/pollers/shared/price-extract-summit-oos.test.mjs
@@ -15,6 +15,12 @@
  *      which carry the 100+ BULK price ($77.78) instead of the 1-9 single-unit
  *      price ($79.22). Fix: prefer firstTableRowFirstPrice() / tierAnchoredPrice()
  *      (first qty tier) before falling back to the "Regular price" cards.
+ *   3. THE ACTUAL PRODUCTION CAUSE: Summit's Shopify JSON-LD advertises
+ *      offer.price = the 100+ BULK tier (e.g. $71.97). The poller treats JSON-LD as
+ *      authoritative and checks it BEFORE extractMarkdownPrice, so the bulk price
+ *      short-circuits and the table-first strategy (#2) never runs. Fix: the Summit
+ *      module sets untrustedOfferPrice:true so extractJsonLdPrice() skips the
+ *      offer.price and the poller falls through to the qty-tier table extraction.
  *
  * The shared helpers are importable, so this test exercises the real parser and
  * OOS helpers end-to-end (registry → Summit module → shared toolkit). A
@@ -31,6 +37,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import {
   detectStockStatus,
+  extractJsonLdPrice,
   extractMarkdownPrice,
   preprocessMarkdown,
 } from "./price-extract-shared.js";
@@ -177,6 +184,23 @@ test("old behavior would have returned the bulk $77.78 (regression guard)", () =
   assert.equal(bulk, 77.78);
   // The fix must NOT return that value.
   assert.notEqual(extractMarkdownPrice(cleaned, "silver", 1, "summitmetals").price, bulk);
+});
+
+test("THE PRODUCTION FIX: Summit's bulk JSON-LD offer.price is skipped (untrusted)", () => {
+  // Faithful to Summit's real Shopify JSON-LD: a flat offer.price = the 100+ bulk
+  // tier ($71.97), InStock — no priceSpecification for the 1-9 wire price.
+  const summitJsonLd = [
+    JSON.stringify({
+      "@type": "Product",
+      offers: { price: "71.97", availability: "http://schema.org/InStock" },
+    }),
+  ];
+  // Summit (untrustedOfferPrice:true) → the bulk offer.price is skipped → null,
+  // so the poller falls through to the qty-tier markdown extraction ($73.30 live).
+  assert.equal(extractJsonLdPrice(summitJsonLd, "silver", 1, "summitmetals"), null);
+  // Control: a vendor that trusts offer.price WOULD return the bulk number — proving
+  // the untrusted flag is exactly what prevents the short-circuit for Summit.
+  assert.equal(extractJsonLdPrice(summitJsonLd, "silver", 1, "apmex"), 71.97);
 });
 
 test("STRUCTURAL: Summit cutoff + table-first strategy live in the Vendor module", () => {

--- a/devops/pollers/shared/price-extract-vendor-apmex.js
+++ b/devops/pollers/shared/price-extract-vendor-apmex.js
@@ -10,6 +10,13 @@ export const vendor = {
   id: "apmex",
   displayName: "APMEX",
   config: APMEX_CONFIG,
+  // No vendor-specific markdown shaping — APMEX needs no cutoff/header trimming.
+  cutoffPatterns: [],
+  headerSkipPattern: null,
+  preorderTolerant: false,
+  untrustedOfferPrice: false,
+  usesAsLowAs: false,
+  // No extractPrice override → shared default strategy (Firecrawl pipe table, table-first).
   async scrape(context) {
     return context.scrapeGeneric({
       ...context,

--- a/devops/pollers/shared/price-extract-vendor-goldback.js
+++ b/devops/pollers/shared/price-extract-vendor-goldback.js
@@ -1,4 +1,4 @@
-import { providerCfg } from "./price-extract-provider-config.js";
+import { mergeProviderConfig } from "./price-extract-provider-config.js";
 
 export function isGoldbackCoinSlug(coinSlug) {
   return String(coinSlug || "").startsWith("goldback");
@@ -15,7 +15,14 @@ export function shouldBypassFirecrawlPreferredForPhase0({
 export const vendor = {
   id: "goldback",
   displayName: "Goldback",
-  config: providerCfg("goldback"),
+  config: mergeProviderConfig({}), // phase0 defaults — owned here, not in LEGACY_PROVIDER_OVERRIDES.
+  // No vendor-specific markdown shaping — Goldback needs no cutoff/header trimming.
+  cutoffPatterns: [],
+  headerSkipPattern: null,
+  preorderTolerant: false,
+  untrustedOfferPrice: false,
+  usesAsLowAs: false,
+  // No extractPrice override → shared default strategy.
   async scrape(context) {
     return context.scrapeGeneric({
       ...context,

--- a/devops/pollers/shared/price-extract-vendor-summit.js
+++ b/devops/pollers/shared/price-extract-vendor-summit.js
@@ -34,7 +34,13 @@ export const vendor = {
   ],
   headerSkipPattern: null,
   preorderTolerant: false,
-  untrustedOfferPrice: false,
+  // Summit's Shopify JSON-LD advertises offer.price = the 100+ BULK tier (e.g.
+  // $71.97), not the 1-9 single-unit Check/Wire price. The poller treats JSON-LD
+  // as authoritative and checks it BEFORE extractMarkdownPrice, so a trusted
+  // offer.price short-circuits straight to the bulk price and the table-first
+  // strategy below never runs. Marking offer.price untrusted makes the JSON-LD
+  // path skip it and fall through to the qty-tier table extraction. (STRK-144)
+  untrustedOfferPrice: true,
   usesAsLowAs: false,
 
   // --- Per-vendor price strategy ---

--- a/devops/pollers/shared/price-extract-vendor-summit.js
+++ b/devops/pollers/shared/price-extract-vendor-summit.js
@@ -1,0 +1,60 @@
+/**
+ * Summit Metals Vendor module (STRK-32 / STRK-144).
+ *
+ * Owns ALL Summit-specific scraping behavior so a change here cannot touch any
+ * other vendor:
+ *   - config: phase0 defaults (Playwright-direct, networkidle).
+ *   - cutoffPatterns: trim the description/reviews/FAQ tail. Every Summit product
+ *     page embeds an FAQ containing "...or marked as 'Out of stock.'", which would
+ *     otherwise false-flag EVERY item OOS, and trailing "Regular price" cards that
+ *     carry the 100+ BULK price.
+ *   - extractPrice: prefer the first qty-tier (1-9 Check/Wire) from the pricing
+ *     table over the "Regular price" bulk cards. Pipe path resolves via
+ *     firstTableRowFirstPrice(); flattened prose path via tierAnchoredPrice();
+ *     regularPricePrices() is the last-resort fallback only.
+ */
+
+import { mergeProviderConfig } from "./price-extract-provider-config.js";
+
+// Summit uses the phase0 defaults (Playwright-direct first, then Firecrawl).
+export const SUMMIT_CONFIG = mergeProviderConfig({
+  // phase: "phase0", waitUntil: "networkidle" — inherited from PROVIDER_DEFAULTS.
+});
+
+export const vendor = {
+  id: "summitmetals",
+  displayName: "Summit Metals",
+  config: SUMMIT_CONFIG,
+
+  // --- Per-vendor markdown shaping (owned here, not in price-extract-shared.js) ---
+  cutoffPatterns: [
+    /^\s*Description Shipping & Returns\s*$/im,
+    /^#{0,6}\s*What Our Clients/im,
+    /^#{0,6}\s*Faq'?s\s*$/im,
+  ],
+  headerSkipPattern: null,
+  preorderTolerant: false,
+  untrustedOfferPrice: false,
+  usesAsLowAs: false,
+
+  // --- Per-vendor price strategy ---
+  // Single-unit (1-9) Check/Wire price first; bulk "Regular price" cards last.
+  extractPrice(helpers) {
+    const tblFirst = helpers.firstTableRowFirstPrice();
+    if (tblFirst !== null) return { price: tblFirst, matchedBy: "tableFirstRow" };
+    const tier = helpers.tierAnchoredPrice();
+    if (tier !== null) return { price: tier, matchedBy: "tierAnchored" };
+    const reg = helpers.regularPricePrices();
+    if (reg.length > 0) return { price: Math.min(...reg), matchedBy: "regularPrice" };
+    return null;
+  },
+
+  async scrape(context) {
+    return context.scrapeGeneric({
+      ...context,
+      config: context.config || vendor.config,
+    });
+  },
+};
+
+export default vendor;

--- a/devops/pollers/shared/price-extract-vendors.js
+++ b/devops/pollers/shared/price-extract-vendors.js
@@ -1,10 +1,12 @@
 import apmexVendor from "./price-extract-vendor-apmex.js";
 import goldbackVendor from "./price-extract-vendor-goldback.js";
+import summitVendor from "./price-extract-vendor-summit.js";
 import legacyVendor from "./price-extract-vendor-legacy.js";
 
 const MIGRATED_VENDOR_MAP = new Map([
   [goldbackVendor.id, goldbackVendor],
   [apmexVendor.id, apmexVendor],
+  [summitVendor.id, summitVendor],
 ]);
 
 export const MIGRATED_VENDOR_IDS = Array.from(MIGRATED_VENDOR_MAP.keys());

--- a/devops/pollers/shared/price-extract-vendors.test.mjs
+++ b/devops/pollers/shared/price-extract-vendors.test.mjs
@@ -60,7 +60,9 @@ test("Summit module owns the full Vendor interface (cutoff + strategy)", async (
   );
   assert.equal(summit.headerSkipPattern, null);
   assert.equal(summit.preorderTolerant, false);
-  assert.equal(summit.untrustedOfferPrice, false);
+  // Summit's JSON-LD offer.price is the 100+ bulk tier, so it must be untrusted —
+  // otherwise the poller's authoritative JSON-LD path short-circuits to the bulk price.
+  assert.equal(summit.untrustedOfferPrice, true);
   assert.equal(summit.usesAsLowAs, false);
   assert.equal(typeof summit.extractPrice, "function");
 

--- a/devops/pollers/shared/price-extract-vendors.test.mjs
+++ b/devops/pollers/shared/price-extract-vendors.test.mjs
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
 
-const migratedVendorIds = ["goldback", "apmex"];
+const migratedVendorIds = ["goldback", "apmex", "summitmetals"];
 const notYetMigratedVendorIds = ["jmbullion"];
 
 const unwrapVendor = (candidate) => candidate?.vendor ?? candidate?.default ?? candidate;
@@ -44,6 +44,51 @@ test("Goldback module exists and uses the standard interface", async () => {
 
   assertStandardVendorModule(goldbackModule, "goldback");
   assert.equal(goldbackModule.default, goldbackModule.vendor);
+});
+
+test("Summit module owns the full Vendor interface (cutoff + strategy)", async () => {
+  const summitModule = await import(new URL("./price-extract-vendor-summit.js", import.meta.url));
+  const summit = unwrapVendor(summitModule);
+
+  assertStandardVendorModule(summitModule, "summitmetals");
+  assert.equal(summitModule.default, summitModule.vendor);
+
+  // Per-vendor markdown shaping + flags live on the module, not in shared.js.
+  assert.ok(
+    Array.isArray(summit.cutoffPatterns) && summit.cutoffPatterns.length > 0,
+    "summit cutoffPatterns missing"
+  );
+  assert.equal(summit.headerSkipPattern, null);
+  assert.equal(summit.preorderTolerant, false);
+  assert.equal(summit.untrustedOfferPrice, false);
+  assert.equal(summit.usesAsLowAs, false);
+  assert.equal(typeof summit.extractPrice, "function");
+
+  // Strategy (tested in isolation via fake helpers): qty-tier first, bulk cards last.
+  assert.deepEqual(
+    summit.extractPrice({
+      firstTableRowFirstPrice: () => 79.22,
+      tierAnchoredPrice: () => 78.83,
+      regularPricePrices: () => [77.78],
+    }),
+    { price: 79.22, matchedBy: "tableFirstRow" }
+  );
+  assert.deepEqual(
+    summit.extractPrice({
+      firstTableRowFirstPrice: () => null,
+      tierAnchoredPrice: () => 79.22,
+      regularPricePrices: () => [77.78],
+    }),
+    { price: 79.22, matchedBy: "tierAnchored" }
+  );
+  assert.deepEqual(
+    summit.extractPrice({
+      firstTableRowFirstPrice: () => null,
+      tierAnchoredPrice: () => null,
+      regularPricePrices: () => [77.78, 79.22],
+    }),
+    { price: 77.78, matchedBy: "regularPrice" }
+  );
 });
 
 test("APMEX module exists and preserves Firecrawl-preferred config", async () => {


### PR DESCRIPTION
## TL;DR

Two things in one PR:
1. **Bug fix** — Summit Metals has been logging the **100+ bulk price** instead of the **1-9 Check/Wire price**. Root cause found + fixed + verified live.
2. **Refactor (STRK-32 completion)** — each vendor now fully owns its own scraping tweaks (config, cutoff patterns, extraction strategy), so one vendor's change can't affect another. The fix above lands cleanly *because of* this refactor.

## The bug (real root cause)

The poller checks **JSON-LD first and treats it as authoritative** ([`price-extract.js` ~L314-328](devops/pollers/shared/price-extract.js)) — before `extractMarkdownPrice` ever runs. Summit's Shopify JSON-LD advertises `offer.price = 71.97` (the **100+ bulk tier**), so the poller returned the bulk price and the STRK-144 markdown table-first fix **never ran for Summit**.

This is a **live code bug, not a deploy gap** (an earlier diagnosis in-thread was wrong and is corrected here). Proven by probing the real page's JSON-LD through the actual poller helper:

```
Product offer.price = 71.97 | availability = InStock
extractJsonLdPrice(summitmetals) => 71.97   (bulk)
```

**Fix:** the Summit Vendor module sets `untrustedOfferPrice: true` (same situation as sdbullion/bullionexchanges), so `extractJsonLdPrice` skips the bulk `offer.price` and the poller falls through to the qty-tier markdown extraction.

**Verified end-to-end on the live Kangaroo page via the real `phase0` path** (Playwright `document.body.innerText` + JSON-LD, exactly as the poller runs it):

```
JSON-LD price (untrusted skip in effect): null
FINAL: 73.3 | source: markdown:tierAnchored   ✅ the 1-9 Check/Wire price
```

## The refactor (STRK-32 interface completion)

Per-vendor `cutoffPatterns`, `headerSkipPattern`, `preorderTolerant`, `untrustedOfferPrice`, `usesAsLowAs`, and the price strategy now live on each `price-extract-vendor-<id>.js` module; `price-extract-shared.js` resolves them via `getVendorModule()` with a renamed `LEGACY_*` fallback for not-yet-migrated vendors (strangler-fig). Summit migrated as the first full example; APMEX + Goldback retrofitted. The bulk-price fix is literally a one-line flag on the Summit module — the payoff of the isolation.

## Verification

- All 13 poller test suites green, incl. a **new regression test**: Summit's bulk JSON-LD `offer.price` is skipped, while a control vendor still trusts it (proves the flag is the guard).
- Live end-to-end confirmation (above).

## After merge

Deploy the home poller to pick this up. Establishes the template for **STRK-150 / 151 / 152** under epic **STRK-104**.

Refs STRK-32, STRK-104, STRK-144.