### PR TITLE
chore(docs): broaden CLAUDE.md coverage-map rule to match AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ npm run format:check
 - Before editing or running Playwright tests, read the Playwright policy reference in `AGENTS.md`.
 - Archived issue acceptance-criteria (AC) matrices are located in
   `tests/playwright/archive/issue-ac-matrices/`.
-- Any PR that touches Playwright tests — adding, renaming, or removing a spec, **or adding/removing test cases in an existing spec** — must update `tests/playwright/coverage-map.csv` (an `AGENTS.md` requirement, broader than "new spec"). Neither ESLint nor `check-release-sync` catches a missing or stale row; only review does.
+- A PR that touches Playwright tests must update `tests/playwright/coverage-map.csv` (`AGENTS.md` requirement). No local gate catches a missing row — only review does.
+  - "Touches" covers test-case changes inside an existing spec, not just spec-file additions, renames, or removals.
 
 ## Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run format:check
 - Before editing or running Playwright tests, read the Playwright policy reference in `AGENTS.md`.
 - Archived issue acceptance-criteria (AC) matrices are located in
   `tests/playwright/archive/issue-ac-matrices/`.
-- Any PR that adds, renames, or removes a Playwright spec must update `tests/playwright/coverage-map.csv` (an `AGENTS.md` requirement) — neither ESLint nor `check-release-sync` catches a missing or stale row.
+- Any PR that touches Playwright tests — adding, renaming, or removing a spec, **or adding/removing test cases in an existing spec** — must update `tests/playwright/coverage-map.csv` (an `AGENTS.md` requirement, broader than "new spec"). Neither ESLint nor `check-release-sync` catches a missing or stale row; only review does.
 
 ## Documentation
 


### PR DESCRIPTION
## What

Broaden the CLAUDE.md "Playwright Test Tier Rules" coverage-map requirement to match AGENTS.md.

CLAUDE.md scoped the `tests/playwright/coverage-map.csv` update to a PR that "adds, renames, or removes a Playwright spec" — narrower than AGENTS.md line 61 ("When a PR touches Playwright tests, update coverage-map.csv"). The narrow phrasing led the STRK-211/212 work (#1291) to skip the coverage-map row for a new test *case* in an existing spec; Codex flagged it P1 in review.

## Change

One line in CLAUDE.md — now explicitly covers test cases added to an existing spec, and notes that only review catches a missing row (no local gate does).

Docs-only chore: no code, no version bump, no Plane issue.