### PR TITLE
v3.35.17 — STRK-188: market data fails over to api2 backup endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.35.17] - 2026-06-11
+
+### Changed — STRK-188: Market data fails over to the backup API
+
+- **Bug fix**: Market data (manifest, coin detail, 30-day history, intraday) now tries `api.staktrakr.com` and falls back to `api2.staktrakr.com` using the same ordered-failover helper as the spot and goldback feeds. Previously `js/market-data.js` hardcoded the primary endpoint, so a GitHub Pages outage blanked the Market tab even while the Fly.io backup API was serving fresh data — defeating the backup's purpose. Surfaced during the 2026-06-11 feed outage (STRK-188).
+
+---
+
 ## [3.35.16] - 2026-06-11
 
 ### Changed — STRK-185: Encrypted backup now includes pattern-rule images

--- a/js/about.js
+++ b/js/about.js
@@ -134,6 +134,7 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.35.17 &ndash; STRK-188: Market data backup API</strong>: Market prices now automatically fall back to the backup API when the primary is unreachable &mdash; the Market tab keeps live data during a primary-feed outage, matching how spot prices already behave (STRK-188).</li>
     <li><strong>v3.35.16 &ndash; STRK-185: Pattern images in backups</strong>: Encrypted backups and cloud photo sync now include the images attached to your custom pattern rules, so they survive a storage wipe and restore instead of leaving rules image-less; older backups still restore normally (STRK-185).</li>
     <li><strong>v3.35.15 &ndash; STRK-184: Storage report cleanup</strong>: Removed an old, unused storage-report generator that could no longer be opened from the app &mdash; eliminating a potential security weak spot and shrinking the codebase; the footer storage meter is unchanged (STRK-184).</li>
     <li><strong>v3.35.14 &ndash; Safer Numista merge</strong>: Importing a Numista CSV now safely merges into your existing inventory instead of replacing it &mdash; identical ungraded copies combine with a summed quantity, graded coins stay separate, re-importing the same file adds no duplicates, and the review screen gains a Keep/Replace/Add quantity choice plus a &ldquo;possible duplicate of a graded item&rdquo; heads-up (STRK-167).</li>
@@ -141,7 +142,6 @@ const getEmbeddedWhatsNew = () => {
     <li><strong>v3.35.12 &ndash; Faster image saves</strong>: Saving coin images stays fast even with a large image library &mdash; the storage check no longer re-scans every stored image on each save, and the storage-full warnings are unchanged (STRK-162).</li>
     <li><strong>v3.35.11 &ndash; Safer Numista import</strong>: The Numista CSV import is now a one-time onboarding tool that clearly warns it replaces your inventory instead of silently creating duplicates, while we rebuild duplicate detection (STRK-165).</li>
     <li><strong>v3.35.10 &ndash; Sync Image URLs</strong>: A new one-button sync backfills Numista coin images for items missing them (like CSV imports) &mdash; it reuses cached lookups to save API quota and never overwrites images you&rsquo;ve already set (STRK-166).</li>
-    <li><strong>v3.35.9 &ndash; Image storage warnings</strong>: Saving an image when device storage is nearly full now shows a clear &ldquo;storage full&rdquo; message instead of silently failing into a broken square, and a heads-up appears as image storage fills up (STRK-146).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.35.16";
+const APP_VERSION = "3.35.17";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -9,17 +9,27 @@ const V2_API = "https://api.staktrakr.com/data/v2";
 // after this file (both deferred) — it exists by the time any market fetch
 // runs, and the typeof guard degrades to the primary endpoint only if not.
 const _marketV2Fetch = async (path) => {
-  if (
-    typeof _staktrakrFetch === "function" &&
+  const endpoints =
     typeof V2_API_ENDPOINTS !== "undefined" &&
     Array.isArray(V2_API_ENDPOINTS) &&
     V2_API_ENDPOINTS.length
-  ) {
-    return _staktrakrFetch(V2_API_ENDPOINTS, path);
+      ? V2_API_ENDPOINTS
+      : [V2_API];
+  if (typeof _staktrakrFetch === "function") {
+    return _staktrakrFetch(endpoints, path);
   }
-  const resp = await fetch(V2_API + path, { signal: AbortSignal.timeout(10000) });
-  if (!resp.ok) throw new Error("HTTP " + resp.status);
-  return resp.json();
+  // Fallback if api.js hasn't executed: same ordered failover with plain fetch.
+  let lastErr;
+  for (const base of endpoints) {
+    try {
+      const resp = await fetch(base + path, { signal: AbortSignal.timeout(10000) });
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      return await resp.json();
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr || new Error("All market endpoints failed");
 };
 
 const _METAL_TO_ISO = { silver: "xag", gold: "xau", platinum: "xpt", palladium: "xpd" };

--- a/js/market-data.js
+++ b/js/market-data.js
@@ -4,6 +4,24 @@
 let _marketDataInitialized = false;
 const V2_API = "https://api.staktrakr.com/data/v2";
 
+// STRK-188: ordered endpoint failover (api1 → api2), mirroring the spot and
+// goldback fetch paths. _staktrakrFetch is defined in api.js, which executes
+// after this file (both deferred) — it exists by the time any market fetch
+// runs, and the typeof guard degrades to the primary endpoint only if not.
+const _marketV2Fetch = async (path) => {
+  if (
+    typeof _staktrakrFetch === "function" &&
+    typeof V2_API_ENDPOINTS !== "undefined" &&
+    Array.isArray(V2_API_ENDPOINTS) &&
+    V2_API_ENDPOINTS.length
+  ) {
+    return _staktrakrFetch(V2_API_ENDPOINTS, path);
+  }
+  const resp = await fetch(V2_API + path, { signal: AbortSignal.timeout(10000) });
+  if (!resp.ok) throw new Error("HTTP " + resp.status);
+  return resp.json();
+};
+
 const _METAL_TO_ISO = { silver: "xag", gold: "xau", platinum: "xpt", palladium: "xpd" };
 const _ISO_TO_METAL = { xag: "silver", xau: "gold", xpt: "platinum", xpd: "palladium" };
 
@@ -105,9 +123,7 @@ const _ensureManifest = async () => {
     Object.keys(vendorMeta).length >= 5;
   if (hasSufficientMeta) return;
   try {
-    const resp = await fetch(V2_API + "/manifest.json", { signal: AbortSignal.timeout(10000) });
-    if (!resp.ok) return;
-    const json = await resp.json();
+    const json = await _marketV2Fetch("/manifest.json");
     const data = json.data || json;
     if (data.coins && Array.isArray(data.coins)) {
       const cm = {};
@@ -524,10 +540,7 @@ const openMarketDetailModal = async (slug) => {
   const metalLower = (coinMeta.metal || "").toLowerCase();
   const metalCode = _METAL_TO_ISO[metalLower] || metalLower;
 
-  const detailPromise = fetch(V2_API + "/retail/" + slug + "/latest.json", {
-    signal: AbortSignal.timeout(10000),
-  })
-    .then((r) => (r.ok ? r.json() : null))
+  const detailPromise = _marketV2Fetch("/retail/" + slug + "/latest.json")
     .then((json) => (json && json.data ? json.data : null))
     .catch((e) => {
       debugLog("[market-data] Detail fetch failed: " + e.message, "warn");
@@ -535,17 +548,11 @@ const openMarketDetailModal = async (slug) => {
     });
 
   // Fetch per-vendor retail history (30d — filter to 7 in chart) and intraday (24h)
-  const historyPromise = fetch(V2_API + "/retail/" + slug + "/history-30d.json", {
-    signal: AbortSignal.timeout(10000),
-  })
-    .then((r) => (r.ok ? r.json() : null))
+  const historyPromise = _marketV2Fetch("/retail/" + slug + "/history-30d.json")
     .then((json) => (json && json.data ? json.data : json))
     .catch(() => null);
 
-  const intradayPromise = fetch(V2_API + "/retail/" + slug + "/intraday.json", {
-    signal: AbortSignal.timeout(10000),
-  })
-    .then((r) => (r.ok ? r.json() : null))
+  const intradayPromise = _marketV2Fetch("/retail/" + slug + "/intraday.json")
     .then((json) => (json && json.data ? json.data : json))
     .catch(() => null);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.35.16",
+  "version": "3.35.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.35.16",
+      "version": "3.35.17",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.35.16",
+  "version": "3.35.17",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.17-b1781188766";
+const CACHE_NAME = "staktrakr-v3.35.17-b1781189623";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.16-b1781152787";
+const CACHE_NAME = "staktrakr-v3.35.17-b1781188766";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/core/retail-market.spec.js
+++ b/tests/playwright/core/retail-market.spec.js
@@ -156,7 +156,13 @@ function latestForSlug(slug) {
 }
 
 async function setupRetailFixture(page, options = {}) {
-  const { savedTab, marketFilter, displayCurrency = "USD", exchangeRates = { EUR: 0.9 } } = options;
+  const {
+    savedTab,
+    marketFilter,
+    displayCurrency = "USD",
+    exchangeRates = { EUR: 0.9 },
+    failPrimary = false,
+  } = options;
 
   await injectSeedInventory(page);
 
@@ -239,7 +245,7 @@ async function setupRetailFixture(page, options = {}) {
     }
   );
 
-  await page.route("https://api.staktrakr.com/data/v2/**", async (route) => {
+  const fulfillV2 = async (route) => {
     const url = new URL(route.request().url());
     const path = url.pathname.replace(/^\/data\/v2\//, "");
     if (path === "manifest.json") {
@@ -301,11 +307,17 @@ async function setupRetailFixture(page, options = {}) {
       contentType: "application/json",
       body: JSON.stringify(data ? { v: 2, generated_at: GENERATED_AT, data } : {}),
     });
-  });
+  };
 
-  await page.route("https://api2.staktrakr.com/data/v2/**", async (route) => {
+  const failV2 = async (route) => {
     await route.fulfill({ status: 503, contentType: "application/json", body: "{}" });
-  });
+  };
+
+  // STRK-188: failPrimary simulates an api1 (GitHub Pages) outage — the primary
+  // endpoint returns 503 while api2 (Fly.io) serves the fixtures, exercising the
+  // ordered failover in the market data fetch path.
+  await page.route("https://api.staktrakr.com/data/v2/**", failPrimary ? failV2 : fulfillV2);
+  await page.route("https://api2.staktrakr.com/data/v2/**", failPrimary ? fulfillV2 : failV2);
 
   // Freeze Date for the market-history 7-day window across the seeded
   // RECENT_DATE fixtures. setFixedTime pins Date.now()/new Date() at FIXED_NOW
@@ -514,6 +526,32 @@ test.describe("core/retail-market", () => {
 
     await expect(page.locator("#marketDetailModal")).toBeVisible();
     await expect(page.locator("#marketDetailTitle")).toContainText("Alpha Silver Bar");
+    await expect(page.locator("#marketDetailChartArea .tv-lightweight-charts")).toHaveAttribute(
+      "data-point-count",
+      /[1-9]/
+    );
+
+    await page.locator('#marketDetailContent button[data-period="24h"]').click();
+    await expect(page.locator("#marketDetailChartArea .tv-lightweight-charts")).toHaveAttribute(
+      "data-point-count",
+      /[1-9]/
+    );
+  });
+
+  test("market detail modal fails over to api2 when the primary API is down (STRK-188)", async ({
+    page,
+  }) => {
+    await setupRetailFixture(page, { failPrimary: true });
+
+    await page
+      .locator(".vendor-prices-table .vp-coin-link", { hasText: "Alpha Silver Bar" })
+      .click();
+
+    await expect(page.locator("#marketDetailModal")).toBeVisible();
+    await expect(page.locator("#marketDetailTitle")).toContainText("Alpha Silver Bar");
+    // The modal chart renders only from the fetched history/intraday feeds —
+    // there is no localStorage fallback in this path. With api1 down, a rendered
+    // chart proves the api2 failover delivered the data.
     await expect(page.locator("#marketDetailChartArea .tv-lightweight-charts")).toHaveAttribute(
       "data-point-count",
       /[1-9]/

--- a/tests/playwright/coverage-map.csv
+++ b/tests/playwright/coverage-map.csv
@@ -78,3 +78,4 @@ tests/playwright/core/smoke.spec.js,3,smoke-shell,P1 core user workflow,active,t
 tests/playwright/core/settings-api.spec.js,2,settings-api,P1 core user workflow,active,tests/playwright/core/settings-api.spec.js,STRK-161: new metal chip toggle + goldback gating
 tests/playwright/extended/visual-layout-regressions.spec.js,2,mobile-layout,P2 integration edge,active,tests/playwright/extended/visual-layout-regressions.spec.js,STRK-161: new metal chip four-theme rendering + mobile layout
 tests/playwright/core/import-export.spec.js,2,import-export,P0 money-data loss,active,tests/playwright/core/import-export.spec.js,STRK-185: added pattern-image vault roundtrip (wipe + restore) and legacy-payload/hash backward-compat coverage
+tests/playwright/core/retail-market.spec.js,1,retail-market,P1 core user workflow,active,tests/playwright/core/retail-market.spec.js,STRK-188: added api2 failover coverage for market detail modal (primary API down)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.35.16",
+  "version": "3.35.17",
   "releaseDate": "2026-06-11",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
## Summary

`js/market-data.js` hardcoded `api.staktrakr.com`, so a GitHub Pages outage blanked the Market tab even while api2 (Fly.io, the pure-HTTP endpoint) was serving fresh data — defeating the backup API's entire purpose. Surfaced during the 2026-06-11 feed outage (incident root-cause work tracked in STRK-187).

All four market fetches (manifest, per-coin `latest.json`, `history-30d.json`, `intraday.json`) now route through a `_marketV2Fetch` helper that uses the shared `_staktrakrFetch` ordered failover (`V2_API_ENDPOINTS`: api1 → api2), matching the existing spot and goldback paths. A `typeof` guard degrades to the primary-only fetch in the (theoretical) case the helper is unavailable, since market-data.js executes before api.js in the deferred script order.

## Tests

- `core/retail-market.spec.js` gains a `failPrimary` fixture mode — api1 returns 503 while api2 serves the fixtures — and a new STRK-188 failover test asserting the market detail modal chart renders from **fetched-only** data (the modal chart path has no localStorage fallback, making it a binding failover assertion).
- TDD: test written first and confirmed failing pre-fix.
- Full core gate: 218/218 passed. (One unrelated `saved tabs` filter-persistence test flaked once under full parallel load; it passes 6/6 in isolation and the full-gate rerun was clean — pre-existing timing sensitivity in this suite, see #1193 clock-freeze history.)
- Test inventory delta: +1 test, +0 files. `coverage-map.csv` updated.

## Version

3.35.17 — standard 6-file bump + sw.js cache stamp via pre-commit hook. Spot bundle verified current (no diff).

## Issues

- STRK-188: market-data.js hardcodes api1 — no api2 failover for market data (this PR)
- STRK-187: publisher self-cleaning (incident root cause — separate infra work)