### PR TITLE
chore: clarify lets-start-session trigger in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ For UI work touching `index.html`, `css/styles.css`, modal/view rendering, or in
 
 ## Pre-Flight Triggers
 
+- Session start: run the `start` skill (not `start-patch`) for reorientation when user says "lets start a session". Run `start-patch` only when starting a patch worktree for a specific Plane issue.
 - Feed, poller, API, or data-path diagnosis: invoke `/api-infrastructure` and `/retail-poller`.
 - Individual dealer scraping failures: invoke `/retail-provider-fix`.
 - Version-bump PRs: run `/update-spot-bundle`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ For UI work touching `index.html`, `css/styles.css`, modal/view rendering, or in
 
 ## Pre-Flight Triggers
 
-- Session start: run the `start` skill (not `start-patch`) for reorientation when user says "lets start a session". Run `start-patch` only when starting a patch worktree for a specific Plane issue.
+- Session start: run the `start` skill (not `start-patch`) for reorientation when user says "let's start a session". Run `start-patch` only when starting a patch worktree for a specific Plane issue.
 - Feed, poller, API, or data-path diagnosis: invoke `/api-infrastructure` and `/retail-poller`.
 - Individual dealer scraping failures: invoke `/retail-provider-fix`.
 - Version-bump PRs: run `/update-spot-bundle`.


### PR DESCRIPTION
As requested, this clarifies that starting a session runs the start skill, not the start-patch skill.