### PR TITLE
chore(STRK-167): address PR #1233 review comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -7262,17 +7262,8 @@
       #diffReviewModal .dm-dup-flag .dm-dup-text {
         line-height: 1.2;
       }
-      .sr-only {
-        position: absolute !important;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
-      }
+      /* .sr-only is defined globally in css/styles.css — the dup-badge sr-only
+         sentence relies on that single definition (STRK-167 PR #1233 follow-up). */
       #diffReviewModal .dm-field-arrow {
         color: var(--text-muted, #6b7094);
         font-size: 0.8rem;

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -40,7 +40,7 @@ const _fallbackItemKey = (item) => {
         .trim()
         .toLowerCase();
     const nid = String(item.numistaId == null ? "" : item.numistaId).trim();
-    const year = item.year == null ? "" : String(item.year);
+    const year = String(item.year == null ? "" : item.year).trim();
     return `${nid}|${year}|${norm(item.grade)}|${norm(item.certNumber)}`;
   }
   return `${item.name || ""}|${item.date || ""}`;

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -28,7 +28,9 @@
  * @returns {string} Stable item key
  */
 const _fallbackItemKey = (item) => {
-  // Mirror DiffEngine's authoritative ladder for the rare case DiffEngine is absent.
+  // duplication-ok: intentional safety net that mirrors DiffEngine's authoritative
+  // ladder ONLY when window.DiffEngine is absent (e.g. an isolated unit harness).
+  // computeItemKey delegates to DiffEngine at runtime; this never fires in the app.
   if (!item) return "";
   if (item.uuid) return String(item.uuid);
   if (item.serial != null && item.serial !== "") return String(item.serial);
@@ -37,8 +39,9 @@ const _fallbackItemKey = (item) => {
       String(v == null ? "" : v)
         .trim()
         .toLowerCase();
+    const nid = String(item.numistaId == null ? "" : item.numistaId).trim();
     const year = item.year == null ? "" : String(item.year);
-    return `${item.numistaId}|${year}|${norm(item.grade)}|${norm(item.certNumber)}`;
+    return `${nid}|${year}|${norm(item.grade)}|${norm(item.certNumber)}`;
   }
   return `${item.name || ""}|${item.date || ""}`;
 };

--- a/js/diff-engine.js
+++ b/js/diff-engine.js
@@ -312,10 +312,11 @@ const DiffEngine = {
   /**
    * Instance-aware catalog key (STRK-167): `numistaId|year|grade|certNumber`.
    * A numistaId identifies a catalog TYPE; grade + certNumber distinguish the
-   * physical INSTANCE, and year keeps distinct issue years separate. grade/cert
-   * are trimmed + lowercased; missing segments collapse to "". Shared by
-   * computeItemKey (tertiary tier) and enrichItemIdentities so the three
-   * historical key copies can never drift again.
+   * physical INSTANCE, and year keeps distinct issue years separate. numistaId is
+   * trimmed (sanitizeObjectFields preserves surrounding spaces, so `" 12345 "` and
+   * `"12345"` must key the same); grade/cert are trimmed + lowercased; missing
+   * segments collapse to "". Shared by computeItemKey (tertiary tier) and
+   * enrichItemIdentities so the three historical key copies can never drift again.
    *
    * @param {object} item
    * @returns {string}
@@ -325,8 +326,9 @@ const DiffEngine = {
       String(v == null ? "" : v)
         .trim()
         .toLowerCase();
+    const nid = String(item.numistaId == null ? "" : item.numistaId).trim();
     const year = item.year == null ? "" : String(item.year);
-    return `${item.numistaId}|${year}|${norm(item.grade)}|${norm(item.certNumber)}`;
+    return `${nid}|${year}|${norm(item.grade)}|${norm(item.certNumber)}`;
   },
 
   // -------------------------------------------------------------------------
@@ -374,9 +376,10 @@ const DiffEngine = {
    * Collapses rows that share an instance key (STRK-167 AC-6), summing qty.
    * Used by the Numista importer to merge the repeated N# rows the export emits
    * for identical ungraded copies BEFORE identity stamping. Distinct years or
-   * grades produce distinct keys and stay separate. Rows without a numistaId
-   * pass through untouched (no instance key to group on). Pure — returns a new
-   * array of (shallow-cloned) rows; inputs are not mutated.
+   * grades produce distinct keys and stay separate. The returned array is always
+   * new and the input rows are never mutated: numistaId rows are shallow-cloned
+   * before their qty is summed, while rows without a numistaId pass through by
+   * reference (no instance key to group on).
    *
    * @param {object[]} rows
    * @returns {object[]}

--- a/js/diff-engine.js
+++ b/js/diff-engine.js
@@ -327,7 +327,7 @@ const DiffEngine = {
         .trim()
         .toLowerCase();
     const nid = String(item.numistaId == null ? "" : item.numistaId).trim();
-    const year = item.year == null ? "" : String(item.year);
+    const year = String(item.year == null ? "" : item.year).trim();
     return `${nid}|${year}|${norm(item.grade)}|${norm(item.certNumber)}`;
   },
 

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.14-b1780879062";
+const CACHE_NAME = "staktrakr-v3.35.14-b1780879805";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.14-b1780879805";
+const CACHE_NAME = "staktrakr-v3.35.14-b1780880079";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/diff-engine-instance-key.test.js
+++ b/tests/unit/diff-engine-instance-key.test.js
@@ -61,6 +61,13 @@ describe("AC-1 — instance key = numistaId|year|grade|certNumber (normalized)",
     );
   });
 
+  test("numistaId is trimmed so surrounding spaces don't fork the key (PR #1233 follow-up)", () => {
+    assert.equal(
+      DiffEngine.computeItemKey(instance({ numistaId: " 12345 " })),
+      DiffEngine.computeItemKey(instance({ numistaId: "12345" }))
+    );
+  });
+
   test("ungraded item collapses grade+cert to empty segments", () => {
     assert.equal(
       DiffEngine.computeItemKey(instance({ grade: "", certNumber: "" })),

--- a/tests/unit/diff-engine-instance-key.test.js
+++ b/tests/unit/diff-engine-instance-key.test.js
@@ -98,6 +98,30 @@ describe("AC-2 — changeLog and DiffEngine produce identical keys (3-site equiv
       );
     });
   }
+
+  // The DiffEngine-absent fallback (`_fallbackItemKey`) is the safety net that
+  // fires only when window.DiffEngine is missing. Load changeLog.js into a window
+  // WITHOUT DiffEngine so computeItemKey exercises the inline fallback directly.
+  describe("changeLog fallback (DiffEngine absent) mirrors the instance key", () => {
+    const bareWin = {};
+    new Function("window", clSrc)(bareWin);
+    const fallbackKey = bareWin.computeItemKey;
+
+    test("fallback is in use (no DiffEngine on this window)", () => {
+      assert.equal(bareWin.DiffEngine, undefined);
+      assert.equal(typeof fallbackKey, "function");
+    });
+
+    test("fallback builds the instance key for a numista item", () => {
+      assert.equal(fallbackKey(instance({ grade: "", certNumber: "" })), "12345|2024||");
+    });
+
+    test("fallback trims numistaId and year (PR #1234 review)", () => {
+      const ref = fallbackKey(instance({ grade: "", certNumber: "" }));
+      assert.equal(fallbackKey(instance({ numistaId: " 12345 ", grade: "", certNumber: "" })), ref);
+      assert.equal(fallbackKey(instance({ year: " 2024 ", grade: "", certNumber: "" })), ref);
+    });
+  });
 });
 
 describe("AC-3 — same ungraded instance from API vs CSV → identical keys", () => {

--- a/tests/unit/diff-engine-instance-key.test.js
+++ b/tests/unit/diff-engine-instance-key.test.js
@@ -61,11 +61,10 @@ describe("AC-1 — instance key = numistaId|year|grade|certNumber (normalized)",
     );
   });
 
-  test("numistaId is trimmed so surrounding spaces don't fork the key (PR #1233 follow-up)", () => {
-    assert.equal(
-      DiffEngine.computeItemKey(instance({ numistaId: " 12345 " })),
-      DiffEngine.computeItemKey(instance({ numistaId: "12345" }))
-    );
+  test("numistaId and year are trimmed so surrounding spaces don't fork the key (PR #1233/#1234 follow-up)", () => {
+    const ref = DiffEngine.computeItemKey(instance({ numistaId: "12345", year: 2024 }));
+    assert.equal(DiffEngine.computeItemKey(instance({ numistaId: " 12345 " })), ref);
+    assert.equal(DiffEngine.computeItemKey(instance({ year: " 2024 " })), ref);
   });
 
   test("ungraded item collapses grade+cert to empty segments", () => {


### PR DESCRIPTION
Follow-up to [#1233](https://github.com/lbruton/StakTrakr/pull/1233) — addresses the 4 advisory review threads (Copilot + Codacy) that posted ~1.5 min after that PR merged.

| # | Finding | Fix |
|---|---------|-----|
| Copilot `diff-engine.js:330` | `_instanceKey` didn't trim `numistaId` (`" 12345 "` ≠ `"12345"`; `sanitizeObjectFields` preserves spaces) | Trim `numistaId` in `_instanceKey` **and** the `changeLog.js` fallback (keeps AC-2 equivalence); added a regression test |
| Copilot `diff-engine.js:380` | `collapseByInstanceKey` doc claimed all rows "shallow-cloned" but non-numistaId rows pass by reference | Tightened the doc to match the implementation |
| Copilot `index.html:7275` | `.sr-only` re-defined inline (with a needless `!important`) when it's already global in `css/styles.css` | Dropped the inline copy; badge relies on the global rule |
| Codacy `changeLog.js:44` | `_fallbackItemKey` is a shadow of `_instanceKey` | Kept (intentional DiffEngine-absent safety net) + added a `duplication-ok` marker and clarifying comment |

## Tests
- [x] `npm run test:unit` — 217 pass (new numistaId-trim assertion in `diff-engine-instance-key.test.js`)
- [x] `numista-import-onboarding.spec.js` — 7 pass (badge sr-only text still resolves via the global rule)

No version bump (chore — review-comment cleanup, no user-facing behavior change beyond the trim edge case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where whitespace in ID and year fields caused key matching failures, preventing duplicate items from being created.

* **Tests**
  * Added unit test verifying whitespace trimming behavior for key generation.

* **Refactor**
  * Consolidated CSS accessibility utilities to use global styles and improved documentation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->