### PR TITLE
docs: correct What's New cap in copilot-instructions (3-5 -> 8)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -247,7 +247,7 @@ If `sw.js` CACHE_NAME does not match the version in `js/constants.js`, the servi
 
 ### 8. What's New Entry Rotation -- Intentional Limit
 
-`js/about.js` (`getEmbeddedWhatsNew()`) is the **sole source of truth** for What's New content. `docs/announcements.md` was deprecated per STAK-513 and no longer exists -- do not flag it as missing or out of sync. Entries in `getEmbeddedWhatsNew()` are **intentionally capped at 3-5**. When a new release is added, the oldest entry is rotated out. Do not flag removed older entries as missing -- this is by design.
+`js/about.js` (`getEmbeddedWhatsNew()`) is the **sole source of truth** for What's New content. `docs/announcements.md` was deprecated per STAK-513 and no longer exists -- do not flag it as missing or out of sync. Entries in `getEmbeddedWhatsNew()` are **intentionally capped at the 8 most recent** -- the `/release` skill enforces this via `grep -c '<li><strong>v' js/about.js` == 8, and the project pre-commit/release flow keeps the count at 8. When a new release is added, the oldest entry is rotated out to maintain 8. Do not flag removed older entries as missing, and do not suggest trimming to fewer (e.g. 3-5) -- 8 is by design.
 
 Similarly, `getEmbeddedRoadmap()` in `about.js` is capped at 3-4 items. Completed roadmap items are removed during releases.
 


### PR DESCRIPTION
## Summary

`.github/copilot-instructions.md` stated `getEmbeddedWhatsNew()` is "capped at 3-5", contradicting the authoritative `/release` skill which keeps the **8 most recent** entries (verified via `grep -c '<li><strong>v' js/about.js` == 8). This stale reviewer guidance caused Copilot + CodeRabbit to flag the correct 8-entry list on [#1214](https://github.com/lbruton/StakTrakr/pull/1214).

Corrected the cap to 8 and added a "do not suggest trimming to fewer" note so reviewers stop flagging it.

## Note (separate, not fixed here)

`.claude/skills/ship/SKILL.md:161` instructs a dev→main ship to *rewrite* What's New to "3-5 thematic entries" — a different phase that still conflicts with `/release`'s `grep == 8`. That's a workflow-design decision (which cap wins at ship time?), tracked separately.

Surfaced during STRK-83.
