### PR TITLE
chore(STRK-225): extract shared vault-fixtures test helper

### DIFF
--- a/tests/playwright/core/attachments-cloud.spec.js
+++ b/tests/playwright/core/attachments-cloud.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from "../helpers/mocks/extended-test.js";
 import { injectSeedInventory } from "../helpers/seed.js";
+import { encryptVaultPayload } from "../helpers/vault-fixtures.js";
 
 const ACCOUNT_ID = "dbid:strk118-test-account";
 const VAULT_PASSWORD = "strk118-test-password";
@@ -169,33 +170,6 @@ async function encryptedManifest(page, manifest) {
     async ({ payload, key }) =>
       Array.from(new Uint8Array(await window.encryptManifest(payload, key))),
     { payload: manifest, key: SYNC_KEY }
-  );
-}
-
-/**
- * Encrypts an arbitrary object as a StakTrakr .stvault file (salt|iv|iter|
- * ciphertext) under the composite sync key, runnable in-page so it uses the
- * app's exact crypto. Used by the STRK-225 vault-first test to serve a remote
- * main sync vault (`{ data: { metalInventory } }`) and image companion vault
- * (`{ records, patternRecords }`) that the in-app decrypt paths accept.
- */
-async function encryptVaultPayload(page, payload) {
-  return page.evaluate(
-    async ({ data, key }) => {
-      const iterations =
-        typeof window.VAULT_PBKDF2_ITERATIONS !== "undefined"
-          ? window.VAULT_PBKDF2_ITERATIONS
-          : 600000;
-      const salt = window.vaultRandomBytes(32);
-      const iv = window.vaultRandomBytes(12);
-      const derived = await window.vaultDeriveKey(key, salt, iterations);
-      const plaintext = new TextEncoder().encode(JSON.stringify(data));
-      const ciphertext = await window.vaultEncrypt(plaintext, derived, iv);
-      return Array.from(
-        new Uint8Array(window.serializeVaultFile(salt, iv, iterations, ciphertext))
-      );
-    },
-    { data: payload, key: SYNC_KEY }
   );
 }
 
@@ -709,12 +683,18 @@ test.describe("core/attachments-cloud", () => {
 
     // Remote main vault differs from local (name) → non-empty diff → execution
     // reaches the preview modal rather than the silent-pull early return.
-    const vaultBytes = await encryptVaultPayload(page, {
-      data: { metalInventory: JSON.stringify([REMOTE_ITEM]) },
-    });
+    const vaultBytes = await encryptVaultPayload(
+      page,
+      { data: { metalInventory: JSON.stringify([REMOTE_ITEM]) } },
+      SYNC_KEY
+    );
     // A valid (decryptable) image vault so the BUGGY code restores + advances the
     // hash; empty records keep the restore a no-op while still exercising the path.
-    const imageVaultBytes = await encryptVaultPayload(page, { records: [], patternRecords: [] });
+    const imageVaultBytes = await encryptVaultPayload(
+      page,
+      { records: [], patternRecords: [] },
+      SYNC_KEY
+    );
     // attachmentNotFound: the attachment vault 404s, which still advances
     // attachmentHash (not-found branch) without needing a valid payload.
     await routeDropbox(page, { vaultBytes, imageVaultBytes, attachmentNotFound: true });

--- a/tests/playwright/core/item-price-history-cloud.spec.js
+++ b/tests/playwright/core/item-price-history-cloud.spec.js
@@ -36,6 +36,7 @@
  */
 
 import { test, expect } from "../helpers/mocks/extended-test.js";
+import { encryptVaultPayload } from "../helpers/vault-fixtures.js";
 
 const ACCOUNT_ID = "dbid:strk147-test-account";
 const VAULT_PASSWORD = "strk147-test-password";
@@ -243,35 +244,6 @@ async function routeDropbox(page, options = {}) {
   });
 }
 
-/**
- * Encrypts a plain object as a StakTrakr vault file (salt|iv|iter|ciphertext)
- * decryptable by the in-app composite-key path (_tryDecryptMetadata / the
- * companion vault decrypt). Runs in-page so it uses the app's exact crypto.
- */
-async function encryptVaultFile(page, payload) {
-  return page.evaluate(
-    async ({ data, key, iterations }) => {
-      const salt = window.vaultRandomBytes(32);
-      const iv = window.vaultRandomBytes(12);
-      const derived = await window.vaultDeriveKey(key, salt, iterations);
-      const plaintext = new TextEncoder().encode(JSON.stringify(data));
-      const ciphertext = await window.vaultEncrypt(plaintext, derived, iv);
-      const bytes = window.serializeVaultFile(salt, iv, iterations, ciphertext);
-      return Array.from(new Uint8Array(bytes));
-    },
-    {
-      data: payload,
-      key: SYNC_KEY,
-      iterations:
-        (await page.evaluate(() =>
-          typeof window.VAULT_PBKDF2_ITERATIONS !== "undefined"
-            ? window.VAULT_PBKDF2_ITERATIONS
-            : 600000
-        )) || 600000,
-    }
-  );
-}
-
 /** Reads the persisted item-price-history from localStorage (decompressed/parsed). */
 async function readPersistedHistory(page) {
   return page.evaluate(() => {
@@ -324,16 +296,20 @@ async function buildRemoteMeta(page, opts = {}) {
     uuidCount: 1,
     entryCount: 1,
   };
-  return encryptVaultFile(page, {
-    syncId: "remote-sync",
-    timestamp: BASE_TS + 5000,
-    rev: "remote-rev",
-    deviceId: "remote-device",
-    itemCount: LOCAL_INVENTORY.length,
-    manifestVersion: 2,
-    itemPriceHistoryVault: pointer,
-    ...(opts.overrides || {}),
-  });
+  return encryptVaultPayload(
+    page,
+    {
+      syncId: "remote-sync",
+      timestamp: BASE_TS + 5000,
+      rev: "remote-rev",
+      deviceId: "remote-device",
+      itemCount: LOCAL_INVENTORY.length,
+      manifestVersion: 2,
+      itemPriceHistoryVault: pointer,
+      ...(opts.overrides || {}),
+    },
+    SYNC_KEY
+  );
 }
 
 /**
@@ -360,7 +336,7 @@ async function seedRemoteCompanion(page, opts = {}) {
     pointer: opts.pointer,
     overrides: opts.metaOverrides,
   });
-  const historyVaultBytes = await encryptVaultFile(page, history);
+  const historyVaultBytes = await encryptVaultPayload(page, history, SYNC_KEY);
   await routeDropbox(page, { metaBytes, historyVaultBytes, ...(opts.routeOptions || {}) });
   if (!opts.keepDiffModal) await suppressDiffModal(page);
   return { remoteHash };

--- a/tests/playwright/helpers/vault-fixtures.js
+++ b/tests/playwright/helpers/vault-fixtures.js
@@ -1,0 +1,45 @@
+/**
+ * Shared cloud-sync vault fixtures for Playwright specs.
+ *
+ * Extracted from the duplicated per-spec helpers in attachments-cloud.spec.js
+ * (`encryptVaultPayload`) and item-price-history-cloud.spec.js
+ * (`encryptVaultFile`), which Codacy flagged as a clone on STRK-225 (#1306).
+ */
+
+/**
+ * Encrypts an arbitrary object as a StakTrakr `.stvault` file
+ * (`salt|iv|iter|ciphertext`) under the composite sync key, runnable in-page so
+ * it uses the app's exact crypto chain (`vaultRandomBytes` / `vaultDeriveKey` /
+ * `vaultEncrypt` / `serializeVaultFile`). The PBKDF2 iteration count is resolved
+ * in-page from `window.VAULT_PBKDF2_ITERATIONS` (falling back to 600000) so the
+ * fixture stays in lockstep with the app's parameters.
+ *
+ * Used to serve decryptable remote vaults to the in-app decrypt paths — e.g. the
+ * STRK-225 vault-first main sync vault (`{ data: { metalInventory } }`) and image
+ * companion vault (`{ records, patternRecords }`), and the STRK-147 sync-metadata
+ * and item-price-history companion vaults.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {object} payload - the object to encrypt as the vault body
+ * @param {string} syncKey - the composite `password:accountId` sync key
+ * @returns {Promise<number[]>} the serialized vault file bytes
+ */
+export async function encryptVaultPayload(page, payload, syncKey) {
+  return page.evaluate(
+    async ({ data, key }) => {
+      const iterations =
+        typeof window.VAULT_PBKDF2_ITERATIONS !== "undefined"
+          ? window.VAULT_PBKDF2_ITERATIONS
+          : 600000;
+      const salt = window.vaultRandomBytes(32);
+      const iv = window.vaultRandomBytes(12);
+      const derived = await window.vaultDeriveKey(key, salt, iterations);
+      const plaintext = new TextEncoder().encode(JSON.stringify(data));
+      const ciphertext = await window.vaultEncrypt(plaintext, derived, iv);
+      return Array.from(
+        new Uint8Array(window.serializeVaultFile(salt, iv, iterations, ciphertext))
+      );
+    },
+    { data: payload, key: syncKey }
+  );
+}


### PR DESCRIPTION
## What

Extract the duplicated in-page vault-encryption helper from two core cloud-sync Playwright specs into a single shared fixture.

Codacy flagged the crypto chain as duplication on [#1306](https://github.com/lbruton/StakTrakr/pull/1306) (STRK-225):
- `encryptVaultPayload` in `tests/playwright/core/attachments-cloud.spec.js`
- `encryptVaultFile` in `tests/playwright/core/item-price-history-cloud.spec.js`

Both ran the same `vaultRandomBytes` → `vaultDeriveKey` → `vaultEncrypt` → `serializeVaultFile` chain in-page to build a `salt|iv|iter|ciphertext` `.stvault` file under the composite `SYNC_KEY`.

## Change

- New `tests/playwright/helpers/vault-fixtures.js` exporting `encryptVaultPayload(page, payload, syncKey)`.
- Both specs import it; each passes its own `SYNC_KEY` constant as the third argument.
- Kept the single-`page.evaluate` shape (one round-trip, in-page `VAULT_PBKDF2_ITERATIONS` fallback) — the cleaner of the two originals.

## Verification

- `npx playwright test` on both specs → **17 passed (0 skipped)**.
- `prettier --check` and `eslint` clean on all three files.
- Pure refactor: no test cases added/removed, no behaviour change → no `coverage-map.csv` row needed (inventory unchanged).

Follow-up to the already-merged STRK-225; lightweight test-hygiene chore.