### PR TITLE
fix(codacy): repo-relative localConfigurationFile paths

### DIFF
--- a/.codacy/codacy.config.json
+++ b/.codacy/codacy.config.json
@@ -386,13 +386,13 @@
     },
     {
       "toolId": "markdownlint",
-      "localConfigurationFile": "/Volumes/DATA/GitHub/StakTrakr/.claude/worktrees/feature/STRK-163-codacy-gen3-migration/.markdownlint.json",
+      "localConfigurationFile": ".markdownlint.json",
       "useLocalConfigurationFile": true,
       "patterns": []
     },
     {
       "toolId": "ESLint9",
-      "localConfigurationFile": "/Volumes/DATA/GitHub/StakTrakr/.claude/worktrees/feature/STRK-163-codacy-gen3-migration/eslint.config.cjs",
+      "localConfigurationFile": "eslint.config.cjs",
       "patterns": [
         {
           "patternId": "ESLint9_@typescript-eslint_related-getter-setter-pairs"


### PR DESCRIPTION
Follow-up to #1220. `codacy-analysis init --remote` wrote **absolute, worktree-specific** `localConfigurationFile` paths for `markdownlint` and `ESLint9` (e.g. `/Volumes/.../worktrees/feature/STRK-163.../eslint.config.cjs`). Those worktrees are deleted, so local Codacy runs can't resolve them. Rewrites to repo-relative basenames (`.markdownlint.json`, `eslint.config.cjs`). Caught by Copilot review on the SpecFlow sibling PR; same fix applied across the fleet.