### PR TITLE
chore(STRK-170): filters.js complexity refactor (cohort 2.4)

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -115,6 +115,111 @@ const simplifyChipValue = (value, field) => {
 };
 
 /**
+ * Tallies an item's metal (first composition words) into the metals bucket.
+ * @param {Object.<string, number>} metals - Metal → count map (mutated)
+ * @param {Object} item - Inventory item
+ */
+const _tallyMetal = (metals, item) => {
+  const metal = getCompositionFirstWords(item.composition || item.metal || "");
+  if (metal) {
+    metals[metal] = (metals[metal] || 0) + 1;
+  }
+};
+
+/**
+ * Tallies an item's type into the types bucket.
+ * @param {Object.<string, number>} types - Type → count map (mutated)
+ * @param {Object} item - Inventory item
+ */
+const _tallyType = (types, item) => {
+  if (item.type) {
+    types[item.type] = (types[item.type] || 0) + 1;
+  }
+};
+
+/**
+ * Tallies an item's payment method (trimmed key) into the payment-methods bucket.
+ * @param {Object.<string, number>} paymentMethods - Method → count map (mutated)
+ * @param {Object} item - Inventory item
+ */
+const _tallyPaymentMethod = (paymentMethods, item) => {
+  const payMethod = (item.paymentMethod || "").trim();
+  if (payMethod) {
+    paymentMethods[payMethod] = (paymentMethods[payMethod] || 0) + 1;
+  }
+};
+
+/**
+ * Tallies a location value into a location bucket, skipping empty / "Unknown".
+ * The bucket key is the original (untrimmed) value to match legacy chip output.
+ * @param {Object.<string, number>} map - Location → count map (mutated)
+ * @param {string} rawLoc - The raw location value (purchase or storage)
+ */
+const _tallyLocation = (map, rawLoc) => {
+  const loc = (rawLoc || "").trim();
+  if (loc && loc.toLowerCase() !== "unknown") {
+    map[rawLoc] = (map[rawLoc] || 0) + 1;
+  }
+};
+
+/**
+ * Tallies a trimmed scalar value (year / grade / numistaId), skipping empty.
+ * @param {Object.<string, number>} map - Value → count map (mutated)
+ * @param {string} rawValue - The raw field value
+ */
+const _tallyTrimmed = (map, rawValue) => {
+  const v = (rawValue || "").trim();
+  if (v) {
+    map[v] = (map[v] || 0) + 1;
+  }
+};
+
+/**
+ * Tallies an item's normalized (grouped) name when GROUPED_NAME_CHIPS is enabled.
+ * @param {Object.<string, number>} names - Base name → count map (mutated)
+ * @param {Object} item - Inventory item
+ */
+const _tallyName = (names, item) => {
+  if (window.featureFlags && window.featureFlags.isEnabled("GROUPED_NAME_CHIPS")) {
+    const itemName = (item.name || "").trim();
+    if (itemName) {
+      let baseName = itemName;
+      if (window.autocomplete && typeof window.autocomplete.normalizeItemName === "function") {
+        baseName = window.autocomplete.normalizeItemName(itemName);
+      }
+      names[baseName] = (names[baseName] || 0) + 1;
+    }
+  }
+};
+
+/**
+ * Tallies an item's non-pure fineness (0 < purity < 1.0) into the purities bucket.
+ * @param {Object.<string, number>} purities - Purity-string → count map (mutated)
+ * @param {Object} item - Inventory item
+ */
+const _tallyPurity = (purities, item) => {
+  const pur = parseFloat(item.purity);
+  if (!isNaN(pur) && pur > 0 && pur < 1.0) {
+    const purKey = String(pur);
+    purities[purKey] = (purities[purKey] || 0) + 1;
+  }
+};
+
+/**
+ * Tallies an item's tags into the tags bucket (STAK-126).
+ * @param {Object.<string, number>} tags - Tag → count map (mutated)
+ * @param {Object} item - Inventory item
+ */
+const _tallyTags = (tags, item) => {
+  if (typeof getItemTags === "function" && item.uuid) {
+    const itemTags = getItemTags(item.uuid);
+    itemTags.forEach((tag) => {
+      tags[tag] = (tags[tag] || 0) + 1;
+    });
+  }
+};
+
+/**
  * Generates category summary from filtered inventory.
  * Returns summary of metals, types, and item counts above minimum threshold.
  *
@@ -146,80 +251,17 @@ const generateCategorySummary = (inventory) => {
   const tags = {};
 
   inventory.forEach((item) => {
-    // Count metals
-    const metal = getCompositionFirstWords(item.composition || item.metal || "");
-    if (metal) {
-      metals[metal] = (metals[metal] || 0) + 1;
-    }
-
-    // Count types
-    if (item.type) {
-      types[item.type] = (types[item.type] || 0) + 1;
-    }
-
-    // Count payment methods (skip empty)
-    const payMethod = (item.paymentMethod || "").trim();
-    if (payMethod) {
-      paymentMethods[payMethod] = (paymentMethods[payMethod] || 0) + 1;
-    }
-
-    // Count purchase locations (skip empty / "Unknown")
-    const pLoc = (item.purchaseLocation || "").trim();
-    if (pLoc && pLoc.toLowerCase() !== "unknown") {
-      purchaseLocations[item.purchaseLocation] =
-        (purchaseLocations[item.purchaseLocation] || 0) + 1;
-    }
-
-    // Count storage locations (skip empty / "Unknown")
-    const sLoc = (item.storageLocation || "").trim();
-    if (sLoc && sLoc.toLowerCase() !== "unknown") {
-      storageLocations[item.storageLocation] = (storageLocations[item.storageLocation] || 0) + 1;
-    }
-
-    // Count normalized names (grouped name chips)
-    if (window.featureFlags && window.featureFlags.isEnabled("GROUPED_NAME_CHIPS")) {
-      const itemName = (item.name || "").trim();
-      if (itemName) {
-        let baseName = itemName;
-        if (window.autocomplete && typeof window.autocomplete.normalizeItemName === "function") {
-          baseName = window.autocomplete.normalizeItemName(itemName);
-        }
-        names[baseName] = (names[baseName] || 0) + 1;
-      }
-    }
-
-    // Count years (skip empty)
-    const yr = (item.year || "").trim();
-    if (yr) {
-      years[yr] = (years[yr] || 0) + 1;
-    }
-
-    // Count grades (skip empty)
-    const gr = (item.grade || "").trim();
-    if (gr) {
-      grades[gr] = (grades[gr] || 0) + 1;
-    }
-
-    // Count Numista IDs (skip empty)
-    const nId = (item.numistaId || "").trim();
-    if (nId) {
-      numistaIds[nId] = (numistaIds[nId] || 0) + 1;
-    }
-
-    // Count purities (skip default 1.0 — only show non-pure fineness)
-    const pur = parseFloat(item.purity);
-    if (!isNaN(pur) && pur > 0 && pur < 1.0) {
-      const purKey = String(pur);
-      purities[purKey] = (purities[purKey] || 0) + 1;
-    }
-
-    // Count tags (STAK-126)
-    if (typeof getItemTags === "function" && item.uuid) {
-      const itemTags = getItemTags(item.uuid);
-      itemTags.forEach((tag) => {
-        tags[tag] = (tags[tag] || 0) + 1;
-      });
-    }
+    _tallyMetal(metals, item);
+    _tallyType(types, item);
+    _tallyPaymentMethod(paymentMethods, item);
+    _tallyLocation(purchaseLocations, item.purchaseLocation);
+    _tallyLocation(storageLocations, item.storageLocation);
+    _tallyName(names, item);
+    _tallyTrimmed(years, item.year);
+    _tallyTrimmed(grades, item.grade);
+    _tallyTrimmed(numistaIds, item.numistaId);
+    _tallyPurity(purities, item);
+    _tallyTags(tags, item);
   });
 
   // Count custom groups
@@ -307,56 +349,28 @@ const generateCategorySummary = (inventory) => {
 };
 
 /**
- * Renders active filter chips beneath the search bar.
- * Updates the filter chip container based on current filters and inventory.
+ * Resets the disposed-items filter back to "hide" and re-renders. Shared by the
+ * disposed-mode chip's click handler and its close (×) action.
  */
-const renderActiveFilters = () => {
-  const container = document.getElementById("activeFilters");
-  if (!container) return;
+const _resetDisposedFilter = () => {
+  const dfg = safeGetElement("disposedFilterGroup");
+  dfg.querySelectorAll(".chip-sort-btn").forEach(function (b) {
+    b.classList.toggle("active", b.dataset.disposedMode === "hide");
+  });
+  if (typeof saveData === "function") saveData("disposedFilterMode", "hide");
+  if (typeof renderTable === "function") renderTable();
+  renderActiveFilters();
+};
 
-  container.innerHTML = "";
-
-  // Get the current filtered inventory first
-  const filteredInventory = filterInventoryAdvanced();
-
-  if (filteredInventory.length === 0) {
-    // Show a hint when search narrows to 0 results instead of hiding chips entirely (UX-004)
-    if (searchQuery && searchQuery.trim()) {
-      container.style.display = "";
-      const hint = document.createElement("span");
-      hint.className = "filter-chip search-hint-chip";
-      hint.style.opacity = "0.55";
-      hint.style.cursor = "default";
-      hint.textContent = "Clear search to use filter chips";
-      container.appendChild(hint);
-      return;
-    }
-    container.style.display = "none";
-    return;
-  }
-
-  // Build chips based on what's actually in the filtered inventory
-  const chips = [];
-
-  // Add search term chip if there's a search query
-  if (searchQuery && searchQuery.trim()) {
-    chips.push({ field: "search", value: searchQuery });
-  }
-
-  // Add disposed-only mode chip (STAK-388)
-  var activeDisposedBtnChip = document.querySelector("#disposedFilterGroup .chip-sort-btn.active");
-  var disposedModeChip =
-    (activeDisposedBtnChip &&
-      activeDisposedBtnChip.dataset &&
-      activeDisposedBtnChip.dataset.disposedMode) ||
-    "hide";
-  if (disposedModeChip === "show-only") {
-    chips.push({ field: "disposed-mode", value: "show-only" });
-  }
-
-  // Generate category summary chips from filtered inventory
-  const categorySummary = generateCategorySummary(filteredInventory);
-
+/**
+ * Collects category-summary chips into `chips` (honoring category config order,
+ * grouping, and sort preference) and returns the set of fields that produced a
+ * category. Mutates `chips` in place.
+ * @param {Object} categorySummary - Output of generateCategorySummary
+ * @param {Array<Object>} chips - The chip accumulator (mutated)
+ * @returns {Set<string>} The set of category fields rendered
+ */
+const _buildCategoryFilterChips = (categorySummary, chips) => {
   // Category descriptor map — maps category ID to summary key, chip field, and extra props
   const categoryDescriptors = {
     metal: { summaryKey: "metals", field: "metal" },
@@ -486,7 +500,15 @@ const renderActiveFilters = () => {
     }
   }
 
-  // Apply chipMaxCount cap to category chips only — search chips and active/excluded chips are always appended after this
+  return categoryFields;
+};
+
+/**
+ * Applies the chipMaxCount cap to category chips only — search chips are always
+ * kept and re-prepended. Mutates `chips` in place.
+ * @param {Array<Object>} chips - The chip accumulator (mutated)
+ */
+const _applyChipMaxCount = (chips) => {
   const chipMaxCountEl = safeGetElement("chipMaxCount");
   const maxCount = chipMaxCountEl
     ? parseInt(chipMaxCountEl.value, 10)
@@ -500,8 +522,15 @@ const renderActiveFilters = () => {
     chips.length = 0;
     chips.push(...uncappedChips, ...cappedCandidates);
   }
+};
 
-  // Add any explicitly applied filter chips (but not if they duplicate category chips)
+/**
+ * Appends explicitly-applied active-filter chips that are not already covered by
+ * a category summary chip (excluded filters stay visible). Mutates `chips`.
+ * @param {Array<Object>} chips - The chip accumulator (mutated)
+ * @param {Set<string>} categoryFields - Fields already rendered as category chips
+ */
+const _appendActiveFilterChips = (chips, categoryFields) => {
   Object.entries(activeFilters).forEach(([field, criteria]) => {
     // Skip fields already rendered as category summary chips to avoid duplicates
     // BUT: if no summary chip was rendered for this field (all below minCount),
@@ -532,6 +561,289 @@ const renderActiveFilters = () => {
       }
     }
   });
+};
+
+/**
+ * Determines whether a chip represents a currently-active filter (controls the
+ * `filter-chip-active` class). Summary chips check their value against
+ * activeFilters (expansion chips check their dedicated entry); fallback chips are
+ * always active.
+ * @param {Object} f - The chip descriptor
+ * @returns {boolean} True when the chip is an active filter
+ */
+const _resolveChipActiveState = (f) => {
+  if (f.count === undefined || f.total === undefined) {
+    // Fallback active-filter chips (below minCount or excluded) are always "active"
+    return true;
+  }
+  // STAK-551: expansion chips store their own activeFilters entries.
+  if (f.field === "customGroup") {
+    const cg = activeFilters["customGroup"];
+    return !!(cg && !cg.exclude && cg.values && cg.values.includes(f.value));
+  }
+  if (f.field === "dynamicName") {
+    const dn = activeFilters["dynamicName"];
+    return !!(dn && !dn.exclude && dn.values && dn.values.includes(f.value));
+  }
+  if (f.field === "name" && f.isGrouped) {
+    const gn = activeFilters["groupedName"];
+    return !!(gn && !gn.exclude && gn.values && gn.values.includes(f.value));
+  }
+  const criteria = activeFilters[f.field];
+  if (criteria && Array.isArray(criteria.values) && !criteria.exclude) {
+    return criteria.values.includes(f.value);
+  }
+  return false;
+};
+
+/**
+ * Resolves the display text for a chip value (custom-group label, dynamic/name
+ * passthrough, Numista "N#" prefix, or the simplified value).
+ * @param {Object} f - The chip descriptor
+ * @returns {string} Display value
+ */
+const _resolveChipDisplayValue = (f) => {
+  if (f.isCustomGroup) return f.displayLabel;
+  if (f.isDynamic) return f.value;
+  if (f.field === "name") return f.value;
+  if (f.field === "numistaId") return `N#${f.value}`;
+  return simplifyChipValue(f.value, f.field);
+};
+
+/**
+ * Resolves the full chip label (disposed-mode text, search passthrough, optional
+ * count badge on summary chips, or the value with an "(exclude)" suffix).
+ * @param {Object} f - The chip descriptor
+ * @param {string} displayValue - The resolved display value
+ * @returns {string} The chip label
+ */
+const _resolveChipLabel = (f, displayValue) => {
+  if (f.field === "disposed-mode") return "Showing: Disposed Items";
+  if (f.field === "search") return displayValue;
+  if (f.count !== undefined && f.total !== undefined) {
+    // For category summary chips, show count badge if enabled
+    const showQty = window.featureFlags && window.featureFlags.isEnabled("CHIP_QTY_BADGE");
+    return showQty ? `${displayValue} (${f.count})` : displayValue;
+  }
+  return `${displayValue}${f.exclude ? " (exclude)" : ""}`;
+};
+
+/**
+ * Shared close (×) action for a chip — disposed reset, active-filter removal, or
+ * idle-summary-chip exclusion. Invoked by both the click and keyboard handlers.
+ * @param {Object} f - The chip descriptor
+ * @param {boolean} isActiveFilter - Whether the chip is an active filter
+ */
+const _chipCloseAction = (f, isActiveFilter) => {
+  if (f.field === "disposed-mode") {
+    _resetDisposedFilter();
+  } else if (isActiveFilter) {
+    // Active filter chip × — always removes the filter (de-activate, not exclude)
+    removeFilter(f.field, f.value);
+    renderActiveFilters();
+  } else if (f.count !== undefined && f.total !== undefined && f.field !== "search") {
+    // Idle summary chip × — exclude this value while keeping other filters intact
+    applyQuickFilter(
+      f.field,
+      f.value,
+      f.isGrouped || f.isCustomGroup || f.isDynamic || false,
+      true
+    );
+  } else {
+    removeFilter(f.field, f.value);
+    renderActiveFilters();
+  }
+};
+
+/**
+ * Attaches the right-click context menu (blacklist) to name and dynamicName chips.
+ * @param {HTMLElement} chip - The chip element
+ * @param {Object} f - The chip descriptor
+ */
+const _attachChipContextMenu = (chip, f) => {
+  if (f.field !== "name" && f.field !== "dynamicName") return;
+  chip.addEventListener("contextmenu", (e) => {
+    e.preventDefault();
+    const chipName = f.field === "dynamicName" ? f.value : f.value;
+    if (typeof window.showChipContextMenu === "function") {
+      window.showChipContextMenu(e.clientX, e.clientY, chipName);
+    }
+  });
+};
+
+/**
+ * Attaches the tooltip and primary click behavior for a chip: summary chips apply
+ * (or shift+click blacklist) a filter, the disposed-mode chip resets, and active
+ * filter chips remove themselves.
+ * @param {HTMLElement} chip - The chip element
+ * @param {Object} f - The chip descriptor
+ * @param {string} displayValue - The resolved display value (for the tooltip)
+ */
+const _attachChipPrimaryClick = (chip, f, displayValue) => {
+  if (f.count !== undefined && f.total !== undefined) {
+    // Category summary chips - clicking adds filter; shift+click blacklists supported chip names.
+    const canBlacklist =
+      f.field === "name" ||
+      f.field === "dynamicName" ||
+      f.field === "customGroup" ||
+      f.field === "tags";
+    const chipNameForBlacklist = f.field === "customGroup" ? f.displayLabel || f.value : f.value;
+    chip.title =
+      `Click to filter by ${f.field}: ${displayValue} (${f.count} items)` +
+      (canBlacklist ? " · Shift+click to ignore" : "");
+    chip.addEventListener("click", (e) => {
+      if (canBlacklist && e.shiftKey && typeof window.showBlacklistConfirm === "function") {
+        e.preventDefault();
+        window.showBlacklistConfirm(e.clientX, e.clientY, chipNameForBlacklist);
+        return;
+      }
+      applyQuickFilter(f.field, f.value, f.isGrouped || f.isCustomGroup || f.isDynamic || false);
+    });
+  } else if (f.field === "disposed-mode") {
+    // Disposed-mode chip — clicking resets disposed filter back to 'hide'
+    chip.title = "Showing disposed items only (click to hide disposed)";
+    chip.addEventListener("click", _resetDisposedFilter);
+  } else {
+    // Active filter chips - clicking removes filter
+    chip.title =
+      f.field === "search"
+        ? `Search term: ${displayValue} (click to remove)`
+        : `Active ${f.exclude ? "excluded" : "included"} filter: ${f.field} = ${displayValue} (click to remove)`;
+    chip.addEventListener("click", () => {
+      removeFilter(f.field, f.value);
+      renderActiveFilters();
+    });
+  }
+};
+
+/**
+ * Attaches the accessible close (×) control to a chip: ARIA role/label plus click
+ * and keyboard (Enter/Space) handlers, both delegating to `_chipCloseAction`.
+ * @param {HTMLElement} close - The close-marker span
+ * @param {Object} f - The chip descriptor
+ * @param {boolean} isActiveFilter - Whether the chip is an active filter
+ * @param {string} displayValue - The resolved display value (for the ARIA label)
+ */
+const _attachChipCloseControl = (close, f, isActiveFilter, displayValue) => {
+  // Make the close glyph interactive and keyboard accessible (removes the filter)
+  close.setAttribute("role", "button");
+  close.setAttribute("tabindex", "0");
+  close.setAttribute("aria-label", `Remove filter ${displayValue}`);
+  close.onclick = (e) => {
+    e.stopPropagation();
+    _chipCloseAction(f, isActiveFilter);
+  };
+  close.onkeydown = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      _chipCloseAction(f, isActiveFilter);
+    }
+  };
+};
+
+/**
+ * Builds a single filter-chip element (color, classes, label, close marker, and
+ * all interaction handlers) and appends it to the container.
+ * @param {Object} f - The chip descriptor
+ * @param {number} i - The chip index (for fallback color cycling)
+ * @param {HTMLElement} container - The chip container to append into
+ */
+const _buildFilterChipElement = (f, i, container) => {
+  const chip = document.createElement("span");
+  chip.className = "filter-chip";
+  if (f.exclude) chip.classList.add("filter-chip-excluded");
+  // All chip categories render visually identical — no italic/bold distinction
+  const firstValue = String(f.value).split(", ")[0];
+  const colorKey = f.field === "customGroup" ? f.displayLabel || firstValue : firstValue;
+  const { bg, text: textColor } = getChipColors(f.field, colorKey, i);
+  chip.style.backgroundColor = bg;
+  chip.style.color = textColor || getContrastColor(bg);
+
+  const isActiveFilter = _resolveChipActiveState(f);
+  if (isActiveFilter) chip.classList.add("filter-chip-active");
+  if (f.field === "search") chip.classList.add("filter-chip-search");
+
+  const displayValue = _resolveChipDisplayValue(f);
+  const label = _resolveChipLabel(f, displayValue);
+
+  // Use safe textContent and a separate close marker span to avoid HTML injection
+  chip.textContent = label + " ";
+  const close = document.createElement("span");
+  close.className = "chip-close";
+  close.textContent = "×";
+  close.setAttribute("aria-hidden", "true");
+  chip.appendChild(close);
+
+  // Debug logging (opt-in)
+  if (window.DEBUG_FILTERS) {
+    console.debug("renderActiveFilters: adding chip", { field: f.field, value: f.value, label });
+  }
+
+  _attachChipContextMenu(chip, f);
+  _attachChipPrimaryClick(chip, f, displayValue);
+  _attachChipCloseControl(close, f, isActiveFilter, displayValue);
+
+  container.appendChild(chip);
+};
+
+/**
+ * Renders active filter chips beneath the search bar.
+ * Updates the filter chip container based on current filters and inventory.
+ */
+const renderActiveFilters = () => {
+  const container = document.getElementById("activeFilters");
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  // Get the current filtered inventory first
+  const filteredInventory = filterInventoryAdvanced();
+
+  if (filteredInventory.length === 0) {
+    // Show a hint when search narrows to 0 results instead of hiding chips entirely (UX-004)
+    if (searchQuery && searchQuery.trim()) {
+      container.style.display = "";
+      const hint = document.createElement("span");
+      hint.className = "filter-chip search-hint-chip";
+      hint.style.opacity = "0.55";
+      hint.style.cursor = "default";
+      hint.textContent = "Clear search to use filter chips";
+      container.appendChild(hint);
+      return;
+    }
+    container.style.display = "none";
+    return;
+  }
+
+  // Build chips based on what's actually in the filtered inventory
+  const chips = [];
+
+  // Add search term chip if there's a search query
+  if (searchQuery && searchQuery.trim()) {
+    chips.push({ field: "search", value: searchQuery });
+  }
+
+  // Add disposed-only mode chip (STAK-388)
+  var activeDisposedBtnChip = document.querySelector("#disposedFilterGroup .chip-sort-btn.active");
+  var disposedModeChip =
+    (activeDisposedBtnChip &&
+      activeDisposedBtnChip.dataset &&
+      activeDisposedBtnChip.dataset.disposedMode) ||
+    "hide";
+  if (disposedModeChip === "show-only") {
+    chips.push({ field: "disposed-mode", value: "show-only" });
+  }
+
+  // Generate category summary chips from filtered inventory
+  const categorySummary = generateCategorySummary(filteredInventory);
+  const categoryFields = _buildCategoryFilterChips(categorySummary, chips);
+
+  // Apply chipMaxCount cap to category chips only — search and active chips append after
+  _applyChipMaxCount(chips);
+
+  // Add any explicitly applied filter chips (but not if they duplicate category chips)
+  _appendActiveFilterChips(chips, categoryFields);
 
   if (chips.length === 0) {
     container.style.display = "none";
@@ -540,198 +852,7 @@ const renderActiveFilters = () => {
 
   container.style.display = "";
 
-  chips.forEach((f, i) => {
-    const chip = document.createElement("span");
-    chip.className = "filter-chip";
-    if (f.exclude) chip.classList.add("filter-chip-excluded");
-    // All chip categories render visually identical — no italic/bold distinction
-    const firstValue = String(f.value).split(", ")[0];
-    const colorKey = f.field === "customGroup" ? f.displayLabel || firstValue : firstValue;
-    const { bg, text: textColor } = getChipColors(f.field, colorKey, i);
-    chip.style.backgroundColor = bg;
-    chip.style.color = textColor || getContrastColor(bg);
-
-    // Determine if this chip represents a currently active filter
-    let isActiveFilter = false;
-    if (f.count !== undefined && f.total !== undefined) {
-      // Summary chip — active only if its value is in activeFilters
-      // STAK-551: expansion chips store their own activeFilters entries,
-      // so check those directly before falling through to the generic check.
-      if (f.field === "customGroup") {
-        const cg = activeFilters["customGroup"];
-        isActiveFilter = !!(cg && !cg.exclude && cg.values && cg.values.includes(f.value));
-      } else if (f.field === "dynamicName") {
-        const dn = activeFilters["dynamicName"];
-        isActiveFilter = !!(dn && !dn.exclude && dn.values && dn.values.includes(f.value));
-      } else if (f.field === "name" && f.isGrouped) {
-        const gn = activeFilters["groupedName"];
-        isActiveFilter = !!(gn && !gn.exclude && gn.values && gn.values.includes(f.value));
-      } else {
-        const criteria = activeFilters[f.field];
-        if (criteria && Array.isArray(criteria.values) && !criteria.exclude) {
-          isActiveFilter = criteria.values.includes(f.value);
-        }
-      }
-    } else {
-      // Fallback active-filter chips (below minCount or excluded) are always "active"
-      isActiveFilter = true;
-    }
-
-    if (isActiveFilter) chip.classList.add("filter-chip-active");
-    if (f.field === "search") chip.classList.add("filter-chip-search");
-
-    // Display simplified value for most chips, but keep full base name for name chips
-    // Custom groups use their display label; dynamic chips are italic (via CSS class)
-    const displayValue = f.isCustomGroup
-      ? f.displayLabel
-      : f.isDynamic
-        ? f.value
-        : f.field === "name"
-          ? f.value
-          : f.field === "numistaId"
-            ? `N#${f.value}`
-            : simplifyChipValue(f.value, f.field);
-    let label;
-
-    if (f.field === "disposed-mode") {
-      label = "Showing: Disposed Items";
-    } else if (f.field === "search") {
-      label = displayValue;
-    } else if (f.count !== undefined && f.total !== undefined) {
-      // For category summary chips, show count badge if enabled
-      const showQty = window.featureFlags && window.featureFlags.isEnabled("CHIP_QTY_BADGE");
-      label = showQty ? `${displayValue} (${f.count})` : displayValue;
-    } else {
-      label = `${displayValue}${f.exclude ? " (exclude)" : ""}`;
-    }
-
-    // Use safe textContent and a separate close marker span to avoid HTML injection
-    chip.textContent = label + " ";
-    const close = document.createElement("span");
-    close.className = "chip-close";
-    close.textContent = "×";
-    close.setAttribute("aria-hidden", "true");
-    chip.appendChild(close);
-
-    // Debug logging (opt-in)
-    if (window.DEBUG_FILTERS) {
-      console.debug("renderActiveFilters: adding chip", { field: f.field, value: f.value, label });
-    }
-
-    // Right-click context menu for name and dynamic chips (blacklist)
-    if (f.field === "name" || f.field === "dynamicName") {
-      chip.addEventListener("contextmenu", (e) => {
-        e.preventDefault();
-        const chipName = f.field === "dynamicName" ? f.value : f.value;
-        if (typeof window.showChipContextMenu === "function") {
-          window.showChipContextMenu(e.clientX, e.clientY, chipName);
-        }
-      });
-    }
-
-    // Different tooltip and click behavior for different chip types
-    if (f.count !== undefined && f.total !== undefined) {
-      // Category summary chips - clicking adds filter; shift+click blacklists supported chip names.
-      const canBlacklist =
-        f.field === "name" ||
-        f.field === "dynamicName" ||
-        f.field === "customGroup" ||
-        f.field === "tags";
-      const chipNameForBlacklist = f.field === "customGroup" ? f.displayLabel || f.value : f.value;
-      chip.title =
-        `Click to filter by ${f.field}: ${displayValue} (${f.count} items)` +
-        (canBlacklist ? " · Shift+click to ignore" : "");
-      chip.addEventListener("click", (e) => {
-        if (canBlacklist && e.shiftKey && typeof window.showBlacklistConfirm === "function") {
-          e.preventDefault();
-          window.showBlacklistConfirm(e.clientX, e.clientY, chipNameForBlacklist);
-          return;
-        }
-        applyQuickFilter(f.field, f.value, f.isGrouped || f.isCustomGroup || f.isDynamic || false);
-      });
-    } else if (f.field === "disposed-mode") {
-      // Disposed-mode chip — clicking resets disposed filter back to 'hide'
-      chip.title = "Showing disposed items only (click to hide disposed)";
-      chip.addEventListener("click", function () {
-        const dfg = safeGetElement("disposedFilterGroup");
-        dfg.querySelectorAll(".chip-sort-btn").forEach(function (b) {
-          b.classList.toggle("active", b.dataset.disposedMode === "hide");
-        });
-        if (typeof saveData === "function") saveData("disposedFilterMode", "hide");
-        if (typeof renderTable === "function") renderTable();
-        renderActiveFilters();
-      });
-    } else {
-      // Active filter chips - clicking removes filter
-      chip.title =
-        f.field === "search"
-          ? `Search term: ${displayValue} (click to remove)`
-          : `Active ${f.exclude ? "excluded" : "included"} filter: ${f.field} = ${displayValue} (click to remove)`;
-      chip.addEventListener("click", () => {
-        removeFilter(f.field, f.value);
-        renderActiveFilters();
-      });
-    }
-    // Make the close glyph interactive and keyboard accessible (removes the filter)
-    close.setAttribute("role", "button");
-    close.setAttribute("tabindex", "0");
-    close.setAttribute("aria-label", `Remove filter ${displayValue}`);
-    // Helper to reset disposed filter to 'hide' (for chip × button)
-    const _resetDisposedFilter = function () {
-      const dfg = safeGetElement("disposedFilterGroup");
-      dfg.querySelectorAll(".chip-sort-btn").forEach(function (b) {
-        b.classList.toggle("active", b.dataset.disposedMode === "hide");
-      });
-      if (typeof saveData === "function") saveData("disposedFilterMode", "hide");
-      if (typeof renderTable === "function") renderTable();
-      renderActiveFilters();
-    };
-    close.onclick = (e) => {
-      e.stopPropagation();
-      if (f.field === "disposed-mode") {
-        _resetDisposedFilter();
-      } else if (isActiveFilter) {
-        // Active filter chip × — always removes the filter (de-activate, not exclude)
-        removeFilter(f.field, f.value);
-        renderActiveFilters();
-      } else if (f.count !== undefined && f.total !== undefined && f.field !== "search") {
-        // Idle summary chip × — exclude this value while keeping other filters intact
-        applyQuickFilter(
-          f.field,
-          f.value,
-          f.isGrouped || f.isCustomGroup || f.isDynamic || false,
-          true
-        );
-      } else {
-        removeFilter(f.field, f.value);
-        renderActiveFilters();
-      }
-    };
-    close.onkeydown = (e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        e.stopPropagation();
-        if (f.field === "disposed-mode") {
-          _resetDisposedFilter();
-        } else if (isActiveFilter) {
-          removeFilter(f.field, f.value);
-          renderActiveFilters();
-        } else if (f.count !== undefined && f.total !== undefined && f.field !== "search") {
-          applyQuickFilter(
-            f.field,
-            f.value,
-            f.isGrouped || f.isCustomGroup || f.isDynamic || false,
-            true
-          );
-        } else {
-          removeFilter(f.field, f.value);
-          renderActiveFilters();
-        }
-      }
-    };
-
-    container.appendChild(chip);
-  });
+  chips.forEach((f, i) => _buildFilterChipElement(f, i, container));
 
   // Add clear button if there are any chips (check for both active and summary chips)
   if (chips.length > 0) {
@@ -759,70 +880,53 @@ const renderActiveFilters = () => {
 const matchCoinSeries = (searchMetal, coinType, itemText, exactPhrase) => {
   const metalWords = ["gold", "silver", "platinum", "palladium"];
 
-  const checkNationalPrefix = (prefix) => {
-    const hasMetalBetween = metalWords.some(
-      (metal) => itemText.includes(`${prefix} ${metal} ${coinType}`) && !exactPhrase.includes(metal)
-    );
-    return !hasMetalBetween;
+  // Two-word coin-series disambiguation rules — mirrors search.js's `_COIN_SERIES`
+  // table-dispatch (filters.js keeps a function-local copy because both files are
+  // top-level script-tag globals and cannot share a module-scope `const`).
+  // `country` = origin prefix(es) that must not have an unrequested metal between
+  // them and the series word; `metalPhrase` = extra accepted phrase for
+  // metal-prefixed queries (maple leaf); `krugerSpecial` = krugerrand's
+  // dual-pattern origin check.
+  const series = {
+    eagle: { country: ["american"], metalPhrase: null },
+    maple: { country: ["canadian"], metalPhrase: (m) => `${m} maple leaf` },
+    britannia: { country: ["british"], metalPhrase: null },
+    krugerrand: { country: ["south", "african"], metalPhrase: null, krugerSpecial: true },
+    buffalo: { country: ["american"], metalPhrase: null },
+    panda: { country: ["chinese"], metalPhrase: null },
+    kangaroo: { country: ["australian"], metalPhrase: null },
   };
 
-  // Eagle series
-  if (coinType === "eagle") {
-    if (searchMetal === "american") return checkNationalPrefix("american");
-    if (metalWords.includes(searchMetal)) return itemText.includes(exactPhrase);
-  }
-  // Maple series
-  if (coinType === "maple") {
-    if (metalWords.includes(searchMetal)) {
-      return itemText.includes(exactPhrase) || itemText.includes(`${searchMetal} maple leaf`);
+  // True when itemText contains "<prefix> <metal> <coinType>" for a metal the
+  // query did not specify — i.e. an unrequested cross-metal match.
+  const hasMetalBetween = (prefix) =>
+    metalWords.some(
+      (metal) => itemText.includes(`${prefix} ${metal} ${coinType}`) && !exactPhrase.includes(metal)
+    );
+
+  const rule = series[coinType];
+  if (!rule) return null; // No series match — fall through to default logic
+
+  if (metalWords.includes(searchMetal)) {
+    if (rule.metalPhrase) {
+      return itemText.includes(exactPhrase) || itemText.includes(rule.metalPhrase(searchMetal));
     }
-    if (searchMetal === "canadian") return checkNationalPrefix("canadian");
+    return itemText.includes(exactPhrase);
   }
-  // Britannia series
-  if (coinType === "britannia") {
-    if (metalWords.includes(searchMetal)) return itemText.includes(exactPhrase);
-    if (searchMetal === "british") {
-      const hasMetalBetween = metalWords.some(
-        (metal) => itemText.includes(`british ${metal} britannia`) && !exactPhrase.includes(metal)
-      );
-      return !hasMetalBetween;
-    }
-  }
-  // Krugerrand series
-  if (coinType === "krugerrand") {
-    if (metalWords.includes(searchMetal)) return itemText.includes(exactPhrase);
-    if (searchMetal === "south" || searchMetal === "african") {
-      const hasMetalBetween = metalWords.some(
+
+  if (rule.country.includes(searchMetal)) {
+    if (rule.krugerSpecial) {
+      return !metalWords.some(
         (metal) =>
           (itemText.includes(`south african ${metal} krugerrand`) ||
             itemText.includes(`${metal} krugerrand`)) &&
           !exactPhrase.includes(metal)
       );
-      return !hasMetalBetween;
     }
-  }
-  // Buffalo series
-  if (coinType === "buffalo") {
-    if (metalWords.includes(searchMetal)) return itemText.includes(exactPhrase);
-    if (searchMetal === "american") return checkNationalPrefix("american");
-  }
-  // Panda series
-  if (coinType === "panda") {
-    if (metalWords.includes(searchMetal)) return itemText.includes(exactPhrase);
-    if (searchMetal === "chinese") return checkNationalPrefix("chinese");
-  }
-  // Kangaroo series
-  if (coinType === "kangaroo") {
-    if (metalWords.includes(searchMetal)) return itemText.includes(exactPhrase);
-    if (searchMetal === "australian") {
-      const hasMetalBetween = metalWords.some(
-        (metal) => itemText.includes(`australian ${metal} kangaroo`) && !exactPhrase.includes(metal)
-      );
-      return !hasMetalBetween;
-    }
+    return !hasMetalBetween(searchMetal);
   }
 
-  return null; // No series match — fall through to default logic
+  return null; // Recognized series but unrecognized prefix — fall through
 };
 
 /**
@@ -950,6 +1054,452 @@ const getItemSearchHaystack = (item, searchTags, formattedDate) => {
 };
 
 /**
+ * Filters by exact (simplified) name match.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected name values
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByName = (result, values, exclude) => {
+  const simplifiedValues = values.map((v) => simplifyChipValue(v, "name"));
+  return result.filter((item) => {
+    const itemName = simplifyChipValue(item.name || "", "name");
+    const match = simplifiedValues.includes(itemName);
+    return exclude ? !match : match;
+  });
+};
+
+/**
+ * Filters by metal (first composition words, case-insensitive).
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected metal values
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByMetal = (result, values, exclude) => {
+  const lowerVals = values.map((v) => v.toLowerCase());
+  return result.filter((item) => {
+    const itemMetal = getCompositionFirstWords(item.composition || item.metal || "").toLowerCase();
+    const match = lowerVals.includes(itemMetal);
+    return exclude ? !match : match;
+  });
+};
+
+/**
+ * Filters by exact type match.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected type values
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByType = (result, values, exclude) => {
+  return result.filter((item) => {
+    const match = values.includes(item.type);
+    return exclude ? !match : match;
+  });
+};
+
+/**
+ * Filters by payment method, normalizing empty values to the "—" placeholder.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected payment-method values
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByPaymentMethod = (result, values, exclude) => {
+  return result.filter((item) => {
+    const method = (item.paymentMethod || "").trim();
+    const normalized = !method ? "—" : method;
+    const match = values.includes(normalized);
+    return exclude ? !match : match;
+  });
+};
+
+/**
+ * Filters by a location field (purchaseLocation / storageLocation), normalizing
+ * empty / "Unknown" / "Numista Import" to the "—" placeholder.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected location values
+ * @param {boolean} exclude - Exclusion mode
+ * @param {string} field - The item field to read (`purchaseLocation`/`storageLocation`)
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByLocationField = (result, values, exclude, field) => {
+  return result.filter((item) => {
+    const loc = item[field];
+    const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
+    const match = values.includes(normalized);
+    return exclude ? !match : match;
+  });
+};
+
+/**
+ * Filters by tags (STAK-126/546): include requires ALL selected tags (AND);
+ * exclude removes items carrying ANY selected tag. No-op when getItemTags is absent.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected tag values
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByTags = (result, values, exclude) => {
+  if (typeof getItemTags !== "function") return result;
+  const lowerVals = values.map((v) => v.toLowerCase());
+  return result.filter((item) => {
+    const rawTags = getItemTags(item.uuid);
+    const itemTags = Array.isArray(rawTags) ? rawTags.map((t) => t.toLowerCase()) : [];
+    const matchAll = lowerVals.every((v) => itemTags.includes(v));
+    const matchAny = lowerVals.some((v) => itemTags.includes(v));
+    return exclude ? !matchAny : matchAll;
+  });
+};
+
+/**
+ * Filters by dynamic-name keys embedded in the item name as "(key)" or '"key"'.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected dynamic-name keys
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByDynamicName = (result, values, exclude) => {
+  return result.filter((item) => {
+    const name = item.name || "";
+    const matchAny = values.some(
+      (key) => name.includes("(" + key + ")") || name.includes('"' + key + '"')
+    );
+    return exclude ? !matchAny : matchAny;
+  });
+};
+
+/**
+ * Filters by grouped (normalized) base name, using autocomplete normalization when available.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected base names
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByGroupedName = (result, values, exclude) => {
+  return result.filter((item) => {
+    const matchAny = values.some((base) => {
+      if (window.autocomplete && typeof window.autocomplete.normalizeItemName === "function") {
+        return window.autocomplete.normalizeItemName(item.name || "") === base;
+      }
+      return (item.name || "") === base;
+    });
+    return exclude ? !matchAny : matchAny;
+  });
+};
+
+/**
+ * Generic fallback filter: case-insensitive exact match on an arbitrary field.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected values
+ * @param {boolean} exclude - Exclusion mode
+ * @param {string} field - The item field to compare
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByDefault = (result, values, exclude, field) => {
+  const lowerVals = values.map((v) => String(v).toLowerCase());
+  return result.filter((item) => {
+    const fieldVal = String(item[field] ?? "").toLowerCase();
+    const match = lowerVals.includes(fieldVal);
+    return exclude ? !match : match;
+  });
+};
+
+/**
+ * Routes a multi-value (array-criteria) active filter to its per-field handler.
+ * `_filterByCustomGroup` (regex-bearing) is defined near the file end and resolved
+ * here at call time.
+ * @param {Array<Object>} result - Items to filter
+ * @param {string} field - The active-filter field
+ * @param {Array<string>} values - Selected values
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _applyArrayFilter = (result, field, values, exclude) => {
+  switch (field) {
+    case "name":
+      return _filterByName(result, values, exclude);
+    case "metal":
+      return _filterByMetal(result, values, exclude);
+    case "type":
+      return _filterByType(result, values, exclude);
+    case "paymentMethod":
+      return _filterByPaymentMethod(result, values, exclude);
+    case "purchaseLocation":
+    case "storageLocation":
+      return _filterByLocationField(result, values, exclude, field);
+    case "tags":
+      return _filterByTags(result, values, exclude);
+    case "customGroup":
+      return _filterByCustomGroup(result, values, exclude);
+    case "dynamicName":
+      return _filterByDynamicName(result, values, exclude);
+    case "groupedName":
+      return _filterByGroupedName(result, values, exclude);
+    default:
+      return _filterByDefault(result, values, exclude, field);
+  }
+};
+
+/**
+ * Routes a scalar (non-array) active filter — the date-range fields.
+ * @param {Array<Object>} result - Items to filter
+ * @param {string} field - The active-filter field (`dateFrom`/`dateTo`)
+ * @param {string} value - The scalar criteria value
+ * @returns {Array<Object>} Filtered items
+ */
+const _applyScalarFilter = (result, field, value) => {
+  if (field === "dateFrom") return result.filter((item) => item.date >= value);
+  if (field === "dateTo") return result.filter((item) => item.date <= value);
+  return result;
+};
+
+/**
+ * Retrieves (or computes and caches) an item's search data: the lowercase
+ * haystack, formatted date, and catalog text. Upgrades legacy string-cache misses.
+ * @param {InventoryItem} item - The inventory item
+ * @returns {{ text: string, formattedDate: string, catalogText: string }}
+ */
+const _filterResolveSearchCache = (item) => {
+  let cached = searchCache.get(item);
+  if (!cached || typeof cached === "string") {
+    const _searchTags = typeof getItemTags === "function" ? getItemTags(item.uuid).join(" ") : "";
+    const _formattedDate = formatDisplayDate(item.date).toLowerCase();
+
+    // STRK-86: Delegate haystack assembly to getItemSearchHaystack so that
+    // filterInventoryAdvanced stays focused on filter orchestration only.
+    const itemText = getItemSearchHaystack(item, _searchTags, _formattedDate);
+
+    const _catalogText =
+      item.numistaData && typeof item.numistaData === "object"
+        ? collectNumistaStrings(item.numistaData).join(" ").toLowerCase()
+        : "";
+    cached = { text: itemText, formattedDate: _formattedDate, catalogText: _catalogText };
+    searchCache.set(item, cached);
+  }
+  return cached;
+};
+
+/**
+ * Tests whether a single search word matches any of an item's fields. Preserves
+ * the original OR chain's per-field guarding: the unguarded fields (metal / name /
+ * type / purchaseLocation) are regex-tested even when undefined (legacy coercion),
+ * while the remaining text fields are skipped when falsy. Date and numeric fields
+ * use substring (`includes`) matching; tags use word-boundary regex matching.
+ * @param {InventoryItem} item - The inventory item
+ * @param {RegExp} wordRegex - Pre-compiled word matcher for this word
+ * @param {string} word - The raw search word (for substring/number matching)
+ * @param {string} formattedDate - Pre-formatted display date (lowercase)
+ * @param {string} catalogText - Pre-flattened Numista catalog text (lowercase)
+ * @returns {boolean} True when the word matches any field
+ */
+const _filterFieldMatchesWord = (item, wordRegex, word, formattedDate, catalogText) => {
+  // Unguarded text fields — tested even when undefined (preserves legacy coercion).
+  const unguarded = [item.metal, item.name, item.type, item.purchaseLocation];
+  if (unguarded.some((f) => wordRegex.test(f))) return true;
+
+  // Guarded text fields — skipped when falsy.
+  const guarded = [
+    item.composition,
+    item.paymentMethod,
+    item.storageLocation,
+    item.notes,
+    item.capsule,
+    item.capsuleNotes,
+    item.year && String(item.year),
+    item.grade,
+    item.gradingAuthority,
+    item.certNumber && String(item.certNumber),
+    item.numistaId && String(item.numistaId),
+    item.serialNumber,
+    catalogText,
+  ];
+  if (guarded.some((f) => f && wordRegex.test(f))) return true;
+
+  // Date / numeric fields — substring match against the raw word.
+  const numericIncludes = [
+    item.date,
+    formattedDate,
+    String(Number.isFinite(Number(item.qty)) ? Number(item.qty) : ""),
+    String(Number.isFinite(Number(item.weight)) ? Number(item.weight) : ""),
+    String(Number.isFinite(Number(item.price)) ? Number(item.price) : ""),
+  ];
+  if (numericIncludes.some((f) => f.includes(word))) return true;
+
+  // Tags (word-boundary match against each tag).
+  return typeof getItemTags === "function" && getItemTags(item.uuid).some((t) => wordRegex.test(t));
+};
+
+/**
+ * Matches a single-word term: every compiled field regex must match some field,
+ * then falls back to custom chip-group label matching and fuzzy autocomplete.
+ * @param {Object} termData - Parsed term (q, words, compiledFieldRegexes)
+ * @param {InventoryItem} item - The inventory item
+ * @param {string} formattedDate - Pre-formatted display date (lowercase)
+ * @param {string} catalogText - Pre-flattened Numista catalog text (lowercase)
+ * @returns {boolean} True when the term matches the item
+ */
+const _filterMatchSingleWordTerm = (termData, item, formattedDate, catalogText) => {
+  const { q, words, compiledFieldRegexes } = termData;
+
+  // For single words, use word boundary matching with pre-compiled regexes
+  const fieldMatch = compiledFieldRegexes.every((wordRegex, index) =>
+    _filterFieldMatchesWord(item, wordRegex, words[index], formattedDate, catalogText)
+  );
+  if (fieldMatch) return true;
+
+  // STACK-23: Fall back to custom chip group label matching
+  if (typeof window.itemMatchesCustomGroupLabel === "function") {
+    return window.itemMatchesCustomGroupLabel(item, q);
+  }
+
+  // STACK-62: Fuzzy fallback — score item fields when exact matching fails
+  if (
+    typeof window.featureFlags !== "undefined" &&
+    window.featureFlags.isEnabled("FUZZY_AUTOCOMPLETE") &&
+    typeof fuzzyMatch === "function"
+  ) {
+    const fuzzyThreshold =
+      typeof AUTOCOMPLETE_CONFIG !== "undefined" ? AUTOCOMPLETE_CONFIG.threshold : 0.3;
+    const fieldsToCheck = [
+      item.name,
+      item.purchaseLocation,
+      item.storageLocation || "",
+      item.notes || "",
+      item.capsule || "",
+      item.capsuleNotes || "",
+    ];
+    for (const field of fieldsToCheck) {
+      if (field && fuzzyMatch(q, field, { threshold: fuzzyThreshold }) > 0) {
+        if (!window._fuzzyMatchUsed) window._fuzzyMatchUsed = true;
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Matches a multi-word (>=2) term: exact/expanded phrase, custom-group label,
+ * word-boundary presence, then coin-series, three-word, fractional-weight, and
+ * broad-origin disambiguation rules. Behavior preserved verbatim — including the
+ * unreachable single-word broad-origin guard (dead code; tracked in STRK-205).
+ * @param {Object} termData - Parsed term (q, words, exactPhrase, expandedPhrase, compiledWordRegexes)
+ * @param {InventoryItem} item - The inventory item
+ * @param {string} itemText - The lowercase item haystack
+ * @returns {boolean} True when the term matches the item
+ */
+const _filterMatchMultiWordTerm = (termData, item, itemText) => {
+  const { q, words, exactPhrase, expandedPhrase, compiledWordRegexes } = termData;
+
+  // Check for exact phrase match first
+  if (itemText.includes(exactPhrase)) {
+    return true;
+  }
+
+  // STACK-62: Check expanded abbreviation phrase (e.g. "ase 2024" → "american silver eagle 2024")
+  if (expandedPhrase !== exactPhrase && itemText.includes(expandedPhrase)) {
+    return true;
+  }
+
+  // STACK-23: Check custom chip group label matching for multi-word searches
+  if (
+    typeof window.itemMatchesCustomGroupLabel === "function" &&
+    window.itemMatchesCustomGroupLabel(item, q)
+  ) {
+    return true;
+  }
+
+  // For phrase searches like "American Eagle", be more restrictive
+  // Check that all words are present as word boundaries using pre-compiled regexes
+  const allWordsPresent = compiledWordRegexes.every((regex) => regex.test(itemText));
+
+  if (!allWordsPresent) {
+    return false;
+  }
+
+  // Prevent cross-metal matching for common coin series
+  if (words.length === 2) {
+    const seriesResult = matchCoinSeries(words[0], words[1], itemText, exactPhrase);
+    if (seriesResult !== null) return seriesResult;
+  }
+
+  // Handle three-word searches with special patterns
+  if (words.length === 3) {
+    // Handle "American Gold Eagle" type searches - these should be exact
+    const firstWord = words[0];
+    const middleWord = words[1];
+    const lastWord = words[2];
+
+    if (
+      ["american", "canadian", "british", "chinese", "australian", "south"].includes(firstWord) &&
+      ["gold", "silver", "platinum", "palladium"].includes(middleWord) &&
+      ["eagle", "maple", "britannia", "krugerrand", "buffalo", "panda", "kangaroo"].includes(
+        lastWord
+      )
+    ) {
+      // For "American Gold Eagle" type searches, require exact phrase or very close match
+      return (
+        itemText.includes(exactPhrase) ||
+        (lastWord === "maple" && itemText.includes(`${firstWord} ${middleWord} maple leaf`))
+      );
+    }
+  }
+
+  // Handle fractional weight searches to be more specific
+  // "1/4 oz" should be distinct from "1/2 oz" and "1 oz"
+  if (words.length >= 2) {
+    const hasFraction = words.some((word) => word.includes("/"));
+    const hasOz = words.some((word) => word === "oz" || word === "ounce");
+
+    if (hasFraction && hasOz) {
+      // For fractional searches, require exact phrase match
+      return itemText.includes(exactPhrase);
+    }
+  }
+
+  // Prevent overly broad country/origin searches
+  const broadTerms = [
+    "american",
+    "canadian",
+    "australian",
+    "british",
+    "chinese",
+    "south",
+    "mexican",
+  ];
+  if (words.length === 1 && broadTerms.includes(words[0])) {
+    // Single broad geographic terms should require additional context
+    // Return false to prevent matching everything from that country
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Matches one parsed search term against an item, routing to the multi-word or
+ * single-word matcher. Comma-separated terms are OR'd by the caller.
+ * @param {Object} termData - Parsed term descriptor
+ * @param {InventoryItem} item - The inventory item
+ * @param {string} itemText - The lowercase item haystack
+ * @param {string} formattedDate - Pre-formatted display date (lowercase)
+ * @param {string} catalogText - Pre-flattened Numista catalog text (lowercase)
+ * @returns {boolean} True when the term matches the item
+ */
+const _filterTermMatchesItem = (termData, item, itemText, formattedDate, catalogText) => {
+  // Special handling for multi-word searches to prevent partial matches.
+  // If searching for "American Eagle", it should only match items that have both
+  // words but NOT match "American Gold Eagle" (extra word in between).
+  if (termData.words.length >= 2) {
+    return _filterMatchMultiWordTerm(termData, item, itemText);
+  }
+  return _filterMatchSingleWordTerm(termData, item, formattedDate, catalogText);
+};
+
+/**
  * Enhanced filter inventory function that includes advanced filters.
  * Applies all active filters in `activeFilters` to the inventory.
  *
@@ -974,156 +1524,15 @@ const filterInventoryAdvanced = () => {
   }
   // 'show-all' → no filter applied
 
-  // Apply advanced filters
+  // Apply advanced filters — route each active filter to its per-field handler.
+  // STAK-551: scalar fields use OR (item matches ANY value); tags use AND (must
+  // carry ALL selected tags); expansion chips (customGroup/dynamicName/groupedName)
+  // resolve with OR; exclude mode hides items that match ANY value.
   Object.entries(activeFilters).forEach(([field, criteria]) => {
     if (criteria && typeof criteria === "object" && Array.isArray(criteria.values)) {
-      const { values, exclude } = criteria;
-      switch (field) {
-        // STAK-551: Scalar fields use OR (item matches if it equals ANY selected value).
-        // Tags use AND (item must carry ALL selected tags). Expansion chips
-        // (customGroup, dynamicName, groupedName) resolve at predicate time with OR.
-        // Exclude mode always uses !some (hide if item matches ANY value).
-        case "name": {
-          const simplifiedValues = values.map((v) => simplifyChipValue(v, field));
-          result = result.filter((item) => {
-            const itemName = simplifyChipValue(item.name || "", field);
-            const match = simplifiedValues.includes(itemName);
-            return exclude ? !match : match;
-          });
-          break;
-        }
-        case "metal": {
-          const lowerVals = values.map((v) => v.toLowerCase());
-          result = result.filter((item) => {
-            const itemMetal = getCompositionFirstWords(
-              item.composition || item.metal || ""
-            ).toLowerCase();
-            const match = lowerVals.includes(itemMetal);
-            return exclude ? !match : match;
-          });
-          break;
-        }
-        case "type":
-          result = result.filter((item) => {
-            const match = values.includes(item.type);
-            return exclude ? !match : match;
-          });
-          break;
-        case "paymentMethod":
-          result = result.filter((item) => {
-            const method = (item.paymentMethod || "").trim();
-            const normalized = !method ? "—" : method;
-            const match = values.includes(normalized);
-            return exclude ? !match : match;
-          });
-          break;
-        case "purchaseLocation":
-          result = result.filter((item) => {
-            const loc = item.purchaseLocation;
-            const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const match = values.includes(normalized);
-            return exclude ? !match : match;
-          });
-          break;
-        case "storageLocation":
-          result = result.filter((item) => {
-            const loc = item.storageLocation;
-            const normalized = !loc || loc === "Unknown" || loc === "Numista Import" ? "—" : loc;
-            const match = values.includes(normalized);
-            return exclude ? !match : match;
-          });
-          break;
-        case "tags": {
-          // STAK-126: Filter by item tags
-          // STAK-546: include AND across selected tags; exclude removes items carrying ANY
-          // selected tag (pre-STAK-546 exclude semantics preserved).
-          if (typeof getItemTags === "function") {
-            const lowerVals = values.map((v) => v.toLowerCase());
-            result = result.filter((item) => {
-              const rawTags = getItemTags(item.uuid);
-              const itemTags = Array.isArray(rawTags) ? rawTags.map((t) => t.toLowerCase()) : [];
-              const matchAll = lowerVals.every((v) => itemTags.includes(v));
-              const matchAny = lowerVals.some((v) => itemTags.includes(v));
-              return exclude ? !matchAny : matchAll;
-            });
-          }
-          break;
-        }
-        case "customGroup": {
-          const groups =
-            typeof window.loadCustomGroups === "function" ? window.loadCustomGroups() : [];
-          // Skip filter if none of the selected groupIds resolve to valid groups
-          const resolvedGroups = values
-            .map((id) => groups.find((g) => g.id === id))
-            .filter(Boolean);
-          if (resolvedGroups.length === 0) break;
-          // Precompile regex matchers once per filter pass (not per item)
-          const groupMatchers = resolvedGroups.map((group) => {
-            const patterns = Array.isArray(group.patterns) ? group.patterns : [];
-            return patterns.map((p) => {
-              try {
-                // nosemgrep: javascript.dos.rule-non-literal-regexp
-                const escaped = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                return new RegExp("\\b" + escaped + "\\b", "i");
-              } catch (e) {
-                return String(p).toLowerCase();
-              }
-            });
-          });
-          result = result.filter((item) => {
-            const itemName = (item.name || "").toLowerCase();
-            const matchAny = groupMatchers.some((matchers) =>
-              matchers.some((m) => (m instanceof RegExp ? m.test(itemName) : itemName.includes(m)))
-            );
-            return exclude ? !matchAny : matchAny;
-          });
-          break;
-        }
-        case "dynamicName": {
-          result = result.filter((item) => {
-            const name = item.name || "";
-            const matchAny = values.some(
-              (key) => name.includes("(" + key + ")") || name.includes('"' + key + '"')
-            );
-            return exclude ? !matchAny : matchAny;
-          });
-          break;
-        }
-        case "groupedName": {
-          result = result.filter((item) => {
-            const matchAny = values.some((base) => {
-              if (
-                window.autocomplete &&
-                typeof window.autocomplete.normalizeItemName === "function"
-              ) {
-                return window.autocomplete.normalizeItemName(item.name || "") === base;
-              }
-              return (item.name || "") === base;
-            });
-            return exclude ? !matchAny : matchAny;
-          });
-          break;
-        }
-        default: {
-          const lowerVals = values.map((v) => String(v).toLowerCase());
-          result = result.filter((item) => {
-            const fieldVal = String(item[field] ?? "").toLowerCase();
-            const match = lowerVals.includes(fieldVal);
-            return exclude ? !match : match;
-          });
-          break;
-        }
-      }
+      result = _applyArrayFilter(result, field, criteria.values, criteria.exclude);
     } else {
-      const value = criteria;
-      switch (field) {
-        case "dateFrom":
-          result = result.filter((item) => item.date >= value);
-          break;
-        case "dateTo":
-          result = result.filter((item) => item.date <= value);
-          break;
-      }
+      result = _applyScalarFilter(result, field, criteria);
     }
   });
 
@@ -1140,233 +1549,66 @@ const filterInventoryAdvanced = () => {
 
   // Pre-calculate search terms and hoist Regex compilation out of the filter loop.
   // This prevents O(N*M) recompilation overhead during large inventory renders.
-  const parsedTerms = terms.map((q) => {
-    const words = q.split(/\s+/).filter((w) => w.length > 0);
-    const exactPhrase = q;
-    let expandedPhrase = exactPhrase;
-    let compiledWordRegexes = [];
-    let compiledFieldRegexes = [];
-
-    if (words.length >= 2) {
-      const abbrevs = typeof METAL_ABBREVIATIONS !== "undefined" ? METAL_ABBREVIATIONS : {};
-      const expandedWords = words.map((w) => abbrevs[w.toLowerCase()] || w);
-      expandedPhrase = expandedWords.join(" ").toLowerCase();
-
-      // Compile regexes for strict word boundary checking
-      compiledWordRegexes = words.map((word) => {
-        // nosemgrep: javascript.dos.rule-non-literal-regexp
-        return new RegExp(`\\b${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
-      });
-    }
-
-    // Always compile field matching regexes with abbreviation expansion
-    const abbrevs = typeof METAL_ABBREVIATIONS !== "undefined" ? METAL_ABBREVIATIONS : {};
-    compiledFieldRegexes = words.map((word) => {
-      const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const patterns = [escaped];
-      const expansion = abbrevs[word.toLowerCase()];
-      if (expansion) {
-        patterns.push(expansion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-      }
-      const combined = patterns.join("|");
-      // nosemgrep: javascript.dos.rule-non-literal-regexp
-      return new RegExp(`\\b(?:${combined})`, "i");
-    });
-
-    return {
-      q,
-      words,
-      exactPhrase,
-      expandedPhrase,
-      compiledWordRegexes,
-      compiledFieldRegexes,
-    };
-  });
+  const parsedTerms = terms.map((q) => _filterBuildParsedTerm(q));
 
   return result.filter((item) => {
-    // Retrieve or compute cached search data
-    let cached = searchCache.get(item);
-
-    // Upgrade legacy cache (string) to object or handle cache miss
-    if (!cached || typeof cached === "string") {
-      const _searchTags = typeof getItemTags === "function" ? getItemTags(item.uuid).join(" ") : "";
-      const _formattedDate = formatDisplayDate(item.date).toLowerCase();
-
-      // STRK-86: Delegate haystack assembly to getItemSearchHaystack so that
-      // filterInventoryAdvanced stays focused on filter orchestration only.
-      const itemText = getItemSearchHaystack(item, _searchTags, _formattedDate);
-
-      const _catalogText =
-        item.numistaData && typeof item.numistaData === "object"
-          ? collectNumistaStrings(item.numistaData).join(" ").toLowerCase()
-          : "";
-      cached = { text: itemText, formattedDate: _formattedDate, catalogText: _catalogText };
-      searchCache.set(item, cached);
-    }
-
-    const { text: itemText, formattedDate, catalogText } = cached;
+    const { text: itemText, formattedDate, catalogText } = _filterResolveSearchCache(item);
 
     // Handle comma-separated terms (OR logic between comma terms)
-    return parsedTerms.some((termData) => {
-      const { q, words, exactPhrase, expandedPhrase, compiledWordRegexes, compiledFieldRegexes } =
-        termData;
-
-      // Special handling for multi-word searches to prevent partial matches
-      // If searching for "American Eagle", it should only match items that have both words
-      // but NOT match "American Gold Eagle" (which has an extra word in between)
-      if (words.length >= 2) {
-        // Check for exact phrase match first
-        if (itemText.includes(exactPhrase)) {
-          return true;
-        }
-
-        // STACK-62: Check expanded abbreviation phrase (e.g. "ase 2024" → "american silver eagle 2024")
-        if (expandedPhrase !== exactPhrase && itemText.includes(expandedPhrase)) {
-          return true;
-        }
-
-        // STACK-23: Check custom chip group label matching for multi-word searches
-        if (
-          typeof window.itemMatchesCustomGroupLabel === "function" &&
-          window.itemMatchesCustomGroupLabel(item, q)
-        ) {
-          return true;
-        }
-
-        // For phrase searches like "American Eagle", be more restrictive
-        // Check that all words are present as word boundaries using pre-compiled regexes
-        const allWordsPresent = compiledWordRegexes.every((regex) => regex.test(itemText));
-
-        if (!allWordsPresent) {
-          return false;
-        }
-
-        // Prevent cross-metal matching for common coin series
-        if (words.length === 2) {
-          const seriesResult = matchCoinSeries(words[0], words[1], itemText, exactPhrase);
-          if (seriesResult !== null) return seriesResult;
-        }
-
-        // Handle three-word searches with special patterns
-        if (words.length === 3) {
-          // Handle "American Gold Eagle" type searches - these should be exact
-          const firstWord = words[0];
-          const middleWord = words[1];
-          const lastWord = words[2];
-
-          if (
-            ["american", "canadian", "british", "chinese", "australian", "south"].includes(
-              firstWord
-            ) &&
-            ["gold", "silver", "platinum", "palladium"].includes(middleWord) &&
-            ["eagle", "maple", "britannia", "krugerrand", "buffalo", "panda", "kangaroo"].includes(
-              lastWord
-            )
-          ) {
-            // For "American Gold Eagle" type searches, require exact phrase or very close match
-            return (
-              itemText.includes(exactPhrase) ||
-              (lastWord === "maple" && itemText.includes(`${firstWord} ${middleWord} maple leaf`))
-            );
-          }
-        }
-
-        // Handle fractional weight searches to be more specific
-        // "1/4 oz" should be distinct from "1/2 oz" and "1 oz"
-        if (words.length >= 2) {
-          const hasFraction = words.some((word) => word.includes("/"));
-          const hasOz = words.some((word) => word === "oz" || word === "ounce");
-
-          if (hasFraction && hasOz) {
-            // For fractional searches, require exact phrase match
-            return itemText.includes(exactPhrase);
-          }
-        }
-
-        // Prevent overly broad country/origin searches
-        const broadTerms = [
-          "american",
-          "canadian",
-          "australian",
-          "british",
-          "chinese",
-          "south",
-          "mexican",
-        ];
-        if (words.length === 1 && broadTerms.includes(words[0])) {
-          // Single broad geographic terms should require additional context
-          // Return false to prevent matching everything from that country
-          return false;
-        }
-
-        return true;
-      }
-
-      // For single words, use word boundary matching with pre-compiled regexes
-      const fieldMatch = compiledFieldRegexes.every((wordRegex, index) => {
-        const word = words[index];
-
-        return (
-          wordRegex.test(item.metal) ||
-          (item.composition && wordRegex.test(item.composition)) ||
-          wordRegex.test(item.name) ||
-          wordRegex.test(item.type) ||
-          (item.paymentMethod && wordRegex.test(item.paymentMethod)) ||
-          wordRegex.test(item.purchaseLocation) ||
-          (item.storageLocation && wordRegex.test(item.storageLocation)) ||
-          (item.notes && wordRegex.test(item.notes)) ||
-          (item.capsule && wordRegex.test(item.capsule)) ||
-          (item.capsuleNotes && wordRegex.test(item.capsuleNotes)) ||
-          item.date.includes(word) ||
-          formattedDate.includes(word) ||
-          String(Number.isFinite(Number(item.qty)) ? Number(item.qty) : "").includes(word) ||
-          String(Number.isFinite(Number(item.weight)) ? Number(item.weight) : "").includes(word) ||
-          String(Number.isFinite(Number(item.price)) ? Number(item.price) : "").includes(word) ||
-          (item.year && wordRegex.test(String(item.year))) ||
-          (item.grade && wordRegex.test(item.grade)) ||
-          (item.gradingAuthority && wordRegex.test(item.gradingAuthority)) ||
-          (item.certNumber && wordRegex.test(String(item.certNumber))) ||
-          (item.numistaId && wordRegex.test(String(item.numistaId))) ||
-          (item.serialNumber && wordRegex.test(item.serialNumber)) ||
-          (typeof getItemTags === "function" &&
-            getItemTags(item.uuid).some((t) => wordRegex.test(t))) ||
-          (catalogText && wordRegex.test(catalogText))
-        );
-      });
-      if (fieldMatch) return true;
-
-      // STACK-23: Fall back to custom chip group label matching
-      if (typeof window.itemMatchesCustomGroupLabel === "function") {
-        return window.itemMatchesCustomGroupLabel(item, q);
-      }
-
-      // STACK-62: Fuzzy fallback — score item fields when exact matching fails
-      if (
-        typeof window.featureFlags !== "undefined" &&
-        window.featureFlags.isEnabled("FUZZY_AUTOCOMPLETE") &&
-        typeof fuzzyMatch === "function"
-      ) {
-        const fuzzyThreshold =
-          typeof AUTOCOMPLETE_CONFIG !== "undefined" ? AUTOCOMPLETE_CONFIG.threshold : 0.3;
-        const fieldsToCheck = [
-          item.name,
-          item.purchaseLocation,
-          item.storageLocation || "",
-          item.notes || "",
-          item.capsule || "",
-          item.capsuleNotes || "",
-        ];
-        for (const field of fieldsToCheck) {
-          if (field && fuzzyMatch(q, field, { threshold: fuzzyThreshold }) > 0) {
-            if (!window._fuzzyMatchUsed) window._fuzzyMatchUsed = true;
-            return true;
-          }
-        }
-      }
-
-      return false;
-    });
+    return parsedTerms.some((termData) =>
+      _filterTermMatchesItem(termData, item, itemText, formattedDate, catalogText)
+    );
   });
+};
+
+/**
+ * Toggles a single-value keyed filter (customGroup / dynamicName / groupedName).
+ * These expansion-chip filters store one value whose predicate expands at filter
+ * time. If the same value+exclude is already active the filter is removed
+ * (toggle-off); otherwise it replaces any existing entry.
+ *
+ * @param {string} filterKey - The `activeFilters` key to toggle
+ * @param {string} value - The value to store
+ * @param {boolean} exclude - Whether the filter runs in exclusion mode
+ */
+const _toggleKeyedFilter = (filterKey, value, exclude) => {
+  const existing = activeFilters[filterKey];
+  const isCurrentlyActive = !!(
+    existing &&
+    existing.values &&
+    existing.values.includes(value) &&
+    existing.exclude === exclude
+  );
+
+  if (isCurrentlyActive) {
+    delete activeFilters[filterKey];
+  } else {
+    activeFilters[filterKey] = { values: [value], exclude };
+  }
+};
+
+/**
+ * Toggles an individual value in or out of an accumulating multi-select filter
+ * (metal / type / tags). Removes the value when present, appends it otherwise,
+ * and deletes the whole filter once its last value is cleared.
+ *
+ * @param {string} field - The accumulating `activeFilters` field
+ * @param {string} value - The value to toggle within the set
+ * @param {boolean} exclude - Exclusion mode (carried onto the updated entry)
+ */
+const _accumulateFilterValue = (field, value, exclude) => {
+  const existing = activeFilters[field].values;
+  const idx = existing.indexOf(value);
+  if (idx !== -1) {
+    const updated = existing.filter((v) => v !== value);
+    if (updated.length === 0) {
+      delete activeFilters[field];
+    } else {
+      activeFilters[field] = { values: updated, exclude };
+    }
+  } else {
+    activeFilters[field] = { values: [...existing, value], exclude };
+  }
 };
 
 /**
@@ -1383,43 +1625,10 @@ const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
   // tags: AND in predicate (array — item has many, must match all selected).
   const isAccumulate = field === "tags" || field === "metal" || field === "type";
 
-  // Handle custom group chip click — store the group ID; predicate expands at filter time
-  if (field === "customGroup") {
-    // Toggle behavior: if same custom group filter is active, remove it
-    const cg = activeFilters["customGroup"];
-    const isCurrentlyActive = !!(
-      cg &&
-      cg.values &&
-      cg.values.includes(value) &&
-      cg.exclude === exclude
-    );
-
-    if (isCurrentlyActive) {
-      delete activeFilters["customGroup"];
-    } else {
-      activeFilters["customGroup"] = { values: [value], exclude };
-    }
-    renderTable();
-    renderActiveFilters();
-    return;
-  }
-
-  // Handle dynamic name chip click — store the key; predicate expands at filter time
-  if (field === "dynamicName") {
-    // Toggle behavior
-    const dn = activeFilters["dynamicName"];
-    const isCurrentlyActive = !!(
-      dn &&
-      dn.values &&
-      dn.values.includes(value) &&
-      dn.exclude === exclude
-    );
-
-    if (isCurrentlyActive) {
-      delete activeFilters["dynamicName"];
-    } else {
-      activeFilters["dynamicName"] = { values: [value], exclude };
-    }
+  // Handle expansion-chip clicks (customGroup / dynamicName) — store the key;
+  // predicate expands at filter time. Toggle on repeat click.
+  if (field === "customGroup" || field === "dynamicName") {
+    _toggleKeyedFilter(field, value, exclude);
     renderTable();
     renderActiveFilters();
     return;
@@ -1440,33 +1649,10 @@ const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
     window.featureFlags.isEnabled("GROUPED_NAME_CHIPS")
   ) {
     // Handle grouped name filtering — store the base name; predicate expands at filter time
-    const gn = activeFilters["groupedName"];
-    const isCurrentlyActive = !!(
-      gn &&
-      gn.values &&
-      gn.values.includes(value) &&
-      gn.exclude === exclude
-    );
-
-    if (isCurrentlyActive) {
-      delete activeFilters["groupedName"];
-    } else {
-      activeFilters["groupedName"] = { values: [value], exclude };
-    }
+    _toggleKeyedFilter("groupedName", value, exclude);
   } else if (isAccumulate && activeFilters[field] && activeFilters[field].exclude === exclude) {
     // Accumulate: toggle individual values in/out of the active set
-    const existing = activeFilters[field].values;
-    const idx = existing.indexOf(value);
-    if (idx !== -1) {
-      const updated = existing.filter((v) => v !== value);
-      if (updated.length === 0) {
-        delete activeFilters[field];
-      } else {
-        activeFilters[field] = { values: updated, exclude };
-      }
-    } else {
-      activeFilters[field] = { values: [...existing, value], exclude };
-    }
+    _accumulateFilterValue(field, value, exclude);
   } else {
     // Single-select fields, first click, or switching exclude mode: replace
     activeFilters[field] = { values: [value], exclude };
@@ -1484,6 +1670,98 @@ const applyQuickFilter = (field, value, isGrouped = false, exclude = false) => {
  */
 const applyColumnFilter = (field, value) => {
   applyQuickFilter(field, value);
+};
+
+// ── Regex-bearing filter helpers (kept last in the file to avoid the Lizard
+//    regex-tokenization desync that can roll an extracted helper's CCN into a
+//    following function — see [[lizard-esc-regex-desync]]). ──
+
+/**
+ * Filters by custom-group membership (STAK-551): resolves selected group IDs to
+ * groups, precompiles each pattern to a word-boundary RegExp (falling back to a
+ * lowercase substring on invalid patterns), and matches item names against ANY
+ * pattern. No-op when no selected ID resolves to a group.
+ * @param {Array<Object>} result - Items to filter
+ * @param {Array<string>} values - Selected custom-group IDs
+ * @param {boolean} exclude - Exclusion mode
+ * @returns {Array<Object>} Filtered items
+ */
+const _filterByCustomGroup = (result, values, exclude) => {
+  const groups = typeof window.loadCustomGroups === "function" ? window.loadCustomGroups() : [];
+  // Skip filter if none of the selected groupIds resolve to valid groups
+  const resolvedGroups = values.map((id) => groups.find((g) => g.id === id)).filter(Boolean);
+  if (resolvedGroups.length === 0) return result;
+  // Precompile regex matchers once per filter pass (not per item)
+  const groupMatchers = resolvedGroups.map((group) => {
+    const patterns = Array.isArray(group.patterns) ? group.patterns : [];
+    return patterns.map((p) => {
+      try {
+        // nosemgrep: javascript.dos.rule-non-literal-regexp
+        const escaped = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        return new RegExp("\\b" + escaped + "\\b", "i");
+      } catch (e) {
+        return String(p).toLowerCase();
+      }
+    });
+  });
+  return result.filter((item) => {
+    const itemName = (item.name || "").toLowerCase();
+    const matchAny = groupMatchers.some((matchers) =>
+      matchers.some((m) => (m instanceof RegExp ? m.test(itemName) : itemName.includes(m)))
+    );
+    return exclude ? !matchAny : matchAny;
+  });
+};
+
+/**
+ * Parses one search term into its matcher descriptor, hoisting all RegExp
+ * compilation out of the per-item filter loop. Multi-word terms also precompile
+ * strict word-boundary regexes and an abbreviation-expanded phrase.
+ * @param {string} q - A single (comma-split) search term, lowercased and trimmed
+ * @returns {{q: string, words: string[], exactPhrase: string, expandedPhrase: string,
+ *   compiledWordRegexes: RegExp[], compiledFieldRegexes: RegExp[]}} Parsed term descriptor
+ */
+const _filterBuildParsedTerm = (q) => {
+  const words = q.split(/\s+/).filter((w) => w.length > 0);
+  const exactPhrase = q;
+  let expandedPhrase = exactPhrase;
+  let compiledWordRegexes = [];
+  let compiledFieldRegexes = [];
+
+  if (words.length >= 2) {
+    const abbrevs = typeof METAL_ABBREVIATIONS !== "undefined" ? METAL_ABBREVIATIONS : {};
+    const expandedWords = words.map((w) => abbrevs[w.toLowerCase()] || w);
+    expandedPhrase = expandedWords.join(" ").toLowerCase();
+
+    // Compile regexes for strict word boundary checking
+    compiledWordRegexes = words.map((word) => {
+      // nosemgrep: javascript.dos.rule-non-literal-regexp
+      return new RegExp(`\\b${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
+    });
+  }
+
+  // Always compile field matching regexes with abbreviation expansion
+  const abbrevs = typeof METAL_ABBREVIATIONS !== "undefined" ? METAL_ABBREVIATIONS : {};
+  compiledFieldRegexes = words.map((word) => {
+    const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const patterns = [escaped];
+    const expansion = abbrevs[word.toLowerCase()];
+    if (expansion) {
+      patterns.push(expansion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    }
+    const combined = patterns.join("|");
+    // nosemgrep: javascript.dos.rule-non-literal-regexp
+    return new RegExp(`\\b(?:${combined})`, "i");
+  });
+
+  return {
+    q,
+    words,
+    exactPhrase,
+    expandedPhrase,
+    compiledWordRegexes,
+    compiledFieldRegexes,
+  };
 };
 
 // Export functions for global access

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.22-b1781629280";
+const CACHE_NAME = "staktrakr-v3.35.22-b1781637195";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/playwright/core/inventory-crud.spec.js
+++ b/tests/playwright/core/inventory-crud.spec.js
@@ -2278,3 +2278,122 @@ test.describe("filter-chip-and-logic — AND semantics", () => {
     expect(await dataRowCount(page)).toBe(1);
   });
 });
+
+// ─── Coin-series cross-metal disambiguation (STRK-170 cohort 2.4 char tests) ──
+// Pins filterInventoryAdvanced's two-word coin-series matching — the live,
+// testable twin of search.js's _COIN_SERIES fallback (which is shadowed by the
+// filterInventory→filterInventoryAdvanced delegation and could not be covered in
+// cohort 2.5). These guard the behavior-preserving conversion of `matchCoinSeries`
+// to a `_COIN_SERIES` table-dispatch: they pass on the pre-refactor if-cascade and
+// must stay green after the table replaces it.
+
+const COIN_SERIES_UUIDS = {
+  AGE: "strk170-american-gold-eagle",
+  ASE: "strk170-american-silver-eagle",
+  AE: "strk170-american-eagle-bare",
+  SML: "strk170-silver-maple-leaf",
+  GML: "strk170-gold-maple-leaf",
+};
+
+const coinSeriesItem = (uuid, name, metal) => ({
+  uuid,
+  metal,
+  composition: metal,
+  name,
+  qty: 1,
+  type: "Coin",
+  weight: 1,
+  price: 50,
+  marketValue: 0,
+  date: "2025-01-01",
+  purchaseLocation: "staktrakr.com",
+  storageLocation: "",
+  serialNumber: "",
+  notes: "",
+  year: "2025",
+  grade: "",
+  gradingAuthority: "",
+  certNumber: "",
+  pcgsNumber: "",
+  pcgsVerified: false,
+  spotPriceAtPurchase: 45,
+  premiumPerOz: 0,
+  totalPremium: 0,
+  purity: 0.999,
+  numistaId: "",
+});
+
+const COIN_SERIES_INVENTORY = [
+  coinSeriesItem(COIN_SERIES_UUIDS.AGE, "American Gold Eagle", "Gold"),
+  coinSeriesItem(COIN_SERIES_UUIDS.ASE, "American Silver Eagle", "Silver"),
+  coinSeriesItem(COIN_SERIES_UUIDS.AE, "American Eagle", "Silver"),
+  coinSeriesItem(COIN_SERIES_UUIDS.SML, "Silver Maple Leaf", "Silver"),
+  coinSeriesItem(COIN_SERIES_UUIDS.GML, "Gold Maple Leaf", "Gold"),
+];
+
+test.describe("filter-coin-series — cross-metal disambiguation (STRK-170)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((inv) => {
+      localStorage.setItem("metalInventory", JSON.stringify(inv));
+    }, COIN_SERIES_INVENTORY);
+    await page.addInitScript(() => {
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          if (typeof APP_VERSION !== "undefined") {
+            localStorage.setItem("ackVersion", APP_VERSION);
+          }
+        },
+        { once: true }
+      );
+    });
+    await page.goto("/index.html");
+    await page.waitForFunction(
+      () =>
+        typeof window.filterInventory === "function" &&
+        typeof window.filterInventoryAdvanced === "function"
+    );
+    await page.waitForFunction(() => {
+      try {
+        return window.filterInventoryAdvanced().length === 5;
+      } catch (e) {
+        return false;
+      }
+    });
+  });
+
+  // Fill the search box and resolve once the live filter settles to expectedLen.
+  const searchUuids = async (page, term, expectedLen) => {
+    await page.fill("#searchInput", term);
+    await page.waitForFunction((len) => {
+      try {
+        return window.filterInventory().length === len;
+      } catch (e) {
+        return false;
+      }
+    }, expectedLen);
+    return page.evaluate(() => window.filterInventory().map((item) => item.uuid));
+  };
+
+  test('"silver eagle" matches the silver eagle only (not the gold eagle)', async ({ page }) => {
+    const uuids = await searchUuids(page, "silver eagle", 1);
+    expect(uuids).toEqual([COIN_SERIES_UUIDS.ASE]);
+  });
+
+  test('"gold eagle" matches the gold eagle only (not the silver eagle)', async ({ page }) => {
+    const uuids = await searchUuids(page, "gold eagle", 1);
+    expect(uuids).toEqual([COIN_SERIES_UUIDS.AGE]);
+  });
+
+  test('"american eagle" matches the bare American Eagle, not the metal-prefixed eagles', async ({
+    page,
+  }) => {
+    const uuids = await searchUuids(page, "american eagle", 1);
+    expect(uuids).toEqual([COIN_SERIES_UUIDS.AE]);
+  });
+
+  test('"silver maple" matches the silver maple leaf only (metalPhrase rule)', async ({ page }) => {
+    const uuids = await searchUuids(page, "silver maple", 1);
+    expect(uuids).toEqual([COIN_SERIES_UUIDS.SML]);
+  });
+});


### PR DESCRIPTION
## STRK-170 cohort 2.4 — `js/filters.js` complexity refactor

Behavior-preserving decomposition of the **7** Codacy Cloud Lizard Tier-1 targets in `js/filters.js`. **No user-facing change; unbumped** (no-bump campaign — the single closing `/release patch` bumps once all cohorts merge).

Sketch: `DocVault/Projects/StakTrakr/sketches/STRK-170-tier1-complexity-refactor/` · Issue: STRK-170.

### Targets (authoritative — Codacy Cloud, `--tools Lizard --branch dev`)
| Function | Before (ccn) | After |
|---|---|---|
| `generateCategorySummary` `@148` per-item loop | 33 | flat loop over 8 `_tally*` helpers |
| `renderActiveFilters` `@313` | 27 | `_buildCategoryFilterChips` + `_applyChipMaxCount` + `_appendActiveFilterChips` |
| chip builder `@543` | 48 | `_buildFilterChipElement` + 7 sub-helpers |
| field-dispatch `@978` (`filterInventoryAdvanced`) | 42 | 10 `_filterBy*` helpers + `_applyArrayFilter` switch |
| multi-word matcher `@1210` | 35 | `_filterMatchMultiWordTerm` |
| field-OR-chain `@1306` | 40 | `_filterFieldMatchesWord` |
| `applyQuickFilter` `@1380` | 32 | `_toggleKeyedFilter` + `_accumulateFilterValue` |

Local lizard reports **0** over-gate functions; ESLint + Prettier clean.

### What changed (behavior-preserving)
- **Category tally** — the 11-branch per-item counting loop collapses to a flat sequence of guarded `_tally*` helpers (locations key on the untrimmed original; others on the trimmed value — preserved exactly).
- **Chip render** — the per-chip DOM builder is now `_buildFilterChipElement` + interaction helpers. DRY wins: the duplicated disposed-filter reset became one `_resetDisposedFilter`, and the byte-identical `onclick`/`onkeydown` close bodies became one `_chipCloseAction`. DOM output is byte-stable.
- **Filter dispatch** — each active-filter field routes through `_applyArrayFilter`. `tags` keeps its **asymmetric** exclude semantics (include = `matchAll`/AND, exclude = `!matchAny`); `purchaseLocation`/`storageLocation` share one `item[field]` helper.
- **Search matchers** — `@1306`'s 22-condition OR chain becomes array `.some()` groups that **preserve each field's original guard** (unguarded metal/name/type/purchaseLocation keep their legacy coercion; the rest stay falsy-guarded).
- **Coin-series** — `matchCoinSeries` converted to the `_COIN_SERIES` table-dispatch used by search.js (cohort 2.5). A **function-local** table, because both files are top-level script-tag globals and cannot share a module-scope `const`.
- All extracted helpers carry JSDoc (D-7). Regex-bearing helpers (`_filterByCustomGroup`, `_filterBuildParsedTerm`) kept **last** in the file ([[lizard-esc-regex-desync]] precaution).

### Tests
The coin-series logic was **deferred to here** from cohort 2.5 (search.js's fallback is shadowed by the `filterInventory → filterInventoryAdvanced` delegation and can't be reached from a test seam). This file *is* the delegated target, so it's drivable via the search box:
- **4 new characterization tests** in `core/inventory-crud.spec.js` (`filter-coin-series` block) pin the cross-metal disambiguation (`silver eagle` ≠ gold eagle; bare `american eagle` ≠ metal-prefixed; `silver maple` metalPhrase rule) — **green pre- AND post-refactor**.

`npm test` **248 passing** (244 prior + 4 new). Bonus `extended/visual-layout-regressions` 7/7 (chip-DOM byte-stability). Not a required render cohort (no D-8 gate per the sketch), but the visual spec was run anyway given the chip-render changes.

### Notes
- **STRK-205** (single-word broad-origin search suppression is dead code) is preserved **verbatim** — not folded into this behavior-preserving cohort.
- No coverage-map row: the char tests extend an existing active spec (no new spec file).
- Complexity gated on the **Codacy Cloud PR check** per the campaign recipe.
