### PR TITLE
chore: Codacy state authoritative via Cloud CLI, not dashboard UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,8 @@ Read the file `.context/implementation-gotchas.md` before touching: `applyBulkEd
 
 Read the file `.context/review-and-ci.md` before: Codacy CLI scans, agentlint runs, pre-PR quality checks, or triaging reviewer false positives.
 
+**Codacy state is authoritative via the Cloud CLI, not the dashboard UI.** Before claiming a Codacy tool toggle or pattern suppression is done, confirm it with the Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend can diverge, and a UI-only check has been wrong repeatedly in a single session. The Codacy MCP server is retired; use the `codacy-skills` plugin CLIs (`codacy-cloud-cli` for cloud state, `codacy-analysis-cli` for local scans).
+
 ## Pre-flight (StakTrakr-specific)
 
 - **Before writing any JavaScript** → read `Foundation/coding-standards.md` (DocVault).


### PR DESCRIPTION
## What

Adds a **Review & CI** rule to `CLAUDE.md`: verify Codacy tool/pattern state through the **Codacy Cloud CLI** (`codacy-skills` plugin), not the dashboard UI.

## Why

Surfaced by `/review-claudemd` analysis of recent sessions. In one session the dashboard UI was asserted as the source of truth **three times** while the backend disagreed (PMD vs PMD7, Biome vs Lizard toggle order). The rule also records that the **Codacy MCP server is retired** in favor of the plugin CLIs (`codacy-cloud-cli` for cloud state, `codacy-analysis-cli` for local scans).

## Scope

Config/tooling change (`CLAUDE.md`) → lightweight chore PR, no Plane issue or version lock. Documentation only; no runtime code touched.