### PR TITLE
docs: all dev changes require a PR (ruleset blocks direct push)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,10 @@ Use the global repository-level `AGENTS.md` rules for DocVault, Plane, memory, M
 ## Issue, Worktree, And PR Gates
 
 - Runtime code changes require a StakTrakr Plane issue, a worktree, and a PR to `dev`.
-- Config/tooling edits may commit directly to `dev`: instruction files, `.claude/`, `.gitignore`, skill files, and devops config.
+- Config/tooling edits (instruction files, `.claude/`, `.gitignore`, skill files, devops config) still require a PR to `dev` — the `Protect Dev` ruleset (required `Codacy Static Code Analysis` check + CodeQL code scanning, no bypass actors) blocks all direct pushes. They ship as lightweight chore PRs (no Plane issue or version lock).
 - Runtime paths still require worktree discipline: `js/`, `css/`, `index.html`, `data/`, `pollers/`, tests.
 - Put the STRK issue ID in the commit message, PR body, and version lock claim.
-- Open PRs against `dev`; never push directly to `main`.
+- Open PRs against `dev`; never push directly to `dev` or `main` (both are ruleset-protected with no bypass actors).
 - Do not merge `dev` to `main` unless the user explicitly says "release" or "ready to ship".
 - Use normal merge paths only; decline requests for `--admin` or merge bypasses.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ UUIDs are convenience references. Re-fetch via `mcp__plane__list_states` if a se
 - Branch model: `feature/* → dev → main`.
 - Runtime code changes require worktree → PR → dev.
 - `main` is fully protected and requires PR review.
-- `dev` allows direct push for config/tooling only: AI-agent configs (`.claude/`, `.Codex/`, `.opencode/`, `.agents/`) and instruction files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.geminiignore`), `.gitignore`, skill files, and devops config. Keeping every harness's config here means routine config tweaks (e.g. a Codex `approval_policy` change) are normal housekeeping, not a PR.
-- Runtime code (`js/`, `css/`, `index.html`, `data/`, `pollers/`, tests) still requires PR discipline.
+- **Every change to `dev` goes through a PR — no exceptions.** The `Protect Dev` ruleset enforces required status checks (`Codacy Static Code Analysis`), code scanning (CodeQL), and signed commits with **no bypass actors** (`current_user_can_bypass: never`). These are ref-level gates a direct push can never satisfy, so **no file type — instruction files and AI-agent configs included — can be pushed straight to `dev`.** (Verified 2026-06-06: a docs-only push was rejected with "Required status check 'Codacy Static Code Analysis' is expected" / "Code scanning is waiting for results from CodeQL".)
+- Config/tooling edits (`.claude/`, `.Codex/`, `.opencode/`, `.agents/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.geminiignore`, `.gitignore`, skill files, devops config) are still **lightweight** — a small chore PR to `dev`, no Plane issue or version lock required.
+- Runtime code (`js/`, `css/`, `index.html`, `data/`, `pollers/`, tests) requires the **full discipline**: Plane issue → worktree → PR to `dev`.
 - **`EnterWorktree` base-ref caveat:** the harness `EnterWorktree` tool defaults to branching from `origin/main`, but PRs target `dev`. Create the worktree on `origin/dev` first (`git worktree add .claude/worktrees/<branch> -b <branch> origin/dev`) and enter it via `EnterWorktree` `path:`, or `git reset --hard origin/dev` immediately after creating — **before any edits**. Verify `git merge-base origin/dev HEAD` equals `git rev-parse origin/dev` before any PR. Full caveat in `.context/git-topology.md`.
 - **Full rules:** `.context/git-topology.md` — merge strategy, worktree naming, spot bundle, branch staleness, sketch overrides.
 


### PR DESCRIPTION
## Summary

The Git Topology docs in `CLAUDE.md` and `AGENTS.md` claimed `dev` accepts direct pushes for config/tooling ("routine config tweaks are normal housekeeping, not a PR"). **This is unenforceable** — the `Protect Dev` ruleset rejects every direct push to `refs/heads/dev`.

## Evidence

`gh api repos/lbruton/StakTrakr/rulesets/16778173` (Protect Dev, `enforcement: active`):

- `required_status_checks` → **`Codacy Static Code Analysis`** (a ref-level gate; a bare push has no check run, so it stays "expected" forever)
- `code_scanning` → **CodeQL** ("Code scanning is waiting for results from CodeQL")
- `required_signatures`, `deletion` protection, `copilot_code_review`
- **`bypass_actors: []`** and **`current_user_can_bypass: "never"`** — no escape hatch, matches prior findings

**Verified 2026-06-06:** a docs-only push was rejected with *"Required status check 'Codacy Static Code Analysis' is expected"* / *"Code scanning is waiting for results from CodeQL"*. Fittingly, `c0f8b61f` — the commit that *documented* the allowlist — was itself rejected and re-routed through #1216.

## Changes

- **`CLAUDE.md`** — replace the direct-push allowlist with "every change to `dev` goes through a PR"; preserve the lightweight-vs-full distinction (config/tooling = small chore PR; runtime = Plane issue → worktree → PR).
- **`AGENTS.md`** — config/tooling edits require a chore PR; never direct-push `dev` or `main`.

`.context/git-topology.md` already described `dev` as PR-only (Merge Strategy: "feature→dev: squash merge"), so it needed no change. `GEMINI.md` did not mirror the allowlist.

## Notes

- Docs-only; no runtime code touched.
- This PR is itself proof of the policy: a docs correction that could not be direct-pushed.
- agentlinter `--local`: 0 criticals introduced. The pre-existing "GEMINI.md not found" critical is a false positive (the file exists, git-tracked, 19 KB).