### PR TITLE
v3.35.22 — STRK-193: remove dead code from diff-modal.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.35.22] - 2026-06-14
+
+### Changed — STRK-193: Remove dead code from the sync diff modal
+
+- **Cleanup**: Removed ~200 lines of unreachable code from `js/diff-modal.js` that was surfaced (and flagged, not deleted) during the STRK-181 split. Gone: the orphaned `_renderProgressTracker` renderer; the self-referential `_renderConflictCards` → `_groupByItem` → `_updateProgress` conflict-card chain (reachable only from its own click handler, never from a live entry point); the write-only `_expandedModified` state; and the unused `sectionType` / `type` parameters on `_swapBtnClass` / `_updateOrphanBtnStyles`. No user-facing behavior change; recovers headroom under the Codacy Lizard file-size gate (diff-modal.js 2702 → 2503 lines) (STRK-193).
+
+---
+
 ## [3.35.21] - 2026-06-14
 
 ### Changed — STRK-169: Oversized-module split campaign complete

--- a/js/about.js
+++ b/js/about.js
@@ -134,11 +134,11 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.35.22 &ndash; STRK-193: Diff-modal cleanup</strong>: Removed roughly 200 lines of unreachable code left behind by the recent diff-modal refactor &mdash; an internal tidy-up with no change to how the sync data-comparison view looks or behaves (STRK-193).</li>
     <li><strong>v3.35.21 &ndash; STRK-169: Codebase modularization complete</strong>: Wrapped up a multi-release cleanup that split StakTrakr's largest source files into smaller, focused modules &mdash; the final and trickiest piece reorganized the sync data-comparison view and removed duplicated rendering code, with no change to how anything looks or behaves. This release also makes the price publisher self-cleaning so a full server disk can no longer stall price updates (STRK-169, STRK-187).</li>
     <li><strong>v3.35.20 &ndash; STRK-190: Offline cache freshness fixed</strong>: The app's offline cache now correctly recognizes live price endpoints, so cached prices respect their intended shelf life &mdash; previously every API response was served from cache without an age check, which could show old prices after time away (STRK-190).</li>
     <li><strong>v3.35.19 &ndash; STRK-189: Stale spot prices rejected</strong>: Spot sync now checks each payload's publication timestamp &mdash; an hours-old price from a cache or stale server can no longer flash over a fresh one, pollute your price history with wrongly-dated entries, or overwrite a newer price; history entries now carry the price's actual publication time (STRK-189).</li>
     <li><strong>v3.35.18 &ndash; STRK-186: Backups keep catalog API keys</strong>: Restoring an encrypted backup or cloud-sync snapshot now correctly brings back your Numista API key and PCGS token &mdash; previously the restored keys looked missing and could be silently erased by the next lookup (STRK-186).</li>
-    <li><strong>v3.35.17 &ndash; STRK-188: Market data backup API</strong>: Market prices now automatically fall back to the backup API when the primary is unreachable &mdash; the Market tab keeps live data during a primary-feed outage, matching how spot prices already behave (STRK-188).</li>
   `;
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.35.21";
+const APP_VERSION = "3.35.22";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -174,37 +174,11 @@
     }
   }
 
-  function _groupByItem(conflictsArray) {
-    var grouped = {};
-    if (!conflictsArray || !conflictsArray.length) return grouped;
-    // Build UUID → name lookup from inventory for human-readable headers
-    var nameByKey = {};
-    if (typeof inventory !== "undefined" && Array.isArray(inventory)) {
-      for (var inv = 0; inv < inventory.length; inv++) {
-        var invItem = inventory[inv];
-        var invKey =
-          typeof DiffEngine !== "undefined" && DiffEngine.computeItemKey
-            ? DiffEngine.computeItemKey(invItem)
-            : invItem.uuid || invItem.id || "";
-        if (invKey && invItem.name) nameByKey[invKey] = invItem.name;
-      }
-    }
-    for (var i = 0; i < conflictsArray.length; i++) {
-      var c = conflictsArray[i];
-      var key = c.itemKey || "";
-      var name = c.itemName || nameByKey[key] || key;
-      if (!grouped[name]) grouped[name] = [];
-      grouped[name].push({ field: c.field, localVal: c.localVal, remoteVal: c.remoteVal, idx: i });
-    }
-    return grouped;
-  }
-
   // ── Internal state ──
   var _options = null;
   var _checkedItems = {}; // { 'added-0': true, 'modified-2': false, ... }
   var _conflictResolutions = {}; // { 'c0': 'local'|'remote', ... }
   var _collapsedCategories = {}; // { added: true, ... }
-  var _expandedModified = {}; // { 0: true, 1: false, ... }
   var _expandedSettingsCategories = {}; // { 'Appearance': true, ... }
   var _selectAllState = 0; // 0=none, 1=added+modified, 2=all
 
@@ -420,178 +394,6 @@
         if (el instanceof HTMLElement) el.scrollIntoView({ behavior: "smooth", block: "start" });
       }
     };
-  }
-
-  function _renderProgressTracker(container, conflicts, source) {
-    if (!container) return;
-    if (!source || source.type !== "sync") {
-      container.style.display = "none";
-      return;
-    }
-
-    var total = 0;
-    var resolved = 0;
-    for (var key in _conflictResolutions) {
-      if (
-        _conflictResolutions.hasOwnProperty(key) &&
-        key.charAt(0) === "c" &&
-        key.indexOf("setting-") !== 0
-      ) {
-        total++;
-        if (_conflictResolutions[key]) resolved++;
-      }
-    }
-
-    var pct = total > 0 ? Math.round((resolved / total) * 100) : 100;
-    var html =
-      '<div style="height:6px;border-radius:3px;background:var(--border);margin:0.5rem 0">';
-    html +=
-      '<div style="height:100%;border-radius:3px;background:var(--success);width:' +
-      pct +
-      '%;transition:width 0.3s"></div>';
-    html += "</div>";
-    html +=
-      '<div id="diffProgressText" style="font-size:0.75rem;opacity:0.6">' +
-      resolved +
-      " of " +
-      total +
-      " conflicts resolved";
-    if (pct === 100 && total > 0) html += " &#9989;";
-    html += "</div>";
-
-    container.innerHTML = html;
-    container.style.display = "";
-  }
-
-  function _updateProgress() {
-    var container = safeGetElement("diffProgressTracker");
-    if (!container) return;
-
-    var total = 0;
-    var resolved = 0;
-    for (var key in _conflictResolutions) {
-      if (
-        _conflictResolutions.hasOwnProperty(key) &&
-        key.charAt(0) === "c" &&
-        key.indexOf("setting-") !== 0
-      ) {
-        total++;
-        if (_conflictResolutions[key]) resolved++;
-      }
-    }
-
-    var pct = total > 0 ? Math.round((resolved / total) * 100) : 100;
-    var bar = container.querySelector("div > div");
-    if (bar) bar.style.width = pct + "%";
-
-    var textDiv = safeGetElement("diffProgressText");
-    if (!(textDiv instanceof HTMLElement)) textDiv = null;
-    if (textDiv) {
-      var txt = resolved + " of " + total + " conflicts resolved";
-      if (pct === 100 && total > 0) txt += " \u2705";
-      textDiv.textContent = txt;
-    }
-  }
-
-  function _renderConflictCards(container, conflicts) {
-    if (!container) return;
-    if (!conflicts || !conflicts.conflicts || conflicts.conflicts.length === 0) {
-      container.style.display = "none";
-      return;
-    }
-
-    var grouped = _groupByItem(conflicts.conflicts);
-    var html = "";
-
-    for (var itemName in grouped) {
-      if (!grouped.hasOwnProperty(itemName)) continue;
-      var fields = grouped[itemName];
-
-      html +=
-        '<div data-conflict-card="' +
-        _esc(itemName) +
-        '" style="border-radius:8px;border:1px solid var(--border);padding:0.75rem;margin-bottom:0.75rem">';
-
-      // Card header
-      html += "<div>";
-      html += '<span style="font-weight:600;font-size:0.85rem">' + _esc(itemName) + "</span>";
-      html +=
-        '<span style="display:inline-block;background:color-mix(in srgb, var(--warning) 10%, transparent);color:var(--warning);border-radius:12px;padding:0.1rem 0.5rem;font-size:0.7rem;margin-left:0.5rem">' +
-        fields.length +
-        " field" +
-        (fields.length !== 1 ? "s" : "") +
-        "</span>";
-      html += "</div>";
-
-      // Field rows
-      for (var f = 0; f < fields.length; f++) {
-        var conflict = fields[f];
-        var resKey = "c" + conflict.idx + "-" + conflict.field;
-        var selected = _conflictResolutions[resKey] || "";
-        var localStyle =
-          "padding:0.25rem 0.6rem;border-radius:4px;cursor:pointer;font-size:0.8rem;";
-        var remoteStyle =
-          "padding:0.25rem 0.6rem;border-radius:4px;cursor:pointer;font-size:0.8rem;";
-
-        if (selected === "local") {
-          localStyle +=
-            "border:1px solid var(--success);background:color-mix(in srgb, var(--success) 8%, transparent)";
-          remoteStyle += "border:1px solid transparent";
-        } else if (selected === "remote") {
-          localStyle += "border:1px solid transparent";
-          remoteStyle +=
-            "border:1px solid var(--success);background:color-mix(in srgb, var(--success) 8%, transparent)";
-        } else {
-          localStyle += "border:1px solid transparent";
-          remoteStyle += "border:1px solid transparent";
-        }
-
-        var localDisplay = _esc(String(conflict.localVal != null ? conflict.localVal : "\u2014"));
-        var remoteDisplay = _esc(
-          String(conflict.remoteVal != null ? conflict.remoteVal : "\u2014")
-        );
-
-        html += '<div style="display:flex;align-items:center;gap:0.4rem;padding:0.3rem 0">';
-        html +=
-          '<span style="min-width:100px;font-size:0.78rem;opacity:0.6">' +
-          _esc(conflict.field) +
-          "</span>";
-        html +=
-          '<span data-resolution="' +
-          _esc(resKey) +
-          '" data-side="local" style="' +
-          localStyle +
-          '">' +
-          localDisplay +
-          "</span>";
-        html += '<span style="opacity:0.3;font-size:0.7rem">\u21C4</span>';
-        html +=
-          '<span data-resolution="' +
-          _esc(resKey) +
-          '" data-side="remote" style="' +
-          remoteStyle +
-          '">' +
-          remoteDisplay +
-          "</span>";
-        html += "</div>";
-      }
-
-      html += "</div>";
-    }
-
-    container.innerHTML = html;
-
-    container.onclick = function (e) {
-      var btn = e.target.closest("[data-resolution]");
-      if (!btn) return;
-      var key = btn.getAttribute("data-resolution");
-      var side = btn.getAttribute("data-side");
-      _conflictResolutions[key] = side;
-      _renderConflictCards(container, conflicts);
-      if (typeof _updateProgress === "function") _updateProgress();
-    };
-
-    container.style.display = "";
   }
 
   function _renderSettingsCards(container, settingsDiff) {
@@ -1710,8 +1512,8 @@
 
   // ── Event delegation (STAK-454 — card-based interactions) ──
 
-  /** Swap a button's style class based on active state and section type */
-  function _swapBtnClass(btn, sectionType, actionName, isActive) {
+  /** Swap a button's style class based on active state */
+  function _swapBtnClass(btn, actionName, isActive) {
     btn.classList.remove(
       "dm-btn-primary",
       "dm-btn-gain",
@@ -1730,11 +1532,11 @@
   }
 
   /** Update both action buttons on an orphan card to reflect the current action */
-  function _updateOrphanBtnStyles(card, type, action) {
+  function _updateOrphanBtnStyles(card, action) {
     var btns = card.querySelectorAll("[data-set-action]");
     for (var bi = 0; bi < btns.length; bi++) {
       var btnAction = btns[bi].dataset.setAction;
-      _swapBtnClass(btns[bi], type, btnAction, btnAction === action);
+      _swapBtnClass(btns[bi], btnAction, btnAction === action);
     }
   }
 
@@ -1760,7 +1562,7 @@
         var isSkipped = action === "skip" || action === "remove";
         card.classList.toggle("skipped", isSkipped);
         card.dataset.action = action;
-        _updateOrphanBtnStyles(card, type, action);
+        _updateOrphanBtnStyles(card, action);
       }
       _updateApplyCount();
       return;
@@ -1784,7 +1586,7 @@
         var bSkipped = bulkAction === "skip" || bulkAction === "remove";
         bCard.classList.toggle("skipped", bSkipped);
         bCard.dataset.action = bulkAction;
-        _updateOrphanBtnStyles(bCard, bulkSection, bulkAction);
+        _updateOrphanBtnStyles(bCard, bulkAction);
       }
       // Update bulk button styles in section header
       var sectionWrapper = bulkBtn.closest(".dm-section-wrapper");
@@ -1793,7 +1595,7 @@
         for (var bbi = 0; bbi < bulkBtns.length; bbi++) {
           var bb = bulkBtns[bbi];
           var isActive = bb.dataset.bulkAction === bulkAction;
-          _swapBtnClass(bb, bulkSection, bb.dataset.bulkAction, isActive);
+          _swapBtnClass(bb, bb.dataset.bulkAction, isActive);
         }
       }
       _updateApplyCount();
@@ -2614,7 +2416,6 @@
       _checkedItems = {};
       _conflictResolutions = {};
       _collapsedCategories = { settings: true };
-      _expandedModified = {};
       _expandedSettingsCategories = {};
       _selectAllState = 0;
       _orphanActions = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.35.21",
+  "version": "3.35.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.35.21",
+      "version": "3.35.22",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.35.21",
+  "version": "3.35.22",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.21-b1781443985";
+const CACHE_NAME = "staktrakr-v3.35.22-b1781445363";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.35.21",
+  "version": "3.35.22",
   "releaseDate": "2026-06-14",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Changes

Removes ~200 lines of unreachable code from `js/diff-modal.js` that was surfaced (and flagged, not deleted) during the STRK-181 split, then bumps `3.35.21 → 3.35.22`.

**Dead code removed** (`js/diff-modal.js` 2702 → 2503 lines):
- `_renderProgressTracker` — orphan renderer, zero call sites
- `_renderConflictCards` — self-referential; only re-called by its own `onclick` handler, never reached from a live entry point
- `_groupByItem` — orphaned by removing `_renderConflictCards` (its sole caller)
- `_updateProgress` — orphaned likewise; the whole conflict-card subsystem was dead (superseded by the card-based STAK-454 rework)
- `_expandedModified` — write-only state, never read
- `sectionType` / `type` params on `_swapBtnClass` / `_updateOrphanBtnStyles` — unused; dropped and call sites updated

**Version bump** `3.35.21 → 3.35.22` across the 6 release files; `sw.js` cache stamped by the pre-commit hook; What's New trimmed to the 5-entry cap.

## Verification

- ESLint + Prettier clean
- Unit: **271 passed**
- Core Playwright: **224 passed**
- No behavior change — pure dead-code removal; recovers headroom under the Codacy Lizard file-nloc gate

## Issues

- STRK-193: Remove dead code in diff-modal.js — **Done**