### PR TITLE
chore: What's New cap 8 → 5 entries (more detail per entry)

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -67,8 +67,8 @@ Edit `getEmbeddedWhatsNew()` (starts at line ~140):
 
 ```html
 <li>
-  <strong>vNEW_VERSION &ndash; ISSUE-ID: Title</strong>: One-sentence summary of the change
-  (ISSUE-ID).
+  <strong>vNEW_VERSION &ndash; ISSUE-ID: Title</strong>: Detailed 2-3 sentence summary of the change
+  &mdash; what changed, why a user cares, and any visible behavior difference (ISSUE-ID).
 </li>
 ```
 
@@ -77,9 +77,10 @@ Format rules:
 - Use `&ndash;` (en dash entity), not `—` or `–`
 - Wrap version + title in `<strong>` tags
 - End with issue reference in parentheses
-- Match the style of existing entries
+- 2-3 sentences per entry is the target — the 5-entry cap exists so each block can carry
+  real detail (changed from the earlier 8 short entries, 2026-06)
 
-**Trim** the list to keep the **8 most recent entries**. Remove the oldest `<li>` elements from the bottom of the list until only 8 remain.
+**Trim** the list to keep the **5 most recent entries**. Remove the oldest `<li>` elements from the bottom of the list until only 5 remain.
 
 ### Handled Automatically — DO NOT EDIT
 
@@ -97,8 +98,8 @@ grep -l "NEW_VERSION" js/constants.js package.json package-lock.json version.jso
 
 # 2. Exactly 6 files listed (if fewer, one was missed)
 
-# 3. What's New entry count is exactly 8 (versioned entries only)
-grep -c '<li><strong>v' js/about.js  # Should be 8
+# 3. What's New entry count is exactly 5 (versioned entries only)
+grep -c '<li><strong>v' js/about.js  # Should be 5
 
 # 4. No stale version in edited files
 grep -n "OLD_VERSION" js/constants.js package.json version.json

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -67,8 +67,8 @@ Edit `getEmbeddedWhatsNew()` (starts at line ~140):
 
 ```html
 <li>
-  <strong>vNEW_VERSION &ndash; ISSUE-ID: Title</strong>: One-sentence summary of the change
-  (ISSUE-ID).
+  <strong>vNEW_VERSION &ndash; ISSUE-ID: Title</strong>: Detailed 2-3 sentence summary of the change
+  &mdash; what changed, why a user cares, and any visible behavior difference (ISSUE-ID).
 </li>
 ```
 
@@ -77,9 +77,10 @@ Format rules:
 - Use `&ndash;` (en dash entity), not `—` or `–`
 - Wrap version + title in `<strong>` tags
 - End with issue reference in parentheses
-- Match the style of existing entries
+- 2-3 sentences per entry is the target — the 5-entry cap exists so each block can carry
+  real detail (changed from the earlier 8 short entries, 2026-06)
 
-**Trim** the list to keep the **8 most recent entries**. Remove the oldest `<li>` elements from the bottom of the list until only 8 remain.
+**Trim** the list to keep the **5 most recent entries**. Remove the oldest `<li>` elements from the bottom of the list until only 5 remain.
 
 ### Handled Automatically — DO NOT EDIT
 
@@ -97,8 +98,8 @@ grep -l "NEW_VERSION" js/constants.js package.json package-lock.json version.jso
 
 # 2. Exactly 6 files listed (if fewer, one was missed)
 
-# 3. What's New entry count is exactly 8 (versioned entries only)
-grep -c '<li><strong>v' js/about.js  # Should be 8
+# 3. What's New entry count is exactly 5 (versioned entries only)
+grep -c '<li><strong>v' js/about.js  # Should be 5
 
 # 4. No stale version in edited files
 grep -n "OLD_VERSION" js/constants.js package.json version.json

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -248,7 +248,7 @@ If `sw.js` CACHE_NAME does not match the version in `js/constants.js`, the servi
 
 ### 8. What's New Entry Rotation -- Intentional Limit
 
-`js/about.js` (`getEmbeddedWhatsNew()`) is the **sole source of truth** for What's New content. `docs/announcements.md` was deprecated per STAK-513 and no longer exists -- do not flag it as missing or out of sync. Entries in `getEmbeddedWhatsNew()` are **intentionally capped at the 8 most recent** -- the `/release` skill enforces this via `grep -c '<li><strong>v' js/about.js` == 8, and the project pre-commit/release flow keeps the count at 8. When a new release is added, the oldest entry is rotated out to maintain 8. Do not flag removed older entries as missing, and do not suggest trimming to fewer (e.g. 3-5) -- 8 is by design.
+`js/about.js` (`getEmbeddedWhatsNew()`) is the **sole source of truth** for What's New content. `docs/announcements.md` was deprecated per STAK-513 and no longer exists -- do not flag it as missing or out of sync. Entries in `getEmbeddedWhatsNew()` are **intentionally capped at the 5 most recent** -- the `/release` skill enforces this via `grep -c '<li><strong>v' js/about.js` == 5. Fewer, more detailed entries are the design: each entry may run 2-3 sentences. When a new release is added, the oldest entry is rotated out to maintain 5. Do not flag removed older entries as missing, and do not flag multi-sentence entries as too long -- 5 detailed entries is by design (changed from the earlier 8-entry cap in 2026-06).
 
 ### 9. Seed Data Files -- Auto-Generated, Must Be Included
 


### PR DESCRIPTION
## Summary

Policy change: the About page What's New list (`getEmbeddedWhatsNew()` in `js/about.js`) is capped at the **5 most recent entries** instead of 8, with each entry targeting **2-3 sentences of detail** — fewer, richer blocks instead of eight one-liners.

Three files encode the cap; all updated together so review bots and the release workflow agree:

- `.github/copilot-instructions.md` §8 — review-bot steering now states the 5-entry cap and that multi-sentence entries are by design
- `.claude/skills/release/SKILL.md` — trim instruction (keep 5), entry template (2-3 sentence summary), Phase 2 verification check (`grep -c == 5`)
- `.agents/skills/release/SKILL.md` — identical fix to the tracked twin

## Notes

- Replaces #1253 (closed): same intent, but that branch was created from `main`, so its effective diff against `dev` resurrected ~60 archived Playwright specs and reverted 5 runtime files (+21k lines).
- `js/about.js` is intentionally untouched — it currently has 8 entries; the next `/release` prepends 1 and trims to 5 per the updated skill.
- Docs/config only — no Plane issue or version bump per repo policy. Agentlint local: 0 criticals; remaining warnings are pre-existing in untouched files.