### PR TITLE
STRK-194: enforce 5-entry What's New cap in check-release-sync hook

### DIFF
--- a/devops/hooks/check-release-sync.sh
+++ b/devops/hooks/check-release-sync.sh
@@ -36,4 +36,14 @@ grep -qE "^## \[${ESCAPED_VERSION}\]" CHANGELOG.md \
 grep -qE "<li><strong>v${ESCAPED_VERSION}[[:space:]]" js/about.js \
   || fail "js/about.js getEmbeddedWhatsNew missing '<li><strong>v$APP_VERSION ...' entry"
 
+# Ceiling check: cap getEmbeddedWhatsNew at WN_MAX versioned entries. The list is
+# trimmed manually by /release, so without this it silently drifts (it grew 5 -> 8
+# across 3.35.15-3.35.20 before being reset). Anchored on "v" + a digit to count
+# only real version <li>s. The substitution is guarded with `|| true` so a zero
+# count surfaces through the explicit fail below rather than aborting under set -e.
+WN_MAX=5
+WN_COUNT=$(grep -cE "<li><strong>v[0-9]" js/about.js || true)
+[ "$WN_COUNT" -le "$WN_MAX" ] \
+  || fail "js/about.js getEmbeddedWhatsNew has $WN_COUNT versioned entries (max $WN_MAX) — trim the oldest"
+
 exit 0

--- a/devops/hooks/check-release-sync.sh
+++ b/devops/hooks/check-release-sync.sh
@@ -39,10 +39,12 @@ grep -qE "<li><strong>v${ESCAPED_VERSION}[[:space:]]" js/about.js \
 # Ceiling check: cap getEmbeddedWhatsNew at WN_MAX versioned entries. The list is
 # trimmed manually by /release, so without this it silently drifts (it grew 5 -> 8
 # across 3.35.15-3.35.20 before being reset). Anchored on "v" + a digit to count
-# only real version <li>s. The substitution is guarded with `|| true` so a zero
-# count surfaces through the explicit fail below rather than aborting under set -e.
+# only real version <li>s. Uses grep -o + wc -l to count occurrences rather than
+# matching lines (grep -c counts lines, so two entries on one line would undercount
+# and let the cap drift). The grep is guarded with `|| true` so a zero count
+# surfaces through the explicit fail below rather than aborting under set -euo pipefail.
 WN_MAX=5
-WN_COUNT=$(grep -cE "<li><strong>v[0-9]" js/about.js || true)
+WN_COUNT=$( { grep -oE "<li><strong>v[0-9]" js/about.js || true; } | wc -l | tr -d ' ')
 [ "$WN_COUNT" -le "$WN_MAX" ] \
   || fail "js/about.js getEmbeddedWhatsNew has $WN_COUNT versioned entries (max $WN_MAX) — trim the oldest"
 


### PR DESCRIPTION
## Summary

Makes the 5-entry **What's New** cap in `js/about.js` (`getEmbeddedWhatsNew`) self-enforcing so it can't silently drift again.

The list is supposed to be capped at 5 versioned `<li>` entries (PR #1254, 8→5), but nothing enforced the *ceiling* — the `/release` "trim to 5" step is manual. As a result it drifted back to **8** entries across the 3.35.15–3.35.20 releases before a manual reset in v3.35.21.

## Root cause & fix

`devops/hooks/check-release-sync.sh` already greps `about.js` to assert the *current* version's entry is **present** (a ≥1 floor check) and is already wired in `.pre-commit-config.yaml` to fire on any commit touching `about.js` — the exact moment the drift occurred. This PR adds the missing **ceiling** assertion right beside the floor check:

```sh
WN_MAX=5
WN_COUNT=$(grep -cE "<li><strong>v[0-9]" js/about.js || true)
[ "$WN_COUNT" -le "$WN_MAX" ] \
  || fail "js/about.js getEmbeddedWhatsNew has $WN_COUNT versioned entries (max $WN_MAX) — trim the oldest"
```

The `grep -c` substitution is guarded with `|| true` so a zero count surfaces through the explicit `fail` rather than aborting under `set -euo pipefail`.

### Why this over the alternatives
- **Unit test (rejected as primary gate):** GitHub CI runs only CodeQL + Codacy — `test:unit`/Playwright are not run in Actions, so a unit test documents the contract but isn't an independent CI gate. The pre-commit hook is the real enforcement surface.
- **Fold into `/release` Phase 2 (rejected):** only runs during `/release`, not on the arbitrary release commits where the drift actually accrued.

## Verification

| AC | Check | Result |
|----|-------|--------|
| AC-1 | Ceiling trips when entries > 5 | ✓ `fail` / exit 1 at 6 |
| AC-2 | Passes at exactly 5 | ✓ real hook `exit 0` |
| AC-3 | Floor + other release-sync checks unchanged | ✓ real hook `exit 0` |
| AC-4 | Failure message states actual count + max | ✓ "has 6 … (max 5) — trim the oldest" |
| AC-5 | No runtime / `getEmbeddedWhatsNew` change | ✓ hook-only diff |

## Scope
Tooling-only change (one shell hook). No version bump, no `/update-spot-bundle` — no release-artifact version delta. No new/modified functions (inline addition), so no docstring-gate impact.

Closes STRK-194.