### PR TITLE
chore: consolidate CodeRabbit config into repo .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
-# SINGLE SOURCE OF TRUTH for CodeRabbit. A repo .coderabbit.yaml REPLACES
-# dashboard settings (priority 2 vs 4 — no merge), so settings omitted here
-# fall back to schema DEFAULTS, not dashboard values. Keep everything in
-# this file; treat the dashboard as read-only.
+# Source of truth for REPO-LEVEL CodeRabbit settings. A repo
+# .coderabbit.yaml REPLACES dashboard repo settings (priority 2 vs 4 —
+# no merge), so settings omitted here fall back to schema DEFAULTS, not
+# dashboard values. Keep repo settings in this file; treat the repo
+# dashboard as read-only. `inheritance: true` below still merges in
+# ORGANIZATION-level UI settings (tone, profile) for keys absent here.
 #
 # Root cause this fixes: auto_review.base_branches defaults to [] (default
 # branch only), so PRs targeting dev were silently never auto-reviewed even

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,36 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
-# Minimal config — profile, poem, early_access, tone, and other settings
-# live in the CodeRabbit dashboard (source of truth). This file provides
-# only path_filters and path_instructions that the dashboard cannot set.
+# SINGLE SOURCE OF TRUTH for CodeRabbit. A repo .coderabbit.yaml REPLACES
+# dashboard settings (priority 2 vs 4 — no merge), so settings omitted here
+# fall back to schema DEFAULTS, not dashboard values. Keep everything in
+# this file; treat the dashboard as read-only.
+#
+# Root cause this fixes: auto_review.base_branches defaults to [] (default
+# branch only), so PRs targeting dev were silently never auto-reviewed even
+# though the dashboard listed dev.
+
+early_access: true
+
+inheritance: true
 
 reviews:
+  request_changes_workflow: true
+  high_level_summary_in_walkthrough: true
+  collapse_walkthrough: false
+  auto_apply_labels: true
+  auto_review:
+    drafts: true
+    base_branches:
+      - dev
+  finishing_touches:
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: true
+  tools:
+    fbinfer:
+      enabled: true
+
   path_filters:
     # Global
     - "!**/node_modules/**"
@@ -62,3 +88,24 @@ reviews:
         - For Playwright tests on vanilla JS: internal state must be injected
           via `localStorage` (`page.addInitScript`), not by patching
           `window.X` post-load.
+
+chat:
+  integrations:
+    jira:
+      usage: disabled
+    linear:
+      usage: disabled
+
+knowledge_base:
+  jira:
+    usage: disabled
+  linear:
+    usage: disabled
+  mcp:
+    usage: enabled
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  labeling:
+    auto_apply_labels: true

--- a/tests/unit/config-validation.test.js
+++ b/tests/unit/config-validation.test.js
@@ -335,14 +335,13 @@ test.describe(".coderabbit.yaml", () => {
     expect(content).toContain("coderabbit.ai/integrations/schema");
   });
 
-  test("CR-3 — minimal config: no dashboard-managed settings in file", () => {
-    expect(content).not.toContain("profile:");
-    expect(content).not.toContain("poem:");
-    expect(content).not.toContain("early_access:");
-    expect(content).not.toContain("language:");
-    expect(content).not.toContain("tone_instructions:");
-    expect(content).not.toContain("knowledge_base:");
-    expect(content).not.toContain("chat:");
+  test("CR-3 — single source of truth: auto_review covers dev base branch", () => {
+    // A repo .coderabbit.yaml REPLACES dashboard repo settings (no merge);
+    // omitted keys fall back to schema defaults. base_branches defaults to
+    // [] (default branch only), so dev must be listed here or PRs targeting
+    // dev silently lose auto-review (the original bug this guards against).
+    expect(content).toContain("auto_review:");
+    expect(content).toMatch(/base_branches:\s*\n\s*- dev/);
   });
 
   test("CR-4 — node_modules path filter is excluded", () => {


### PR DESCRIPTION
## Summary

CodeRabbit was not auto-reviewing PRs targeting `dev` despite the dashboard listing `dev` under `auto_review.base_branches`.

**Root cause:** a repo `.coderabbit.yaml` *replaces* dashboard settings (priority 2 vs 4 — sources don't merge). Our previous minimal file only carried `path_filters`/`path_instructions`, so every omitted setting fell back to **schema defaults**, not dashboard values. `auto_review.base_branches` defaults to `[]` (default branch only), which silently disabled auto-review on `dev`-targeted PRs.

## Changes

- Merge all dashboard settings (auto_review with `base_branches: [dev]` and `drafts: true`, early_access, finishing_touches, fbinfer, chat/knowledge_base/issue_enrichment) into `.coderabbit.yaml`
- Keep existing `path_filters` and `path_instructions` unchanged
- Update header comment: this file is now the single source of truth; treat the dashboard as read-only

## Verification

- YAML parses clean against the v2 schema layout
- After merge, the next PR targeting `dev` should receive an automatic CodeRabbit review