### PR TITLE
chore: parse ES-module test specs in legacy ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,5 +24,14 @@
   "plugins": [],
   "parserOptions": {
     "ecmaVersion": 2020
-  }
+  },
+  "overrides": [
+    {
+      "files": ["tests/**/*.js"],
+      "parserOptions": {
+        "ecmaVersion": 2022,
+        "sourceType": "module"
+      }
+    }
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,11 +191,12 @@ Read the file `.context/review-and-ci.md` before: Codacy CLI scans, agentlint ru
 
 **Async bot reviewers land after checks go green.** Copilot and Codacy AI post review threads 1–3 min _after_ required checks pass — often after the merge window opens. Before merging: confirm required checks are green, pause ~2–3 min, then re-query review threads. Treat a `null` result or `errors` array from a `gh api graphql` query as a failure (a malformed query can silently return `null`); an empty `nodes` array is the valid "no active threads" state — confirm the response is a valid list before merging.
 
-### Dual ESLint config — `.eslintrc.json` is Codacy-only
+### Dual ESLint config — `.eslintrc.json` is read by Codacy AND CodeRabbit
 
-The repo carries two ESLint configs: `eslint.config.cjs` (flat — used by local `npm run lint`) and `.eslintrc.json` (legacy — read only by Codacy's server-side ESLint). With a flat config present, ESLint 9 ignores the legacy file locally.
+The repo carries two ESLint configs: `eslint.config.cjs` (flat — used by local `npm run lint`) and `.eslintrc.json` (legacy — read server-side by Codacy's ESLint **and** by CodeRabbit's sandbox, which resolves the legacy eslintrc over the flat config). With a flat config present, ESLint 9 ignores the legacy file locally.
 The `no-restricted-globals` ban on native `alert`/`confirm`/`prompt` (use `showAppAlert`/`showAppConfirm`/`showAppPrompt`) lives **only** in `.eslintrc.json`, so a native `confirm()` passes `npm run lint` but Codacy flags it.
-Before deleting `.eslintrc.json` or bumping to ESLint 10 (Dependabot PR #1228 is deferred pending Codacy support), migrate that rule into `eslint.config.cjs`.
+The legacy config defaults `sourceType` to `script`, so an `overrides` block sets `sourceType: module` for `tests/**/*.js` — without it CodeRabbit fails to parse ES-module Playwright/unit specs (`'import' and 'export' may appear only with 'sourceType: module'`) on every PR that touches a spec (`npm run lint` never globs `tests/playwright/**`, so it can't catch this).
+Before deleting `.eslintrc.json` or bumping to ESLint 10 (Dependabot PR #1228 is deferred pending Codacy support), migrate the `no-restricted-globals` rule into `eslint.config.cjs`.
 
 ## Pre-flight (StakTrakr-specific)
 


### PR DESCRIPTION
## What

Add an `overrides` block to `.eslintrc.json` scoping `tests/**/*.js` to `ecmaVersion: 2022` + `sourceType: module`.

## Why

CodeRabbit's ESLint sandbox resolves the **legacy `.eslintrc.json`**, not the flat `eslint.config.cjs`. The legacy config's `parserOptions` had no `sourceType`, so it defaulted to `"script"` and failed to parse every ES-module Playwright/unit spec:

```
Parsing error: 'import' and 'export' may appear only with 'sourceType: module'
```

This surfaced as a recurring "ESLint tool failed" warning on **every PR that adds or edits a spec** (e.g. `tests/playwright/core/vault-modal.spec.js`). It went undetected locally because:
- `npm run lint` only globs `js/*.js sw.js sw-router.js "tests/unit/**/*.js"` — never `tests/playwright/**`.
- The flat config defaults unmatched files to `sourceType: module`, so local ESLint 9 passes.

## Scope safety

- `tests/**/*.js` → `sourceType: module` (Playwright + unit specs + helpers, all ES modules).
- Runtime `js/**` stays script-mode — **unchanged for Codacy**.

## Verification

- `.eslintrc.json` parses as valid JSON.
- Legacy-mode lint of `tests/playwright/core/vault-modal.spec.js` → exit 0 (was the failing case).
- Legacy-mode lint of `js/dialogs.js` → exit 0 (no runtime regression).
- `npm run lint` → exit 0.

Also corrects the stale `CLAUDE.md` note that described the legacy config as "Codacy-only" — CodeRabbit reads it too.