### PR TITLE
chore(codacy): tune Lizard baselines + exclude package-lock.json

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,11 +1,15 @@
-# Codacy CLOUD PLATFORM config — read by dashboard scans only.
-# The local CLI (codacy-cli-v2) does NOT read this file.
-# Local CLI exclusions live per-tool in .codacy/tools-configs/.
+# Codacy CLOUD PLATFORM config — read by dashboard scans.
+# Also respected by the Gen-3 `codacy-analysis init --remote` when it
+# regenerates the local mirror at .codacy/codacy.config.json.
+# (Gen-2 codacy-cli-v2 / .codacy/tools-configs/ were removed in the Gen-3 migration.)
 ---
 exclude_paths:
   - "AGENTS.md"
   - "CLAUDE.md"
   - "GEMINI.md"
+  # Generated lockfile — Lizard counts its ~1600 NLOC as a complexity finding.
+  - "package-lock.json"
+  - "**/package-lock.json"
   - ".agents/**"
   - ".Codex/**"
   - ".codacy/**"

--- a/.codacy/codacy.config.json
+++ b/.codacy/codacy.config.json
@@ -361,25 +361,25 @@
         {
           "patternId": "Lizard_file-nloc-medium",
           "parameters": {
-            "threshold": "500"
+            "threshold": "1500"
           }
         },
         {
           "patternId": "Lizard_parameter-count-medium",
           "parameters": {
-            "threshold": "8"
+            "threshold": "15"
           }
         },
         {
           "patternId": "Lizard_nloc-medium",
           "parameters": {
-            "threshold": "50"
+            "threshold": "100"
           }
         },
         {
           "patternId": "Lizard_ccn-medium",
           "parameters": {
-            "threshold": "8"
+            "threshold": "10"
           }
         }
       ]


### PR DESCRIPTION
## What

Aligns the in-repo Codacy config with the tuned **StakTrakr** coding standard (edited on the cloud) so local scans and the dashboard stay in lockstep, and stops Lizard from scanning the generated lockfile.

### Lizard threshold sync (`.codacy/codacy.config.json`)
| Pattern | Before | After |
|---------|-------:|------:|
| `Lizard_ccn-medium` | 8 | 10 |
| `Lizard_nloc-medium` | 50 | 100 |
| `Lizard_file-nloc-medium` | 500 | 1500 |
| `Lizard_parameter-count-medium` | 8 | 15 |

Surgical value edits only — **no `init --remote`**, so no absolute `localConfigurationFile` paths are reintroduced (verified `grep -cE '/Users/|/Volumes/'` == 0).

### `.codacy.yml`
- Exclude `package-lock.json` (generated; ~1600 NLOC tripped Lizard `file-nloc` even at the new 1500 threshold).
- Corrected the stale header comment (referenced the removed Gen-2 `codacy-cli-v2` / `.codacy/tools-configs/`).

## Why

The Codacy dashboard carried ~468 issues on `dev`, **94% Lizard complexity** noise from thresholds (CCN>8, NLOC>50) mismatched to a mature vanilla-JS codebase. Thresholds were tuned to fit the code; this PR records that in-repo.

## Cloud-only (not in this diff)
- The 4 Lizard thresholds were changed on the **StakTrakr coding standard** (org-level; not stored in git).
- The 28 `ESLint9_no-undef` service-worker global false positives (`self`/`caches`/`fetch`/`importScripts`/`module`/`classifyEndpoint`) were marked **FalsePositive** via `codacy issues --ignore`. The rule remains **enabled** so genuine undeclared variables still flag for case-by-case review.

## Verification
- `jq -e .` passes; 0 absolute paths.
- Post-merge reanalysis of `dev` will reflect the reduced count.