### PR TITLE
fix: STRK-187 publisher self-cleaning + publish-freshness watchdog

### DIFF
--- a/devops/pollers/home-poller/check-flyio.sh
+++ b/devops/pollers/home-poller/check-flyio.sh
@@ -14,6 +14,9 @@
 FLYIO_TAILSCALE_IP="${FLYIO_TAILSCALE_IP:-100.90.171.110}"
 FLYIO_HTTP_URL="${FLYIO_HTTP_URL:-https://api2.staktrakr.com/data/retail/providers.json}"
 SQLD_HEALTH_URL="${SQLD_HEALTH_URL:-https://api2.staktrakr.com/health/sqld-reachable}"
+PUBLISHED_MANIFEST_URL="${PUBLISHED_MANIFEST_URL:-https://api.staktrakr.com/data/api/manifest.json}"
+API2_MANIFEST_URL="${API2_MANIFEST_URL:-https://api2.staktrakr.com/data/api/manifest.json}"
+PUBLISH_FRESH_MAX_MIN="${PUBLISH_FRESH_MAX_MIN:-45}"
 STATUS_FILE="/tmp/flyio-health.json"
 TIMEOUT=10
 SQLD_HEALTH_TIMEOUT=8
@@ -71,15 +74,48 @@ else
   log "WARN: sqld-reachable FAIL (${sqld_error_class:-no_response} ${sqld_latency_ms:-?}ms)"
 fi
 
-# Preserve sqld_reachable_last_success across runs — set to now on OK,
-# carry forward the previous timestamp on FAIL so the dashboard can render
-# "Xm ago" elapsed-time.
+# ── Publish freshness (STRK-187) ──────────────────────────────────────────────
+# The 2026-06-11 outage was invisible for ~7h because nothing watched the
+# published manifest's generated_at. api (GitHub Pages) is the published feed;
+# api2 (serve.js) reads the export dir directly — comparing both distinguishes
+# "push broken" (api2 fresh, published stale) from "publish broken" (both stale).
+manifest_age_min() { # $1 = manifest URL → echoes age in minutes, rc 1 on failure
+  local body gen ts now
+  body=$(curl -s --max-time "$TIMEOUT" "$1" 2>/dev/null | tr -d '\n')
+  gen=$(json_str "$body" "generated_at")
+  [ -z "$gen" ] && return 1
+  ts=$(date -d "$gen" +%s 2>/dev/null) || return 1
+  now=$(date -u +%s)
+  echo $(((now - ts) / 60))
+}
+
+pub_age=$(manifest_age_min "$PUBLISHED_MANIFEST_URL") || pub_age=""
+api2_age=$(manifest_age_min "$API2_MANIFEST_URL") || api2_age=""
+pub_fresh=false
+api2_fresh=false
+[ -n "$pub_age" ] && [ "$pub_age" -le "$PUBLISH_FRESH_MAX_MIN" ] && pub_fresh=true
+[ -n "$api2_age" ] && [ "$api2_age" -le "$PUBLISH_FRESH_MAX_MIN" ] && api2_fresh=true
+if [ "$pub_fresh" = "true" ]; then
+  log "Publish freshness OK (published ${pub_age}m, api2 ${api2_age:-?}m)"
+else
+  log "WARN: publish freshness FAIL (published ${pub_age:-no_data}m, api2 ${api2_age:-no_data}m, max ${PUBLISH_FRESH_MAX_MIN}m)"
+fi
+
+# Preserve sqld_reachable_last_success / publish_fresh_last_success across
+# runs — set to now on OK, carry forward the previous timestamp on FAIL so
+# the dashboard can render "Xm ago" elapsed-time.
 sqld_last_success=""
+publish_fresh_last_success=""
 if [ -f "$STATUS_FILE" ]; then
-  sqld_last_success=$(json_str "$(cat "$STATUS_FILE" 2>/dev/null | tr -d '\n')" "sqld_reachable_last_success")
+  _prev_status=$(cat "$STATUS_FILE" 2>/dev/null | tr -d '\n')
+  sqld_last_success=$(json_str "$_prev_status" "sqld_reachable_last_success")
+  publish_fresh_last_success=$(json_str "$_prev_status" "publish_fresh_last_success")
 fi
 if [ "$sqld_ok" = "true" ]; then
   sqld_last_success=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+fi
+if [ "$pub_fresh" = "true" ]; then
+  publish_fresh_last_success=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 fi
 
 # ── Write status JSON (dashboard reads this) ─────────────────────────────────
@@ -96,6 +132,12 @@ cat > "$STATUS_FILE" << EOF
   "sqld_reachable_ok": ${sqld_ok},
   "sqld_reachable_latency_ms": ${sqld_latency_ms:-null},
   "sqld_reachable_error_class": "${sqld_error_class}",
-  "sqld_reachable_last_success": "${sqld_last_success}"
+  "sqld_reachable_last_success": "${sqld_last_success}",
+  "published_manifest_url": "${PUBLISHED_MANIFEST_URL}",
+  "published_fresh_ok": ${pub_fresh},
+  "published_age_min": ${pub_age:-null},
+  "api2_fresh_ok": ${api2_fresh},
+  "api2_age_min": ${api2_age:-null},
+  "publish_fresh_last_success": "${publish_fresh_last_success}"
 }
 EOF

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -595,6 +595,13 @@ function renderAttentionSidebar(failures) {
     <div style="margin-top:6px;text-align:center;"><a href="/failures" style="font-size:11px;">View all failures &rarr;</a></div></div>`;
 }
 
+/**
+ * Build the compact status-bar HTML — one colored dot + label per subsystem,
+ * including the STRK-187 publish-freshness indicator (api2-fresh-but-published-
+ * stale renders PUSH STALE vs STALE) — from an aggregated health snapshot.
+ * @param {object} data - aggregated health snapshot (flyio/poller/sqld fields)
+ * @returns {string} status-bar HTML
+ */
 function renderStatusBar(data) {
   const { cpu, uptime, lockStatus, flyioHealth, tursoUp, failureCount, retailStats, spotCoverage } =
     data;
@@ -675,6 +682,14 @@ function renderStatusBar(data) {
   </div>`;
 }
 
+/**
+ * Build the infrastructure detail row HTML — per-service label + color,
+ * including the STRK-187 publish-freshness item (PUSH STALE when api2 is fresh
+ * but the published manifest is stale, STALE when both are) — from an
+ * aggregated health snapshot.
+ * @param {object} data - aggregated health snapshot (flyio/poller/sqld fields)
+ * @returns {string} infra-row HTML
+ */
 function renderInfraRow(data) {
   const { cpu, uptime, net, lockStatus, flyioHealth, tursoUp, dockerContainers, supervisord } =
     data;

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -646,6 +646,23 @@ function renderStatusBar(data) {
   }
   items.push(dot(sqldOk ? "green" : sqldOk === false ? "red" : "amber") + `Fly→sqld: ${sqldLabel}`);
 
+  // Publish freshness (api.staktrakr.com manifest generated_at age; STRK-187).
+  // api2 fresh while published stale = push broken; both stale = publish broken.
+  const pubFresh = flyioHealth?.published_fresh_ok;
+  const api2Fresh = flyioHealth?.api2_fresh_ok;
+  let pubLabel;
+  if (pubFresh === true) {
+    pubLabel = `OK (${flyioHealth.published_age_min}m)`;
+  } else if (pubFresh === false) {
+    const pubAge = flyioHealth?.published_age_min ?? "?";
+    pubLabel = api2Fresh ? `PUSH STALE (${pubAge}m)` : `STALE (${pubAge}m)`;
+  } else {
+    pubLabel = "?";
+  }
+  items.push(
+    dot(pubFresh ? "green" : pubFresh === false ? "red" : "amber") + `Publish: ${pubLabel}`
+  );
+
   // Lock
   const anyLocked = (lockStatus || []).some((l) => l.locked);
   items.push(dot(anyLocked ? "amber" : "green") + `Lock: ${anyLocked ? "BUSY" : "free"}`);
@@ -676,6 +693,19 @@ function renderInfraRow(data) {
     sqldLabel = "?";
     sqldColor = "var(--amber)";
   }
+  const pubFresh = flyioHealth?.published_fresh_ok;
+  let pubLabel, pubColor;
+  if (pubFresh === true) {
+    pubLabel = `OK (${flyioHealth.published_age_min}m)`;
+    pubColor = "var(--green)";
+  } else if (pubFresh === false) {
+    const pubAge = flyioHealth?.published_age_min ?? "?";
+    pubLabel = flyioHealth?.api2_fresh_ok ? `PUSH STALE (${pubAge}m)` : `STALE (${pubAge}m)`;
+    pubColor = "var(--red)";
+  } else {
+    pubLabel = "?";
+    pubColor = "var(--amber)";
+  }
   const anyLocked = (lockStatus || []).some((l) => l.locked);
   const containerCount = (dockerContainers || []).filter((c) => c.state === "running").length;
   const serviceCount = (supervisord || []).filter((s) => s.state === "RUNNING").length;
@@ -700,6 +730,7 @@ function renderInfraRow(data) {
     }
     ${item("Fly API", flyOk ? "OK" : flyOk === false ? "DOWN" : "?", flyOk ? "var(--green)" : "var(--red)")}
     ${item("Fly→sqld", sqldLabel, sqldColor)}
+    ${item("Publish", pubLabel, pubColor)}
     ${item("Turso", tursoUp ? "OK" : "DOWN", tursoUp ? "var(--green)" : "var(--red)")}
     ${item("Containers", `${containerCount} up`, "var(--green)")}
     ${item("Services", `${serviceCount} up`, "var(--green)")}

--- a/devops/pollers/remote-poller/Dockerfile
+++ b/devops/pollers/remote-poller/Dockerfile
@@ -50,9 +50,9 @@ RUN npm install --omit=dev
 
 COPY shared/*.js ./
 
-# Remote-specific scripts (spot + publish only)
-COPY remote-poller/run-spot.sh remote-poller/run-publish.sh ./
-RUN chmod +x run-spot.sh run-publish.sh
+# Remote-specific scripts (spot + publish + cleanup)
+COPY remote-poller/run-spot.sh remote-poller/run-publish.sh remote-poller/cleanup-export.sh ./
+RUN chmod +x run-spot.sh run-publish.sh cleanup-export.sh
 
 # Git config for committing to api branch
 RUN git config --global user.name "StakTrakr Poller" \
@@ -61,7 +61,8 @@ RUN git config --global user.name "StakTrakr Poller" \
 # ── Cron jobs (baked-in defaults — entrypoint overwrites) ──
 RUN (echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1"; \
      echo "8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1"; \
-     echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1") \
+     echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1"; \
+     echo "17 3 * * 0 root . /etc/environment; /app/cleanup-export.sh >> /var/log/cleanup.log 2>&1") \
     > /etc/cron.d/retail-poller \
     && chmod 0644 /etc/cron.d/retail-poller
 

--- a/devops/pollers/remote-poller/cleanup-export.sh
+++ b/devops/pollers/remote-poller/cleanup-export.sh
@@ -17,6 +17,7 @@ set -e
 REPO_DIR="/data/staktrakr-api-export"
 PUBLISH_LOCK=/tmp/retail-publish.lock
 
+# Emit a UTC-timestamped, [cleanup]-tagged log line. Args: message words.
 log() { echo "[$(date -u +%H:%M:%S)] [cleanup] $*"; }
 
 # Serialize with run-publish.sh unless the caller already holds the lock.

--- a/devops/pollers/remote-poller/cleanup-export.sh
+++ b/devops/pollers/remote-poller/cleanup-export.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# StakTrakr Publisher cleanup — retention sweep + memory-capped git maintenance
+# STRK-187: keeps /data inode/block usage bounded (2026-06-11 outage root-cause fix).
+#
+# Callers:
+#   - Weekly cron (Sunday 03:17 UTC) — standalone, takes the publish lock
+#   - run-publish.sh pre-flight backstop — CLEANUP_SKIP_LOCK=1 (lock already held)
+#   - Manual via `fly ssh console --app staktrakr`
+#
+# Retention: data/15min day-dirs >90d, data/hourly day-dirs >365d (path-derived
+# dates, NOT mtime — a re-clone resets every mtime but paths never lie).
+# Git: reflog expire → memory-capped repack → prune → pack-refs. No `git gc`
+# (it OOMs on the 512MB machine; gc.auto=0 in repo config). GNU date required.
+
+set -e
+
+REPO_DIR="/data/staktrakr-api-export"
+PUBLISH_LOCK=/tmp/retail-publish.lock
+
+log() { echo "[$(date -u +%H:%M:%S)] [cleanup] $*"; }
+
+# Serialize with run-publish.sh unless the caller already holds the lock.
+if [ "${CLEANUP_SKIP_LOCK:-0}" != "1" ]; then
+  if [ -f "$PUBLISH_LOCK" ]; then
+    log "Publish lock held, skipping (will retry next schedule)"
+    exit 0
+  fi
+  touch "$PUBLISH_LOCK"
+  trap 'rm -f "$PUBLISH_LOCK"' EXIT
+fi
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  log "ERROR: $REPO_DIR is not a git repo."
+  exit 1
+fi
+
+cd "$REPO_DIR"
+
+log "df before:"
+df -P /data
+df -Pi /data
+
+# ── Retention sweep ─────────────────────────────────────────────────────
+# Day dirs are data/<tree>/YYYY/MM/DD — zero-padded, so lexicographic
+# comparison against a cutoff path is a correct date comparison.
+prune_tree() { # $1 = subdir under data/, $2 = days to keep
+  local tree="$1" keep_days="$2" cutoff rel
+  cutoff=$(date -u -d "-${keep_days} days" +%Y/%m/%d)
+  [ -d "data/$tree" ] || return 0
+  find "data/$tree" -mindepth 3 -maxdepth 3 -type d | sort | while read -r d; do
+    rel="${d#data/"$tree"/}" # YYYY/MM/DD
+    if [[ "$rel" < "$cutoff" ]]; then
+      rm -rf "$d"
+      log "Pruned $d (older than ${keep_days}d)"
+    fi
+  done
+  # Remove now-empty YYYY/MM and YYYY dirs (each empty dir still costs an inode)
+  find "data/$tree" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+}
+
+prune_tree 15min 90
+prune_tree hourly 365
+
+# ── Git maintenance (512MB-safe) ────────────────────────────────────────
+# Flags duplicate the repo's pack.* config on purpose: they survive a fresh
+# re-clone where someone forgets to re-apply the config (the documented
+# failure mode behind the 2026-06-11 outage).
+log "git objects before:"
+git count-objects -v | sed 's/^/[cleanup]   /'
+
+git reflog expire --expire=now --all
+git repack -a -d -l --threads=1 --window=5 --window-memory=32m --depth=20
+git prune --expire=now
+git pack-refs --all
+
+log "git objects after:"
+git count-objects -v | sed 's/^/[cleanup]   /'
+
+log "df after:"
+df -P /data
+df -Pi /data
+
+log "Done."

--- a/devops/pollers/remote-poller/cleanup-export.sh
+++ b/devops/pollers/remote-poller/cleanup-export.sh
@@ -20,12 +20,12 @@ PUBLISH_LOCK=/tmp/retail-publish.lock
 log() { echo "[$(date -u +%H:%M:%S)] [cleanup] $*"; }
 
 # Serialize with run-publish.sh unless the caller already holds the lock.
+# noclobber makes test-and-create atomic (no race with the publish cron).
 if [ "${CLEANUP_SKIP_LOCK:-0}" != "1" ]; then
-  if [ -f "$PUBLISH_LOCK" ]; then
+  if ! (set -o noclobber; echo "$$" > "$PUBLISH_LOCK") 2>/dev/null; then
     log "Publish lock held, skipping (will retry next schedule)"
     exit 0
   fi
-  touch "$PUBLISH_LOCK"
   trap 'rm -f "$PUBLISH_LOCK"' EXIT
 fi
 

--- a/devops/pollers/remote-poller/docker-entrypoint-slim.sh
+++ b/devops/pollers/remote-poller/docker-entrypoint-slim.sh
@@ -16,11 +16,12 @@ if [ -n "$_GIT_TOKEN" ]; then
 fi
 
 # ── 3. Write cron schedule ─────────────────────────────────────────────
-echo "[entrypoint] Writing cron schedule (spot + publish + provider-export)..."
+echo "[entrypoint] Writing cron schedule (spot + publish + provider-export + weekly cleanup)..."
 : > /etc/cron.d/retail-poller
 echo "0,30 * * * * root . /etc/environment; /app/run-spot.sh >> /var/log/spot-poller.log 2>&1" >> /etc/cron.d/retail-poller
 echo "8,23,38,53 * * * * root . /etc/environment; /app/run-publish.sh >> /var/log/publish.log 2>&1" >> /etc/cron.d/retail-poller
 echo "*/5 * * * * root . /etc/environment; cd /app && node export-providers-json.js >> /var/log/provider-export.log 2>&1" >> /etc/cron.d/retail-poller
+echo "17 3 * * 0 root . /etc/environment; /app/cleanup-export.sh >> /var/log/cleanup.log 2>&1" >> /etc/cron.d/retail-poller
 chmod 0644 /etc/cron.d/retail-poller
 
 # ── 4. Tailscale state directory (on persistent /data volume) ──────────
@@ -28,7 +29,7 @@ mkdir -p /data/tailscale /var/run/tailscale /data/retail
 
 # ── 5. Create log files ────────────────────────────────────────────────
 touch /var/log/spot-poller.log /var/log/publish.log \
-      /var/log/http-server.log /var/log/provider-export.log
+      /var/log/http-server.log /var/log/provider-export.log /var/log/cleanup.log
 
 echo "[entrypoint] Handing off to supervisord..."
 exec "$@"

--- a/devops/pollers/remote-poller/run-publish.sh
+++ b/devops/pollers/remote-poller/run-publish.sh
@@ -6,13 +6,13 @@
 
 set -e
 
-# Lockfile guard — skip if previous publish is still running
+# Lockfile guard — skip if previous publish is still running.
+# noclobber makes test-and-create atomic (no race with cleanup-export.sh).
 PUBLISH_LOCK=/tmp/retail-publish.lock
-if [ -f "$PUBLISH_LOCK" ]; then
+if ! (set -o noclobber; echo "$$" > "$PUBLISH_LOCK") 2>/dev/null; then
   echo "[$(date -u +%H:%M:%S)] Previous publish still running, skipping"
   exit 0
 fi
-touch "$PUBLISH_LOCK"
 trap 'rm -f "$PUBLISH_LOCK"' EXIT
 
 REPO_DIR="/data/staktrakr-api-export"
@@ -93,8 +93,14 @@ if [ -z "$GEN_AT" ]; then
 fi
 if $HAS_STAGED; then
   # Freshness check only when this cycle exported — a push-only retry cycle
-  # legitimately serves an older manifest.
-  AGE_MIN=$((($(date -u +%s) - $(date -d "$GEN_AT" +%s)) / 60))
+  # legitimately serves an older manifest. Parse the timestamp into a variable
+  # first: an empty command substitution inside $(( )) is a fatal syntax error.
+  GEN_TS=$(date -d "$GEN_AT" +%s 2>/dev/null) || GEN_TS=""
+  if [ -z "$GEN_TS" ]; then
+    echo "[$(date -u +%H:%M:%S)] ERROR: api2 manifest generated_at unparseable (${GEN_AT}) — SKIPPING push"
+    exit 1
+  fi
+  AGE_MIN=$((($(date -u +%s) - GEN_TS) / 60))
   if [ "$AGE_MIN" -gt 30 ]; then
     echo "[$(date -u +%H:%M:%S)] ERROR: api2 manifest stale (${AGE_MIN}m, generated_at=${GEN_AT}) — SKIPPING push"
     exit 1

--- a/devops/pollers/remote-poller/run-publish.sh
+++ b/devops/pollers/remote-poller/run-publish.sh
@@ -30,6 +30,23 @@ fi
 
 cd "$REPO_DIR"
 
+# ── Pre-flight space backstop (STRK-187) ────────────────────────────────
+# Floors sized to absorb one inter-cleanup week of growth (~30k inodes) on
+# the 3GB / 195,840-inode volume. Below floor → clean now, then publish.
+INODE_FLOOR=25000
+BLOCKS_FLOOR_KB=307200 # 300MB
+free_inodes=$(df -Pi /data | awk 'NR==2{print $4}')
+free_kb=$(df -P /data | awk 'NR==2{print $4}')
+if [ "${free_inodes:-0}" -lt "$INODE_FLOOR" ] || [ "${free_kb:-0}" -lt "$BLOCKS_FLOOR_KB" ]; then
+  echo "[$(date -u +%H:%M:%S)] WARN: low space (free inodes=${free_inodes}, free kb=${free_kb}) — running cleanup"
+  CLEANUP_SKIP_LOCK=1 /app/cleanup-export.sh || echo "[$(date -u +%H:%M:%S)] ERROR: cleanup failed"
+  free_inodes=$(df -Pi /data | awk 'NR==2{print $4}')
+  free_kb=$(df -P /data | awk 'NR==2{print $4}')
+  if [ "${free_inodes:-0}" -lt "$INODE_FLOOR" ] || [ "${free_kb:-0}" -lt "$BLOCKS_FLOOR_KB" ]; then
+    echo "[$(date -u +%H:%M:%S)] CRITICAL: still below floor after cleanup (free inodes=${free_inodes}, free kb=${free_kb}) — publishing anyway"
+  fi
+fi
+
 # Export latest data from Turso → JSON files (picks up data from all pollers)
 DATA_DIR="$REPO_DIR/data" node /app/api-export.js
 
@@ -39,7 +56,9 @@ DATA_DIR="$REPO_DIR/data" node /app/api-export-v2.js || echo "[$(date -u +%H:%M:
 # Generate providers.json from Turso (non-fatal — keeps existing file if Turso is down)
 DATA_DIR="$REPO_DIR/data" node /app/export-providers-json.js || true
 
-# Stage all data changes (retail, spot hourly, goldback)
+# Stage all data changes (retail, spot hourly, goldback).
+# NOTE: `git add <path>` stages DELETIONS of tracked files too (git ≥2.0) —
+# the cleanup-export.sh retention sweep relies on this. Do not "fix".
 git add data/
 
 HAS_STAGED=false
@@ -60,9 +79,34 @@ if $HAS_STAGED; then
   git commit -m "publish: ${DATE} | retail=${RETAIL_TS}"
 fi
 
+# ── Verify-then-push (STRK-187) ─────────────────────────────────────────
+# api2 (local serve.js) is the primary by design; git/Pages is redundancy.
+# Before pushing, prove serve.js is alive and the manifest on disk is fresh,
+# complete JSON — catches a dead server, a zero-byte/truncated manifest
+# (the full-disk failure mode), and an exporter that silently stopped
+# refreshing generated_at.
+MANIFEST=$(curl -s --max-time 10 http://localhost:8080/data/api/manifest.json || true)
+GEN_AT=$(echo "$MANIFEST" | jq -r '.generated_at // empty' 2>/dev/null || true)
+if [ -z "$GEN_AT" ]; then
+  echo "[$(date -u +%H:%M:%S)] ERROR: api2 manifest missing/unparseable — SKIPPING push (api2 unaffected, exports on disk)"
+  exit 1
+fi
+if $HAS_STAGED; then
+  # Freshness check only when this cycle exported — a push-only retry cycle
+  # legitimately serves an older manifest.
+  AGE_MIN=$((($(date -u +%s) - $(date -d "$GEN_AT" +%s)) / 60))
+  if [ "$AGE_MIN" -gt 30 ]; then
+    echo "[$(date -u +%H:%M:%S)] ERROR: api2 manifest stale (${AGE_MIN}m, generated_at=${GEN_AT}) — SKIPPING push"
+    exit 1
+  fi
+fi
+
 # Force-push to api branch — sole writer, no merge conflicts.
 # IMPORTANT: push to api, NOT main. main holds devops code.
-git push --force "$REMOTE" HEAD:api
+if ! git push --force "$REMOTE" HEAD:api; then
+  echo "[$(date -u +%H:%M:%S)] ERROR: git push to api branch FAILED — api2 still fresh, published feed (api.staktrakr.com) goes stale until a later cycle succeeds"
+  exit 1
+fi
 
 RETAIL_TS=$(jq -r '.generated_at // "unknown"' data/api/manifest.json 2>/dev/null || echo "unknown")
 echo "[$(date -u +%H:%M:%S)] Published to api. Retail ts: ${RETAIL_TS}"

--- a/devops/pollers/remote-poller/run-publish.sh
+++ b/devops/pollers/remote-poller/run-publish.sh
@@ -72,13 +72,6 @@ if ! $HAS_STAGED && ! $HAS_UNPUSHED; then
   exit 0
 fi
 
-if $HAS_STAGED; then
-  # Build a meaningful commit message
-  RETAIL_TS=$(jq -r '.generated_at // "unknown"' data/api/manifest.json 2>/dev/null || echo "unknown")
-  DATE=$(date -u +%Y-%m-%dT%H:%MZ)
-  git commit -m "publish: ${DATE} | retail=${RETAIL_TS}"
-fi
-
 # ── Verify-then-push (STRK-187) ─────────────────────────────────────────
 # api2 (local serve.js) is the primary by design; git/Pages is redundancy.
 # Before pushing, prove serve.js is alive and the manifest on disk is fresh,
@@ -105,6 +98,18 @@ if $HAS_STAGED; then
     echo "[$(date -u +%H:%M:%S)] ERROR: api2 manifest stale (${AGE_MIN}m, generated_at=${GEN_AT}) — SKIPPING push"
     exit 1
   fi
+fi
+
+# Commit only after the freshness gate passes (STRK-187). Committing before the
+# gate left an unpushed local commit on any gate `exit 1`; the next cron run
+# (HAS_STAGED=false / HAS_UNPUSHED=true) skips the freshness check entirely and
+# force-pushes that stale/rejected commit — defeating verify-then-push. Keep the
+# commit here, behind the gate, so a rejected cycle leaves no commit to resurrect.
+if $HAS_STAGED; then
+  # Build a meaningful commit message
+  RETAIL_TS=$(jq -r '.generated_at // "unknown"' data/api/manifest.json 2>/dev/null || echo "unknown")
+  DATE=$(date -u +%Y-%m-%dT%H:%MZ)
+  git commit -m "publish: ${DATE} | retail=${RETAIL_TS}"
 fi
 
 # Force-push to api branch — sole writer, no merge conflicts.

--- a/devops/pollers/shared/backfill-spot-files.js
+++ b/devops/pollers/shared/backfill-spot-files.js
@@ -137,6 +137,11 @@ export function rowsToEntries(rows) {
   return entries;
 }
 
+/**
+ * Whether a path exists and is accessible (async wrapper over fs.access).
+ * @param {string} filePath
+ * @returns {Promise<boolean>}
+ */
 async function fileExists(filePath) {
   try {
     await access(filePath);
@@ -146,6 +151,13 @@ async function fileExists(filePath) {
   }
 }
 
+/**
+ * CLI entry point: parse args, then for each UTC hour in range read the latest
+ * sqld spot rows and write a byte-compatible hourly JSON file (skipping existing
+ * files unless --overwrite, and only logging under --dry-run). Requires the
+ * DATA_DIR env var; exits non-zero when it is unset.
+ * @returns {Promise<void>}
+ */
 async function main() {
   const dataDir = process.env.DATA_DIR;
   if (!dataDir) {

--- a/devops/pollers/shared/backfill-spot-files.js
+++ b/devops/pollers/shared/backfill-spot-files.js
@@ -1,0 +1,211 @@
+/**
+ * backfill-spot-files.js — Regenerate hourly spot JSON files from sqld.
+ *
+ * Reverse of backfill-spot.js (which imports files INTO sqld). Used to heal
+ * publication gaps where spot rows kept landing in sqld but file writes
+ * failed (e.g. the 2026-06-11 inode-exhaustion outage, STRK-187).
+ *
+ * Usage (on the Fly machine, or anywhere with sqld access):
+ *   DATA_DIR=/data/staktrakr-api-export/data node backfill-spot-files.js \
+ *     --from 2026-06-11T06 --to 2026-06-11T13 [--overwrite] [--dry-run]
+ *
+ * Hours are UTC, inclusive on both ends; --to defaults to --from.
+ * Existing files are skipped unless --overwrite. Output is byte-compatible
+ * with the hourly files spot-extract.js writes.
+ */
+
+import { mkdir, writeFile, access } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const METAL_ORDER = ["Gold", "Silver", "Platinum", "Palladium"];
+const HOUR_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})$/;
+const MAX_RANGE_HOURS = 24 * 366; // sanity cap — one year
+
+/**
+ * Parse CLI arguments.
+ * @param {string[]} argv - e.g. process.argv.slice(2)
+ * @returns {{ from: string, to: string, overwrite: boolean, dryRun: boolean }}
+ */
+export function parseArgs(argv) {
+  const opts = { from: null, to: null, overwrite: false, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--from") opts.from = argv[++i];
+    else if (arg === "--to") opts.to = argv[++i];
+    else if (arg === "--overwrite") opts.overwrite = true;
+    else if (arg === "--dry-run") opts.dryRun = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!opts.from) throw new Error("--from YYYY-MM-DDTHH is required");
+  if (!opts.to) opts.to = opts.from;
+  for (const [name, value] of [
+    ["--from", opts.from],
+    ["--to", opts.to],
+  ]) {
+    const m = HOUR_RE.exec(value);
+    if (!m || Number(m[4]) > 23) {
+      throw new Error(`${name} must be YYYY-MM-DDTHH (UTC, hour 00-23), got: ${value}`);
+    }
+  }
+  return opts;
+}
+
+/**
+ * Enumerate inclusive UTC hours between two "YYYY-MM-DDTHH" bounds.
+ * @param {string} fromHour
+ * @param {string} toHour
+ * @returns {string[]} e.g. ["2026-06-11T06", "2026-06-11T07", ...]
+ */
+export function enumerateHours(fromHour, toHour) {
+  const toMs = (h) => {
+    const [, y, mo, d, hh] = HOUR_RE.exec(h);
+    return Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(hh));
+  };
+  const start = toMs(fromHour);
+  const end = toMs(toHour);
+  if (end < start) throw new Error(`--to (${toHour}) is before --from (${fromHour})`);
+  const hours = (end - start) / 3600000 + 1;
+  if (hours > MAX_RANGE_HOURS) {
+    throw new Error(`Range of ${hours} hours exceeds sanity cap (${MAX_RANGE_HOURS})`);
+  }
+  const out = [];
+  for (let t = start; t <= end; t += 3600000) {
+    out.push(new Date(t).toISOString().slice(0, 13));
+  }
+  return out;
+}
+
+/**
+ * Hourly file path for a "YYYY-MM-DDTHH" hour, matching spot-extract.js layout.
+ * @param {string} dataDir
+ * @param {string} hour
+ * @returns {string} dataDir/hourly/YYYY/MM/DD/HH.json
+ */
+export function hourlyPathFor(dataDir, hour) {
+  const [, y, mo, d, hh] = HOUR_RE.exec(hour);
+  return join(dataDir, "hourly", y, mo, d, `${hh}.json`);
+}
+
+/**
+ * Convert ISO 8601 "YYYY-MM-DDTHH:MM:SSZ" to "YYYY-MM-DD HH:MM:SS"
+ * (the format spot-extract.js writes into hourly entries).
+ * @param {string} iso
+ * @returns {string}
+ */
+export function isoToSpaceTs(iso) {
+  return iso.replace("T", " ").replace(/(?:\.\d+)?Z?$/, "");
+}
+
+/**
+ * Build hourly-file entries from sqld spot_prices rows for one hour.
+ * Picks the latest row (max timestamp_floor) per metal — matching
+ * spot-extract's overwrite-wins-last hourly semantics. Returns null if any
+ * of the four metals is missing.
+ * @param {Array<{metal: string, spot: number, timestamp: string, timestamp_floor: string}>} rows
+ * @returns {Array<object> | null}
+ */
+export function rowsToEntries(rows) {
+  const latest = {};
+  for (const row of rows ?? []) {
+    const key = row.metal?.toLowerCase();
+    if (!key) continue;
+    if (!latest[key] || row.timestamp_floor > latest[key].timestamp_floor) {
+      latest[key] = row;
+    }
+  }
+  const entries = [];
+  for (const metal of METAL_ORDER) {
+    const row = latest[metal.toLowerCase()];
+    if (!row) return null;
+    entries.push({
+      spot: row.spot,
+      metal,
+      source: "hourly",
+      provider: "StakTrakr",
+      timestamp: isoToSpaceTs(row.timestamp),
+    });
+  }
+  return entries;
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const dataDir = process.env.DATA_DIR;
+  if (!dataDir) {
+    console.error("ERROR: DATA_DIR environment variable is required.");
+    process.exit(1);
+  }
+
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Lazy import so unit tests can load the pure helpers above without
+  // @libsql/client being installed (root CI has no shared/node_modules).
+  const { createSqldClient } = await import("./sqld-client.js");
+  const { readSpotHourly } = await import("./db.js");
+
+  const client = createSqldClient();
+  const hours = enumerateHours(opts.from, opts.to);
+  console.log(
+    `Backfilling ${hours.length} hour(s) ${opts.from}..${opts.to}` +
+      `${opts.dryRun ? " (dry-run)" : ""}${opts.overwrite ? " (overwrite)" : ""}`
+  );
+
+  let written = 0;
+  let skipped = 0;
+
+  for (const hour of hours) {
+    const filePath = hourlyPathFor(dataDir, hour);
+    if (!opts.overwrite && (await fileExists(filePath))) {
+      console.log(`SKIP (exists): ${filePath}`);
+      skipped++;
+      continue;
+    }
+    const [date, hh] = hour.split("T");
+    const rows = await readSpotHourly(client, date, Number(hh));
+    const entries = rowsToEntries(rows);
+    if (!entries) {
+      console.warn(`SKIP (incomplete sqld data, ${rows.length} rows): ${hour}`);
+      skipped++;
+      continue;
+    }
+    if (opts.dryRun) {
+      console.log(`WOULD WRITE: ${filePath} (ts=${entries[0].timestamp})`);
+    } else {
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, JSON.stringify(entries, null, 2), "utf-8");
+      console.log(`Wrote: ${filePath} (ts=${entries[0].timestamp})`);
+    }
+    written++;
+  }
+
+  console.log(
+    `Backfill complete: ${written} file(s) ${opts.dryRun ? "would be " : ""}written, ${skipped} skipped`
+  );
+}
+
+// Run only when executed directly (unlike backfill-spot.js) so tests can
+// import the pure helpers without side effects.
+const isDirectRun = (() => {
+  try {
+    return realpathSync(process.argv[1] ?? "") === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/devops/pollers/shared/backfill-spot-files.js
+++ b/devops/pollers/shared/backfill-spot-files.js
@@ -48,6 +48,13 @@ export function parseArgs(argv) {
     if (!m || Number(m[4]) > 23) {
       throw new Error(`${name} must be YYYY-MM-DDTHH (UTC, hour 00-23), got: ${value}`);
     }
+    // Reject impossible calendar dates (e.g. 2026-02-31) instead of letting
+    // Date.UTC silently normalize them into a different day's files.
+    const [, y, mo, d, hh] = m;
+    const dt = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(hh)));
+    if (dt.toISOString().slice(0, 13) !== value) {
+      throw new Error(`${name} contains an invalid calendar date: ${value}`);
+    }
   }
   return opts;
 }
@@ -174,7 +181,11 @@ async function main() {
     const rows = await readSpotHourly(client, date, Number(hh));
     const entries = rowsToEntries(rows);
     if (!entries) {
-      console.warn(`SKIP (incomplete sqld data, ${rows.length} rows): ${hour}`);
+      const present = new Set(rows.map((r) => r.metal?.toLowerCase()).filter(Boolean));
+      const missing = METAL_ORDER.filter((name) => !present.has(name.toLowerCase()));
+      console.warn(
+        `SKIP (incomplete sqld data, missing: ${missing.join(", ")}; ${rows.length} rows): ${hour}`
+      );
       skipped++;
       continue;
     }

--- a/tests/unit/backfill-spot-files.test.js
+++ b/tests/unit/backfill-spot-files.test.js
@@ -1,0 +1,169 @@
+// Unit tests for the pure helpers in devops/pollers/shared/backfill-spot-files.js
+// (STRK-187 sqld→hourly-JSON reverse backfill).
+// Run: npm run test:unit
+//
+// The script lazy-imports its sqld client inside main(), so importing the
+// helpers here needs no @libsql/client install and has no side effects.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { sep } from "node:path";
+
+import {
+  parseArgs,
+  enumerateHours,
+  hourlyPathFor,
+  rowsToEntries,
+  isoToSpaceTs,
+} from "../../devops/pollers/shared/backfill-spot-files.js";
+
+describe("parseArgs", () => {
+  it("parses --from/--to and flags", () => {
+    const opts = parseArgs(["--from", "2026-06-11T06", "--to", "2026-06-11T13", "--dry-run"]);
+    assert.deepEqual(opts, {
+      from: "2026-06-11T06",
+      to: "2026-06-11T13",
+      overwrite: false,
+      dryRun: true,
+    });
+  });
+
+  it("defaults --to to --from (single hour)", () => {
+    const opts = parseArgs(["--from", "2026-06-11T06"]);
+    assert.equal(opts.to, "2026-06-11T06");
+  });
+
+  it("requires --from", () => {
+    assert.throws(() => parseArgs([]), /--from/);
+  });
+
+  it("rejects malformed hour strings", () => {
+    assert.throws(() => parseArgs(["--from", "2026-06-11"]), /YYYY-MM-DDTHH/);
+    assert.throws(() => parseArgs(["--from", "2026-06-11T6"]), /YYYY-MM-DDTHH/);
+    assert.throws(() => parseArgs(["--from", "2026-06-11T24"]), /YYYY-MM-DDTHH/);
+  });
+
+  it("rejects unknown arguments", () => {
+    assert.throws(() => parseArgs(["--frmo", "2026-06-11T06"]), /Unknown argument/);
+  });
+});
+
+describe("enumerateHours", () => {
+  it("enumerates an inclusive range", () => {
+    assert.deepEqual(enumerateHours("2026-06-11T06", "2026-06-11T08"), [
+      "2026-06-11T06",
+      "2026-06-11T07",
+      "2026-06-11T08",
+    ]);
+  });
+
+  it("returns a single hour when from == to", () => {
+    assert.deepEqual(enumerateHours("2026-06-11T06", "2026-06-11T06"), ["2026-06-11T06"]);
+  });
+
+  it("rolls over day boundaries", () => {
+    assert.deepEqual(enumerateHours("2026-06-30T23", "2026-07-01T01"), [
+      "2026-06-30T23",
+      "2026-07-01T00",
+      "2026-07-01T01",
+    ]);
+  });
+
+  it("rejects reversed ranges", () => {
+    assert.throws(() => enumerateHours("2026-06-11T13", "2026-06-11T06"), /before/);
+  });
+
+  it("rejects ranges beyond the sanity cap", () => {
+    assert.throws(() => enumerateHours("2024-01-01T00", "2026-01-01T00"), /sanity cap/);
+  });
+});
+
+describe("hourlyPathFor", () => {
+  it("builds the spot-extract hourly layout with zero-padding", () => {
+    const p = hourlyPathFor("/data/export", "2026-06-11T06");
+    assert.equal(p, ["/data/export", "hourly", "2026", "06", "11", "06.json"].join(sep));
+  });
+});
+
+describe("isoToSpaceTs", () => {
+  it("converts ISO-Z to the space-separated hourly format", () => {
+    assert.equal(isoToSpaceTs("2026-06-11T06:05:00Z"), "2026-06-11 06:05:00");
+  });
+
+  it("tolerates fractional seconds and missing Z", () => {
+    assert.equal(isoToSpaceTs("2026-06-11T06:05:00.000Z"), "2026-06-11 06:05:00");
+    assert.equal(isoToSpaceTs("2026-06-11T06:05:00"), "2026-06-11 06:05:00");
+  });
+});
+
+describe("rowsToEntries", () => {
+  const row = (metal, spot, floor, ts) => ({
+    metal,
+    spot,
+    timestamp_floor: floor,
+    timestamp: ts,
+  });
+
+  const fullHour = [
+    row("gold", 3380.1, "2026-06-11T06:00:00Z", "2026-06-11T06:05:00Z"),
+    row("silver", 48.2, "2026-06-11T06:00:00Z", "2026-06-11T06:05:00Z"),
+    row("platinum", 1410.5, "2026-06-11T06:00:00Z", "2026-06-11T06:05:00Z"),
+    row("palladium", 1320.7, "2026-06-11T06:00:00Z", "2026-06-11T06:05:00Z"),
+  ];
+
+  it("emits the four metals in spot-extract order with the exact entry shape", () => {
+    const entries = rowsToEntries(fullHour);
+    assert.deepEqual(entries, [
+      {
+        spot: 3380.1,
+        metal: "Gold",
+        source: "hourly",
+        provider: "StakTrakr",
+        timestamp: "2026-06-11 06:05:00",
+      },
+      {
+        spot: 48.2,
+        metal: "Silver",
+        source: "hourly",
+        provider: "StakTrakr",
+        timestamp: "2026-06-11 06:05:00",
+      },
+      {
+        spot: 1410.5,
+        metal: "Platinum",
+        source: "hourly",
+        provider: "StakTrakr",
+        timestamp: "2026-06-11 06:05:00",
+      },
+      {
+        spot: 1320.7,
+        metal: "Palladium",
+        source: "hourly",
+        provider: "StakTrakr",
+        timestamp: "2026-06-11 06:05:00",
+      },
+    ]);
+  });
+
+  it("picks the latest row per metal (max timestamp_floor — overwrite-wins-last)", () => {
+    const twoPolls = [
+      ...fullHour,
+      row("gold", 3390.9, "2026-06-11T06:30:00Z", "2026-06-11T06:35:00Z"),
+      row("silver", 48.9, "2026-06-11T06:30:00Z", "2026-06-11T06:35:00Z"),
+      row("platinum", 1411.0, "2026-06-11T06:30:00Z", "2026-06-11T06:35:00Z"),
+      row("palladium", 1321.0, "2026-06-11T06:30:00Z", "2026-06-11T06:35:00Z"),
+    ];
+    const entries = rowsToEntries(twoPolls);
+    assert.equal(entries[0].spot, 3390.9);
+    assert.equal(entries[0].timestamp, "2026-06-11 06:35:00");
+  });
+
+  it("returns null when a metal is missing", () => {
+    assert.equal(rowsToEntries(fullHour.slice(0, 3)), null);
+  });
+
+  it("returns null on empty or undefined input", () => {
+    assert.equal(rowsToEntries([]), null);
+    assert.equal(rowsToEntries(undefined), null);
+  });
+});

--- a/tests/unit/backfill-spot-files.test.js
+++ b/tests/unit/backfill-spot-files.test.js
@@ -46,6 +46,15 @@ describe("parseArgs", () => {
   it("rejects unknown arguments", () => {
     assert.throws(() => parseArgs(["--frmo", "2026-06-11T06"]), /Unknown argument/);
   });
+
+  it("rejects impossible calendar dates (no Date.UTC normalization)", () => {
+    assert.throws(() => parseArgs(["--from", "2026-02-31T06"]), /invalid calendar date/);
+    assert.throws(() => parseArgs(["--from", "2026-13-01T06"]), /invalid calendar date/);
+    assert.throws(
+      () => parseArgs(["--from", "2026-06-11T06", "--to", "2026-04-31T06"]),
+      /invalid calendar date/
+    );
+  });
 });
 
 describe("enumerateHours", () => {


### PR DESCRIPTION
## Summary

Root-cause fix for the 2026-06-11 outage: the Fly volume ran out of inodes (~96 ungc'd commits/day + unbounded spot files), freezing publication for 8.5h while every health check stayed green. This makes the publisher self-cleaning and adds the missing freshness tripwire. Plane: STRK-187.

### Publisher (Fly.io remote poller)
- **`cleanup-export.sh` (new)** — retention sweep (15min day-dirs >90d, hourly >365d; path-derived dates, immune to mtime resets) + memory-capped git maintenance (`reflog expire` → `repack -a -d -l --threads=1 --window-memory=32m` → `prune` → `pack-refs`; no `git gc`, it OOMs on the 512MB machine). Serializes with publish via the existing lockfile.
- **`run-publish.sh`** — pre-flight space backstop (floors: 25k free inodes / 300MB free) runs cleanup immediately when breached, then publishes anyway (publishing is the product); verify-then-push gate proves api2 serves a fresh, parseable manifest before `git push` (catches the zero-byte/truncated-manifest full-disk failure mode); explicit push-failure logging — a push failure never affects api2.
- **Weekly cleanup cron** (Sun 03:17 UTC) added to both cron definition sites (Dockerfile baked defaults + entrypoint rewrite).

### Gap healing
- **`backfill-spot-files.js` (new)** — sqld→hourly-JSON reverse backfill (inverse of `backfill-spot.js`). Idempotent (skip-existing default), `--dry-run`, output byte-compatible with `spot-extract.js` hourly files. Will be run once post-deploy for the 2026-06-11 06:00–13:00 UTC gap.

### Watchdog (home poller)
- **`check-flyio.sh`** — fetches published (api.staktrakr.com) and api2 manifest `generated_at`, compares against 45 min; 6 new fields in `/tmp/flyio-health.json`.
- **`dashboard.js`** — `Publish:` status-bar + infra-row items; api2-fresh-but-published-stale renders **PUSH STALE** (push broken) vs **STALE** (pipeline broken).

No frontend changes → no version bump. Devops-only; deploys via `fly deploy` (remote) + Portainer redeploy (home) after merge.

## Testing
- `npm run test:unit` — 256/256 (17 new tests for the backfill pure helpers)
- `npm run lint` clean; Prettier clean; `bash -n` on all touched scripts
- Retention prune logic smoke-tested against synthetic day-dir trees (old pruned, recent kept, empty parents removed)

## Acceptance criteria mapping
- Bounded inode/block usage → retention sweep + weekly repack + pre-flight backstop
- Full-disk self-heals within one publish cycle → pre-flight floor check triggers cleanup inline
- api2 verified before push; push failure isolated → verify-then-push block
- 06-11 hourly gap backfilled from sqld → backfill-spot-files.js (post-deploy step)