### PR TITLE
v3.35.24 — STRK-214: bulk image cache init failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.35.24] - 2026-06-17
+
+### Changed — STRK-214: Bulk image cache startup failures now complete cleanly
+
+- **Bulk image cache**: Bulk image caching now catches image cache initialization failures and routes them through the normal completion callback with one failed startup result, so the image cache modal can reset controls and show a clear failure instead of leaving Sync All stuck (STRK-214).
+
+---
+
 ## [3.35.23] - 2026-06-16
 
 ### Changed — STRK-170: Tier-1 complexity refactor (cohorts 1.1–3.9)

--- a/js/about.js
+++ b/js/about.js
@@ -134,11 +134,11 @@ const setupWhatsNewPopupEvents = () => {};
 
 const getEmbeddedWhatsNew = () => {
   return `
+    <li><strong>v3.35.24 &ndash; STRK-214: Bulk image cache startup failure fixed</strong>: Bulk image caching now treats image cache startup failures as a handled completion instead of leaving the Sync All controls stuck. If local image storage cannot initialize, the sync reports one failed startup with a clear error and resets the modal controls without attempting catalog lookups or saves (STRK-214).</li>
     <li><strong>v3.35.23 &ndash; STRK-170: Code-health complexity refactor</strong>: Reorganized 19 of StakTrakr's most complex core modules &mdash; inventory editing, import/backup/restore, the vault, market &amp; retail views, the sync diff, charts, and CSV export &mdash; into smaller, well-documented helpers. An under-the-hood maintainability pass with no change to how anything looks, behaves, or stores your data, making future features and fixes faster and safer to land (STRK-170).</li>
     <li><strong>v3.35.22 &ndash; STRK-193: Diff-modal cleanup</strong>: Removed roughly 200 lines of unreachable code left behind by the recent diff-modal refactor &mdash; an internal tidy-up with no change to how the sync data-comparison view looks or behaves (STRK-193).</li>
     <li><strong>v3.35.21 &ndash; STRK-169: Codebase modularization complete</strong>: Wrapped up a multi-release cleanup that split StakTrakr's largest source files into smaller, focused modules &mdash; the final and trickiest piece reorganized the sync data-comparison view and removed duplicated rendering code, with no change to how anything looks or behaves. This release also makes the price publisher self-cleaning so a full server disk can no longer stall price updates (STRK-169, STRK-187).</li>
     <li><strong>v3.35.20 &ndash; STRK-190: Offline cache freshness fixed</strong>: The app's offline cache now correctly recognizes live price endpoints, so cached prices respect their intended shelf life &mdash; previously every API response was served from cache without an age check, which could show old prices after time away (STRK-190).</li>
-    <li><strong>v3.35.19 &ndash; STRK-189: Stale spot prices rejected</strong>: Spot sync now checks each payload's publication timestamp &mdash; an hours-old price from a cache or stale server can no longer flash over a fresh one, pollute your price history with wrongly-dated entries, or overwrite a newer price; history entries now carry the price's actual publication time (STRK-189).</li>
   `;
 };
 

--- a/js/bulk-image-cache.js
+++ b/js/bulk-image-cache.js
@@ -15,6 +15,7 @@
 const BulkImageCache = (() => {
   let _aborted = false;
   let _running = false;
+  let _starting = false;
 
   /**
    * Resolves catalog ID for an inventory item.
@@ -75,23 +76,40 @@ const BulkImageCache = (() => {
    * @returns {Promise<{ok:boolean, error:string}>} Availability status for cacheAll.
    */
   async function ensureImageCacheReady() {
-    if (!window.imageCache) {
+    const cache = typeof window !== "undefined" ? window.imageCache : null;
+    if (!cache || typeof cache.isAvailable !== "function") {
       return { ok: false, error: "Image cache is not available" };
     }
-    if (!imageCache.isAvailable()) {
+    if (!cache.isAvailable()) {
       try {
-        await imageCache.init();
+        if (typeof cache.init !== "function") {
+          return { ok: false, error: "Image cache is not available" };
+        }
+        await cache.init();
       } catch (err) {
         return {
           ok: false,
           error: `Image cache initialization failed: ${err?.message || err}`,
         };
       }
-      if (!imageCache.isAvailable()) {
+      if (!cache.isAvailable()) {
         return { ok: false, error: "Image cache is not available" };
       }
     }
     return { ok: true, error: "" };
+  }
+
+  /**
+   * Build a completion summary using the current elapsed time.
+   * @param {{synced:number, skipped:number, failed:number, apiLookups:number}} totals
+   * @param {number} startTime
+   * @param {string} [error]
+   * @returns {{synced:number, skipped:number, failed:number, apiLookups:number, elapsed:number, error?:string}}
+   */
+  function buildCompletion(totals, startTime, error) {
+    const completion = { ...totals, elapsed: Date.now() - startTime };
+    if (error) completion.error = error;
+    return completion;
   }
 
   /**
@@ -360,58 +378,64 @@ const BulkImageCache = (() => {
     delay = 200,
     respectEdits = false,
   } = {}) {
-    if (_running) return;
-    const startTime = Date.now();
-    const readiness = await ensureImageCacheReady();
-    if (!readiness.ok) {
-      if (onComplete) {
-        onComplete({
-          synced: 0,
-          skipped: 0,
-          failed: 1,
-          apiLookups: 0,
-          elapsed: Date.now() - startTime,
-          error: readiness.error,
-        });
-      }
-      return;
-    }
-
-    _running = true;
+    if (_starting || _running) return;
+    _starting = true;
     _aborted = false;
 
+    const startTime = Date.now();
     const totals = { synced: 0, skipped: 0, failed: 0, apiLookups: 0 };
+    let completion = null;
 
-    const entries = buildEligibleList();
-    const total = entries.length;
-    const catalogIdToUuids = buildCatalogIdToUuids();
-
-    for (let i = 0; i < entries.length; i++) {
-      if (_aborted) break;
-
-      if (onProgress) {
-        onProgress({ current: i + 1, total, catalogId: entries[i].catalogId });
+    try {
+      const readiness = await ensureImageCacheReady();
+      if (!readiness.ok) {
+        completion = buildCompletion(
+          { synced: 0, skipped: 0, failed: 1, apiLookups: 0 },
+          startTime,
+          readiness.error
+        );
+        return;
       }
 
-      const delta = await processEntry(entries[i], catalogIdToUuids, respectEdits, onLog);
-      totals.synced += delta.synced;
-      totals.skipped += delta.skipped;
-      totals.failed += delta.failed;
-      totals.apiLookups += delta.apiLookups;
+      _running = true;
 
-      // Delay between requests to avoid rate-limiting
-      if (i < entries.length - 1 && !_aborted) {
-        await new Promise((r) => setTimeout(r, delay));
+      const entries = buildEligibleList();
+      const total = entries.length;
+      const catalogIdToUuids = buildCatalogIdToUuids();
+
+      for (let i = 0; i < entries.length; i++) {
+        if (_aborted) break;
+
+        if (onProgress) {
+          onProgress({ current: i + 1, total, catalogId: entries[i].catalogId });
+        }
+
+        const delta = await processEntry(entries[i], catalogIdToUuids, respectEdits, onLog);
+        totals.synced += delta.synced;
+        totals.skipped += delta.skipped;
+        totals.failed += delta.failed;
+        totals.apiLookups += delta.apiLookups;
+
+        // Delay between requests to avoid rate-limiting
+        if (i < entries.length - 1 && !_aborted) {
+          await new Promise((r) => setTimeout(r, delay));
+        }
       }
-    }
 
-    _running = false;
-
-    persistLoopResults(totals);
-
-    const elapsed = Date.now() - startTime;
-    if (onComplete) {
-      onComplete({ ...totals, elapsed });
+      persistLoopResults(totals);
+      completion = buildCompletion(totals, startTime);
+    } catch (err) {
+      totals.failed++;
+      completion = buildCompletion(totals, startTime, err?.message || String(err));
+    } finally {
+      _running = false;
+      try {
+        if (completion && onComplete) {
+          await onComplete(completion);
+        }
+      } finally {
+        _starting = false;
+      }
     }
   }
 

--- a/js/bulk-image-cache.js
+++ b/js/bulk-image-cache.js
@@ -72,15 +72,26 @@ const BulkImageCache = (() => {
   /**
    * Ensure the IndexedDB image cache is available, re-opening it if the browser
    * closed the connection (storage pressure, backgrounding).
-   * @returns {Promise<boolean>} true when the cache can be used.
+   * @returns {Promise<{ok:boolean, error:string}>} Availability status for cacheAll.
    */
   async function ensureImageCacheReady() {
-    if (!window.imageCache) return false;
-    if (!imageCache.isAvailable()) {
-      await imageCache.init();
-      if (!imageCache.isAvailable()) return false;
+    if (!window.imageCache) {
+      return { ok: false, error: "Image cache is not available" };
     }
-    return true;
+    if (!imageCache.isAvailable()) {
+      try {
+        await imageCache.init();
+      } catch (err) {
+        return {
+          ok: false,
+          error: `Image cache initialization failed: ${err?.message || err}`,
+        };
+      }
+      if (!imageCache.isAvailable()) {
+        return { ok: false, error: "Image cache is not available" };
+      }
+    }
+    return { ok: true, error: "" };
   }
 
   /**
@@ -337,7 +348,7 @@ const BulkImageCache = (() => {
    * loaded on-demand when the user opens the view modal.
    * @param {Object} opts
    * @param {function({current:number, total:number, catalogId:string}):void} [opts.onProgress]
-   * @param {function({synced:number, skipped:number, failed:number, apiLookups:number, elapsed:number}):void} [opts.onComplete]
+   * @param {function({synced:number, skipped:number, failed:number, apiLookups:number, elapsed:number, error?:string}):void} [opts.onComplete]
    * @param {function({catalogId:string, status:string, message:string}):void} [opts.onLog]
    * @param {number} [opts.delay=200] - Delay (ms) between network requests
    * @returns {Promise<void>}
@@ -350,12 +361,25 @@ const BulkImageCache = (() => {
     respectEdits = false,
   } = {}) {
     if (_running) return;
-    if (!(await ensureImageCacheReady())) return;
+    const startTime = Date.now();
+    const readiness = await ensureImageCacheReady();
+    if (!readiness.ok) {
+      if (onComplete) {
+        onComplete({
+          synced: 0,
+          skipped: 0,
+          failed: 1,
+          apiLookups: 0,
+          elapsed: Date.now() - startTime,
+          error: readiness.error,
+        });
+      }
+      return;
+    }
 
     _running = true;
     _aborted = false;
 
-    const startTime = Date.now();
     const totals = { synced: 0, skipped: 0, failed: 0, apiLookups: 0 };
 
     const entries = buildEligibleList();

--- a/js/constants.js
+++ b/js/constants.js
@@ -305,7 +305,7 @@ const CERT_LOOKUP_URLS = {
  * Updated: 2026-05-12 - STRK-66: Add ¼ Goldback denomination (Idaho, g0.25)
  */
 
-const APP_VERSION = "3.35.23";
+const APP_VERSION = "3.35.24";
 
 /**
  * Numista metadata cache TTL: 30 days in milliseconds.

--- a/js/image-cache-modal.js
+++ b/js/image-cache-modal.js
@@ -319,14 +319,16 @@ const startBulkSync = async () => {
       };
       logSyncActivity(`${catalogId}: ${message}`, logTypeMap[status] || "info");
     },
-    onComplete: async ({ synced, skipped, failed, apiLookups, elapsed }) => {
+    onComplete: async ({ synced, skipped, failed, apiLookups, elapsed, error }) => {
       if (startBtn) startBtn.disabled = false;
       if (cancelBtn) cancelBtn.style.display = "none";
       if (progressBar) progressBar.style.display = "none";
 
       const secs = (elapsed / 1000).toFixed(1);
-      let msg = `Complete in ${secs}s: ${synced} synced, ${skipped} skipped, ${failed} failed`;
-      if (apiLookups > 0) msg += `, ${apiLookups} API calls`;
+      let msg = error
+        ? `Failed in ${secs}s: ${error}`
+        : `Complete in ${secs}s: ${synced} synced, ${skipped} skipped, ${failed} failed`;
+      if (!error && apiLookups > 0) msg += `, ${apiLookups} API calls`;
       msg += ".";
       logSyncActivity(msg, failed > 0 ? "warn" : "success");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staktrakr",
-  "version": "3.35.23",
+  "version": "3.35.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staktrakr",
-      "version": "3.35.23",
+      "version": "3.35.24",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staktrakr",
   "private": true,
-  "version": "3.35.23",
+  "version": "3.35.24",
   "license": "MIT",
   "type": "module",
   "description": "Precious metals inventory tracker",

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.23-b1781657498";
+const CACHE_NAME = "staktrakr-v3.35.24-b1781659215";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.24-b1781659215";
+const CACHE_NAME = "staktrakr-v3.35.24-b1781660673";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/bulk-image-cache.test.js
+++ b/tests/unit/bulk-image-cache.test.js
@@ -111,11 +111,49 @@ describe("BulkImageCache.cacheAll() — observable behavior (STRK-170 cohort 3.2
     };
   }
 
-  test("no-op (no result) when window.imageCache is absent", async () => {
+  test("cache readiness failure reports a completion error when imageCache is absent", async () => {
     const mod = loadModule(baseEnv({ imageCache: undefined, inventory: [] }));
-    let completed = false;
-    await mod.cacheAll(opts({ onComplete: () => (completed = true) }));
-    assert.equal(completed, false, "onComplete must not fire with no imageCache");
+    let summary = null;
+    await mod.cacheAll(opts({ onComplete: (s) => (summary = s) }));
+    assert.ok(summary, "onComplete fired");
+    assert.equal(summary.synced, 0);
+    assert.equal(summary.skipped, 0);
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.apiLookups, 0);
+    assert.match(summary.error, /image cache/i);
+    assert.equal(progress.length, 0, "no progress before cache readiness");
+    assert.equal(saveItemTagsCalls, 0, "saveItemTags not called");
+    assert.equal(saveInventoryCalls, 0, "saveInventory not called");
+  });
+
+  test("rejected imageCache.init resolves cacheAll and reports one completion error", async () => {
+    const imageCache = {
+      isAvailable: () => false,
+      init: async () => {
+        throw new Error("init boom");
+      },
+      getMetadata: async () => null,
+      cacheMetadata: async () => {},
+    };
+    const mod = loadModule(baseEnv({ imageCache, inventory: [{ uuid: "u1", numistaId: "100" }] }));
+    let summary = null;
+    let rejected = null;
+    try {
+      await mod.cacheAll(opts({ onComplete: (s) => (summary = s) }));
+    } catch (err) {
+      rejected = err;
+    }
+    assert.equal(rejected, null, "cacheAll resolves instead of rejecting");
+    assert.ok(summary, "onComplete fired");
+    assert.equal(summary.synced, 0);
+    assert.equal(summary.skipped, 0);
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.apiLookups, 0);
+    assert.match(summary.error, /init boom/);
+    assert.equal(progress.length, 0, "no progress before cache readiness");
+    assert.equal(saveItemTagsCalls, 0, "saveItemTags not called");
+    assert.equal(saveInventoryCalls, 0, "saveInventory not called");
+    assert.equal(mod.isRunning(), false, "running flag never sticks after readiness failure");
   });
 
   test("empty inventory reports an all-zero summary", async () => {

--- a/tests/unit/bulk-image-cache.test.js
+++ b/tests/unit/bulk-image-cache.test.js
@@ -30,15 +30,21 @@ function loadModule(env) {
   // window.catalogAPI, window.catalogManager). Mirror the doubles onto both the
   // bare scope and the fake window so every access path resolves.
   const inventory = env.inventory ?? [];
+  const windowImageCache = Object.prototype.hasOwnProperty.call(env, "windowImageCache")
+    ? env.windowImageCache
+    : env.imageCache;
+  const bareImageCache = Object.prototype.hasOwnProperty.call(env, "bareImageCache")
+    ? env.bareImageCache
+    : env.imageCache;
   const win = {
-    imageCache: env.imageCache,
+    imageCache: windowImageCache,
     catalogAPI: env.catalogAPI,
     catalogManager: env.catalogManager,
   };
   const scope = {
     window: win,
     inventory,
-    imageCache: env.imageCache,
+    imageCache: bareImageCache,
     catalogManager: env.catalogManager,
     catalogAPI: env.catalogAPI,
     applyNumistaTags: env.applyNumistaTags,
@@ -67,6 +73,20 @@ function makeImageCache(seedMeta = {}) {
       store.set(id, data);
     },
   };
+}
+
+/**
+ * Create a manually controlled Promise for async lifecycle assertions.
+ * @returns {{promise: Promise<void>, resolve: function():void, reject: function(Error):void}}
+ */
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("BulkImageCache.cacheAll() — observable behavior (STRK-170 cohort 3.2)", () => {
@@ -112,21 +132,42 @@ describe("BulkImageCache.cacheAll() — observable behavior (STRK-170 cohort 3.2
   }
 
   test("cache readiness failure reports a completion error when imageCache is absent", async () => {
-    const mod = loadModule(baseEnv({ imageCache: undefined, inventory: [] }));
+    let lookups = 0;
+    const catalogAPI = {
+      lookupItem: async () => {
+        lookups++;
+        return null;
+      },
+    };
+    const mod = loadModule(
+      baseEnv({ imageCache: undefined, inventory: [{ uuid: "u1", numistaId: "100" }], catalogAPI })
+    );
     let summary = null;
-    await mod.cacheAll(opts({ onComplete: (s) => (summary = s) }));
+    let completions = 0;
+    await mod.cacheAll(
+      opts({
+        onComplete: (s) => {
+          completions++;
+          summary = s;
+        },
+      })
+    );
     assert.ok(summary, "onComplete fired");
+    assert.equal(completions, 1, "onComplete fired exactly once");
     assert.equal(summary.synced, 0);
     assert.equal(summary.skipped, 0);
     assert.equal(summary.failed, 1);
     assert.equal(summary.apiLookups, 0);
     assert.match(summary.error, /image cache/i);
     assert.equal(progress.length, 0, "no progress before cache readiness");
+    assert.equal(lookups, 0, "catalog lookup not called before cache readiness");
     assert.equal(saveItemTagsCalls, 0, "saveItemTags not called");
     assert.equal(saveInventoryCalls, 0, "saveInventory not called");
+    assert.equal(mod.isRunning(), false, "running flag never sticks after readiness failure");
   });
 
   test("rejected imageCache.init resolves cacheAll and reports one completion error", async () => {
+    let lookups = 0;
     const imageCache = {
       isAvailable: () => false,
       init: async () => {
@@ -135,25 +176,59 @@ describe("BulkImageCache.cacheAll() — observable behavior (STRK-170 cohort 3.2
       getMetadata: async () => null,
       cacheMetadata: async () => {},
     };
-    const mod = loadModule(baseEnv({ imageCache, inventory: [{ uuid: "u1", numistaId: "100" }] }));
+    const catalogAPI = {
+      lookupItem: async () => {
+        lookups++;
+        return null;
+      },
+    };
+    const mod = loadModule(
+      baseEnv({ imageCache, inventory: [{ uuid: "u1", numistaId: "100" }], catalogAPI })
+    );
     let summary = null;
+    let completions = 0;
     let rejected = null;
     try {
-      await mod.cacheAll(opts({ onComplete: (s) => (summary = s) }));
+      await mod.cacheAll(
+        opts({
+          onComplete: (s) => {
+            completions++;
+            summary = s;
+          },
+        })
+      );
     } catch (err) {
       rejected = err;
     }
     assert.equal(rejected, null, "cacheAll resolves instead of rejecting");
     assert.ok(summary, "onComplete fired");
+    assert.equal(completions, 1, "onComplete fired exactly once");
     assert.equal(summary.synced, 0);
     assert.equal(summary.skipped, 0);
     assert.equal(summary.failed, 1);
     assert.equal(summary.apiLookups, 0);
     assert.match(summary.error, /init boom/);
     assert.equal(progress.length, 0, "no progress before cache readiness");
+    assert.equal(lookups, 0, "catalog lookup not called before cache readiness");
     assert.equal(saveItemTagsCalls, 0, "saveItemTags not called");
     assert.equal(saveInventoryCalls, 0, "saveInventory not called");
     assert.equal(mod.isRunning(), false, "running flag never sticks after readiness failure");
+  });
+
+  test("cache readiness uses the guarded window.imageCache reference", async () => {
+    const imageCache = makeImageCache();
+    const mod = loadModule(
+      baseEnv({
+        windowImageCache: imageCache,
+        bareImageCache: undefined,
+        inventory: [],
+      })
+    );
+    let summary = null;
+    await mod.cacheAll(opts({ onComplete: (s) => (summary = s) }));
+    assert.ok(summary, "onComplete fired");
+    assert.equal(summary.failed, 0);
+    assert.equal(summary.error, undefined);
   });
 
   test("empty inventory reports an all-zero summary", async () => {
@@ -277,6 +352,108 @@ describe("BulkImageCache.cacheAll() — observable behavior (STRK-170 cohort 3.2
     assert.equal(mod.isRunning(), false);
     await mod.cacheAll(opts());
     assert.equal(mod.isRunning(), false, "running flag reset after completion");
+  });
+
+  test("concurrent starts while cache readiness is pending do not run two syncs", async () => {
+    const initStarted = deferred();
+    const initGate = deferred();
+    let available = false;
+    let initCalls = 0;
+    let lookups = 0;
+    const imageCache = {
+      isAvailable: () => available,
+      init: async () => {
+        initCalls++;
+        initStarted.resolve();
+        await initGate.promise;
+        available = true;
+      },
+      getMetadata: async () => null,
+      cacheMetadata: async () => {},
+    };
+    const catalogAPI = {
+      lookupItem: async (id) => {
+        lookups++;
+        return { id, tags: [] };
+      },
+    };
+    const mod = loadModule(
+      baseEnv({ imageCache, inventory: [{ uuid: "u1", numistaId: "100" }], catalogAPI })
+    );
+    const completions = [];
+
+    const first = mod.cacheAll(
+      opts({ onComplete: (s) => completions.push({ run: "first", summary: s }) })
+    );
+    await initStarted.promise;
+    assert.equal(mod.isRunning(), false, "readiness guard does not expose a running sync");
+
+    await mod.cacheAll(
+      opts({ onComplete: (s) => completions.push({ run: "second", summary: s }) })
+    );
+    assert.equal(initCalls, 1, "second call did not start another readiness init");
+    assert.equal(lookups, 0, "sync loop waits for the first readiness pass");
+
+    initGate.resolve();
+    await first;
+    assert.equal(lookups, 1, "only one sync loop ran");
+    assert.equal(completions.length, 1, "only the accepted run completed");
+    assert.equal(completions[0].run, "first");
+    assert.equal(completions[0].summary.synced, 1);
+    assert.equal(mod.isRunning(), false, "running flag reset after the accepted run");
+  });
+
+  test("unexpected processing errors reset running and report a completion failure", async () => {
+    const imageCache = {
+      isAvailable: () => true,
+      init: async () => {},
+      getMetadata: async () => {
+        throw new Error("metadata boom");
+      },
+      cacheMetadata: async () => {},
+    };
+    const catalogAPI = {
+      lookupItem: async () => ({ tags: [] }),
+    };
+    const mod = loadModule(
+      baseEnv({ imageCache, inventory: [{ uuid: "u1", numistaId: "100" }], catalogAPI })
+    );
+    const completeStarted = deferred();
+    const completeGate = deferred();
+    let summary = null;
+    let callbackFinished = false;
+    let settled = false;
+
+    const run = mod.cacheAll(
+      opts({
+        onComplete: async (s) => {
+          summary = s;
+          assert.equal(mod.isRunning(), false, "running is reset before onComplete");
+          completeStarted.resolve();
+          await completeGate.promise;
+          callbackFinished = true;
+        },
+      })
+    );
+    run.then(() => {
+      settled = true;
+    });
+
+    await completeStarted.promise;
+    assert.equal(settled, false, "cacheAll awaits async onComplete");
+    completeGate.resolve();
+    await run;
+
+    assert.equal(callbackFinished, true, "async onComplete finished before cacheAll resolved");
+    assert.ok(summary, "onComplete fired");
+    assert.equal(summary.synced, 0);
+    assert.equal(summary.skipped, 0);
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.apiLookups, 0);
+    assert.match(summary.error, /metadata boom/);
+    assert.equal(saveItemTagsCalls, 0, "saveItemTags not called after processing error");
+    assert.equal(saveInventoryCalls, 0, "saveInventory not called after processing error");
+    assert.equal(mod.isRunning(), false, "running flag reset after processing error");
   });
 
   test("abort stops the loop early (second item not processed)", async () => {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.35.23",
-  "releaseDate": "2026-06-16",
+  "version": "3.35.24",
+  "releaseDate": "2026-06-17",
   "releaseUrl": "https://github.com/lbruton/StakTrakr/releases/latest"
 }


### PR DESCRIPTION
> **Draft — QA preview.** Merge to `dev` after review.

## Summary

- Fixes `BulkImageCache.cacheAll()` startup/readiness failures so a rejected `imageCache.init()` resolves through `onComplete` instead of rejecting and leaving controls stuck.
- Adds an optional completion `error` payload for readiness failures and logs it in the image cache modal while preserving the existing control reset path.
- Bumps StakTrakr to `v3.35.24`; `sw.js` was stamped by the pre-commit hook.

## Issue

- STRK-214: bulk-image-cache: `imageCache.init()` rejection leaves `cacheAll` UI stuck

## Test Plan

- [x] `node --test tests/unit/bulk-image-cache.test.js`
- [x] `npm run test:unit`
- [x] `npm run lint`
- [x] `npm run lint:md:changed`
- [x] `npm test` — 270 passed

## Test Inventory Delta

- `+1 -0` unit tests
- `+0 -0` Playwright files

## Pre-PR Checks

| Check                           | Status | Detail |
| ------------------------------- | ------ | ------ |
| 1. Version bump                 | PASS   | `3.35.23` to `3.35.24` |
| 2. SW + index.html registration | PASS   | No new JS files in this branch |
| 3. Duplicate functions          | WARN   | Skipped; `js/events.js` and `js/api.js` unchanged |
| 4. DocVault                     | WARN   | Broad historical references to changed files exist; no doc update needed for this focused bug fix |
| 5. Codacy                       | WARN   | One pre-existing High issue in `sw-router.js:125`, outside changed files |
