### PR TITLE
fix(STRK-230): pass WEBSCALE_* env through docker-compose.home.yml

### DIFF
--- a/devops/pollers/docker-compose.home.yml
+++ b/devops/pollers/docker-compose.home.yml
@@ -40,6 +40,13 @@ services:
       - CF_CLEARANCE_SCRAPER_URL=${CF_CLEARANCE_SCRAPER_URL:-http://byparr:8191}
       - CF_CLEARANCE_ENABLED=${CF_CLEARANCE_ENABLED:-1}
       - CF_CLEARANCE_TIMEOUT_MS=${CF_CLEARANCE_TIMEOUT_MS:-30000}
+      # Webscale Protection Mode bypass — per-host wspc cookie + base64 UA (STRK-230).
+      # Values supplied by the Portainer stack env; re-solve ~weekly via webscale-solve.mjs.
+      # MUST be listed here or compose drops them (the stack env array alone is not enough).
+      - WEBSCALE_WSPC_WWW_JMBULLION_COM=${WEBSCALE_WSPC_WWW_JMBULLION_COM:-}
+      - WEBSCALE_UA_WWW_JMBULLION_COM=${WEBSCALE_UA_WWW_JMBULLION_COM:-}
+      - WEBSCALE_WSPC_WWW_PROVIDENTMETALS_COM=${WEBSCALE_WSPC_WWW_PROVIDENTMETALS_COM:-}
+      - WEBSCALE_UA_WWW_PROVIDENTMETALS_COM=${WEBSCALE_UA_WWW_PROVIDENTMETALS_COM:-}
     ports:
       - "3010:3010" # Dashboard (HTTP)
       - "3011:3011" # Dashboard (HTTPS for iframe embed)


### PR DESCRIPTION
## Why
Completes the STRK-230 env-var path (PR #1303). The home-poller compose `environment:` block is an **explicit allow-list** — a var in the Portainer stack env reaches the container **only if compose names it**. The 4 `WEBSCALE_WSPC_*` / `WEBSCALE_UA_*` vars were added to the Portainer stack env but never referenced in `docker-compose.home.yml`, so docker-compose dropped them.

## Symptom (verified live)
A **successful** "Pulled and redeployed" recreated the container (`StartedAt` advanced) but `/etc/environment` still had **zero** `WEBSCALE_*` names → `run-home.sh`'s export loop found nothing → the wspc cookie never reached node → JM/Provident kept failing while everything *looked* deployed.

## Fix
Add the 4 per-host vars to the compose `environment:` block, interpolated from the stack env with empty defaults. After merge → **pull-and-redeploy** → `/etc/environment` gets them → injection fires.

## Scope
4 lines (+ comment). No code/behavior change beyond env passthrough. This is the missing hop between Portainer stack env and the container.