### PR TITLE
chore: document no-bump-campaign branch convention

### DIFF
--- a/.context/sketch-conventions.md
+++ b/.context/sketch-conventions.md
@@ -7,8 +7,9 @@ Per-project overrides for the `/sketch-*` family. Pairs with the universal mecha
 ## Worktree & branch
 
 - **StakTrakr requires `patch/<version>` branches via `/start-patch`** — NOT the generic `sketch/{ISSUE-ID}-{slug}` convention. If a generated `tasks.md` uses the sketch-style name, override it.
+- **Exception — no-bump campaigns:** a multi-PR refactor/cleanup campaign that ships its intermediate PRs **unbumped** (one closing `/release patch` bumps once for the whole campaign) does **not** use `patch/<version>` per cohort — `/start-patch` claims a version lock per branch, which is incoherent when 19 cohorts share one bump. Such cohort PRs use descriptive **`chore/<issue>-<file>`** (or `refactor/<issue>-<file>`) branches off `origin/dev`. `patch/<version>` via `/start-patch` applies **only** to the single closing `/release` PR. Precedent: STRK-169 (split PRs on `feature/strk-169-*` / `refactor/strk-176-*`); see STRK-170.
 - Worktree path: `.worktrees/<issue>-<slug>/` (`/start-patch`) or `.worktrees/patch-<version>/` (`/release`).
-- Cohort 0 setup invokes **`/start-patch`**, not `using-git-worktrees`.
+- Cohort 0 setup invokes **`/start-patch`**, not `using-git-worktrees` — except in a no-bump campaign, where Cohort 0 only enables tooling and each cohort creates its own `chore/<issue>-<file>` worktree.
 - Full rules: `.context/git-topology.md` §Worktrees, §Merge Strategy, §Sketch & Spec Branch Overrides.
 
 ## Version & release


### PR DESCRIPTION
## What
Adds a no-bump-campaign exception to `.context/sketch-conventions.md` §Worktree & branch.

## Why
StakTrakr's documented rule is `patch/<version>` via `/start-patch` for sketch work. But `/start-patch` claims a **version lock per branch** — incoherent for a **no-bump campaign** (a multi-PR refactor that ships intermediate PRs unbumped, with one closing `/release patch`). 19 cohorts can't each claim a version. The existing rule had no clause for this shape.

## Change
- Cohort PRs in a no-bump campaign use descriptive `chore/<issue>-<file>` (or `refactor/<issue>-<file>`) branches off `origin/dev`.
- `patch/<version>` via `/start-patch` applies **only** to the single closing `/release` PR.
- Cohort 0 in a no-bump campaign only enables tooling; each cohort creates its own worktree.

## Precedent
STRK-169 split PRs used `feature/strk-169-*` / `refactor/strk-176-*`, not `patch/<version>`.

## Context
Surfaced by Codex's review of the STRK-170 `tasks.md`, which correctly flagged `feature/strk-170-<file>` as outside the documented convention. Config/doc-tier chore — no Plane issue or version bump.