### PR TITLE
chore(STRK-210): remove dead rById/rSet maps in diff-modal.js merge helpers

### DIFF
--- a/js/diff-modal.js
+++ b/js/diff-modal.js
@@ -2026,15 +2026,10 @@
     var lArr = Array.isArray(localVal) ? localVal : [];
     var rArr = Array.isArray(remoteVal) ? remoteVal : [];
     var lById = {};
-    var rById = {};
     var i, id;
     for (i = 0; i < lArr.length; i++) {
       id = lArr[i].id || lArr[i].label || i;
       lById[id] = lArr[i];
-    }
-    for (i = 0; i < rArr.length; i++) {
-      id = rArr[i].id || rArr[i].label || i;
-      rById[id] = rArr[i];
     }
     // Preserve original array order — use remote array as base order (default wins),
     // then append any local-only items at the end
@@ -2112,12 +2107,10 @@
   function _mergeSlugChips(prefix, localVal, remoteVal) {
     if (!Array.isArray(localVal) && !Array.isArray(remoteVal)) return null;
     var lSet = {};
-    var rSet = {};
     var lList = Array.isArray(localVal) ? localVal : [];
     var rList = Array.isArray(remoteVal) ? remoteVal : [];
     var i;
     for (i = 0; i < lList.length; i++) lSet[lList[i]] = true;
-    for (i = 0; i < rList.length; i++) rSet[rList[i]] = true;
     var mergedArr = [];
     var slugSeen = {};
     // First pass: iterate remote array in order (default wins)

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.26-b1781738790";
+const CACHE_NAME = "staktrakr-v3.35.26-b1781742585";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## What

Removes two pre-existing built-but-never-read maps in the `js/diff-modal.js` setting-merge helpers:

- `_mergeChipStrip()` built an `rById` map that nothing ever read — the merge iterates `rArr` directly and only consults `lById`.
- `_mergeSlugChips()` built an `rSet` set that nothing ever read — only `lSet` is consulted.

7-line, behavior-neutral excision (no additions). The live `lById`/`lSet` reads, the merge loops, and the loop counters are untouched.

## Why

Dead code surfaced — and preserved verbatim — by the STRK-170 cohort 2.3 complexity refactor (#1276), which was behavior-preserving and intentionally deferred the cleanup. ESLint never flagged these because property assignment (`rById[id] = ...`) counts as a "use" of the variable; only a manual liveness trace confirms they are dead.

Resolves STRK-210.

## Testing

- `tests/playwright/core/diff-modal-merge.spec.js` — 11/11 green (the cohort-2.3 characterization spec; covers chip-strip default + per-element local-pick and slug-chips local-only-append, i.e. the exact `lById`/`lSet` consumption paths).
- `npm test` (core gate) — 281/281 green.
- `npm run lint` — clean.

## Release

No version bump — behavior-neutral chore, no user-facing change. `dev` stays at 3.35.26. (`sw.js` cache stamp re-stamped by the standard pre-commit hook; version unchanged.)