### PR TITLE
chore(config): make Codacy local config portable across worktrees

### DIFF
--- a/.codacy/codacy.config.json
+++ b/.codacy/codacy.config.json
@@ -357,7 +357,7 @@
     },
     {
       "toolId": "markdownlint",
-      "localConfigurationFile": "/Volumes/DATA/GitHub/StakTrakr/.markdownlint.json",
+      "localConfigurationFile": ".markdownlint.json",
       "useLocalConfigurationFile": true,
       "patterns": []
     },
@@ -434,7 +434,7 @@
     },
     {
       "toolId": "ESLint9",
-      "localConfigurationFile": "/Volumes/DATA/GitHub/StakTrakr/eslint.config.cjs",
+      "localConfigurationFile": "eslint.config.cjs",
       "patterns": [
         {
           "patternId": "ESLint9_@typescript-eslint_related-getter-setter-pairs"

--- a/.context/review-and-ci.md
+++ b/.context/review-and-ci.md
@@ -44,8 +44,8 @@ Run the local scan with the official Codacy analysis CLI (installed machine-wide
   `/Volumes/...` paths that then break in worktrees. Refresh **only** when the cloud
   "StakTrakr" standard actually changes, and do it **in the main checkout** — run
   `codacy-analysis init --remote gh lbruton StakTrakr`, then re-relativize the two paths and
-  commit:
-  `sed -i '' 's#"/Volumes/DATA/GitHub/StakTrakr/\(\.markdownlint\.json\|eslint\.config\.cjs\)"#"\1"#g' .codacy/codacy.config.json`
+  commit (path-agnostic, runs on macOS and Linux):
+  `perl -i -pe 's#("localConfigurationFile":\s*")[^"]*/(\.markdownlint\.json|eslint\.config\.cjs)"#$1$2"#g' .codacy/codacy.config.json`
 - **Cloud state is authoritative via the Cloud CLI, not the dashboard UI.** Before
   claiming a Codacy tool toggle or pattern suppression is done, confirm it with the
   Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend

--- a/.context/review-and-ci.md
+++ b/.context/review-and-ci.md
@@ -31,14 +31,21 @@ Run the local scan with the official Codacy analysis CLI (installed machine-wide
 `npm i -g @codacy/analysis-cli`; no per-project bootstrap):
 
 - Scan changed files: `codacy-analysis analyze --diff --output-format sarif --output codacy-findings.sarif`
-- Config: `.codacy/codacy.config.json` — a 1:1 mirror of the Codacy Cloud dashboard,
-  regenerated with `codacy-analysis init --remote gh lbruton StakTrakr`.
+- Config: `.codacy/codacy.config.json` — a near-1:1 mirror of the Codacy Cloud dashboard,
+  regenerated with `codacy-analysis init --remote gh lbruton StakTrakr`. The two
+  `localConfigurationFile` entries (ESLint9, markdownlint) are deliberately kept
+  **repo-relative** (`eslint.config.cjs`, `.markdownlint.json`) — `analyze` resolves them
+  against the project root, so the tracked file is portable across the main checkout and
+  every worktree.
 - `analyze` does **not** mutate the config file (verified), so there is no churn to revert.
-- **Refresh before trusting it:** the tracked copy can lag the cloud "StakTrakr"
-  standard. Run `codacy-analysis init --remote gh lbruton StakTrakr` to pull the
-  latest before relying on local analysis. Git tracking does NOT affect `init`'s
-  output — it overwrites from cloud regardless — so the file is tracked purely so
-  it's present in every worktree, not as a source of truth.
+- **Do NOT run `init --remote` in a worktree.** The tracked, repo-relative config is the
+  working copy and resolves correctly in any checkout, so re-init buys nothing and actively
+  harms: `init` overwrites from cloud regardless of git tracking and re-bakes absolute
+  `/Volumes/...` paths that then break in worktrees. Refresh **only** when the cloud
+  "StakTrakr" standard actually changes, and do it **in the main checkout** — run
+  `codacy-analysis init --remote gh lbruton StakTrakr`, then re-relativize the two paths and
+  commit:
+  `sed -i '' 's#"/Volumes/DATA/GitHub/StakTrakr/\(\.markdownlint\.json\|eslint\.config\.cjs\)"#"\1"#g' .codacy/codacy.config.json`
 - **Cloud state is authoritative via the Cloud CLI, not the dashboard UI.** Before
   claiming a Codacy tool toggle or pattern suppression is done, confirm it with the
   Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend


### PR DESCRIPTION
## Why

We kept "re-installing Codacy" on every new worktree/spec. The real cause: nothing
reinstalls the CLI or analyzers (those are machine-global and shared) — what repeated
was `codacy-analysis init --remote`, a full cloud config refresh, driven by two things:

1. `.context/review-and-ci.md` told the agent to "refresh before trusting" local analysis
   in every worktree.
2. The tracked `.codacy/codacy.config.json` hardcoded **absolute** `localConfigurationFile`
   paths bound to the main checkout (`/Volumes/DATA/GitHub/StakTrakr/.markdownlint.json`,
   `…/eslint.config.cjs`). Those don't resolve inside a worktree, so the inherited config
   was effectively unusable → re-init.

## What changed

- **`.codacy/codacy.config.json`** — relativize the two `localConfigurationFile` entries
  (`.markdownlint.json`, `eslint.config.cjs`). Codacy resolves them against the invocation
  cwd, so the tracked config now works as-is in the main checkout **and** every worktree.
- **`.context/review-and-ci.md`** — rewrite the Pre-PR scan guidance: **do not** run
  `init --remote` in a worktree. Refresh only in the main checkout when the cloud "StakTrakr"
  standard actually changes, then re-relativize the two paths (with a documented `sed`
  one-liner) and commit.

## Verification

- `codacy-analysis analyze . --files .context/review-and-ci.md` run **in a fresh worktree
  with no `init --remote`** → `exit 0`; Configuration column shows `./.markdownlint.json`
  and `./eslint.config.cjs` resolving correctly, markdownlint ran clean (0 issues).
- `python3 -m json.tool` confirms the config is valid JSON; `grep -c /Volumes …` → `0`.
- Skills sweep (`.claude/skills`, `.agents/skills`) found no per-worktree `init` instruction —
  the doc was the sole driver.

## Scope / process

Config + docs chore: no runtime code, no version bump, no spot bundle, no Plane issue
(lightweight per `.context/git-topology.md`). Required `Codacy Static Code Analysis` + CodeQL
checks are unaffected — they read the cloud standard, not this local file.
