### PR TITLE
chore(playground): flag stale diff-modal prototypes as do-not-use

### DIFF
--- a/playground/diff-modal-playground.html
+++ b/playground/diff-modal-playground.html
@@ -1,4 +1,13 @@
 <!doctype html>
+<!--
+  ⚠️  STALE PROTOTYPE — DO NOT USE AS REFERENCE (marked stale 2026-06-07, STRK-167).
+
+  This is a self-contained copy of the diff modal that has drifted from the live
+  implementation and no longer matches it. Do not treat its markup, CSS, or
+  behavior as authoritative. Source of truth: js/diff-modal.js (rendering +
+  behavior) and the production diff-modal CSS in index.html. Kept only for
+  historical context.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/playground/diffmodal-item-cards.html
+++ b/playground/diffmodal-item-cards.html
@@ -1,4 +1,13 @@
 <!doctype html>
+<!--
+  ⚠️  STALE PROTOTYPE — DO NOT USE AS REFERENCE (marked stale 2026-06-07, STRK-167).
+
+  This is a self-contained copy of the diff modal that has drifted from the live
+  implementation and no longer matches it. Do not treat its markup, CSS, or
+  behavior as authoritative. Source of truth: js/diff-modal.js (rendering +
+  behavior) and the production diff-modal CSS in index.html. Kept only for
+  historical context.
+-->
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## What

Adds a **STALE PROTOTYPE — DO NOT USE AS REFERENCE** banner comment to the top of the two April-2026 diff-modal prototypes:

- `playground/diff-modal-playground.html`
- `playground/diffmodal-item-cards.html`

Both are self-contained copies of the diff modal that have drifted from the live `js/diff-modal.js` + production CSS and no longer match it. The banner (marked stale 2026-06-07, STRK-167) points readers to the runtime source of truth.

## Why annotate instead of delete

The task offered delete-or-annotate. Investigation surfaced two facts that tipped it to annotate:

1. **Two runtime provenance comments cite one of these files** — [`index.html:7065`](https://github.com/lbruton/StakTrakr/blob/dev/index.html#L7065) and [`js/diff-modal.js:1510`](https://github.com/lbruton/StakTrakr/blob/dev/js/diff-modal.js#L1510) both reference `diffmodal-item-cards.html` as the origin of the card renderers. Deleting the file would dangle those comments; cleaning them would mean editing runtime code (`js/` + `index.html`) → full discipline + a Plane issue, outside this lightweight chore's scope. Annotating instead makes those comments land on a file that self-documents as stale.
2. **The STRK-167 replacement harness doesn't exist at this `dev` HEAD** — `playground/STRK-167-numista-merge/` is not tracked and not on disk, so deletion would leave no diff-modal prototype behind. The banner therefore points to runtime source, not that path.

There are **no functional references** to either file (no `<script src>`, `import`, `fetch`, or link) — only the two comments above plus a file-manifest entry in `.codacy/codacy.config.json`.

## Scope / process

- Lightweight chore: change is confined to `playground/` (no runtime code, no Plane issue, no version lock).
- Diff: **2 files, +18 lines** (banner only).
- `prettier --check` passes on both files; pre-commit hooks (secret scan, signing key, prettier) all green; commit signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)