### PR TITLE
fix(STRK-230): bypass Webscale reCAPTCHA on JM Bullion + Provident via wspc cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ devops/firecrawl-docker/
 # Must NOT follow worktrees: copies would conflict every bump and break the claim.
 devops/version.lock
 
+# Webscale wspc cookie store (STRK-230) — holds live bot-clearance cookies.
+# Never commit. On the home poller WEBSCALE_COOKIE_FILE points outside the repo;
+# this guard catches the module-local default too.
+webscale-cookies.json
+
 # Playwright test artifacts
 test-results/
 playwright-report/

--- a/devops/pollers/home-poller/run-home.sh
+++ b/devops/pollers/home-poller/run-home.sh
@@ -24,6 +24,19 @@ if [ -f "$SCRIPT_DIR/.env" ]; then
   set +a
 fi
 
+# STRK-230: cron runs `. /etc/environment` before this script, but plain
+# assignments sourced that way are NOT exported, so this child script (→ node)
+# never sees them. Re-export ONLY the WEBSCALE_* cookie vars from the container
+# env so price-extract.js can inject the wspc cookie for JM/Provident. Scoped to
+# WEBSCALE_* deliberately, to leave every other var's behavior untouched.
+if [ -f /etc/environment ]; then
+  while IFS= read -r _line; do
+    case "$_line" in
+      WEBSCALE_*=*) export "${_line}" ;;
+    esac
+  done < /etc/environment
+fi
+
 DATE=$(date -u +%Y-%m-%d)
 echo "[$(date -u +%H:%M:%S)] Starting home retail price run for $DATE"
 

--- a/devops/pollers/home-poller/sync-from-fly.sh
+++ b/devops/pollers/home-poller/sync-from-fly.sh
@@ -25,6 +25,7 @@ SHARED_FILES=(
   price-extract-vendor-legacy.js
   price-extract-vendor-goldback.js
   price-extract-vendor-apmex.js
+  webscale-cookies.js
   api-export.js
   capture.js
   extract-vision.js

--- a/devops/pollers/shared/price-extract-deploy-manifest.test.mjs
+++ b/devops/pollers/shared/price-extract-deploy-manifest.test.mjs
@@ -24,6 +24,7 @@ const expectedRuntimeModules = [
   "price-extract-vendor-legacy.js",
   "price-extract-vendor-goldback.js",
   "price-extract-vendor-apmex.js",
+  "webscale-cookies.js",
 ];
 
 const readRepoFile = (relativePath) => readFileSync(join(repoRoot, relativePath), "utf8");

--- a/devops/pollers/shared/price-extract-provider-config.js
+++ b/devops/pollers/shared/price-extract-provider-config.js
@@ -42,14 +42,26 @@ const LEGACY_PROVIDER_OVERRIDES = {
     retryOn408: false, // page either renders in time or does not
   },
   jmbullion: {
-    phase: "phase0", // Playwright-direct first; Byparr reserved as fallback
-    // JM's CF tier upgraded beyond Byparr's 45s window around 2026-04-23;
-    // fresh-session Byparr gets a harder challenge than a long-lived poller browser.
+    phase: "phase0", // Playwright-direct with an injected wspc cookie (STRK-230)
+    // NOT Cloudflare: JM Bullion + Provident (shared A-Mark/JMB front end) sit
+    // behind Webscale "Protection Mode" — Google reCAPTCHA v2 on product pages.
+    // Byparr/cf_clearance cannot solve it. The bypass is a cloned ~7-day `wspc`
+    // cookie injected in scrapeWithPlaywrightDirect (see webscale-cookies.js).
+    // The old "JM CF tier upgraded 2026-04-23" note was a misdiagnosis.
     waitFor: 10_000,
     timeout: 40_000,
     onlyMainContent: false, // React pages return empty with onlyMainContent
     retryOn408: false, // retrying will not help; skip to save about 40s
-    cf_clearance_fallback: true,
+    cf_clearance_fallback: false, // Byparr is the wrong tool for Webscale reCAPTCHA
+    fractionalExempt: true, // mega-menu lists fractional coins on every page
+  },
+  providentmetals: {
+    phase: "phase0", // Same Webscale reCAPTCHA as jmbullion — wspc cookie bypass (STRK-230)
+    waitFor: 10_000,
+    timeout: 40_000,
+    onlyMainContent: false, // React pages return empty with onlyMainContent
+    retryOn408: false,
+    cf_clearance_fallback: false, // Byparr cannot solve Webscale reCAPTCHA
     fractionalExempt: true, // mega-menu lists fractional coins on every page
   },
   bullionexchanges: {

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -554,7 +554,7 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     // so Firecrawl/FBP can take over rather than extracting garbage (STRK-230).
     if (looksLikeWebscaleChallenge(text)) {
       warn(
-        `  (playwright-direct) ⚠️ WEBSCALE CHALLENGE for ${providerId} (${urlObj.hostname}) — wspc cookie missing/stale, RE-SOLVE NEEDED: node webscale-cookies.js set ${urlObj.hostname} <wspc> "<UA>"`
+        `  (playwright-direct) ⚠️ WEBSCALE CHALLENGE for ${providerId} (${urlObj.hostname}) — wspc cookie missing/stale, RE-SOLVE NEEDED: run webscale-solve.mjs (or webscale-cookies.js set ${urlObj.hostname} <wspc> "<UA>")`
       );
       return null;
     }

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -24,6 +24,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { loadProviders } from "./provider-db.js";
 import { getCFClearanceCookie } from "./cf-clearance.js";
+import { loadWebscaleCookie, looksLikeWebscaleChallenge } from "./webscale-cookies.js";
 import { shouldBypassFirecrawlPreferredForPhase0 } from "./price-extract-vendor-goldback.js";
 import {
   FIRECRAWL_PREFERRED_PROVIDERS,
@@ -473,11 +474,34 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
       args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
     });
 
+    // Webscale-protected vendors (jmbullion, providentmetals): if an operator
+    // has stashed a solved wspc cookie for this host, inject it with the UA it
+    // was solved under. Webscale binds clearance to IP + Chrome-class UA + wspc,
+    // and the poller shares the operator's public IP (STRK-230). No cookie → we
+    // proceed bare and the challenge detector below flags the need to re-solve.
+    const urlObj = new URL(url);
+    const webscaleCookie = loadWebscaleCookie(urlObj.hostname);
+    const DEFAULT_UA =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
     const context = await browser.newContext({
-      userAgent:
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+      userAgent: webscaleCookie?.userAgent || DEFAULT_UA,
       viewport: { width: 1920, height: 1080 },
     });
+    if (webscaleCookie) {
+      await context.addCookies([
+        {
+          name: "wspc",
+          value: webscaleCookie.wspc,
+          domain: urlObj.hostname,
+          path: "/",
+          httpOnly: false,
+          secure: true,
+        },
+      ]);
+      log(
+        `  (playwright-direct) injected Webscale wspc for ${providerId} (UA ${webscaleCookie.userAgent ? "matched" : "default"}, updated ${webscaleCookie.updatedAt || "?"})`
+      );
+    }
     const page = await context.newPage();
 
     // Block non-essential resource types to reduce bandwidth ~60-80%
@@ -525,6 +549,15 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
         .forEach((el) => el.remove());
       return [document.body.innerText, scripts];
     });
+    // Stale/missing wspc → Webscale serves a reCAPTCHA interstitial instead of
+    // the product. Surface it loudly so the operator knows to re-solve, and bail
+    // so Firecrawl/FBP can take over rather than extracting garbage (STRK-230).
+    if (looksLikeWebscaleChallenge(text)) {
+      warn(
+        `  (playwright-direct) ⚠️ WEBSCALE CHALLENGE for ${providerId} (${urlObj.hostname}) — wspc cookie missing/stale, RE-SOLVE NEEDED: node webscale-cookies.js set ${urlObj.hostname} <wspc> "<UA>"`
+      );
+      return null;
+    }
     const cleaned = preprocessMarkdown(text, providerId);
     const stock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
 

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -539,20 +539,24 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     // removing those elements first would return empty scripts. After capturing, strip
     // nav/header/footer to prevent spot tickers from polluting innerText and causing
     // firstInRangePriceProse() to match the spot price instead of the product price.
-    const [text, jsonLdScripts] = await page.evaluate(() => {
+    const [text, jsonLdScripts, pageHtmlHead] = await page.evaluate(() => {
       const scripts = Array.from(
         document.querySelectorAll('script[type="application/ld+json"]'),
         (s) => s.textContent
       );
+      // Capture a small HTML slice BEFORE stripping nav: the Webscale challenge
+      // markers live in <head>/<script> (errorpage.css, i-am-a-human), which
+      // innerText drops. The interstitial is tiny so the head + visible text fit.
+      const htmlHead = document.documentElement.outerHTML.slice(0, 8192);
       document
         .querySelectorAll("nav, header, footer, [role='navigation'], [role='banner']")
         .forEach((el) => el.remove());
-      return [document.body.innerText, scripts];
+      return [document.body.innerText, scripts, htmlHead];
     });
     // Stale/missing wspc → Webscale serves a reCAPTCHA interstitial instead of
     // the product. Surface it loudly so the operator knows to re-solve, and bail
     // so Firecrawl/FBP can take over rather than extracting garbage (STRK-230).
-    if (looksLikeWebscaleChallenge(text)) {
+    if (looksLikeWebscaleChallenge(pageHtmlHead) || looksLikeWebscaleChallenge(text)) {
       warn(
         `  (playwright-direct) ⚠️ WEBSCALE CHALLENGE for ${providerId} (${urlObj.hostname}) — wspc cookie missing/stale, RE-SOLVE NEEDED: run webscale-solve.mjs (or webscale-cookies.js set ${urlObj.hostname} <wspc> "<UA>")`
       );

--- a/devops/pollers/shared/webscale-cookies.js
+++ b/devops/pollers/shared/webscale-cookies.js
@@ -19,7 +19,9 @@
  *      hostname upper-cased with non-alphanumerics → "_" (see webscaleEnvKeys).
  *      e.g. WEBSCALE_WSPC_WWW_JMBULLION_COM / WEBSCALE_UA_WWW_JMBULLION_COM.
  *      The entrypoint dumps Docker env into /etc/environment and the scrape cron
- *      sources it, so a pasted var reaches the poller after a container recreate.
+ *      sources it as shell, so a pasted var reaches the poller after a container
+ *      recreate. The UA value is **base64** (see encodeUaForEnv) — a raw UA's
+ *      spaces/parens/semicolons would be a shell syntax error when sourced.
  *
  *   2. JSON file keyed by hostname (dev / file-based deploys):
  *      { "www.jmbullion.com": { "wspc": "...", "userAgent": "...", "updatedAt": "..." } }
@@ -71,6 +73,29 @@ export function webscaleEnvKeys(hostname) {
 }
 
 /**
+ * The UA env value MUST be base64 — the home-poller entrypoint writes Docker env
+ * to /etc/environment and the cron jobs `. ` (source) that file as shell. A raw
+ * UA ("Mozilla/5.0 (Windows NT 10.0; ...)") has spaces, parens and semicolons,
+ * which is a shell syntax error that breaks env for the whole scrape job. wspc
+ * tokens are already shell-safe, so only the UA is encoded.
+ */
+export function encodeUaForEnv(ua) {
+  return ua ? Buffer.from(ua, "utf8").toString("base64") : "";
+}
+
+/** Decode a UA env value. Falls back to the raw string if it is not base64
+ *  (e.g. a hand-set plain UA), detected via a round-trip re-encode. */
+function decodeUaFromEnv(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const decoded = Buffer.from(value, "base64").toString("utf8");
+  const strip = (s) => s.replace(/=+$/, "");
+  if (decoded && strip(Buffer.from(decoded, "utf8").toString("base64")) === strip(value)) {
+    return decoded;
+  }
+  return value;
+}
+
+/**
  * Load the injectable cookie for a hostname. Environment variables win over the
  * file store so the operator can paste a fresh cookie into Portainer and
  * recreate the container without touching a file inside it (the entrypoint dumps
@@ -85,10 +110,9 @@ export function loadWebscaleCookie(hostname, env = process.env) {
   const { wspcKey, uaKey } = webscaleEnvKeys(hostname);
   const envWspc = env[wspcKey];
   if (typeof envWspc === "string" && envWspc.length > 0) {
-    const envUa = env[uaKey];
     return {
       wspc: envWspc,
-      userAgent: typeof envUa === "string" && envUa.length > 0 ? envUa : null,
+      userAgent: decodeUaFromEnv(env[uaKey]),
       updatedAt: "env",
       source: "env",
     };

--- a/devops/pollers/shared/webscale-cookies.js
+++ b/devops/pollers/shared/webscale-cookies.js
@@ -117,9 +117,16 @@ export function setWebscaleCookie(hostname, wspc, userAgent, env = process.env, 
     updatedAt: now.toISOString(),
   };
   mkdirSync(dirname(file), { recursive: true });
-  writeFileSync(file, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  // mode 0600: the file holds live bot-clearance credentials.
+  writeFileSync(file, `${JSON.stringify(store, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   return store[hostname];
 }
+
+// Markers of the Webscale "Protection Mode" reCAPTCHA interstitial. Kept free of
+// escaped forward slashes (i-am-a-human, not /.webscale/i-am-a-human) so static
+// analyzers don't mis-tokenize the literal.
+const WEBSCALE_CHALLENGE_RE =
+  /confirm your humanity|i-am-a-human|resources\.webscale\.com|protection-mode-captcha/i;
 
 /**
  * True when page content (raw HTML or innerText) is a Webscale "Protection Mode"
@@ -129,9 +136,7 @@ export function setWebscaleCookie(hostname, wspc, userAgent, env = process.env, 
  */
 export function looksLikeWebscaleChallenge(content) {
   if (!content) return false;
-  return /confirm your humanity|\/\.webscale\/i-am-a-human|resources\.webscale\.com|protection-mode-captcha/i.test(
-    content
-  );
+  return WEBSCALE_CHALLENGE_RE.test(content);
 }
 
 // ── CLI ────────────────────────────────────────────────────────────────────
@@ -157,9 +162,11 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
       console.log(`(empty) ${webscaleCookieFilePath()}`);
     } else {
       for (const h of hosts) {
-        const e = store[h];
+        const raw = store[h];
+        const e = raw && typeof raw === "object" ? raw : {};
+        const wspcPrefix = typeof e.wspc === "string" ? e.wspc.slice(0, 8) : "";
         console.log(
-          `${h}\twspc=${(e.wspc || "").slice(0, 8)}…\tUA=${e.userAgent ? "set" : "MISSING"}\tupdated=${e.updatedAt || "?"}`
+          `${h}\twspc=${wspcPrefix}…\tUA=${e.userAgent ? "set" : "MISSING"}\tupdated=${e.updatedAt || "?"}`
         );
       }
     }

--- a/devops/pollers/shared/webscale-cookies.js
+++ b/devops/pollers/shared/webscale-cookies.js
@@ -12,15 +12,23 @@
  * This is a deliberately temporary stopgap that needs a manual re-solve roughly
  * weekly per site. See the issue for the durable plan (proxy / solver / FBP).
  *
- * Storage: a JSON map keyed by hostname:
- *   { "www.jmbullion.com": { "wspc": "...", "userAgent": "...", "updatedAt": "..." } }
+ * Two storage backends, env wins over file:
  *
- * The file path comes from WEBSCALE_COOKIE_FILE. On the home poller set it to a
- * path OUTSIDE any git checkout (e.g. /data/webscale-cookies.json) so live
- * cookies are never committed to the data branch. The default is module-local
- * for dev/tests; `.gitignore` also guards the filename as defense-in-depth.
+ *   1. Environment variables (recommended for the home poller — Portainer path).
+ *      Per host: WEBSCALE_WSPC_<HOST> and WEBSCALE_UA_<HOST>, where <HOST> is the
+ *      hostname upper-cased with non-alphanumerics → "_" (see webscaleEnvKeys).
+ *      e.g. WEBSCALE_WSPC_WWW_JMBULLION_COM / WEBSCALE_UA_WWW_JMBULLION_COM.
+ *      The entrypoint dumps Docker env into /etc/environment and the scrape cron
+ *      sources it, so a pasted var reaches the poller after a container recreate.
  *
- * CLI:
+ *   2. JSON file keyed by hostname (dev / file-based deploys):
+ *      { "www.jmbullion.com": { "wspc": "...", "userAgent": "...", "updatedAt": "..." } }
+ *      Path from WEBSCALE_COOKIE_FILE (default module-local). Point it OUTSIDE any
+ *      git checkout on the poller; `.gitignore` also guards the filename.
+ *
+ * Re-solving (weekly): run the interactive helper on a machine sharing the
+ * poller's public IP — `node webscale-solve.mjs` — solve each captcha once, and
+ * it prints the env lines to paste into Portainer. Manual CLI alternatives:
  *   node webscale-cookies.js set <hostname> <wspc> "<userAgent>"
  *   node webscale-cookies.js list
  */
@@ -50,12 +58,43 @@ export function loadWebscaleStore(env = process.env) {
 }
 
 /**
- * Load the injectable cookie for a hostname.
- * @returns {{ wspc: string, userAgent: string|null, updatedAt: string|null } | null}
- *   null when the host is absent or its wspc value is missing/empty.
+ * Per-host environment variable names. Derived from the hostname so there is no
+ * mapping table to keep in sync — e.g. www.jmbullion.com →
+ * { wspcKey: "WEBSCALE_WSPC_WWW_JMBULLION_COM", uaKey: "WEBSCALE_UA_WWW_JMBULLION_COM" }.
+ * The solve helper prints these so they can be pasted straight into Portainer.
+ */
+export function webscaleEnvKeys(hostname) {
+  const suffix = String(hostname || "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_");
+  return { wspcKey: `WEBSCALE_WSPC_${suffix}`, uaKey: `WEBSCALE_UA_${suffix}` };
+}
+
+/**
+ * Load the injectable cookie for a hostname. Environment variables win over the
+ * file store so the operator can paste a fresh cookie into Portainer and
+ * recreate the container without touching a file inside it (the entrypoint dumps
+ * the Docker env into /etc/environment, which the scrape cron sources).
+ * @returns {{ wspc: string, userAgent: string|null, updatedAt: string|null, source: string } | null}
+ *   null when neither env nor file provides a non-empty wspc.
  */
 export function loadWebscaleCookie(hostname, env = process.env) {
   if (!hostname) return null;
+
+  // 1) Environment variables (Portainer-friendly path).
+  const { wspcKey, uaKey } = webscaleEnvKeys(hostname);
+  const envWspc = env[wspcKey];
+  if (typeof envWspc === "string" && envWspc.length > 0) {
+    const envUa = env[uaKey];
+    return {
+      wspc: envWspc,
+      userAgent: typeof envUa === "string" && envUa.length > 0 ? envUa : null,
+      updatedAt: "env",
+      source: "env",
+    };
+  }
+
+  // 2) File store fallback (dev / file-based deploys).
   const entry = loadWebscaleStore(env)[hostname];
   if (!entry || typeof entry.wspc !== "string" || entry.wspc.length === 0) return null;
   return {
@@ -63,6 +102,7 @@ export function loadWebscaleCookie(hostname, env = process.env) {
     userAgent:
       typeof entry.userAgent === "string" && entry.userAgent.length > 0 ? entry.userAgent : null,
     updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : null,
+    source: "file",
   };
 }
 

--- a/devops/pollers/shared/webscale-cookies.js
+++ b/devops/pollers/shared/webscale-cookies.js
@@ -1,0 +1,130 @@
+/**
+ * Webscale "Protection Mode" cookie store (STRK-230).
+ *
+ * JM Bullion and Provident Metals (both A-Mark/JMB properties, shared front end)
+ * sit behind **Webscale** — NOT Cloudflare — which throws a Google reCAPTCHA v2
+ * interstitial on product pages. Byparr/Firecrawl cannot solve it. The only
+ * no-cost bypass is to clone a `wspc` cookie ("WebScale Protection Cookie",
+ * ~7-day life) that an operator solves manually in a browser on the SAME public
+ * IP as the poller, then inject it into the poller's headless Chromium with a
+ * matching user-agent. Webscale binds clearance to IP + Chrome-class UA + wspc.
+ *
+ * This is a deliberately temporary stopgap that needs a manual re-solve roughly
+ * weekly per site. See the issue for the durable plan (proxy / solver / FBP).
+ *
+ * Storage: a JSON map keyed by hostname:
+ *   { "www.jmbullion.com": { "wspc": "...", "userAgent": "...", "updatedAt": "..." } }
+ *
+ * The file path comes from WEBSCALE_COOKIE_FILE. On the home poller set it to a
+ * path OUTSIDE any git checkout (e.g. /data/webscale-cookies.json) so live
+ * cookies are never committed to the data branch. The default is module-local
+ * for dev/tests; `.gitignore` also guards the filename as defense-in-depth.
+ *
+ * CLI:
+ *   node webscale-cookies.js set <hostname> <wspc> "<userAgent>"
+ *   node webscale-cookies.js list
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Resolve the cookie store path, honoring the WEBSCALE_COOKIE_FILE override. */
+export function webscaleCookieFilePath(env = process.env) {
+  return env.WEBSCALE_COOKIE_FILE || join(__dirname, "webscale-cookies.json");
+}
+
+/** Read and parse the whole store. Returns {} on any missing/unreadable file. */
+export function loadWebscaleStore(env = process.env) {
+  const file = webscaleCookieFilePath(env);
+  if (!existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    // Corrupt store should degrade to "no cookie" (poller falls through to
+    // Firecrawl/FBP), never crash the run.
+    return {};
+  }
+}
+
+/**
+ * Load the injectable cookie for a hostname.
+ * @returns {{ wspc: string, userAgent: string|null, updatedAt: string|null } | null}
+ *   null when the host is absent or its wspc value is missing/empty.
+ */
+export function loadWebscaleCookie(hostname, env = process.env) {
+  if (!hostname) return null;
+  const entry = loadWebscaleStore(env)[hostname];
+  if (!entry || typeof entry.wspc !== "string" || entry.wspc.length === 0) return null;
+  return {
+    wspc: entry.wspc,
+    userAgent:
+      typeof entry.userAgent === "string" && entry.userAgent.length > 0 ? entry.userAgent : null,
+    updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : null,
+  };
+}
+
+/** Upsert a hostname's cookie + solving UA, stamping updatedAt. */
+export function setWebscaleCookie(hostname, wspc, userAgent, env = process.env, now = new Date()) {
+  if (!hostname || !wspc) throw new Error("setWebscaleCookie: hostname and wspc are required");
+  const file = webscaleCookieFilePath(env);
+  const store = loadWebscaleStore(env);
+  store[hostname] = {
+    wspc,
+    userAgent: userAgent || null,
+    updatedAt: now.toISOString(),
+  };
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  return store[hostname];
+}
+
+/**
+ * True when page content (raw HTML or innerText) is a Webscale "Protection Mode"
+ * reCAPTCHA interstitial rather than a real page — i.e. the wspc cookie is
+ * missing/stale and a re-solve is needed. Distinct from the Cloudflare patterns
+ * in looksLikeChallengePage().
+ */
+export function looksLikeWebscaleChallenge(content) {
+  if (!content) return false;
+  return /confirm your humanity|\/\.webscale\/i-am-a-human|resources\.webscale\.com|protection-mode-captcha/i.test(
+    content
+  );
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (cmd === "set") {
+    const [hostname, wspc, userAgent] = rest;
+    if (!hostname || !wspc) {
+      console.error('Usage: node webscale-cookies.js set <hostname> <wspc> "<userAgent>"');
+      process.exit(1);
+    }
+    if (!userAgent) {
+      console.warn("WARNING: no userAgent given — clearance is UA-bound, this will likely fail.");
+    }
+    const saved = setWebscaleCookie(hostname, wspc, userAgent);
+    console.log(
+      `Saved wspc for ${hostname} (UA ${saved.userAgent ? "set" : "MISSING"}) -> ${webscaleCookieFilePath()}`
+    );
+  } else if (cmd === "list") {
+    const store = loadWebscaleStore();
+    const hosts = Object.keys(store);
+    if (hosts.length === 0) {
+      console.log(`(empty) ${webscaleCookieFilePath()}`);
+    } else {
+      for (const h of hosts) {
+        const e = store[h];
+        console.log(
+          `${h}\twspc=${(e.wspc || "").slice(0, 8)}…\tUA=${e.userAgent ? "set" : "MISSING"}\tupdated=${e.updatedAt || "?"}`
+        );
+      }
+    }
+  } else {
+    console.error("Usage: node webscale-cookies.js <set|list> …");
+    process.exit(1);
+  }
+}

--- a/devops/pollers/shared/webscale-cookies.test.mjs
+++ b/devops/pollers/shared/webscale-cookies.test.mjs
@@ -13,6 +13,7 @@ import {
   setWebscaleCookie,
   webscaleCookieFilePath,
   webscaleEnvKeys,
+  encodeUaForEnv,
   looksLikeWebscaleChallenge,
 } from "./webscale-cookies.js";
 
@@ -133,13 +134,34 @@ test("derives per-host env var names from hostname", () => {
 });
 
 console.log("\n--- env-var source (Portainer path) ---");
-test("env var wspc + UA wins and reports source=env", () => {
+const REAL_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+test("env UA is base64 and round-trips through encodeUaForEnv", () => {
   const got = loadWebscaleCookie("www.jmbullion.com", {
     WEBSCALE_WSPC_WWW_JMBULLION_COM: "ENVWSPC",
-    WEBSCALE_UA_WWW_JMBULLION_COM: "ENV/UA",
+    WEBSCALE_UA_WWW_JMBULLION_COM: encodeUaForEnv(REAL_UA),
   });
   eq(got.wspc, "ENVWSPC");
-  eq(got.userAgent, "ENV/UA");
+  eq(got.userAgent, REAL_UA);
+  eq(got.source, "env");
+});
+test("encoded UA env value contains no shell-unsafe chars (sourceable)", () => {
+  const encoded = encodeUaForEnv(REAL_UA);
+  eq(/[\s();$`&|<>'"]/.test(encoded), false);
+});
+test("raw (non-base64) UA env value falls back to the literal string", () => {
+  const got = loadWebscaleCookie("www.jmbullion.com", {
+    WEBSCALE_WSPC_WWW_JMBULLION_COM: "ENVWSPC",
+    WEBSCALE_UA_WWW_JMBULLION_COM: "Mozilla/5.0 (raw)",
+  });
+  eq(got.userAgent, "Mozilla/5.0 (raw)");
+});
+test("wspc-only env (no UA) → userAgent null, source env", () => {
+  const got = loadWebscaleCookie("www.jmbullion.com", {
+    WEBSCALE_WSPC_WWW_JMBULLION_COM: "ENVWSPC",
+  });
+  eq(got.wspc, "ENVWSPC");
+  eq(got.userAgent, null);
   eq(got.source, "env");
 });
 test("env var wspc overrides the file store", () => {

--- a/devops/pollers/shared/webscale-cookies.test.mjs
+++ b/devops/pollers/shared/webscale-cookies.test.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// Tests for webscale-cookies.js — run with:
+//   node devops/pollers/shared/webscale-cookies.test.mjs
+//
+// Covers the per-hostname wspc cookie store (load/set round-trip, robustness)
+// and the Webscale "Protection Mode" challenge detector used to flag a stale or
+// missing cookie (STRK-230).
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadWebscaleCookie,
+  setWebscaleCookie,
+  webscaleCookieFilePath,
+  looksLikeWebscaleChallenge,
+} from "./webscale-cookies.js";
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log("  PASS ", name);
+    passed++;
+  } catch (err) {
+    console.log("  FAIL ", name, "-", err.message);
+    failed++;
+  }
+}
+function eq(actual, expected, msg = "") {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`${msg} expected ${e} got ${a}`);
+}
+
+// Each call gets an isolated cookie file under a fresh temp dir so tests never
+// touch the real store or each other.
+function tmpEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "wspc-"));
+  return { env: { WEBSCALE_COOKIE_FILE: join(dir, "webscale-cookies.json") } };
+}
+
+console.log("--- webscaleCookieFilePath ---");
+test("honors WEBSCALE_COOKIE_FILE env override", () => {
+  eq(webscaleCookieFilePath({ WEBSCALE_COOKIE_FILE: "/data/webscale-cookies.json" }), "/data/webscale-cookies.json");
+});
+test("falls back to a module-local default when unset", () => {
+  const p = webscaleCookieFilePath({});
+  eq(p.endsWith("webscale-cookies.json"), true);
+});
+
+console.log("\n--- loadWebscaleCookie (absent) ---");
+test("missing file → null", () => {
+  eq(loadWebscaleCookie("www.jmbullion.com", tmpEnv().env), null);
+});
+test("null / empty hostname → null", () => {
+  const { env } = tmpEnv();
+  eq(loadWebscaleCookie(null, env), null);
+  eq(loadWebscaleCookie("", env), null);
+});
+
+console.log("\n--- set + load round-trip ---");
+test("set then load returns wspc + UA + timestamp", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "ABC123", "UA/1.0", env, new Date("2026-06-19T00:00:00Z"));
+  const got = loadWebscaleCookie("www.jmbullion.com", env);
+  eq(got.wspc, "ABC123");
+  eq(got.userAgent, "UA/1.0");
+  eq(got.updatedAt, "2026-06-19T00:00:00.000Z");
+});
+test("unknown hostname in a populated store → null", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "ABC", "UA", env);
+  eq(loadWebscaleCookie("www.providentmetals.com", env), null);
+});
+test("two hosts coexist independently", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "JM", "UA1", env);
+  setWebscaleCookie("www.providentmetals.com", "PV", "UA2", env);
+  eq(loadWebscaleCookie("www.jmbullion.com", env).wspc, "JM");
+  eq(loadWebscaleCookie("www.providentmetals.com", env).wspc, "PV");
+});
+test("re-set overwrites the same host", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "OLD", "UA", env);
+  setWebscaleCookie("www.jmbullion.com", "NEW", "UA", env);
+  eq(loadWebscaleCookie("www.jmbullion.com", env).wspc, "NEW");
+});
+
+console.log("\n--- robustness ---");
+test("malformed JSON → null (no throw)", () => {
+  const { env } = tmpEnv();
+  writeFileSync(env.WEBSCALE_COOKIE_FILE, "{not json", "utf8");
+  eq(loadWebscaleCookie("www.jmbullion.com", env), null);
+});
+test("entry missing wspc → null", () => {
+  const { env } = tmpEnv();
+  writeFileSync(env.WEBSCALE_COOKIE_FILE, JSON.stringify({ "www.jmbullion.com": { userAgent: "UA" } }), "utf8");
+  eq(loadWebscaleCookie("www.jmbullion.com", env), null);
+});
+test("empty wspc string → null", () => {
+  const { env } = tmpEnv();
+  writeFileSync(env.WEBSCALE_COOKIE_FILE, JSON.stringify({ "www.jmbullion.com": { wspc: "", userAgent: "UA" } }), "utf8");
+  eq(loadWebscaleCookie("www.jmbullion.com", env), null);
+});
+test("missing userAgent → wspc still returned, userAgent null", () => {
+  const { env } = tmpEnv();
+  writeFileSync(env.WEBSCALE_COOKIE_FILE, JSON.stringify({ "www.jmbullion.com": { wspc: "X" } }), "utf8");
+  const got = loadWebscaleCookie("www.jmbullion.com", env);
+  eq(got.wspc, "X");
+  eq(got.userAgent, null);
+});
+test("set requires hostname and wspc", () => {
+  const { env } = tmpEnv();
+  let threw = 0;
+  try { setWebscaleCookie("", "x", "UA", env); } catch { threw++; }
+  try { setWebscaleCookie("h", "", "UA", env); } catch { threw++; }
+  eq(threw, 2);
+});
+
+console.log("\n--- looksLikeWebscaleChallenge ---");
+test("real product innerText → false", () => {
+  eq(looksLikeWebscaleChallenge("1 oz American Gold Eagle  Price $4,269.17  Add to Cart"), false);
+});
+test("null / empty → false", () => {
+  eq(looksLikeWebscaleChallenge(null), false);
+  eq(looksLikeWebscaleChallenge(""), false);
+});
+test("'confirm your humanity' innerText → true", () => {
+  eq(looksLikeWebscaleChallenge("Please confirm your humanity. We are temporarily requesting additional verification"), true);
+});
+test("/.webscale/i-am-a-human marker → true", () => {
+  eq(looksLikeWebscaleChallenge('xhr.open("POST", "/.webscale/i-am-a-human")'), true);
+});
+test("resources.webscale.com errorpage marker → true", () => {
+  eq(looksLikeWebscaleChallenge('<link href="https://resources.webscale.com/css/errorpage.css">'), true);
+});
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/devops/pollers/shared/webscale-cookies.test.mjs
+++ b/devops/pollers/shared/webscale-cookies.test.mjs
@@ -12,6 +12,7 @@ import {
   loadWebscaleCookie,
   setWebscaleCookie,
   webscaleCookieFilePath,
+  webscaleEnvKeys,
   looksLikeWebscaleChallenge,
 } from "./webscale-cookies.js";
 
@@ -116,6 +117,45 @@ test("set requires hostname and wspc", () => {
   try { setWebscaleCookie("", "x", "UA", env); } catch { threw++; }
   try { setWebscaleCookie("h", "", "UA", env); } catch { threw++; }
   eq(threw, 2);
+});
+
+console.log("\n--- webscaleEnvKeys ---");
+test("derives per-host env var names from hostname", () => {
+  eq(webscaleEnvKeys("www.jmbullion.com"), {
+    wspcKey: "WEBSCALE_WSPC_WWW_JMBULLION_COM",
+    uaKey: "WEBSCALE_UA_WWW_JMBULLION_COM",
+  });
+});
+
+console.log("\n--- env-var source (Portainer path) ---");
+test("env var wspc + UA wins and reports source=env", () => {
+  const got = loadWebscaleCookie("www.jmbullion.com", {
+    WEBSCALE_WSPC_WWW_JMBULLION_COM: "ENVWSPC",
+    WEBSCALE_UA_WWW_JMBULLION_COM: "ENV/UA",
+  });
+  eq(got.wspc, "ENVWSPC");
+  eq(got.userAgent, "ENV/UA");
+  eq(got.source, "env");
+});
+test("env var wspc overrides the file store", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "FILEWSPC", "FILE/UA", env);
+  const got = loadWebscaleCookie("www.jmbullion.com", {
+    ...env,
+    WEBSCALE_WSPC_WWW_JMBULLION_COM: "ENVWSPC",
+  });
+  eq(got.wspc, "ENVWSPC");
+  eq(got.source, "env");
+});
+test("empty env var falls through to file store", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "FILEWSPC", "FILE/UA", env);
+  const got = loadWebscaleCookie("www.jmbullion.com", {
+    ...env,
+    WEBSCALE_WSPC_WWW_JMBULLION_COM: "",
+  });
+  eq(got.wspc, "FILEWSPC");
+  eq(got.source, "file");
 });
 
 console.log("\n--- looksLikeWebscaleChallenge ---");

--- a/devops/pollers/shared/webscale-cookies.test.mjs
+++ b/devops/pollers/shared/webscale-cookies.test.mjs
@@ -5,7 +5,7 @@
 // Covers the per-hostname wspc cookie store (load/set round-trip, robustness)
 // and the Webscale "Protection Mode" challenge detector used to flag a stale or
 // missing cookie (STRK-230).
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -110,6 +110,11 @@ test("missing userAgent → wspc still returned, userAgent null", () => {
   const got = loadWebscaleCookie("www.jmbullion.com", env);
   eq(got.wspc, "X");
   eq(got.userAgent, null);
+});
+test("set writes the cookie file with 0600 perms (credentials)", () => {
+  const { env } = tmpEnv();
+  setWebscaleCookie("www.jmbullion.com", "X", "UA", env);
+  eq(statSync(env.WEBSCALE_COOKIE_FILE).mode & 0o777, 0o600);
 });
 test("set requires hostname and wspc", () => {
   const { env } = tmpEnv();

--- a/devops/pollers/shared/webscale-solve.mjs
+++ b/devops/pollers/shared/webscale-solve.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Interactive Webscale re-solve helper (STRK-230).
+ *
+ * The weekly ritual: JM Bullion / Provident sit behind Webscale Protection Mode
+ * (Google reCAPTCHA v2 on product pages). The bypass is a cloned ~7-day `wspc`
+ * cookie. This helper opens a real browser so you can solve the captcha once per
+ * site, then captures the cleared `wspc` AND the exact user-agent and prints
+ * lines you paste straight into the home poller's Portainer env (then recreate
+ * the container). No DevTools, no manual cookie hunting, UA-match guaranteed.
+ *
+ * MUST run on a machine sharing the poller's public IP (your home network), with
+ * a display. Requires Playwright's browser once: `npx playwright install chromium`.
+ *
+ *   node devops/pollers/shared/webscale-solve.mjs
+ *   node devops/pollers/shared/webscale-solve.mjs --write   # also write the file store
+ *   node devops/pollers/shared/webscale-solve.mjs https://www.jmbullion.com/  # custom start URLs
+ */
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import { chromium } from "playwright";
+import {
+  setWebscaleCookie,
+  webscaleEnvKeys,
+  looksLikeWebscaleChallenge,
+} from "./webscale-cookies.js";
+
+// Hosts to solve. Start URLs are just a landing point — navigate to any PRODUCT
+// page in the window to trigger (and solve) the challenge; the cleared wspc is
+// site-wide, so the exact product does not matter.
+const DEFAULT_TARGETS = [
+  { host: "www.jmbullion.com", start: "https://www.jmbullion.com/1-oz-american-gold-eagle/" },
+  { host: "www.providentmetals.com", start: "https://www.providentmetals.com/" },
+];
+
+const args = process.argv.slice(2);
+const writeFile = args.includes("--write");
+const urlArgs = args.filter((a) => a.startsWith("http"));
+const targets = urlArgs.length
+  ? urlArgs.map((u) => ({ host: new URL(u).hostname, start: u }))
+  : DEFAULT_TARGETS;
+
+const rl = createInterface({ input: stdin, output: stdout });
+const envLines = [];
+
+const browser = await chromium.launch({ headless: false });
+const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+const page = await context.newPage();
+
+for (const { host, start } of targets) {
+  console.log(`\n=== ${host} ===`);
+  try {
+    await page.goto(start, { waitUntil: "domcontentloaded", timeout: 45000 });
+  } catch {
+    console.log(`  (could not auto-open ${start} — navigate there manually)`);
+  }
+  console.log(`  In the browser: open ANY product page on ${host} and solve the`);
+  console.log(`  "confirm your humanity" check so the product actually loads.`);
+  await rl.question("  Press Enter once the product page is showing… ");
+
+  let content = "";
+  try {
+    content = await page.content();
+  } catch {
+    /* mid-navigation; ignore */
+  }
+  if (looksLikeWebscaleChallenge(content)) {
+    console.log("  ⚠️ That page still looks like the challenge. Solve it, then…");
+    await rl.question("  Press Enter to retry capture… ");
+    content = await page.content().catch(() => "");
+  }
+
+  const cookies = await context.cookies(`https://${host}/`);
+  const wspc = cookies.find((c) => c.name === "wspc")?.value;
+  const ua = await page.evaluate(() => navigator.userAgent).catch(() => null);
+
+  if (!wspc) {
+    console.log(`  ❌ No wspc cookie found for ${host} — skipped. (Did the page load?)`);
+    continue;
+  }
+  const { wspcKey, uaKey } = webscaleEnvKeys(host);
+  envLines.push(`${wspcKey}=${wspc}`, `${uaKey}=${ua || ""}`);
+  console.log(`  ✅ captured wspc (${wspc.slice(0, 10)}…) + UA ${ua ? "✓" : "MISSING"}`);
+  if (writeFile) {
+    setWebscaleCookie(host, wspc, ua);
+    console.log("  ✅ also written to the file store");
+  }
+}
+
+rl.close();
+await browser.close();
+
+if (envLines.length) {
+  console.log("\n──────── paste into Portainer env, then RECREATE the container ────────");
+  for (const line of envLines) console.log(line);
+  console.log("───────────────────────────────────────────────────────────────────────");
+} else {
+  console.log("\nNothing captured.");
+}

--- a/devops/pollers/shared/webscale-solve.mjs
+++ b/devops/pollers/shared/webscale-solve.mjs
@@ -22,6 +22,7 @@ import { chromium } from "playwright";
 import {
   setWebscaleCookie,
   webscaleEnvKeys,
+  encodeUaForEnv,
   looksLikeWebscaleChallenge,
 } from "./webscale-cookies.js";
 
@@ -79,8 +80,10 @@ for (const { host, start } of targets) {
     continue;
   }
   const { wspcKey, uaKey } = webscaleEnvKeys(host);
-  envLines.push(`${wspcKey}=${wspc}`, `${uaKey}=${ua || ""}`);
-  console.log(`  ✅ captured wspc (${wspc.slice(0, 10)}…) + UA ${ua ? "✓" : "MISSING"}`);
+  // UA is base64 in env transport — /etc/environment is sourced as shell and a
+  // raw UA's spaces/parens/semicolons would be a syntax error.
+  envLines.push(`${wspcKey}=${wspc}`, `${uaKey}=${encodeUaForEnv(ua)}`);
+  console.log(`  ✅ captured wspc (${wspc.slice(0, 10)}…) + UA ${ua ? "✓ (base64)" : "MISSING"}`);
   if (writeFile) {
     setWebscaleCookie(host, wspc, ua);
     console.log("  ✅ also written to the file store");


### PR DESCRIPTION
## Problem
JM Bullion and Provident Metals (both A-Mark/JMB properties, shared front end) serve a **Webscale "Protection Mode" Google reCAPTCHA v2** interstitial on *product* pages (homepages render). This is **not Cloudflare** — markers: `resources.webscale.com/css/errorpage.css`, POST `/.webscale/i-am-a-human`, `grecaptcha.render`, "Please confirm your humanity". The existing Cloudflare/Byparr machinery can't solve it; updating Byparr/Firecrawl doesn't help. The code's `2026-04-23` "JM CF tier" comment was a misdiagnosis.

## Root cause (confirmed live)
Webscale binds cleared access to **IP + Chrome-class UA + `wspc` cookie** (~7-day life). The home poller shares the operator's Cox public IP. Verified: headless Chromium + injected `wspc` + same IP returned the real JM product page with live tier pricing, no challenge — even with a 3h-old cookie.

## Change
- **`webscale-cookies.js`** — per-host `{wspc, userAgent}` store. **Env-var source (prod) wins over a JSON file (dev).** `looksLikeWebscaleChallenge` detector; `webscaleEnvKeys`; `encodeUaForEnv` (UA is base64 in env — see below); `set`/`list` CLI.
- **`webscale-solve.mjs`** — interactive helper: opens a browser, you solve each captcha once, it captures `wspc` + the exact UA and prints **Portainer-ready env lines** (UA base64-encoded).
- **`scrapeWithPlaywrightDirect`** — injects the stored `wspc` + matching UA (shared, **host-keyed** phase-0 path, so it survives a future vendor split). Stale/missing cookie → logs loudly with the re-solve command and falls through to Firecrawl/FBP.
- **`providentmetals` PROVIDER_CONFIG** added; `jmbullion` comment corrected; Byparr `cf_clearance_fallback` disabled for both (wrong tool for Webscale).
- **`run-home.sh`** re-exports only `WEBSCALE_*` from `/etc/environment` before invoking node (cron sources but doesn't export to children — verified live).
- **`.gitignore`** guard; `SHARED_FILES` + deploy-manifest test updated.

## Deploy (home poller, Portainer stack 7, tracks `dev`)
- **Env vars (per host):** `WEBSCALE_WSPC_WWW_JMBULLION_COM`, `WEBSCALE_UA_WWW_JMBULLION_COM` (+ providentmetals). **UA value is base64** — `/etc/environment` is sourced as shell, so a raw UA (spaces/parens) would break sourcing. The file backend is dev-only; no `WEBSCALE_COOKIE_FILE` needed in prod.
- **Adding the vars:** use the **Portainer Web UI stack editor** (additive — preserves the existing 15 vars). A manual `/git/redeploy` **replaces** env, so only use it with the full array. GitOps auto-poll preserves stored env.
- **Non-breaking:** with no cookies set, `loadWebscaleCookie` returns `null` and the poller behaves exactly as today (JM/Provident keep failing; nothing else changes). Deploy first, set cookies after.
- **Weekly:** re-solve (~7-day cookie) via `webscale-solve.mjs`; the poller logs `⚠️ WEBSCALE CHALLENGE … RE-SOLVE NEEDED` when stale.

## Verification
- 26 unit tests + deploy-manifest 2/2; ESLint + Prettier + `node --check` + `bash -n` clean; signed commits.
- Live: cookie injection clears Webscale on the real JM product page; `run-home.sh` export loop confirmed to pass `WEBSCALE_*` to a child while leaving other vars untouched; cron non-export of `/etc/environment` confirmed in-container.

## Caveats / follow-ups
- Fragile (breaks if Webscale adds JA3/behavioral scoring); IP-bound; ~2 manual solves/week.
- Follow-ups (separate): schedule the dormant `run-fbp.sh` + wire Provident's FBP dealer mapping; durable long-term solution.
- `stakscrapr` repo is retired (2026-03-07) — `sync-from-fly.sh` is vestigial; the manifest change just keeps the existing test green.

Closes STRK-230.