### PR TITLE
chore(docs): fix PBKDF2 iteration count + check-release-sync inputs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -234,7 +234,7 @@ When any version-related file changes, verify every version-bearing file matches
 | `js/about.js`              | `getEmbeddedWhatsNew()` version |
 | `data/spot-history-*.json` | Seed data should be refreshed   |
 
-If only some files are updated, flag the missing ones. The `check-release-sync` pre-commit hook validates only a **subset** -- `constants.js`, `package.json`, `version.json`, `CHANGELOG.md`, and the `js/about.js` What's New entry -- so a green hook does **not** mean the release is complete (`sw.js` cache is not hook-checked). `manifest.json` carries no version field; do not flag it for version sync.
+If only some files are updated, flag the missing ones. The `check-release-sync` pre-commit hook validates only a **subset** -- `constants.js`, `package.json`, `version.json`, `CHANGELOG.md`, and the `js/about.js` What's New entry (asserting the current-version <li> is present and enforcing the 5-entry cap; STRK-194, #1262) -- so a green hook does **not** mean the release is complete (`sw.js` cache and README badges are not hook-checked). `manifest.json` carries no version field; do not flag it for version sync.
 
 **Version Lock**: Multiple AI agents work concurrently on this repo. A `devops/version.lock`
 file (gitignored) is used as a mutual-exclusion token. If you see an orphaned lock file in a

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -234,7 +234,7 @@ When any version-related file changes, verify every version-bearing file matches
 | `js/about.js`              | `getEmbeddedWhatsNew()` version |
 | `data/spot-history-*.json` | Seed data should be refreshed   |
 
-If only some files are updated, flag the missing ones. The `check-release-sync` pre-commit hook validates only a **subset** -- `constants.js`, `package.json`, `package-lock.json`, `version.json`, `CHANGELOG.md` -- so a green hook does **not** mean the release is complete (`about.js` and `sw.js` are not hook-checked). `manifest.json` carries no version field; do not flag it for version sync.
+If only some files are updated, flag the missing ones. The `check-release-sync` pre-commit hook validates only a **subset** -- `constants.js`, `package.json`, `version.json`, `CHANGELOG.md`, and the `js/about.js` What's New entry -- so a green hook does **not** mean the release is complete (`sw.js` cache is not hook-checked). `manifest.json` carries no version field; do not flag it for version sync.
 
 **Version Lock**: Multiple AI agents work concurrently on this repo. A `devops/version.lock`
 file (gitignored) is used as a mutual-exclusion token. If you see an orphaned lock file in a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ After saving a catalog key, call `catalogAPI.initializeProviders()` to refresh s
 
 ### `check-release-sync` hook is a SUBSET
 
-Validates `constants.js ↔ package.json ↔ package-lock.json ↔ version.json ↔ CHANGELOG.md`, plus the `js/about.js` What's New block — it asserts the current-version `<li>` entry is present **and** enforces the 5-entry cap (STRK-194, #1262).
+Validates `constants.js ↔ package.json ↔ version.json ↔ CHANGELOG.md`, plus the `js/about.js` What's New block — it asserts the current-version `<li>` entry is present **and** enforces the 5-entry cap (STRK-194, #1262).
 Does not check `manifest.json`, README badges, or `sw.js` cache.
 **Hook green ≠ release complete.**
 `/release` is the only path that touches all release-bearing files.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Four card styles (sparkline header, full-bleed image, split layout, accessible t
 
 ### Cloud Sync — Encrypted, Zero-Knowledge
 
-Connect Dropbox via OAuth PKCE and sync an encrypted `.stvault` across devices. AES-256-GCM + PBKDF2-SHA256 (100,000 iterations) via the Web Crypto API — the cloud provider only ever receives ciphertext. Bi-directional sync with conflict detection; a **DiffModal** for visual item-level and settings-level review with click-to-pick field selection; encrypted image vault for photo sync; BroadcastChannel leader election prevents concurrent multi-tab races; multi-account switching; backup-before-overwrite with configurable history depth. Google Drive, OneDrive, pCloud, and Box are coming (same encryption, all client-side).
+Connect Dropbox via OAuth PKCE and sync an encrypted `.stvault` across devices. AES-256-GCM + PBKDF2-SHA256 (600,000 iterations) via the Web Crypto API — the cloud provider only ever receives ciphertext. Bi-directional sync with conflict detection; a **DiffModal** for visual item-level and settings-level review with click-to-pick field selection; encrypted image vault for photo sync; BroadcastChannel leader election prevents concurrent multi-tab races; multi-account switching; backup-before-overwrite with configurable history depth. Google Drive, OneDrive, pCloud, and Box are coming (same encryption, all client-side).
 
 ### Data Tools — Import, Export, Backup, Bulk Edit
 
@@ -124,7 +124,7 @@ Two optional integrations enhance the experience: a free [Numista API](https://e
 
 - **No server-side component** — the developer has no technical means to access your data.
 - **No cookies, no tracking SDKs, no advertising** — only localStorage and IndexedDB are used for your data.
-- **Cloud backup is zero-knowledge** — AES-256-GCM + PBKDF2-SHA256 (100,000 iterations); the cloud provider receives only ciphertext.
+- **Cloud backup is zero-knowledge** — AES-256-GCM + PBKDF2-SHA256 (600,000 iterations); the cloud provider receives only ciphertext.
 - **localStorage caveat** — browser storage can be cleared. Export ZIP or vault backups regularly, especially on iOS Safari.
 - Cloudflare Web Analytics runs on the hosted site (aggregated, anonymous page-views only — not present when running locally).
 


### PR DESCRIPTION
Doc-correctness follow-ups from the **2026-06-16 `/vault-drift` audit**. All changes source-verified at HEAD (v3.35.23). No runtime code touched — lightweight docs chore, no Plane issue.

## Changes

| File | Fix | Source of truth |
|------|-----|-----------------|
| `README.md` (×2) | PBKDF2-SHA256 **"100,000 iterations" → "600,000 iterations"** | `VAULT_PBKDF2_ITERATIONS = 600000` (`js/vault.js:23`) |
| `CLAUDE.md` | Drop `package-lock.json` from the `check-release-sync` input list | `devops/hooks/check-release-sync.sh` validates `constants.js`, `version.json`, `package.json`, `CHANGELOG.md`, `js/about.js` only |
| `.github/copilot-instructions.md` | Same `package-lock.json` removal **+** correct the stale "about.js is not hook-checked" claim | Hook greps `about.js` for the What's New `<li>` and enforces the 5-entry cap (STRK-194, #1262) |

## Why

- The README's **100K** iteration figure understated the real cloud-backup security parameter by 6× — a user-facing factual error in the privacy/security copy.
- Two instruction files listed `package-lock.json` as a release-sync gate it never checks, which would mislead an agent during a release. The `about.js` claim in the Copilot file additionally contradicted the current hook behavior.

## Verification

- Hook claims checked directly against `devops/hooks/check-release-sync.sh`.
- Iteration count grep-confirmed against `js/vault.js`.
- Pre-commit hooks (secret scan, markdown lint, prettier, signing) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)