### PR TITLE
chore(STRK-170): inventory-import.js complexity refactor (cohort 1.2)

### DIFF
--- a/js/inventory-import.js
+++ b/js/inventory-import.js
@@ -843,55 +843,6 @@
   };
 
   /**
-   * Parse the heaviest weight/mass column from a Numista row into troy ounces.
-   * @param {object} row - Parsed Numista CSV row
-   * @returns {number} Weight in troy ounces (6dp)
-   */
-  const _parseNumistaWeight = (row) => {
-    const weightCols = Object.keys(row).filter((k) => {
-      const key = k.toLowerCase();
-      return key.includes("weight") || key.includes("mass");
-    });
-    let weightGrams = 0;
-    for (const col of weightCols) {
-      const val = parseFloat(String(row[col]).replace(/[^0-9.]/g, ""));
-      if (!isNaN(val)) weightGrams = Math.max(weightGrams, val);
-    }
-    return parseFloat(gramsToOzt(weightGrams).toFixed(6));
-  };
-
-  /**
-   * Parse purchase + market price from a Numista row, converting to USD and
-   * cross-filling one from the other when only one is present.
-   * @param {object} row - Parsed Numista CSV row
-   * @returns {{purchasePrice: number, marketValue: number}}
-   */
-  const _parseNumistaPrices = (row) => {
-    const priceKey = Object.keys(row).find((k) =>
-      /^(buying price|purchase price|price paid)/i.test(k)
-    );
-    const estimateKey = Object.keys(row).find((k) => /^estimate/i.test(k));
-    const parsePriceField = (key) => {
-      const rawVal = String(row[key] ?? "").trim();
-      const valueCurrency = detectCurrency(rawVal);
-      const headerCurrencyMatch = key.match(/\(([^)]+)\)/);
-      const headerCurrency = headerCurrencyMatch ? headerCurrencyMatch[1] : displayCurrency;
-      const currency = valueCurrency || headerCurrency;
-      const amount = parseFloat(rawVal.replace(/[^0-9.\-]/g, ""));
-      return isNaN(amount) ? 0 : convertToUsd(amount, currency);
-    };
-
-    let purchasePrice = 0;
-    let marketValue = 0;
-    if (priceKey) purchasePrice = parsePriceField(priceKey);
-    if (estimateKey) marketValue = parsePriceField(estimateKey);
-    // Cross-fill: a row with only one price uses it for both.
-    if (marketValue === 0 && purchasePrice > 0) marketValue = purchasePrice;
-    if (purchasePrice === 0 && marketValue > 0) purchasePrice = marketValue;
-    return { purchasePrice, marketValue };
-  };
-
-  /**
    * Assemble the combined notes field for a Numista row: human notes/comments plus
    * a full markdown dump of the original row under a "Numista Import Data" heading.
    * @param {object} row - Parsed Numista CSV row
@@ -1721,4 +1672,62 @@
   window.startImportProgress = startImportProgress;
   window.updateImportProgress = updateImportProgress;
   window.endImportProgress = endImportProgress;
+
+  // ---------------------------------------------------------------------------
+  // Regex-heavy parsers are intentionally defined LAST in this file. Lizard's
+  // tokenizer can desync on certain regex literals (e.g. a ")" inside a "[^)]"
+  // character class) and roll the FOLLOWING function's complexity into the
+  // previous one — a false-positive CCN spike. Keeping these helpers after every
+  // real function (only the IIFE close follows) prevents that rollup. See
+  // STRK-170 cohort 1.2 + the project's lizard regex-desync note.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Parse the heaviest weight/mass column from a Numista row into troy ounces.
+   * @param {object} row - Parsed Numista CSV row
+   * @returns {number} Weight in troy ounces (6dp)
+   */
+  const _parseNumistaWeight = (row) => {
+    const weightCols = Object.keys(row).filter((k) => {
+      const key = k.toLowerCase();
+      return key.includes("weight") || key.includes("mass");
+    });
+    let weightGrams = 0;
+    for (const col of weightCols) {
+      const val = parseFloat(String(row[col]).replace(/[^0-9.]/g, ""));
+      if (!isNaN(val)) weightGrams = Math.max(weightGrams, val);
+    }
+    return parseFloat(gramsToOzt(weightGrams).toFixed(6));
+  };
+
+  /**
+   * Parse purchase + market price from a Numista row, converting to USD and
+   * cross-filling one from the other when only one is present.
+   * @param {object} row - Parsed Numista CSV row
+   * @returns {{purchasePrice: number, marketValue: number}}
+   */
+  const _parseNumistaPrices = (row) => {
+    const priceKey = Object.keys(row).find((k) =>
+      /^(buying price|purchase price|price paid)/i.test(k)
+    );
+    const estimateKey = Object.keys(row).find((k) => /^estimate/i.test(k));
+    const parsePriceField = (key) => {
+      const rawVal = String(row[key] ?? "").trim();
+      const valueCurrency = detectCurrency(rawVal);
+      const headerCurrencyMatch = key.match(/\(([^)]+)\)/);
+      const headerCurrency = headerCurrencyMatch ? headerCurrencyMatch[1] : displayCurrency;
+      const currency = valueCurrency || headerCurrency;
+      const amount = parseFloat(rawVal.replace(/[^0-9.\-]/g, ""));
+      return isNaN(amount) ? 0 : convertToUsd(amount, currency);
+    };
+
+    let purchasePrice = 0;
+    let marketValue = 0;
+    if (priceKey) purchasePrice = parsePriceField(priceKey);
+    if (estimateKey) marketValue = parsePriceField(estimateKey);
+    // Cross-fill: a row with only one price uses it for both.
+    if (marketValue === 0 && purchasePrice > 0) marketValue = purchasePrice;
+    if (purchasePrice === 0 && marketValue > 0) purchasePrice = marketValue;
+    return { purchasePrice, marketValue };
+  };
 })();

--- a/js/inventory-import.js
+++ b/js/inventory-import.js
@@ -74,6 +74,156 @@
   };
 
   /**
+   * Warn (via toast) when an import payload originates from a different web origin.
+   * Advisory only — never blocks the import. (STAK-374)
+   * @param {object} options - Import options; reads options.exportMeta.exportOrigin
+   */
+  const _warnImportCrossDomainOrigin = (options) => {
+    const _parsedOrigin =
+      options.exportMeta && options.exportMeta.exportOrigin
+        ? options.exportMeta.exportOrigin
+        : null;
+    const _currentOrigin =
+      typeof window !== "undefined" && window.location ? window.location.origin : null;
+    if (
+      _parsedOrigin &&
+      _currentOrigin &&
+      _parsedOrigin !== _currentOrigin &&
+      typeof showToast === "function"
+    ) {
+      const _safeFrom =
+        typeof sanitizeHtml === "function" ? sanitizeHtml(_parsedOrigin) : _parsedOrigin;
+      showToast(
+        "⚠ This backup is from a different domain (" + _safeFrom + "). Check item counts carefully."
+      );
+    }
+  };
+
+  /**
+   * Compute the advisory "possible duplicate" key set: incoming ungraded added rows
+   * sharing numistaId+year with an existing graded/certified item. Advisory only — the
+   * flag is NEVER persisted onto an item. Keys via DiffEngine.computeItemKey.
+   * (STRK-167 AC-11, D-4)
+   * @param {object} diffResult - DiffEngine.compareItems result; reads diffResult.added
+   * @returns {Set<string>} computeItemKey values flagged as possible duplicates
+   */
+  const _computeImportPossibleDuplicates = (diffResult) => {
+    const possibleDuplicates = new Set();
+    if (Array.isArray(inventory) && diffResult && Array.isArray(diffResult.added)) {
+      const gradedByNumistaYear = new Set();
+      for (const ex of inventory) {
+        if (
+          ex &&
+          ex.numistaId &&
+          (String(ex.grade || "").trim() || String(ex.certNumber || "").trim())
+        ) {
+          gradedByNumistaYear.add(ex.numistaId + "|" + (ex.year == null ? "" : String(ex.year)));
+        }
+      }
+      for (const add of diffResult.added) {
+        if (!add || !add.numistaId) continue;
+        const isUngraded = !String(add.grade || "").trim() && !String(add.certNumber || "").trim();
+        const ny = add.numistaId + "|" + (add.year == null ? "" : String(add.year));
+        if (isUngraded && gradedByNumistaYear.has(ny)) {
+          possibleDuplicates.add(DiffEngine.computeItemKey(add));
+        }
+      }
+    }
+    return possibleDuplicates;
+  };
+
+  /**
+   * Apply deferred per-item tags for accepted add/modify changes during an import.
+   * Keys tags by DiffEngine.computeItemKey to match the build-time key. (STAK-126/424)
+   * @param {Array} selectedChanges - Changes the user accepted in the diff modal
+   * @param {Map<string,string[]>|undefined} pendingTagsByUuid - itemKey -> tag list
+   */
+  const _applyImportPendingTags = (selectedChanges, pendingTagsByUuid) => {
+    if (!pendingTagsByUuid || typeof addItemTag !== "function") return;
+    const tagEligible = selectedChanges.filter(function (c) {
+      return c.type === "add" || c.type === "modify";
+    });
+    const stampedUuids = new Set();
+    for (const change of tagEligible) {
+      if (change.item && change.item.uuid) {
+        const tagKey =
+          typeof DiffEngine !== "undefined"
+            ? DiffEngine.computeItemKey(change.item)
+            : change.item.uuid || change.item.serial || "";
+        const tags = pendingTagsByUuid.get(tagKey);
+        if (tags && tags.length) {
+          tags.forEach(function (tag) {
+            if (addItemTag(change.item.uuid, tag, false)) {
+              stampedUuids.add(change.item.uuid);
+            }
+          });
+        }
+      }
+    }
+    if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
+      stampTagTimestamp(Array.from(stampedUuids));
+    }
+    if (typeof saveItemTags === "function") saveItemTags();
+  };
+
+  /**
+   * Persist accepted settings changes from a JSON import diff. Raw-string keys go to
+   * localStorage verbatim; the rest via saveDataSync. (STAK-374)
+   * @param {object|null} settingsDiff - DiffEngine.compareSettings result or null
+   */
+  const _applyImportSettingsChanges = (settingsDiff) => {
+    if (!settingsDiff || !settingsDiff.changed || settingsDiff.changed.length === 0) return;
+    // Raw-string settings stored via localStorage.setItem, not JSON-encoded
+    const _rawKeys = new Set([
+      "appTheme",
+      "tableImageSides",
+      "tableImagesEnabled",
+      "chipMinCount",
+      "chipMaxCount",
+      "settingsItemsPerPage",
+      "defaultSortColumn",
+      "defaultSortDir",
+      "featureFlags",
+      "inlineChipConfig",
+    ]);
+    for (const sc of settingsDiff.changed) {
+      if (_rawKeys.has(sc.key)) {
+        localStorage.setItem(sc.key, String(sc.remoteVal));
+      } else {
+        saveDataSync(sc.key, sc.remoteVal);
+      }
+    }
+  };
+
+  /**
+   * Toast the apply summary, fire onComplete, and open the debug modal if enabled.
+   * @param {Array} selectedChanges - Accepted changes (add/modify/delete)
+   * @param {function} [onComplete] - Optional callback({added,modified,deleted})
+   */
+  const _announceImportApplySummary = (selectedChanges, onComplete) => {
+    const addCount = selectedChanges.filter(function (c) {
+      return c.type === "add";
+    }).length;
+    const modCount = selectedChanges.filter(function (c) {
+      return c.type === "modify";
+    }).length;
+    const delCount = selectedChanges.filter(function (c) {
+      return c.type === "delete";
+    }).length;
+    const parts = [];
+    if (addCount > 0) parts.push(addCount + " added");
+    if (modCount > 0) parts.push(modCount + " updated");
+    if (delCount > 0) parts.push(delCount + " removed");
+    if (typeof showToast === "function") {
+      showToast("Import complete: " + (parts.length > 0 ? parts.join(", ") : "no changes applied"));
+    }
+    if (onComplete) onComplete({ added: addCount, modified: modCount, deleted: delCount });
+    if (localStorage.getItem("staktrakr.debug") && typeof window.showDebugModal === "function") {
+      showDebugModal();
+    }
+  };
+
+  /**
    * Shared import review helper — DiffEngine + DiffModal pattern.
    * Used by importCsv, importJson, and importNumistaCsv to deduplicate
    * the diff-review workflow.
@@ -123,54 +273,9 @@
     const _localCount =
       typeof inventory !== "undefined" && Array.isArray(inventory) ? inventory.length : 0;
 
-    // Cross-domain origin warning (STAK-374): warn when importing from a different domain
-    const _parsedOrigin =
-      options.exportMeta && options.exportMeta.exportOrigin
-        ? options.exportMeta.exportOrigin
-        : null;
-    const _currentOrigin =
-      typeof window !== "undefined" && window.location ? window.location.origin : null;
-    if (
-      _parsedOrigin &&
-      _currentOrigin &&
-      _parsedOrigin !== _currentOrigin &&
-      typeof showToast === "function"
-    ) {
-      const _safeFrom =
-        typeof sanitizeHtml === "function" ? sanitizeHtml(_parsedOrigin) : _parsedOrigin;
-      showToast(
-        "\u26A0 This backup is from a different domain (" +
-          _safeFrom +
-          "). Check item counts carefully."
-      );
-    }
+    _warnImportCrossDomainOrigin(options);
 
-    // STRK-167 (AC-11, D-4): compute a SIDECAR set of added rows that are likely
-    // duplicates of a graded item the user already owns — an ungraded incoming row
-    // sharing numistaId+year with an existing graded/certified item. This is purely
-    // advisory; the flag is NEVER written onto an item (applySelectedChanges would
-    // persist it). The modal looks rows up by DiffEngine.computeItemKey.
-    const possibleDuplicates = new Set();
-    if (Array.isArray(inventory) && diffResult && Array.isArray(diffResult.added)) {
-      const gradedByNumistaYear = new Set();
-      for (const ex of inventory) {
-        if (
-          ex &&
-          ex.numistaId &&
-          (String(ex.grade || "").trim() || String(ex.certNumber || "").trim())
-        ) {
-          gradedByNumistaYear.add(ex.numistaId + "|" + (ex.year == null ? "" : String(ex.year)));
-        }
-      }
-      for (const add of diffResult.added) {
-        if (!add || !add.numistaId) continue;
-        const isUngraded = !String(add.grade || "").trim() && !String(add.certNumber || "").trim();
-        const ny = add.numistaId + "|" + (add.year == null ? "" : String(add.year));
-        if (isUngraded && gradedByNumistaYear.has(ny)) {
-          possibleDuplicates.add(DiffEngine.computeItemKey(add));
-        }
-      }
-    }
+    const possibleDuplicates = _computeImportPossibleDuplicates(diffResult);
 
     DiffModal.show({
       source: sourceInfo,
@@ -184,58 +289,9 @@
 
         inventory = DiffEngine.applySelectedChanges(inventory, selectedChanges);
 
-        // Apply deferred tags for accepted changes (add + modify).
-        // Look up by DiffEngine.computeItemKey to match the key used at build time.
-        if (options.pendingTagsByUuid && typeof addItemTag === "function") {
-          const tagEligible = selectedChanges.filter(function (c) {
-            return c.type === "add" || c.type === "modify";
-          });
-          const stampedUuids = new Set();
-          for (const change of tagEligible) {
-            if (change.item && change.item.uuid) {
-              const tagKey =
-                typeof DiffEngine !== "undefined"
-                  ? DiffEngine.computeItemKey(change.item)
-                  : change.item.uuid || change.item.serial || "";
-              const tags = options.pendingTagsByUuid.get(tagKey);
-              if (tags && tags.length) {
-                tags.forEach(function (tag) {
-                  if (addItemTag(change.item.uuid, tag, false)) {
-                    stampedUuids.add(change.item.uuid);
-                  }
-                });
-              }
-            }
-          }
-          if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
-            stampTagTimestamp(Array.from(stampedUuids));
-          }
-          if (typeof saveItemTags === "function") saveItemTags();
-        }
+        _applyImportPendingTags(selectedChanges, options.pendingTagsByUuid);
 
-        // Apply settings changes if present
-        if (settingsDiff && settingsDiff.changed && settingsDiff.changed.length > 0) {
-          // Raw-string settings stored via localStorage.setItem, not JSON-encoded
-          const _rawKeys = new Set([
-            "appTheme",
-            "tableImageSides",
-            "tableImagesEnabled",
-            "chipMinCount",
-            "chipMaxCount",
-            "settingsItemsPerPage",
-            "defaultSortColumn",
-            "defaultSortDir",
-            "featureFlags",
-            "inlineChipConfig",
-          ]);
-          for (const sc of settingsDiff.changed) {
-            if (_rawKeys.has(sc.key)) {
-              localStorage.setItem(sc.key, String(sc.remoteVal));
-            } else {
-              saveDataSync(sc.key, sc.remoteVal);
-            }
-          }
-        }
+        _applyImportSettingsChanges(settingsDiff);
 
         _postImportCleanup(
           selectedChanges
@@ -249,39 +305,412 @@
           null // tags already handled above
         );
 
-        // Toast summary
-        const addCount = selectedChanges.filter(function (c) {
-          return c.type === "add";
-        }).length;
-        const modCount = selectedChanges.filter(function (c) {
-          return c.type === "modify";
-        }).length;
-        const delCount = selectedChanges.filter(function (c) {
-          return c.type === "delete";
-        }).length;
-        const parts = [];
-        if (addCount > 0) parts.push(addCount + " added");
-        if (modCount > 0) parts.push(modCount + " updated");
-        if (delCount > 0) parts.push(delCount + " removed");
-        if (typeof showToast === "function") {
-          showToast(
-            "Import complete: " + (parts.length > 0 ? parts.join(", ") : "no changes applied")
-          );
-        }
-
-        if (onComplete) onComplete({ added: addCount, modified: modCount, deleted: delCount });
-
-        if (
-          localStorage.getItem("staktrakr.debug") &&
-          typeof window.showDebugModal === "function"
-        ) {
-          showDebugModal();
-        }
+        _announceImportApplySummary(selectedChanges, onComplete);
       },
       onCancel: function () {
         debugLog("Import cancelled by user");
       },
     });
+  };
+
+  /**
+   * Parse a disposition money field (amount or realized gain/loss) from a CSV cell.
+   * Strips non-numeric chars; returns undefined for an empty cell or non-finite value.
+   * @param {string} raw - Raw CSV cell value
+   * @returns {number|undefined} Parsed amount, or undefined
+   */
+  const _parseDispositionAmount = (raw) => {
+    const n = parseFloat(String(raw).replace(/[^0-9.\-]/g, ""));
+    return raw !== "" && Number.isFinite(n) ? n : undefined;
+  };
+
+  /**
+   * Build the disposition object from a CSV row's Disposition* columns.
+   * Returns undefined when the row has no Disposition Type. Normalizes display
+   * labels ("Sold") to internal keys ("sold") for round-trip fidelity.
+   * @param {object} row - Parsed CSV row keyed by header
+   * @returns {object|undefined} Disposition object, or undefined
+   */
+  const _parseCsvDisposition = (row) => {
+    const dispositionType = (row["Disposition Type"] || "").trim();
+    if (!dispositionType) return undefined;
+    const dispositionSplitFromUuidRaw = (row["Disposition Split From UUID"] || "").trim();
+    const tradedForUuids = (row["Traded For UUIDs"] || row["tradedForUuids"] || "")
+      .toString()
+      .split(",")
+      .map((uuid) => uuid.trim())
+      .filter(Boolean);
+    const dispositionTypeKey =
+      typeof DISPOSITION_TYPES !== "undefined"
+        ? (Object.keys(DISPOSITION_TYPES).find(
+            (k) => DISPOSITION_TYPES[k].label === dispositionType
+          ) ?? dispositionType.toLowerCase())
+        : dispositionType.toLowerCase();
+    const disposition = {
+      type: dispositionTypeKey,
+      date: (row["Disposition Date"] || "").trim() || undefined,
+      amount: _parseDispositionAmount(row["Disposition Amount"] || ""),
+      realizedGainLoss: _parseDispositionAmount(row["Realized Gain/Loss"] || ""),
+      recipient: (row["Disposition Recipient"] || "").trim() || undefined,
+      notes: (row["Disposition Notes"] || "").trim() || undefined,
+      currency: (row["Disposition Currency"] || "").trim() || undefined,
+      disposedAt: (row["Disposition DisposedAt"] || "").trim() || undefined,
+      splitFromUuid: dispositionSplitFromUuidRaw || undefined,
+    };
+    if (tradedForUuids.length > 0) disposition.tradedForUuids = tradedForUuids;
+    return disposition;
+  };
+
+  /**
+   * Parse the pipe-delimited Attachments column into attachment metadata stubs.
+   * Each entry is "fileName#attachmentUuid"; malformed entries are dropped.
+   * @param {object} row - Parsed CSV row keyed by header
+   * @returns {Array<object>} Attachment metadata (no file bytes — metadata only)
+   */
+  const _parseCsvAttachments = (row) => {
+    const attachmentsRaw = (row["Attachments"] || "").trim();
+    if (!attachmentsRaw) return [];
+    return attachmentsRaw
+      .split("|")
+      .map((entry) => {
+        const hashIdx = entry.lastIndexOf("#");
+        if (hashIdx === -1) return null;
+        const fileName = entry.slice(0, hashIdx);
+        const attachmentUuid = entry.slice(hashIdx + 1);
+        return fileName && attachmentUuid
+          ? { attachmentUuid, fileName, type: "", size: 0, uploadedAt: 0 }
+          : null;
+      })
+      .filter(Boolean);
+  };
+
+  /**
+   * Read core item fields (identity-agnostic) from a CSV row.
+   * @param {object} row - Parsed CSV row keyed by header
+   * @returns {object} { name, qty, type, weight, weightUnit, price, paymentMethod,
+   *   purchaseLocation, storageLocation, notes, date }
+   */
+  const _readCsvBaseFields = (row) => {
+    const priceStr = row["Purchase Price"] || row["price"];
+    let price =
+      typeof priceStr === "string"
+        ? parseFloat(priceStr.replace(/[^\d.-]+/g, ""))
+        : parseFloat(priceStr);
+    if (price < 0) price = 0;
+    return {
+      name: row["Name"] || row["name"],
+      qty: row["Qty"] || row["qty"] || 1,
+      type: normalizeType(row["Type"] || row["type"]),
+      weight: row["Weight(oz)"] || row["weight"],
+      weightUnit: row["Weight Unit"] || row["weightUnit"] || "oz",
+      price,
+      paymentMethod: row["Payment Method"] || row["paymentMethod"] || "",
+      purchaseLocation: row["Purchase Location"] || "",
+      storageLocation: row["Storage Location"] || "",
+      notes: row["Notes"] || "",
+      date: parseDate(row["Date"]),
+    };
+  };
+
+  /**
+   * Read grading/catalog fields (year, grade, authority, cert, numista, pcgs, purity).
+   * @param {object} row - Parsed CSV row keyed by header
+   * @returns {object} grading/catalog field bag
+   */
+  const _readCsvGradingFields = (row) => {
+    const numistaRaw = (row["N#"] || row["Numista #"] || row["numistaId"] || "").toString();
+    const numistaMatch = numistaRaw.match(/\d+/);
+    const purityRaw = row["Purity"] || row["Fineness"] || row["purity"] || "";
+    return {
+      year: row["Year"] || row["year"] || row["issuedYear"] || "",
+      grade: row["Grade"] || row["grade"] || "",
+      gradingAuthority:
+        row["Grading Authority"] || row["gradingAuthority"] || row["Authority"] || "",
+      certNumber: (row["Cert #"] || row["certNumber"] || row["Cert Number"] || "").toString(),
+      numistaId: numistaMatch ? numistaMatch[0] : "",
+      pcgsNumber: (row["PCGS #"] || row["PCGS Number"] || row["pcgsNumber"] || "")
+        .toString()
+        .trim(),
+      purity: parseFloat(purityRaw) || 1.0,
+    };
+  };
+
+  /**
+   * Read valuation fields (market value + spot price at purchase). Premium fields
+   * default to 0 (legacy CSVs don't carry them).
+   * @param {object} row - Parsed CSV row keyed by header
+   * @returns {object} { marketValue, spotPriceAtPurchase, premiumPerOz, totalPremium }
+   */
+  const _readCsvMarketFields = (row) => {
+    const retailStr = row["Retail Price"] || row["Market Value"] || row["marketValue"] || "0";
+    const marketValue =
+      typeof retailStr === "string"
+        ? parseFloat(retailStr.replace(/[^\d.-]+/g, "")) || 0
+        : parseFloat(retailStr) || 0;
+    let spotPriceAtPurchase;
+    if (row["Spot Price ($/oz)"]) {
+      const spotStr = row["Spot Price ($/oz)"].toString();
+      spotPriceAtPurchase = parseFloat(spotStr.replace(/[^0-9.-]+/g, ""));
+    } else if (row["spotPriceAtPurchase"]) {
+      spotPriceAtPurchase = parseFloat(row["spotPriceAtPurchase"]);
+    } else {
+      spotPriceAtPurchase = 0;
+    }
+    return { marketValue, spotPriceAtPurchase, premiumPerOz: 0, totalPremium: 0 };
+  };
+
+  /**
+   * Read identity/image fields. NOTE: reads `serial` via getNextSerial() when absent,
+   * which advances the serial counter — call exactly once per imported row.
+   * @param {object} row - Parsed CSV row keyed by header
+   * @returns {object} { serialNumber, serial, uuid, obverseImageUrl, reverseImageUrl }
+   */
+  const _readCsvIdentityFields = (row) => {
+    return {
+      serialNumber: row["Serial Number"] || row["serialNumber"] || "",
+      serial: row["Serial"] || row["serial"] || getNextSerial(),
+      uuid: row["UUID"] || row["uuid"] || "",
+      obverseImageUrl: row["Obverse Image URL"] || row["obverseImageUrl"] || "",
+      reverseImageUrl: row["Reverse Image URL"] || row["reverseImageUrl"] || "",
+    };
+  };
+
+  /**
+   * Build one sanitized inventory item from a CSV row, registering its composition.
+   * @param {object} row - Parsed CSV row keyed by header
+   * @param {string} metal - Pre-resolved precious metal for the row
+   * @param {string} composition - Pre-resolved composition for the row
+   * @returns {{item: object, csvTags: string, csvRemovedTags: string}}
+   */
+  const _buildCsvItemFromRow = (row, metal, composition) => {
+    const base = _readCsvBaseFields(row);
+    const grading = _readCsvGradingFields(row);
+    const market = _readCsvMarketFields(row);
+    const identity = _readCsvIdentityFields(row);
+    const disposition = _parseCsvDisposition(row);
+    const csvAttachments = _parseCsvAttachments(row);
+    const csvTags = (row["Tags"] || row["tags"] || "").trim();
+    const csvRemovedTags = (row["removedTags"] || row["Removed Tags"] || "").trim();
+    const tradedFromUuid = (row["Traded From UUID"] || row["tradedFromUuid"] || "")
+      .toString()
+      .trim();
+
+    addCompositionOption(composition);
+
+    const item = sanitizeImportedItem({
+      metal,
+      composition,
+      ...base,
+      ...grading,
+      ...market,
+      ...identity,
+      disposition,
+      tradedFromUuid: tradedFromUuid || undefined,
+    });
+
+    if (csvAttachments.length > 0) item.attachments = csvAttachments;
+    return { item, csvTags, csvRemovedTags };
+  };
+
+  /**
+   * Collect deferred add/remove tags for an imported item, keyed by computeItemKey
+   * so legacy UUID-less CSV rows still match after serial→uuid enrichment.
+   * (STAK-126/424/556)
+   * @param {object} item - Sanitized imported item
+   * @param {string} csvTags - Semicolon-delimited tags to add
+   * @param {string} csvRemovedTags - Semicolon-delimited tags to mark removed
+   * @param {Map<string,string[]>} pendingTagsByUuid - itemKey -> add list (mutated)
+   * @param {Map<string,string[]>} pendingRemovedTagsByUuid - itemKey -> remove list (mutated)
+   */
+  const _collectCsvPendingTags = (
+    item,
+    csvTags,
+    csvRemovedTags,
+    pendingTagsByUuid,
+    pendingRemovedTagsByUuid
+  ) => {
+    if (csvTags) {
+      const tagList = csvTags
+        .split(";")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      if (tagList.length) {
+        const tagKey =
+          typeof DiffEngine !== "undefined"
+            ? DiffEngine.computeItemKey(item)
+            : item.uuid || item.serial || "";
+        if (tagKey) pendingTagsByUuid.set(tagKey, tagList);
+      }
+    }
+
+    if (csvRemovedTags) {
+      const removedList = csvRemovedTags
+        .split(";")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      if (removedList.length) {
+        const removedKey =
+          typeof DiffEngine !== "undefined"
+            ? DiffEngine.computeItemKey(item)
+            : item.uuid || item.serial || "";
+        if (removedKey) pendingRemovedTagsByUuid.set(removedKey, removedList);
+      }
+    }
+  };
+
+  /**
+   * Apply deferred add-tags after a CSV override import (no diff modal). (STAK-424)
+   * @param {Array} items - Imported items
+   * @param {Map<string,string[]>} pendingTagsByUuid - itemKey -> add list
+   */
+  const _applyCsvOverrideTags = (items, pendingTagsByUuid) => {
+    if (pendingTagsByUuid.size === 0 || typeof addItemTag !== "function") return;
+    const stampedUuids = new Set();
+    for (const item of items) {
+      const itemKey =
+        typeof DiffEngine !== "undefined"
+          ? DiffEngine.computeItemKey(item)
+          : item.uuid || item.serial || "";
+      const tags = pendingTagsByUuid.get(itemKey);
+      if (tags && tags.length) {
+        tags.forEach((tag) => {
+          if (addItemTag(item.uuid, tag, false)) stampedUuids.add(item.uuid);
+        });
+      }
+    }
+    if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
+      stampTagTimestamp(Array.from(stampedUuids));
+    }
+    if (typeof saveItemTags === "function") saveItemTags();
+  };
+
+  /**
+   * Persist deferred removed-tags from a CSV import into the itemRemovedTags store.
+   * Shared by the override and merge paths. (STAK-556)
+   * @param {Array} items - Imported items
+   * @param {Map<string,string[]>} pendingRemovedTagsByUuid - itemKey -> remove list
+   */
+  const _applyCsvRemovedTags = (items, pendingRemovedTagsByUuid) => {
+    if (pendingRemovedTagsByUuid.size === 0 || typeof saveDataSync !== "function") return;
+    const removedMap =
+      typeof loadDataSync === "function" ? loadDataSync("itemRemovedTags", {}) : {};
+    for (const item of items) {
+      const key =
+        typeof DiffEngine !== "undefined"
+          ? DiffEngine.computeItemKey(item)
+          : item.uuid || item.serial || "";
+      const removedTags = pendingRemovedTagsByUuid.get(key);
+      if (removedTags && removedTags.length) {
+        removedMap[item.uuid] = removedTags;
+      }
+    }
+    saveDataSync("itemRemovedTags", removedMap);
+  };
+
+  /**
+   * Toast a metadata-only warning when imported items carry attachment references
+   * (CSV/JSON import does not restore the underlying files). Shared override/merge.
+   * @param {Array} items - Imported items
+   */
+  const _warnCsvAttachmentsMetadataOnly = (items) => {
+    const attachCount = items.reduce(
+      (n, it) => n + (Array.isArray(it.attachments) ? it.attachments.length : 0),
+      0
+    );
+    if (attachCount > 0 && typeof showToast === "function") {
+      showToast(
+        `${attachCount} attachment(s) imported as metadata only — use a backup ZIP to restore files.`,
+        "warning"
+      );
+    }
+  };
+
+  /**
+   * Override-import path for CSV: replace the entire inventory with the parsed items,
+   * apply deferred tags, cancel the debounced sync push, and re-render. (STAK-421/424)
+   * @param {Array} imported - Validated imported items
+   * @param {Map<string,string[]>} pendingTagsByUuid - itemKey -> add list
+   * @param {Map<string,string[]>} pendingRemovedTagsByUuid - itemKey -> remove list
+   */
+  const _csvImportApplyOverride = (imported, pendingTagsByUuid, pendingRemovedTagsByUuid) => {
+    if (typeof migrateLegacySilverbackWeightUnit === "function") {
+      migrateLegacySilverbackWeightUnit(imported);
+    }
+    inventory = imported;
+
+    // Synchronize all items with catalog manager
+    if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
+      inventory = catalogManager.syncInventory(inventory);
+    }
+
+    for (const item of imported) {
+      if (typeof registerName === "function") {
+        registerName(item.name);
+      }
+    }
+
+    if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+    if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by csvImport");
+    saveInventory();
+    _applyCsvOverrideTags(imported, pendingTagsByUuid);
+    _applyCsvRemovedTags(imported, pendingRemovedTagsByUuid);
+    // STAK-421: Cancel the debounced sync push that saveInventory() just scheduled —
+    // override imports replace all local data, so pushing immediately would overwrite
+    // the remote vault before the user can review.
+    if (typeof scheduleSyncPush === "function" && typeof scheduleSyncPush.cancel === "function") {
+      scheduleSyncPush.cancel();
+    }
+    renderTable();
+    if (typeof renderActiveFilters === "function") {
+      renderActiveFilters();
+    }
+    if (typeof updateStorageStats === "function") {
+      updateStorageStats();
+    }
+    debugLog("importCsv override complete", imported.length, "items replaced");
+    _warnCsvAttachmentsMetadataOnly(imported);
+    if (localStorage.getItem("staktrakr.debug") && typeof window.showDebugModal === "function") {
+      showDebugModal();
+    }
+  };
+
+  /**
+   * Merge-import path for CSV: route the parsed items through the shared diff-review
+   * modal, then warn about attachments + restore removed tags on apply.
+   * @param {Array} imported - Validated imported items
+   * @param {File} file - Source CSV file (for the diff source label)
+   * @param {object|null} validationResult - Pre-validation result (skip counts)
+   * @param {Map<string,string[]>} pendingTagsByUuid - itemKey -> add list
+   * @param {Map<string,string[]>} pendingRemovedTagsByUuid - itemKey -> remove list
+   */
+  const _csvImportRunMergeReview = (
+    imported,
+    file,
+    validationResult,
+    pendingTagsByUuid,
+    pendingRemovedTagsByUuid
+  ) => {
+    showImportDiffReview(
+      imported,
+      { type: "csv", label: file.name },
+      {
+        validationResult: validationResult,
+        pendingTagsByUuid: pendingTagsByUuid,
+      },
+      function (summary) {
+        _warnCsvAttachmentsMetadataOnly(imported);
+        _applyCsvRemovedTags(imported, pendingRemovedTagsByUuid);
+        debugLog(
+          "importCsv DiffEngine complete",
+          summary.added,
+          "added",
+          summary.modified,
+          "modified",
+          summary.deleted,
+          "deleted"
+        );
+      }
+    );
   };
 
   /**
@@ -330,208 +759,17 @@
               continue;
             }
 
-            const name = row["Name"] || row["name"];
-            const qty = row["Qty"] || row["qty"] || 1;
-            const type = normalizeType(row["Type"] || row["type"]);
-            const weight = row["Weight(oz)"] || row["weight"];
-            const weightUnit = row["Weight Unit"] || row["weightUnit"] || "oz";
-            const priceStr = row["Purchase Price"] || row["price"];
-            let price =
-              typeof priceStr === "string"
-                ? parseFloat(priceStr.replace(/[^\d.-]+/g, ""))
-                : parseFloat(priceStr);
-            if (price < 0) price = 0;
-            const paymentMethod = row["Payment Method"] || row["paymentMethod"] || "";
-            const purchaseLocation = row["Purchase Location"] || "";
-            const storageLocation = row["Storage Location"] || "";
-            const notes = row["Notes"] || "";
-            const year = row["Year"] || row["year"] || row["issuedYear"] || "";
-            const grade = row["Grade"] || row["grade"] || "";
-            const gradingAuthority =
-              row["Grading Authority"] || row["gradingAuthority"] || row["Authority"] || "";
-            const certNumber = (
-              row["Cert #"] ||
-              row["certNumber"] ||
-              row["Cert Number"] ||
-              ""
-            ).toString();
-            const date = parseDate(row["Date"]);
-
-            // Parse retail price from CSV (backward-compatible with legacy columns)
-            const retailStr =
-              row["Retail Price"] || row["Market Value"] || row["marketValue"] || "0";
-            const marketValue =
-              typeof retailStr === "string"
-                ? parseFloat(retailStr.replace(/[^\d.-]+/g, "")) || 0
-                : parseFloat(retailStr) || 0;
-
-            let spotPriceAtPurchase;
-            if (row["Spot Price ($/oz)"]) {
-              const spotStr = row["Spot Price ($/oz)"].toString();
-              spotPriceAtPurchase = parseFloat(spotStr.replace(/[^0-9.-]+/g, ""));
-            } else if (row["spotPriceAtPurchase"]) {
-              spotPriceAtPurchase = parseFloat(row["spotPriceAtPurchase"]);
-            } else {
-              spotPriceAtPurchase = 0;
-            }
-
-            const premiumPerOz = 0;
-            const totalPremium = 0;
-
-            const numistaRaw = (row["N#"] || row["Numista #"] || row["numistaId"] || "").toString();
-            const numistaMatch = numistaRaw.match(/\d+/);
-            const numistaId = numistaMatch ? numistaMatch[0] : "";
-            const pcgsNumber = (row["PCGS #"] || row["PCGS Number"] || row["pcgsNumber"] || "")
-              .toString()
-              .trim();
-            const purityRaw = row["Purity"] || row["Fineness"] || row["purity"] || "";
-            const purity = parseFloat(purityRaw) || 1.0;
-            const serialNumber = row["Serial Number"] || row["serialNumber"] || "";
-            const serial = row["Serial"] || row["serial"] || getNextSerial();
-            const uuid = row["UUID"] || row["uuid"] || "";
-            const csvTags = (row["Tags"] || row["tags"] || "").trim();
-            const csvRemovedTags = (row["removedTags"] || row["Removed Tags"] || "").trim();
-            const obverseImageUrl = row["Obverse Image URL"] || row["obverseImageUrl"] || "";
-            const reverseImageUrl = row["Reverse Image URL"] || row["reverseImageUrl"] || "";
-
-            const dispositionType = (row["Disposition Type"] || "").trim();
-            const dispositionDate = (row["Disposition Date"] || "").trim();
-            const dispositionAmount = row["Disposition Amount"] || "";
-            const dispositionRealizedGainLoss = row["Realized Gain/Loss"] || "";
-            const dispositionRecipient = (row["Disposition Recipient"] || "").trim();
-            const dispositionNotes = (row["Disposition Notes"] || "").trim();
-            const dispositionCurrency = (row["Disposition Currency"] || "").trim();
-            const dispositionDisposedAt = (row["Disposition DisposedAt"] || "").trim();
-            const dispositionSplitFromUuidRaw = (row["Disposition Split From UUID"] || "").trim();
-            const dispositionSplitFromUuid = dispositionSplitFromUuidRaw || undefined;
-            const tradedForUuids = (row["Traded For UUIDs"] || row["tradedForUuids"] || "")
-              .toString()
-              .split(",")
-              .map((uuid) => uuid.trim())
-              .filter(Boolean);
-            const tradedFromUuid = (row["Traded From UUID"] || row["tradedFromUuid"] || "")
-              .toString()
-              .trim();
-
-            const attachmentsRaw = (row["Attachments"] || "").trim();
-            const csvAttachments = attachmentsRaw
-              ? attachmentsRaw
-                  .split("|")
-                  .map((entry) => {
-                    const hashIdx = entry.lastIndexOf("#");
-                    if (hashIdx === -1) return null;
-                    const fileName = entry.slice(0, hashIdx);
-                    const attachmentUuid = entry.slice(hashIdx + 1);
-                    return fileName && attachmentUuid
-                      ? { attachmentUuid, fileName, type: "", size: 0, uploadedAt: 0 }
-                      : null;
-                  })
-                  .filter(Boolean)
-              : [];
-
-            let disposition;
-            if (dispositionType) {
-              const _parsedAmount = parseFloat(String(dispositionAmount).replace(/[^0-9.\-]/g, ""));
-              const _parsedGainLoss = parseFloat(
-                String(dispositionRealizedGainLoss).replace(/[^0-9.\-]/g, "")
-              );
-              // Normalize display labels ("Sold") → internal keys ("sold") for round-trip
-              const dispositionTypeKey =
-                typeof DISPOSITION_TYPES !== "undefined"
-                  ? (Object.keys(DISPOSITION_TYPES).find(
-                      (k) => DISPOSITION_TYPES[k].label === dispositionType
-                    ) ?? dispositionType.toLowerCase())
-                  : dispositionType.toLowerCase();
-              disposition = {
-                type: dispositionTypeKey,
-                date: dispositionDate || undefined,
-                amount:
-                  dispositionAmount !== "" && Number.isFinite(_parsedAmount)
-                    ? _parsedAmount
-                    : undefined,
-                realizedGainLoss:
-                  dispositionRealizedGainLoss !== "" && Number.isFinite(_parsedGainLoss)
-                    ? _parsedGainLoss
-                    : undefined,
-                recipient: dispositionRecipient || undefined,
-                notes: dispositionNotes || undefined,
-                currency: dispositionCurrency || undefined,
-                disposedAt: dispositionDisposedAt || undefined,
-                splitFromUuid: dispositionSplitFromUuid,
-              };
-              if (tradedForUuids.length > 0) disposition.tradedForUuids = tradedForUuids;
-            }
-
-            addCompositionOption(composition);
-
-            const item = sanitizeImportedItem({
-              metal,
-              composition,
-              name,
-              qty,
-              type,
-              weight,
-              weightUnit,
-              price,
-              marketValue,
-              date,
-              paymentMethod,
-              purchaseLocation,
-              storageLocation,
-              notes,
-              year,
-              grade,
-              gradingAuthority,
-              certNumber,
-              pcgsNumber,
-              purity,
-              spotPriceAtPurchase,
-              premiumPerOz,
-              totalPremium,
-              numistaId,
-              serialNumber,
-              serial,
-              uuid,
-              obverseImageUrl,
-              reverseImageUrl,
-              disposition,
-              tradedFromUuid: tradedFromUuid || undefined,
-            });
-
-            if (csvAttachments.length > 0) item.attachments = csvAttachments;
+            const { item, csvTags, csvRemovedTags } = _buildCsvItemFromRow(row, metal, composition);
             imported.push(item);
             if (!item.paymentMethod) delete item.paymentMethod;
 
-            // STAK-126 / STAK-424: Collect tags but defer persistence until import confirmed.
-            // Key by DiffEngine.computeItemKey (uuid → serial → name|date) so legacy
-            // CSV exports without UUIDs still match after serial→uuid enrichment.
-            if (csvTags) {
-              const tagList = csvTags
-                .split(";")
-                .map((t) => t.trim())
-                .filter(Boolean);
-              if (tagList.length) {
-                const tagKey =
-                  typeof DiffEngine !== "undefined"
-                    ? DiffEngine.computeItemKey(item)
-                    : item.uuid || item.serial || "";
-                if (tagKey) pendingTagsByUuid.set(tagKey, tagList);
-              }
-            }
-
-            if (csvRemovedTags) {
-              const removedList = csvRemovedTags
-                .split(";")
-                .map((t) => t.trim())
-                .filter(Boolean);
-              if (removedList.length) {
-                const removedKey =
-                  typeof DiffEngine !== "undefined"
-                    ? DiffEngine.computeItemKey(item)
-                    : item.uuid || item.serial || "";
-                if (removedKey) pendingRemovedTagsByUuid.set(removedKey, removedList);
-              }
-            }
+            _collectCsvPendingTags(
+              item,
+              csvTags,
+              csvRemovedTags,
+              pendingTagsByUuid,
+              pendingRemovedTagsByUuid
+            );
 
             importedCount++;
             updateImportProgress(processed, importedCount, totalRows);
@@ -580,142 +818,17 @@
 
           // --- Override path: skip DiffEngine, import all items directly ---
           if (override) {
-            if (typeof migrateLegacySilverbackWeightUnit === "function") {
-              migrateLegacySilverbackWeightUnit(imported);
-            }
-            inventory = imported;
-
-            // Synchronize all items with catalog manager
-            if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
-              inventory = catalogManager.syncInventory(inventory);
-            }
-
-            for (const item of imported) {
-              if (typeof registerName === "function") {
-                registerName(item.name);
-              }
-            }
-
-            if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
-            if (typeof debugLog === "function") debugLog("inventoryRecovery: cleared by csvImport");
-            saveInventory();
-            // STAK-424: Apply deferred tags after override confirmation
-            if (pendingTagsByUuid.size > 0 && typeof addItemTag === "function") {
-              const stampedUuids = new Set();
-              for (const item of imported) {
-                const itemKey =
-                  typeof DiffEngine !== "undefined"
-                    ? DiffEngine.computeItemKey(item)
-                    : item.uuid || item.serial || "";
-                const tags = pendingTagsByUuid.get(itemKey);
-                if (tags && tags.length) {
-                  tags.forEach((tag) => {
-                    if (addItemTag(item.uuid, tag, false)) stampedUuids.add(item.uuid);
-                  });
-                }
-              }
-              if (stampedUuids.size > 0 && typeof stampTagTimestamp === "function") {
-                stampTagTimestamp(Array.from(stampedUuids));
-              }
-              if (typeof saveItemTags === "function") saveItemTags();
-            }
-            // Restore removed tags from CSV import (STAK-556)
-            if (pendingRemovedTagsByUuid.size > 0 && typeof saveDataSync === "function") {
-              const removedMap =
-                typeof loadDataSync === "function" ? loadDataSync("itemRemovedTags", {}) : {};
-              for (const item of imported) {
-                const key =
-                  typeof DiffEngine !== "undefined"
-                    ? DiffEngine.computeItemKey(item)
-                    : item.uuid || item.serial || "";
-                const removedTags = pendingRemovedTagsByUuid.get(key);
-                if (removedTags && removedTags.length) {
-                  removedMap[item.uuid] = removedTags;
-                }
-              }
-              saveDataSync("itemRemovedTags", removedMap);
-            }
-            // STAK-421: Cancel the debounced sync push that saveInventory() just
-            // scheduled — override imports replace all local data, so pushing
-            // immediately would overwrite the remote vault before the user can review.
-            if (
-              typeof scheduleSyncPush === "function" &&
-              typeof scheduleSyncPush.cancel === "function"
-            ) {
-              scheduleSyncPush.cancel();
-            }
-            renderTable();
-            if (typeof renderActiveFilters === "function") {
-              renderActiveFilters();
-            }
-            if (typeof updateStorageStats === "function") {
-              updateStorageStats();
-            }
-            debugLog("importCsv override complete", imported.length, "items replaced");
-            const _overrideAttachCount = imported.reduce(
-              (n, it) => n + (Array.isArray(it.attachments) ? it.attachments.length : 0),
-              0
-            );
-            if (_overrideAttachCount > 0 && typeof showToast === "function") {
-              showToast(
-                `${_overrideAttachCount} attachment(s) imported as metadata only — use a backup ZIP to restore files.`,
-                "warning"
-              );
-            }
-            if (
-              localStorage.getItem("staktrakr.debug") &&
-              typeof window.showDebugModal === "function"
-            ) {
-              showDebugModal();
-            }
+            _csvImportApplyOverride(imported, pendingTagsByUuid, pendingRemovedTagsByUuid);
             return;
           }
 
           // --- Merge path: use shared DiffEngine + DiffModal helper ---
-          showImportDiffReview(
+          _csvImportRunMergeReview(
             imported,
-            { type: "csv", label: file.name },
-            {
-              validationResult: _validationResult,
-              pendingTagsByUuid: pendingTagsByUuid,
-            },
-            function (summary) {
-              const _csvAttachCount = imported.reduce(
-                (n, it) => n + (Array.isArray(it.attachments) ? it.attachments.length : 0),
-                0
-              );
-              if (_csvAttachCount > 0 && typeof showToast === "function") {
-                showToast(
-                  `${_csvAttachCount} attachment(s) imported as metadata only — use a backup ZIP to restore files.`,
-                  "warning"
-                );
-              }
-              // Restore removed tags from CSV import (STAK-556)
-              if (pendingRemovedTagsByUuid.size > 0 && typeof saveDataSync === "function") {
-                const removedMap =
-                  typeof loadDataSync === "function" ? loadDataSync("itemRemovedTags", {}) : {};
-                for (const item of imported) {
-                  const key =
-                    typeof DiffEngine !== "undefined"
-                      ? DiffEngine.computeItemKey(item)
-                      : item.uuid || item.serial || "";
-                  const removedTags = pendingRemovedTagsByUuid.get(key);
-                  if (removedTags && removedTags.length) {
-                    removedMap[item.uuid] = removedTags;
-                  }
-                }
-                saveDataSync("itemRemovedTags", removedMap);
-              }
-              debugLog(
-                "importCsv DiffEngine complete",
-                summary.added,
-                "added",
-                summary.modified,
-                "modified",
-                summary.deleted,
-                "deleted"
-              );
-            }
+            file,
+            _validationResult,
+            pendingTagsByUuid,
+            pendingRemovedTagsByUuid
           );
         },
         error: function (error) {
@@ -727,6 +840,238 @@
       endImportProgress();
       handleError(error, "CSV import initialization");
     }
+  };
+
+  /**
+   * Parse the heaviest weight/mass column from a Numista row into troy ounces.
+   * @param {object} row - Parsed Numista CSV row
+   * @returns {number} Weight in troy ounces (6dp)
+   */
+  const _parseNumistaWeight = (row) => {
+    const weightCols = Object.keys(row).filter((k) => {
+      const key = k.toLowerCase();
+      return key.includes("weight") || key.includes("mass");
+    });
+    let weightGrams = 0;
+    for (const col of weightCols) {
+      const val = parseFloat(String(row[col]).replace(/[^0-9.]/g, ""));
+      if (!isNaN(val)) weightGrams = Math.max(weightGrams, val);
+    }
+    return parseFloat(gramsToOzt(weightGrams).toFixed(6));
+  };
+
+  /**
+   * Parse purchase + market price from a Numista row, converting to USD and
+   * cross-filling one from the other when only one is present.
+   * @param {object} row - Parsed Numista CSV row
+   * @returns {{purchasePrice: number, marketValue: number}}
+   */
+  const _parseNumistaPrices = (row) => {
+    const priceKey = Object.keys(row).find((k) =>
+      /^(buying price|purchase price|price paid)/i.test(k)
+    );
+    const estimateKey = Object.keys(row).find((k) => /^estimate/i.test(k));
+    const parsePriceField = (key) => {
+      const rawVal = String(row[key] ?? "").trim();
+      const valueCurrency = detectCurrency(rawVal);
+      const headerCurrencyMatch = key.match(/\(([^)]+)\)/);
+      const headerCurrency = headerCurrencyMatch ? headerCurrencyMatch[1] : displayCurrency;
+      const currency = valueCurrency || headerCurrency;
+      const amount = parseFloat(rawVal.replace(/[^0-9.\-]/g, ""));
+      return isNaN(amount) ? 0 : convertToUsd(amount, currency);
+    };
+
+    let purchasePrice = 0;
+    let marketValue = 0;
+    if (priceKey) purchasePrice = parsePriceField(priceKey);
+    if (estimateKey) marketValue = parsePriceField(estimateKey);
+    // Cross-fill: a row with only one price uses it for both.
+    if (marketValue === 0 && purchasePrice > 0) marketValue = purchasePrice;
+    if (purchasePrice === 0 && marketValue > 0) purchasePrice = marketValue;
+    return { purchasePrice, marketValue };
+  };
+
+  /**
+   * Assemble the combined notes field for a Numista row: human notes/comments plus
+   * a full markdown dump of the original row under a "Numista Import Data" heading.
+   * @param {object} row - Parsed Numista CSV row
+   * @param {function} getValue - Case-insensitive multi-key row accessor
+   * @returns {string} Final notes string
+   */
+  const _buildNumistaNotes = (row, getValue) => {
+    const baseNote = (getValue(row, ["Note", "Notes"]) || "").trim();
+    const privateComment = (getValue(row, ["Private comment"]) || "").trim();
+    const publicComment = (getValue(row, ["Public comment"]) || "").trim();
+    const otherComment = (getValue(row, ["Comment"]) || "").trim();
+    const noteParts = [];
+    if (baseNote) noteParts.push(baseNote);
+    if (privateComment) noteParts.push(`Private Comment: ${privateComment}`);
+    if (publicComment) noteParts.push(`Public Comment: ${publicComment}`);
+    if (otherComment) noteParts.push(`Comment: ${otherComment}`);
+    const notes = noteParts.join("\n");
+
+    const markdownLines = Object.entries(row)
+      .filter(([, v]) => v && String(v).trim())
+      .map(([k, v]) => `- **${k.trim()}**: ${String(v).trim()}`);
+    const markdownNote = markdownLines.length
+      ? `### Numista Import Data\n${markdownLines.join("\n")}`
+      : "";
+    return markdownNote ? (notes ? `${notes}\n\n${markdownNote}` : markdownNote) : notes;
+  };
+
+  /**
+   * Build one sanitized inventory item from a Numista export row. Registers the
+   * composition for EVERY row (including non-PM rows that are skipped afterward).
+   * @param {object} row - Parsed Numista CSV row
+   * @param {function} getValue - Case-insensitive multi-key row accessor
+   * @returns {{skipped: true, name: string, compositionRaw: string} |
+   *   {skipped: false, item: object}}
+   */
+  const _buildNumistaItemFromRow = (row, getValue) => {
+    const supportedMetals = ["Silver", "Gold", "Platinum", "Palladium"];
+    const numistaRaw = (
+      getValue(row, [
+        "N# number",
+        "N# number (with link)",
+        "Numista #",
+        "Numista number",
+        "Numista id",
+      ]) || ""
+    ).toString();
+    const numistaMatch = numistaRaw.match(/\d+/);
+    const numistaId = numistaMatch ? numistaMatch[0] : "";
+    const title = (getValue(row, ["Title", "Name"]) || "").trim();
+    const year = (getValue(row, ["Year", "Date"]) || "").trim();
+    const name = year.length >= 4 ? `${title} ${year}`.trim() : title;
+    const issuedYear = year.length >= 4 ? year : "";
+    const compositionRaw = getValue(row, ["Composition", "Metal"]) || "";
+    const composition = getCompositionFirstWords(compositionRaw);
+
+    addCompositionOption(composition);
+
+    const metal = parseNumistaMetal(composition);
+
+    // Skip non-precious-metal items (Paper, Alloy, Copper, Nickel, etc.)
+    if (!supportedMetals.includes(metal)) {
+      return { skipped: true, name, compositionRaw };
+    }
+
+    const qty = parseInt(getValue(row, ["Quantity", "Qty", "Quantity owned"]) || 1, 10);
+    const type = normalizeType(mapNumistaType(getValue(row, ["Type"]) || ""));
+    const weight = _parseNumistaWeight(row);
+    const { purchasePrice, marketValue } = _parseNumistaPrices(row);
+
+    const purchaseLocRaw = getValue(row, ["Acquisition place", "Acquired from", "Purchase place"]);
+    const purchaseLocation = purchaseLocRaw && purchaseLocRaw.trim() ? purchaseLocRaw.trim() : "—";
+    const paymentMethod = getValue(row, ["Payment Method", "Payment method"]) || "";
+    const storageLocRaw = getValue(row, ["Storage location", "Stored at", "Storage place"]);
+    const storageLocation = storageLocRaw && storageLocRaw.trim() ? storageLocRaw.trim() : "—";
+
+    const dateStrRaw = getValue(row, ["Acquisition date", "Date acquired", "Date"]);
+    const dateStr = dateStrRaw && dateStrRaw.trim() ? dateStrRaw.trim() : "—";
+    const date = parseDate(dateStr);
+
+    const finalNotes = _buildNumistaNotes(row, getValue);
+
+    // STRK-167 (D-3): do NOT pre-stamp uuid/serial here. A pre-stamped uuid makes
+    // computeItemKey return it first, masking the instance tier so the diff never
+    // matches existing items (the STRK-165 duplication bug). Identity is stamped
+    // later: enrich backfills matched rows, then unmatched rows are stamped pre-diff.
+    const item = sanitizeImportedItem({
+      metal,
+      composition,
+      name,
+      qty,
+      type,
+      weight,
+      price: purchasePrice,
+      purchasePrice,
+      marketValue,
+      date,
+      paymentMethod,
+      purchaseLocation,
+      storageLocation,
+      notes: finalNotes,
+      spotPriceAtPurchase: 0,
+      premiumPerOz: 0,
+      totalPremium: 0,
+      numistaId,
+      year: issuedYear,
+      grade: "",
+      gradingAuthority: "",
+      certNumber: "",
+      pcgsNumber: "",
+    });
+
+    return { skipped: false, item };
+  };
+
+  /**
+   * Stamp uuid + serial on rows that still lack identity (matched rows get a uuid
+   * backfilled by enrichItemIdentities; genuinely-new rows are stamped here). (STRK-167 D-3)
+   * @param {Array} rows - Items to stamp in place
+   */
+  const _stampNumistaIdentity = (rows) => {
+    for (const it of rows) {
+      if (it.serial == null || it.serial === "") it.serial = getNextSerial();
+      if (!it.uuid) it.uuid = generateUUID();
+    }
+  };
+
+  /**
+   * Override-import path for Numista CSV (AC-13): replace the entire inventory with
+   * the collapsed rows, no diff modal. (STAK-421)
+   * @param {Array} collapsed - Instance-collapsed imported items
+   */
+  const _numistaImportOverride = (collapsed) => {
+    _stampNumistaIdentity(collapsed);
+    const runReplace = async () => {
+      inventory = collapsed;
+      for (const item of collapsed) {
+        if (typeof registerName === "function") registerName(item.name);
+      }
+      if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
+        inventory = catalogManager.syncInventory(inventory);
+      }
+      if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
+      await saveInventory();
+      // STAK-421: cancel debounced sync push after a replace import.
+      if (typeof scheduleSyncPush === "function") scheduleSyncPush.cancel?.();
+      renderTable();
+      if (typeof renderActiveFilters === "function") renderActiveFilters();
+      if (typeof updateStorageStats === "function") updateStorageStats();
+    };
+    runReplace().catch((error) => handleError(error, "Numista CSV import"));
+  };
+
+  /**
+   * Merge-import path for Numista CSV (AC-7/9/12): enrich identities, stamp the
+   * still-unmatched rows, then route through the shared diff-review modal.
+   * @param {Array} collapsed - Instance-collapsed imported items
+   * @param {File} file - Source CSV file (for the diff source label)
+   */
+  const _numistaImportRunMergeReview = (collapsed, file) => {
+    if (
+      typeof DiffEngine !== "undefined" &&
+      typeof DiffEngine.enrichItemIdentities === "function"
+    ) {
+      DiffEngine.enrichItemIdentities(inventory, collapsed); // backfill matched uuids
+    }
+    _stampNumistaIdentity(collapsed); // stamp still-unmatched before the diff
+
+    showImportDiffReview(collapsed, { type: "csv", label: file.name }, {}, function (summary) {
+      if (typeof debugLog === "function") {
+        debugLog(
+          "importNumistaCsv merge complete",
+          summary.added,
+          "added",
+          summary.modified,
+          "modified",
+          summary.deleted,
+          "deleted"
+        );
+      }
+    });
   };
 
   /**
@@ -755,7 +1100,6 @@
           });
           const rawTable = results.data;
           const imported = [];
-          const supportedMetals = ["Silver", "Gold", "Platinum", "Palladium"];
           const skippedNonPM = [];
           const totalRows = rawTable.length;
           startImportProgress(totalRows);
@@ -773,163 +1117,16 @@
           for (const row of rawTable) {
             processed++;
 
-            const numistaRaw = (
-              getValue(row, [
-                "N# number",
-                "N# number (with link)",
-                "Numista #",
-                "Numista number",
-                "Numista id",
-              ]) || ""
-            ).toString();
-            const numistaMatch = numistaRaw.match(/\d+/);
-            const numistaId = numistaMatch ? numistaMatch[0] : "";
-            const title = (getValue(row, ["Title", "Name"]) || "").trim();
-            const year = (getValue(row, ["Year", "Date"]) || "").trim();
-            const name = year.length >= 4 ? `${title} ${year}`.trim() : title;
-            const issuedYear = year.length >= 4 ? year : "";
-            const compositionRaw = getValue(row, ["Composition", "Metal"]) || "";
-            const composition = getCompositionFirstWords(compositionRaw);
-
-            addCompositionOption(composition);
-
-            let metal = parseNumistaMetal(composition);
-
-            // Skip non-precious-metal items (Paper, Alloy, Copper, Nickel, etc.)
-            if (!supportedMetals.includes(metal)) {
-              skippedNonPM.push(`${name || `Row ${processed}`} (${compositionRaw || "unknown"})`);
+            const built = _buildNumistaItemFromRow(row, getValue);
+            if (built.skipped) {
+              skippedNonPM.push(
+                `${built.name || `Row ${processed}`} (${built.compositionRaw || "unknown"})`
+              );
               updateImportProgress(processed, importedCount, totalRows);
               continue;
             }
-
-            const qty = parseInt(getValue(row, ["Quantity", "Qty", "Quantity owned"]) || 1, 10);
-
-            let type = normalizeType(mapNumistaType(getValue(row, ["Type"]) || ""));
-
-            const weightCols = Object.keys(row).filter((k) => {
-              const key = k.toLowerCase();
-              return key.includes("weight") || key.includes("mass");
-            });
-            let weightGrams = 0;
-            for (const col of weightCols) {
-              const val = parseFloat(String(row[col]).replace(/[^0-9.]/g, ""));
-              if (!isNaN(val)) weightGrams = Math.max(weightGrams, val);
-            }
-            const weight = parseFloat(gramsToOzt(weightGrams).toFixed(6));
-
-            const priceKey = Object.keys(row).find((k) =>
-              /^(buying price|purchase price|price paid)/i.test(k)
-            );
-            const estimateKey = Object.keys(row).find((k) => /^estimate/i.test(k));
-            const parsePriceField = (key) => {
-              const rawVal = String(row[key] ?? "").trim();
-              const valueCurrency = detectCurrency(rawVal);
-              const headerCurrencyMatch = key.match(/\(([^)]+)\)/);
-              const headerCurrency = headerCurrencyMatch ? headerCurrencyMatch[1] : displayCurrency;
-              const currency = valueCurrency || headerCurrency;
-              const amount = parseFloat(rawVal.replace(/[^0-9.\-]/g, ""));
-              return isNaN(amount) ? 0 : convertToUsd(amount, currency);
-            };
-
-            let purchasePrice = 0;
-            let marketValue = 0;
-
-            // Set purchase price from buying price
-            if (priceKey) {
-              purchasePrice = parsePriceField(priceKey);
-            }
-
-            // Set market value from estimate price
-            if (estimateKey) {
-              marketValue = parsePriceField(estimateKey);
-            }
-
-            // If no market value but we have buying price, use buying price for both
-            if (marketValue === 0 && purchasePrice > 0) {
-              marketValue = purchasePrice;
-            }
-
-            // If no purchase price but we have estimate, use estimate for both
-            if (purchasePrice === 0 && marketValue > 0) {
-              purchasePrice = marketValue;
-            }
-
-            const purchaseLocRaw = getValue(row, [
-              "Acquisition place",
-              "Acquired from",
-              "Purchase place",
-            ]);
-            const purchaseLocation =
-              purchaseLocRaw && purchaseLocRaw.trim() ? purchaseLocRaw.trim() : "—";
-            const paymentMethod = getValue(row, ["Payment Method", "Payment method"]) || "";
-            const storageLocRaw = getValue(row, ["Storage location", "Stored at", "Storage place"]);
-            const storageLocation =
-              storageLocRaw && storageLocRaw.trim() ? storageLocRaw.trim() : "—";
-
-            const dateStrRaw = getValue(row, ["Acquisition date", "Date acquired", "Date"]);
-            const dateStr = dateStrRaw && dateStrRaw.trim() ? dateStrRaw.trim() : "—";
-            const date = parseDate(dateStr);
-
-            const baseNote = (getValue(row, ["Note", "Notes"]) || "").trim();
-            const privateComment = (getValue(row, ["Private comment"]) || "").trim();
-            const publicComment = (getValue(row, ["Public comment"]) || "").trim();
-            const otherComment = (getValue(row, ["Comment"]) || "").trim();
-            const noteParts = [];
-            if (baseNote) noteParts.push(baseNote);
-            if (privateComment) noteParts.push(`Private Comment: ${privateComment}`);
-            if (publicComment) noteParts.push(`Public Comment: ${publicComment}`);
-            if (otherComment) noteParts.push(`Comment: ${otherComment}`);
-            const notes = noteParts.join("\n");
-
-            const markdownLines = Object.entries(row)
-              .filter(([, v]) => v && String(v).trim())
-              .map(([k, v]) => `- **${k.trim()}**: ${String(v).trim()}`);
-            const markdownNote = markdownLines.length
-              ? `### Numista Import Data\n${markdownLines.join("\n")}`
-              : "";
-            const finalNotes = markdownNote
-              ? notes
-                ? `${notes}\n\n${markdownNote}`
-                : markdownNote
-              : notes;
-
-            const spotPriceAtPurchase = 0;
-            const premiumPerOz = 0;
-            const totalPremium = 0;
-            // STRK-167 (D-3): do NOT pre-stamp uuid/serial here. A pre-stamped uuid
-            // makes computeItemKey return it first, masking the instance tier so the
-            // diff never matches existing items (the STRK-165 duplication bug).
-            // Identity is stamped later: enrich backfills matched rows, then any
-            // still-unmatched row is stamped before the diff.
-
-            const item = sanitizeImportedItem({
-              metal,
-              composition,
-              name,
-              qty,
-              type,
-              weight,
-              price: purchasePrice,
-              purchasePrice,
-              marketValue,
-              date,
-              paymentMethod,
-              purchaseLocation,
-              storageLocation,
-              notes: finalNotes,
-              spotPriceAtPurchase,
-              premiumPerOz,
-              totalPremium,
-              numistaId,
-              year: issuedYear,
-              grade: "",
-              gradingAuthority: "",
-              certNumber: "",
-              pcgsNumber: "",
-            });
-
-            imported.push(item);
-            if (!item.paymentMethod) delete item.paymentMethod;
+            imported.push(built.item);
+            if (!built.item.paymentMethod) delete built.item.paymentMethod;
             importedCount++;
             updateImportProgress(processed, importedCount, totalRows);
           }
@@ -961,68 +1158,12 @@
               ? DiffEngine.collapseByInstanceKey(imported)
               : imported;
 
-          // Stamp uuid + serial on rows that still lack identity. Matched rows get a
-          // backfilled uuid from enrichItemIdentities; genuinely-new rows are stamped
-          // here so accepted adds are never saved keyless (D-3).
-          const stampIdentity = (rows) => {
-            for (const it of rows) {
-              if (it.serial == null || it.serial === "") it.serial = getNextSerial();
-              if (!it.uuid) it.uuid = generateUUID();
-            }
-          };
-
-          // --- Override path (AC-13): replace the entire inventory, no modal. ---
           if (override) {
-            stampIdentity(collapsed);
-            const runReplace = async () => {
-              inventory = collapsed;
-              for (const item of collapsed) {
-                if (typeof registerName === "function") registerName(item.name);
-              }
-              if (typeof catalogManager !== "undefined" && catalogManager.syncInventory) {
-                inventory = catalogManager.syncInventory(inventory);
-              }
-              if (typeof clearInventoryRecovery === "function") clearInventoryRecovery();
-              await saveInventory();
-              // STAK-421: cancel debounced sync push after a replace import.
-              if (typeof scheduleSyncPush === "function") scheduleSyncPush.cancel?.();
-              renderTable();
-              if (typeof renderActiveFilters === "function") renderActiveFilters();
-              if (typeof updateStorageStats === "function") updateStorageStats();
-            };
-            runReplace().catch((error) => handleError(error, "Numista CSV import"));
+            _numistaImportOverride(collapsed);
             return;
           }
 
-          // --- Merge path (AC-7/9/12): route through the shared diff-review modal,
-          // exactly as importCsv does. The STRK-165 interim onboarding/replace gate
-          // is gone — instance-aware dedup makes merging safe again. ---
-          if (
-            typeof DiffEngine !== "undefined" &&
-            typeof DiffEngine.enrichItemIdentities === "function"
-          ) {
-            DiffEngine.enrichItemIdentities(inventory, collapsed); // backfill matched uuids
-          }
-          stampIdentity(collapsed); // stamp still-unmatched before the diff
-
-          showImportDiffReview(
-            collapsed,
-            { type: "csv", label: file.name },
-            {},
-            function (summary) {
-              if (typeof debugLog === "function") {
-                debugLog(
-                  "importNumistaCsv merge complete",
-                  summary.added,
-                  "added",
-                  summary.modified,
-                  "modified",
-                  summary.deleted,
-                  "deleted"
-                );
-              }
-            }
-          );
+          _numistaImportRunMergeReview(collapsed, file);
         } catch (error) {
           endImportProgress();
           handleError(error, "Numista CSV import");

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.22-b1781567625";
+const CACHE_NAME = "staktrakr-v3.35.22-b1781572773";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.22-b1781572773";
+const CACHE_NAME = "staktrakr-v3.35.22-b1781574189";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## STRK-170 Tier-1 complexity refactor — cohort 1.2 (`inventory-import.js`)

Behavior-preserving **extract-helper** refactor of the 4 Codacy Lizard over-gate functions in `js/inventory-import.js`. No-bump campaign cohort (one closing `/release patch` bumps at the end).

Sketch: `DocVault/Projects/StakTrakr/sketches/STRK-170-tier1-complexity-refactor/` · Plane: [STRK-170](https://plane.lbruton.cc/lbruton/projects/026dbe54-fe52-4a9f-9f1b-7edcb9bbdceb/)

### Targets (Codacy Cloud ccn/nloc → after)
| Function | Before | After |
|---|---|---|
| `complete` (importCsv) | **132 ccn / 322 nloc** | orchestrator + 14 helpers (≤25/≤150) |
| `showImportDiffReview` | **44 ccn** | orchestrator + 5 helpers |
| `onApply` (nested) | **29 ccn** | slim callback delegating to helpers |
| `reader.onload` (importNumistaCsv) | **37 ccn** | orchestrator + 7 helpers |

Shared helpers also **dedupe** the override↔merge tail paths (`_applyCsvRemovedTags`, `_warnCsvAttachmentsMetadataOnly`) and the disposition/price parsing — a Codacy duplication win alongside the complexity win. Every extracted helper carries a JSDoc block (docstring-coverage gate).

### Verification
- `npm test` (core gate) — **226 passing**; `core/import-export.spec.js` + `core/numista-import-onboarding.spec.js` green pre- **and** post-refactor (AC-4: existing specs are the regression guard; no new char test required for this cohort).
- ESLint + Prettier clean; `node --check` OK.
- File NLOC 1724 < 2500 → all in-file, no D-1a sibling.
- No behavior change: DOM output, localStorage/IndexedDB shape, and CSV/JSON/Numista import flows unchanged (`getNextSerial()` side-effect ordering preserved — one call per imported row, in row order).

### Reviewer note — local lizard desync (please don't flag as regressions)
Local lizard `1.21.0` (standalone **and** via `codacy-analysis`) **desyncs** on this file — it mis-tokenizes a regex literal and scrambles function boundaries, so it cannot reliably verify complexity locally here (it never even identifies the real `complete` function). The authoritative gate is **Codacy Cloud**, which parses the file correctly. Local lizard's two residual "findings" (`importJson`, `importCsvFromText`) are **pre-existing desync phantoms in code this PR does not touch** — not Codacy Cloud findings, not introduced here.