### PR TITLE
refactor: STRK-181 follow-up — dedup chip renderers + unit coverage

### DIFF
--- a/js/diff-modal-settings.js
+++ b/js/diff-modal-settings.js
@@ -160,6 +160,52 @@
   }
 
   /**
+   * Build one local/remote diff chip span. Shared by the chip-strip and
+   * toggle-map renderers to keep their per-element markup identical.
+   * @param {string} side "local" or "remote"
+   * @param {boolean} enabled whether this side's value is on
+   * @param {boolean} selected whether this side is the current field selection
+   * @returns {string} chip HTML (trailing space included)
+   */
+  function _renderDiffChip(fieldKey, label, side, enabled, selected) {
+    var icon = enabled ? "✓" : "✗";
+    var cls =
+      "dm-chip-" +
+      side +
+      " " +
+      (enabled ? "dm-chip-enabled" : "dm-chip-disabled") +
+      (selected ? " dm-selected" : "");
+    return (
+      '<span class="' +
+      cls +
+      '" data-field="' +
+      _esc(fieldKey) +
+      '" data-side="' +
+      side +
+      '">' +
+      icon +
+      " " +
+      _esc(label) +
+      "</span> "
+    );
+  }
+
+  /**
+   * Build one matched (both-sides-equal) chip span. Shared by the chip-strip
+   * and toggle-map renderers.
+   * @returns {string} chip HTML (trailing space included)
+   */
+  function _renderMatchedChip(label, enabled) {
+    var icon = enabled ? "✓" : "✗";
+    return '<span class="dm-chip-matched">' + icon + " " + _esc(label) + "</span> ";
+  }
+
+  /** Resolve a chip-strip element's identity key (id → label → index fallback). */
+  function _chipKey(item, idx) {
+    return item.id || item.label || idx;
+  }
+
+  /**
    * Render an enabled/ordered chip-strip setting (e.g. section layout) as a diff.
    * @param {Object} fieldSelections per-element local/remote picks (read-only, for highlight)
    */
@@ -172,11 +218,11 @@
     var remoteById = {};
     var i, id;
     for (i = 0; i < localArr.length; i++) {
-      id = localArr[i].id || localArr[i].label || i;
+      id = _chipKey(localArr[i], i);
       localById[id] = localArr[i];
     }
     for (i = 0; i < remoteArr.length; i++) {
-      id = remoteArr[i].id || remoteArr[i].label || i;
+      id = _chipKey(remoteArr[i], i);
       remoteById[id] = remoteArr[i];
     }
     var allIds = {};
@@ -198,47 +244,21 @@
       var selSide = fieldSelections[fieldKey] || "";
 
       if (loc && rem && loc.enabled === rem.enabled) {
-        var icon = loc.enabled ? "✓" : "✗";
-        matchedHtml +=
-          '<span class="dm-chip-matched">' + icon + " " + _esc(String(chipLabel)) + "</span> ";
+        matchedHtml += _renderMatchedChip(String(chipLabel), loc.enabled);
       } else {
         diffCount++;
-        var localChip = "";
-        var remoteChip = "";
-        if (loc) {
-          var lIcon = loc.enabled ? "✓" : "✗";
-          var lCls =
-            "dm-chip-local " +
-            (loc.enabled ? "dm-chip-enabled" : "dm-chip-disabled") +
-            (selSide === "local" ? " dm-selected" : "");
-          localChip =
-            '<span class="' +
-            lCls +
-            '" data-field="' +
-            _esc(fieldKey) +
-            '" data-side="local">' +
-            lIcon +
-            " " +
-            _esc(String(chipLabel)) +
-            "</span> ";
-        }
-        if (rem) {
-          var rIcon = rem.enabled ? "✓" : "✗";
-          var rCls =
-            "dm-chip-remote " +
-            (rem.enabled ? "dm-chip-enabled" : "dm-chip-disabled") +
-            (selSide === "remote" ? " dm-selected" : "");
-          remoteChip =
-            '<span class="' +
-            rCls +
-            '" data-field="' +
-            _esc(fieldKey) +
-            '" data-side="remote">' +
-            rIcon +
-            " " +
-            _esc(String(chipLabel)) +
-            "</span> ";
-        }
+        var localChip = loc
+          ? _renderDiffChip(fieldKey, String(chipLabel), "local", loc.enabled, selSide === "local")
+          : "";
+        var remoteChip = rem
+          ? _renderDiffChip(
+              fieldKey,
+              String(chipLabel),
+              "remote",
+              rem.enabled,
+              selSide === "remote"
+            )
+          : "";
         if (diffCount <= 15) {
           localHtml += localChip;
           remoteHtml += remoteChip;
@@ -295,47 +315,17 @@
       var humanLabel = _titleCase(k);
 
       if (lv !== undefined && rv !== undefined && lv === rv) {
-        var mIcon = lv ? "✓" : "✗";
-        matchedHtml +=
-          '<span class="dm-chip-matched">' + mIcon + " " + _esc(humanLabel) + "</span> ";
+        matchedHtml += _renderMatchedChip(humanLabel, lv);
       } else {
         diffCount++;
-        var localChip = "";
-        var remoteChip = "";
-        if (lv !== undefined) {
-          var lIcon = lv ? "✓" : "✗";
-          var lCls =
-            "dm-chip-local " +
-            (lv ? "dm-chip-enabled" : "dm-chip-disabled") +
-            (selSide === "local" ? " dm-selected" : "");
-          localChip =
-            '<span class="' +
-            lCls +
-            '" data-field="' +
-            _esc(fieldKey) +
-            '" data-side="local">' +
-            lIcon +
-            " " +
-            _esc(humanLabel) +
-            "</span> ";
-        }
-        if (rv !== undefined) {
-          var rIcon = rv ? "✓" : "✗";
-          var rCls =
-            "dm-chip-remote " +
-            (rv ? "dm-chip-enabled" : "dm-chip-disabled") +
-            (selSide === "remote" ? " dm-selected" : "");
-          remoteChip =
-            '<span class="' +
-            rCls +
-            '" data-field="' +
-            _esc(fieldKey) +
-            '" data-side="remote">' +
-            rIcon +
-            " " +
-            _esc(humanLabel) +
-            "</span> ";
-        }
+        var localChip =
+          lv !== undefined
+            ? _renderDiffChip(fieldKey, humanLabel, "local", lv, selSide === "local")
+            : "";
+        var remoteChip =
+          rv !== undefined
+            ? _renderDiffChip(fieldKey, humanLabel, "remote", rv, selSide === "remote")
+            : "";
         if (diffCount <= 15) {
           localHtml += localChip;
           remoteHtml += remoteChip;

--- a/js/diff-modal-settings.js
+++ b/js/diff-modal-settings.js
@@ -162,6 +162,8 @@
   /**
    * Build one local/remote diff chip span. Shared by the chip-strip and
    * toggle-map renderers to keep their per-element markup identical.
+   * @param {string} fieldKey unique field id (e.g. "setting-<key>-<id>")
+   * @param {string} label chip label text (HTML-escaped on output)
    * @param {string} side "local" or "remote"
    * @param {boolean} enabled whether this side's value is on
    * @param {boolean} selected whether this side is the current field selection
@@ -193,6 +195,8 @@
   /**
    * Build one matched (both-sides-equal) chip span. Shared by the chip-strip
    * and toggle-map renderers.
+   * @param {string} label chip label text (HTML-escaped on output)
+   * @param {boolean} enabled whether the agreed value is on
    * @returns {string} chip HTML (trailing space included)
    */
   function _renderMatchedChip(label, enabled) {

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.20-b1781394565";
+const CACHE_NAME = "staktrakr-v3.35.20-b1781409401";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.20-b1781409401";
+const CACHE_NAME = "staktrakr-v3.35.20-b1781409653";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/diff-modal-settings.test.js
+++ b/tests/unit/diff-modal-settings.test.js
@@ -1,0 +1,146 @@
+// Unit tests for js/diff-modal-settings.js (STRK-181 split of diff-modal.js).
+// Run: npm run test:unit  (node --test tests/unit/diff-modal-settings.test.js)
+//
+// The module is a browser IIFE that assigns window.DiffModalSettings. We load it
+// via new Function() with an injected `window` object so the IIFE's
+// `typeof window !== "undefined"` guard fires and exposes the public API without
+// any DOM. sanitizeHtml / __decompressIfNeeded are intentionally left undefined
+// so _esc falls back to its inline HTML-escape branch (deterministic output).
+//
+// Focus: the shared _renderDiffChip / _renderMatchedChip helpers must produce
+// identical chip markup for both the chip-strip and toggle-map renderers, plus
+// the slug-chips, count-summary, value-formatter and metal-color paths.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+
+const code = readFileSync(new URL("../../js/diff-modal-settings.js", import.meta.url), "utf-8");
+const window = {};
+new Function("window", code)(window);
+const DMS = window.DiffModalSettings;
+
+describe("DiffModalSettings public API", () => {
+  it("exposes the four documented methods", () => {
+    assert.equal(typeof DMS.renderSettingRow, "function");
+    assert.equal(typeof DMS.formatSettingValue, "function");
+    assert.equal(typeof DMS.metalColor, "function");
+    assert.equal(typeof DMS.metalBgGradient, "function");
+  });
+
+  it("returns null for a key with no rich renderer", () => {
+    assert.equal(DMS.renderSettingRow("displayCurrency", "USD", "EUR"), null);
+  });
+});
+
+describe("renderSettingRow — chip-strip", () => {
+  const local = [{ id: "a", label: "Alpha", enabled: true }];
+  const remote = [{ id: "a", label: "Alpha", enabled: false }];
+
+  it("renders an enabled/disabled diff with both side chips", () => {
+    const html = DMS.renderSettingRow("layoutSectionConfig", local, remote, {});
+    assert.match(html, /dm-chip-local/);
+    assert.match(html, /dm-chip-remote/);
+    assert.match(html, /data-side="local"/);
+    assert.match(html, /data-side="remote"/);
+    assert.match(html, /Alpha/);
+    assert.match(html, /✓/); // local enabled
+    assert.match(html, /✗/); // remote disabled
+    assert.match(html, /data-field="setting-layoutSectionConfig-a"/);
+  });
+
+  it("applies the dm-selected highlight from fieldSelections", () => {
+    const sel = { "setting-layoutSectionConfig-a": "local" };
+    const html = DMS.renderSettingRow("layoutSectionConfig", local, remote, sel);
+    // Only the local side should carry dm-selected.
+    assert.match(html, /dm-chip-local[^"]*dm-selected/);
+    assert.doesNotMatch(html, /dm-chip-remote[^"]*dm-selected/);
+  });
+
+  it("renders a matched chip when both sides agree", () => {
+    const same = [{ id: "a", label: "Alpha", enabled: true }];
+    const html = DMS.renderSettingRow("layoutSectionConfig", same, same, {});
+    assert.match(html, /dm-chip-matched/);
+  });
+});
+
+describe("renderSettingRow — toggle-map shares chip markup with chip-strip", () => {
+  it("emits the same chip classes/icons as chip-strip for an enabled/disabled diff", () => {
+    const html = DMS.renderSettingRow("numistaViewFields", { fieldA: true }, { fieldA: false }, {});
+    assert.match(html, /dm-chip-local dm-chip-enabled/);
+    assert.match(html, /dm-chip-remote dm-chip-disabled/);
+    assert.match(html, /data-side="local"/);
+    assert.match(html, /✓/);
+    assert.match(html, /✗/);
+    // _titleCase humanizes the key.
+    assert.match(html, /Field A/);
+  });
+
+  it("threads fieldSelections highlight through the shared helper", () => {
+    const sel = { "setting-numistaViewFields-fieldA": "remote" };
+    const html = DMS.renderSettingRow(
+      "numistaViewFields",
+      { fieldA: true },
+      { fieldA: false },
+      sel
+    );
+    assert.match(html, /dm-chip-remote[^"]*dm-selected/);
+    assert.doesNotMatch(html, /dm-chip-local[^"]*dm-selected/);
+  });
+});
+
+describe("renderSettingRow — slug-chips", () => {
+  it("maps a slug to its human label from SLUG_LABELS", () => {
+    const html = DMS.renderSettingRow("headerBtnOrder", ["themeBtn"], [], {});
+    assert.match(html, /Theme/); // SLUG_LABELS.themeBtn
+    assert.match(html, /dm-chip-local/);
+  });
+
+  it("falls back to Title Case for an unknown slug", () => {
+    const html = DMS.renderSettingRow("headerBtnOrder", ["someCustomBtn"], [], {});
+    assert.match(html, /Some Custom Btn/);
+  });
+});
+
+describe("renderSettingRow — count-summary", () => {
+  it("marks the chosen side active from conflictResolutions", () => {
+    const conflicts = { "setting-chipCustomGroups": "remote" };
+    const html = DMS.renderSettingRow("chipCustomGroups", { a: 1 }, { a: 1, b: 2 }, {}, conflicts);
+    assert.match(html, /dm-count-summary/);
+    assert.match(html, /data-side="remote"[^>]*>Use Remote/);
+    // The remote button carries the active class.
+    assert.match(
+      html,
+      /dm-count-btn active" data-setting-resolution="setting-chipCustomGroups" data-side="remote"/
+    );
+  });
+});
+
+describe("formatSettingValue", () => {
+  it("masks configured API-key settings", () => {
+    assert.equal(DMS.formatSettingValue("metalApiConfig", "secret"), "••• configured");
+    assert.equal(DMS.formatSettingValue("catalog_api_config", ""), "not set");
+  });
+
+  it("renders booleans, nulls, arrays, and objects", () => {
+    assert.equal(DMS.formatSettingValue("x", true), "On");
+    assert.equal(DMS.formatSettingValue("x", null), "—");
+    assert.match(DMS.formatSettingValue("x", ["a", "b", "c"]), /^3 items \(a, b/);
+    assert.equal(DMS.formatSettingValue("x", { a: 1, b: 2 }), "2 entries");
+  });
+});
+
+describe("metal color helpers", () => {
+  it("resolves known metals and falls back for unknown", () => {
+    assert.equal(DMS.metalColor("gold"), "var(--gold)");
+    assert.equal(DMS.metalColor("SILVER"), "var(--silver)");
+    assert.equal(DMS.metalColor("unobtanium"), "var(--text-muted)");
+  });
+
+  it("builds an rgb-tinted gradient per metal", () => {
+    assert.match(DMS.metalBgGradient("silver"), /192,192,192/);
+    assert.match(DMS.metalBgGradient("platinum"), /229,228,226/);
+    assert.match(DMS.metalBgGradient("unknown"), /128,128,128/);
+  });
+});


### PR DESCRIPTION
Follow-up to #1257 (which merged before this landed). Resolves the Codacy findings that #1257 introduced on `dev` and adds the unit coverage CodeRabbit requested.

## Fixes (Codacy was flagging these on #1257)
- **Complexity:** `_renderChipStrip` ccn **33 → 22**, `_renderToggleMap` ccn **29 → 22** (under the 25 gate). Every sibling fn is now ccn ≤ 24.
- **Duplication:** removes the chipStrip↔toggleMap clone Codacy flagged.

## How
Extract three shared, behavior-preserving helpers in `js/diff-modal-settings.js`:
- `_renderDiffChip(fieldKey, label, side, enabled, selected)` — one local/remote diff chip span (was duplicated inline across both renderers)
- `_renderMatchedChip(label, enabled)` — one both-sides-equal chip span
- `_chipKey(item, idx)` — `id → label → index` resolution (was duplicated in both chip-strip build loops)

The chip HTML is assembled **identically** to before — pure consolidation, no output change.

## Tests (new)
`tests/unit/diff-modal-settings.test.js` — 14 unit tests covering chip-strip, toggle-map (asserting both emit identical `dm-chip-*` markup via the shared helpers), slug-chips → SLUG_LABELS, count-summary active state, `formatSettingValue` (API-key masking, array/object), and the metal color helpers. Loaded via the `new Function()` pattern from the existing `sw-router.test.js` (trusted local source, no DOM).

## Verify
- every sibling fn ccn ≤ 24
- `npm run test:unit` → **271 pass**
- `npm test` (core) → **224 pass**
- ESLint + Prettier clean

Completes the review feedback for STRK-181.