### PR TITLE
chore(start-patch): readable Plane states via list_states join + fix phantom tool

### DIFF
--- a/.agents/skills/start-patch/SKILL.md
+++ b/.agents/skills/start-patch/SKILL.md
@@ -2,7 +2,7 @@
 name: start-patch
 description: Use when starting a new patch session and needing to pick a Plane issue to work on before claiming a version lock and creating a worktree.
 user-invocable: true
-allowed-tools: Bash, Read, mcp__mem0__search_memories, mcp__plane__list_issues
+allowed-tools: Bash, Read, mcp__mem0__search_memories, mcp__plane__list_project_issues, mcp__plane__list_states
 ---
 
 # Start Patch
@@ -52,16 +52,23 @@ git status --short
 
 ### Plane query
 
-Use the Plane MCP project ID from `.specflow/config.json` and fetch non-completed issues
-from the StakTrakr project. Do not query Linear and do not read DocVault issue files for
-active work.
+Use the Plane MCP project ID from `.specflow/config.json`. This needs **two** calls —
+`list_project_issues` returns each issue's state as a bare UUID with `name: null` (the
+MCP never populates the state name in either list or single-issue responses), so the
+human-readable state name has to come from a separate `list_states` join.
 
 ```text
-mcp__plane__list_issues(project_id: "<plane_project_id>")
+mcp__plane__list_states(project_id: "<plane_project_id>")
+mcp__plane__list_project_issues(project_id: "<plane_project_id>")
 ```
 
+Build a `{state_id → state_name}` map from `list_states` once, then resolve each issue's
+`state.id` against it to recover the readable state (`In Progress`, `Todo`, `Backlog`, …).
+Priority needs no such join — it already comes back readable on `priority.id` (`urgent`,
+`high`, `medium`, `low`, `none`).
+
 Filter out completed and canceled states, then keep In Progress, Todo, and Backlog items.
-Plane priorities are strings such as `urgent`, `high`, `medium`, `low`, or `none`.
+Do not query Linear and do not read DocVault issue files for active work.
 
 ### mem0 — session continuity
 

--- a/.agents/skills/start-patch/SKILL.md
+++ b/.agents/skills/start-patch/SKILL.md
@@ -53,9 +53,10 @@ git status --short
 ### Plane query
 
 Use the Plane MCP project ID from `.specflow/config.json`. This needs **two** calls —
-`list_project_issues` returns each issue's state as a bare UUID with `name: null` (the
-MCP never populates the state name in either list or single-issue responses), so the
-human-readable state name has to come from a separate `list_states` join.
+`mcp__plane__list_project_issues` returns each issue's `state` as an object whose
+`state.id` is the UUID but whose `state.name` is `null`; `mcp__plane__get_issue_using_readable_identifier`
+returns `state` as a bare UUID string. The MCP never populates the state name in either
+response, so the human-readable name has to come from a separate `mcp__plane__list_states` join.
 
 ```text
 mcp__plane__list_states(project_id: "<plane_project_id>")
@@ -67,7 +68,7 @@ Build a `{state_id → state_name}` map from `list_states` once, then resolve ea
 Priority needs no such join — it already comes back readable on `priority.id` (`urgent`,
 `high`, `medium`, `low`, `none`).
 
-Filter out completed and canceled states, then keep In Progress, Todo, and Backlog items.
+Filter out completed and cancelled states, then keep In Progress, Todo, and Backlog items.
 Do not query Linear and do not read DocVault issue files for active work.
 
 ### mem0 — session continuity

--- a/.claude/skills/start-patch/SKILL.md
+++ b/.claude/skills/start-patch/SKILL.md
@@ -2,7 +2,7 @@
 name: start-patch
 description: Use when starting a new patch session and needing to pick a Plane issue to work on before claiming a version lock and creating a worktree.
 user-invocable: true
-allowed-tools: Bash, Read, mcp__mem0__search_memories, mcp__plane__list_issues
+allowed-tools: Bash, Read, mcp__mem0__search_memories, mcp__plane__list_project_issues, mcp__plane__list_states
 ---
 
 # Start Patch
@@ -52,16 +52,23 @@ git status --short
 
 ### Plane query
 
-Use the Plane MCP project ID from `.specflow/config.json` and fetch non-completed issues
-from the StakTrakr project. Do not query Linear and do not read DocVault issue files for
-active work.
+Use the Plane MCP project ID from `.specflow/config.json`. This needs **two** calls —
+`list_project_issues` returns each issue's state as a bare UUID with `name: null` (the
+MCP never populates the state name in either list or single-issue responses), so the
+human-readable state name has to come from a separate `list_states` join.
 
 ```text
-mcp__plane__list_issues(project_id: "<plane_project_id>")
+mcp__plane__list_states(project_id: "<plane_project_id>")
+mcp__plane__list_project_issues(project_id: "<plane_project_id>")
 ```
 
+Build a `{state_id → state_name}` map from `list_states` once, then resolve each issue's
+`state.id` against it to recover the readable state (`In Progress`, `Todo`, `Backlog`, …).
+Priority needs no such join — it already comes back readable on `priority.id` (`urgent`,
+`high`, `medium`, `low`, `none`).
+
 Filter out completed and canceled states, then keep In Progress, Todo, and Backlog items.
-Plane priorities are strings such as `urgent`, `high`, `medium`, `low`, or `none`.
+Do not query Linear and do not read DocVault issue files for active work.
 
 ### mem0 — session continuity
 

--- a/.claude/skills/start-patch/SKILL.md
+++ b/.claude/skills/start-patch/SKILL.md
@@ -53,9 +53,10 @@ git status --short
 ### Plane query
 
 Use the Plane MCP project ID from `.specflow/config.json`. This needs **two** calls —
-`list_project_issues` returns each issue's state as a bare UUID with `name: null` (the
-MCP never populates the state name in either list or single-issue responses), so the
-human-readable state name has to come from a separate `list_states` join.
+`mcp__plane__list_project_issues` returns each issue's `state` as an object whose
+`state.id` is the UUID but whose `state.name` is `null`; `mcp__plane__get_issue_using_readable_identifier`
+returns `state` as a bare UUID string. The MCP never populates the state name in either
+response, so the human-readable name has to come from a separate `mcp__plane__list_states` join.
 
 ```text
 mcp__plane__list_states(project_id: "<plane_project_id>")
@@ -67,7 +68,7 @@ Build a `{state_id → state_name}` map from `list_states` once, then resolve ea
 Priority needs no such join — it already comes back readable on `priority.id` (`urgent`,
 `high`, `medium`, `low`, `none`).
 
-Filter out completed and canceled states, then keep In Progress, Todo, and Backlog items.
+Filter out completed and cancelled states, then keep In Progress, Todo, and Backlog items.
 Do not query Linear and do not read DocVault issue files for active work.
 
 ### mem0 — session continuity


### PR DESCRIPTION
## What

`/start-patch` now resolves Plane issue states to readable names instead of showing raw UUIDs, and no longer references a tool that doesn't exist.

## Why

Verified against the live Plane MCP:

| Tool | state field | priority field |
|------|-------------|----------------|
| `list_project_issues` | `state: { id: "<uuid>", name: null }` | `priority.id: "medium"` ✅ |
| `get_issue_using_readable_identifier` | `state: "<uuid>"` (bare) | `priority: "medium"` ✅ |
| `list_states` | full `{id, name, color, group}` | — |

The MCP **never** populates the state name in list or single-issue responses — only `list_states` maps UUID→name. Separately, the skill referenced `mcp__plane__list_issues`, which is a phantom (real tool: `list_project_issues`).

## Changes

- `allowed-tools` + body now use `list_project_issues`
- Added a one-time `list_states` UUID→name join so the candidate table renders real states (In Progress / Todo / Backlog)
- Noted priority is already readable on `priority.id` (no join needed)
- Applied to both skill twins (`.claude/` + `.agents/`)

Lightweight chore (skill docs only) — no Plane issue or version lock. `ship` and `plane-archive` already use the correct `list_states` pattern; no change needed there.