### PR TITLE
docs(claudemd): capture session learnings from /review-claudemd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run format:check
 - Before editing or running Playwright tests, read the Playwright policy reference in `AGENTS.md`.
 - Archived issue acceptance-criteria (AC) matrices are located in
   `tests/playwright/archive/issue-ac-matrices/`.
-- Any PR that adds a Playwright spec must add a matching row to `tests/playwright/coverage-map.csv` (an `AGENTS.md` requirement) — neither ESLint nor `check-release-sync` catches a missing row.
+- Any PR that adds, renames, or removes a Playwright spec must update `tests/playwright/coverage-map.csv` (an `AGENTS.md` requirement) — neither ESLint nor `check-release-sync` catches a missing or stale row.
 
 ## Documentation
 
@@ -185,7 +185,7 @@ Read the file `.context/review-and-ci.md` before: Codacy CLI scans, agentlint ru
 
 **Codacy state is authoritative via the Cloud CLI, not the dashboard UI.** Before claiming a Codacy tool toggle or pattern suppression is done, confirm it with the Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend can diverge, and a UI-only check has been wrong repeatedly in a single session. The Codacy MCP server is retired; use the `codacy-skills` plugin CLIs (`codacy-cloud-cli` for cloud state, `codacy-analysis-cli` for local scans).
 
-**Async bot reviewers land after checks go green.** Copilot and Codacy AI post review threads 1–3 min _after_ required checks pass — often after the merge window opens. Before merging: confirm required checks are green, pause ~2–3 min, then re-query review threads. A `null` or empty result from a `gh api graphql` thread query must be treated as a failed check (a malformed query can silently return `null`), not as "no threads" — confirm the query returns a list before merging.
+**Async bot reviewers land after checks go green.** Copilot and Codacy AI post review threads 1–3 min _after_ required checks pass — often after the merge window opens. Before merging: confirm required checks are green, pause ~2–3 min, then re-query review threads. Treat a `null` result or `errors` array from a `gh api graphql` query as a failure (a malformed query can silently return `null`); an empty `nodes` array is the valid "no active threads" state — confirm the response is a valid list before merging.
 
 ### Dual ESLint config — `.eslintrc.json` is Codacy-only
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ npm run format:check
 - Before editing or running Playwright tests, read the Playwright policy reference in `AGENTS.md`.
 - Archived issue acceptance-criteria (AC) matrices are located in
   `tests/playwright/archive/issue-ac-matrices/`.
+- Any PR that adds a Playwright spec must add a matching row to `tests/playwright/coverage-map.csv` (an `AGENTS.md` requirement) — neither ESLint nor `check-release-sync` catches a missing row.
 
 ## Documentation
 
@@ -73,6 +74,7 @@ UUIDs are convenience references. Re-fetch via `mcp__plane__list_states` if a se
 - Config/tooling edits (`.claude/`, `.Codex/`, `.opencode/`, `.agents/`, `CLAUDE.md`, `AGENTS.md`, `.geminiignore`, `.gitignore`, skill files, devops config) are still **lightweight** — a small chore PR to `dev`, no Plane issue or version lock required.
 - Runtime code (`js/`, `css/`, `index.html`, `data/`, `pollers/`, tests) requires the **full discipline**: Plane issue → worktree → PR to `dev`.
 - **`EnterWorktree` base-ref caveat:** the harness `EnterWorktree` tool defaults to branching from `origin/main`, but PRs target `dev`. Create the worktree on `origin/dev` first (`git worktree add .claude/worktrees/<branch> -b <branch> origin/dev`) and enter it via `EnterWorktree` `path:`, or `git reset --hard origin/dev` immediately after creating — **before any edits**. Verify `git merge-base origin/dev HEAD` equals `git rev-parse origin/dev` before any PR. Full caveat in `.context/git-topology.md`.
+- `devops/version.lock` is gitignored — it exists only in the main checkout, never in a worktree. Claim the version lock by writing to `<main-checkout>/devops/version.lock`, not the worktree path.
 - **Full rules:** `.context/git-topology.md` — merge strategy, worktree naming, spot bundle, branch staleness, sketch overrides.
 
 ## Model Context Protocol Notes
@@ -110,6 +112,8 @@ UUIDs are convenience references. Re-fetch via `mcp__plane__list_states` if a se
 | `/ui-mockup`                      | New multi-element UI — Playground prototype first                   |
 
 **Skill authoring:** filename must be `SKILL.md` (`.gitignore` silently excludes other `.md` names).
+
+**Skill copies:** every `.claude/skills/<name>/SKILL.md` has a tracked twin under `.agents/skills/<name>/SKILL.md`. When fixing a skill doc, `git grep` the sibling and apply the identical fix to both — Copilot flags stale twins.
 
 ## Required Context
 
@@ -180,6 +184,14 @@ Read the file `.context/implementation-gotchas.md` before touching: `applyBulkEd
 Read the file `.context/review-and-ci.md` before: Codacy CLI scans, agentlint runs, pre-PR quality checks, or triaging reviewer false positives.
 
 **Codacy state is authoritative via the Cloud CLI, not the dashboard UI.** Before claiming a Codacy tool toggle or pattern suppression is done, confirm it with the Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend can diverge, and a UI-only check has been wrong repeatedly in a single session. The Codacy MCP server is retired; use the `codacy-skills` plugin CLIs (`codacy-cloud-cli` for cloud state, `codacy-analysis-cli` for local scans).
+
+**Async bot reviewers land after checks go green.** Copilot and Codacy AI post review threads 1–3 min _after_ required checks pass — often after the merge window opens. Before merging: confirm required checks are green, pause ~2–3 min, then re-query review threads. A `null` or empty result from a `gh api graphql` thread query must be treated as a failed check (a malformed query can silently return `null`), not as "no threads" — confirm the query returns a list before merging.
+
+### Dual ESLint config — `.eslintrc.json` is Codacy-only
+
+The repo carries two ESLint configs: `eslint.config.cjs` (flat — used by local `npm run lint`) and `.eslintrc.json` (legacy — read only by Codacy's server-side ESLint). With a flat config present, ESLint 9 ignores the legacy file locally.
+The `no-restricted-globals` ban on native `alert`/`confirm`/`prompt` (use `showAppAlert`/`showAppConfirm`/`showAppPrompt`) lives **only** in `.eslintrc.json`, so a native `confirm()` passes `npm run lint` but Codacy flags it.
+Before deleting `.eslintrc.json` or bumping to ESLint 10 (Dependabot PR #1228 is deferred pending Codacy support), migrate that rule into `eslint.config.cjs`.
 
 ## Pre-flight (StakTrakr-specific)
 


### PR DESCRIPTION
## What

Adds five project-specific notes to `CLAUDE.md`, surfaced by running `/review-claudemd` over the last 20 sessions (8 parallel Sonnet analysis agents). Each was verified against the live codebase before inclusion.

| # | Addition | Section | Verified |
|---|----------|---------|----------|
| 1 | Skill files have a tracked twin under `.agents/skills/` — fix both | Skills | ✅ `.claude/` + `.agents/` copies of `api-infrastructure/SKILL.md` both tracked |
| 2 | New Playwright specs must add a `coverage-map.csv` row | Playwright Test Tier Rules | ✅ `AGENTS.md:55,59` mandate it |
| 3 | `devops/version.lock` is gitignored / main-checkout-only | Git Topology | ✅ `.gitignore:105` |
| 4 | Dual ESLint config — `no-restricted-globals` lives only in `.eslintrc.json` | Required Context (new subsection) | ✅ rule present in legacy, absent from flat config |
| 5 | Async bot reviewers post threads after checks go green | Review & CI | Behavioral lesson from PR #1233 (merged over late Copilot threads) |

## Dropped finding

A sixth candidate — *"`computeItemKey` is mirrored in 3 places, change in lockstep"* — was **dropped after verification**. STRK-167 already consolidated it to a single authoritative key in `diff-engine.js` with `changeLog.js` delegating at runtime. The analysis agent had read the pre-consolidation session and reported a fixed problem as current.

## Scope

- Docs-only, +12 lines to `CLAUDE.md`. Lightweight chore PR per Git Topology — no Plane issue or version lock.
- The global `~/.claude/CLAUDE.md` was updated separately (personal file, not in this repo): reinforced two recurring rule violations as STOP checkpoints + 6 cross-project additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)