### PR TITLE
docs(review-ci): clarify codacy-analysis-cli is a skill, not a command

### DIFF
--- a/.context/review-and-ci.md
+++ b/.context/review-and-ci.md
@@ -27,8 +27,12 @@ Copilot and Codacy AI post review threads 1–3 min _after_ required checks pass
 
 ## Pre-PR scan — Codacy local analysis (Gen-3)
 
-Run the local scan with the official Codacy analysis CLI (installed machine-wide via
-`npm i -g @codacy/analysis-cli`; no per-project bootstrap):
+Run the local scan with the **`codacy-analysis`** command (npm package `@codacy/analysis-cli`),
+which is **already installed machine-wide** — there is no per-project bootstrap and no
+per-task reinstall. NOTE: `codacy-analysis-cli` is the _skill_ name, **not** a command or npm
+package (it is also the name of the deprecated Gen-1 tool) — never run `codacy-analysis-cli` as
+a command, and do not `npm install`/`npx` the CLI per scan. Verify presence with
+`command -v codacy-analysis`; only run `npm i -g @codacy/analysis-cli` if that check fails.
 
 - Scan changed files: `codacy-analysis analyze --diff --output-format sarif --output codacy-findings.sarif`
 - Config: `.codacy/codacy.config.json` — a near-1:1 mirror of the Codacy Cloud dashboard,
@@ -50,8 +54,10 @@ Run the local scan with the official Codacy analysis CLI (installed machine-wide
   claiming a Codacy tool toggle or pattern suppression is done, confirm it with the
   Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend
   can diverge, and a UI-only check has been wrong repeatedly in a single session. The
-  Codacy MCP server is retired; use the `codacy-skills` plugin CLIs (`codacy-cloud-cli`
-  for cloud state, `codacy-analysis-cli` for local scans).
+  Codacy MCP server is retired; use the `codacy-skills` plugin **skills** — the
+  `codacy-cloud-cli` skill (which drives the `codacy` command) for cloud state, and the
+  `codacy-analysis-cli` skill (which drives the `codacy-analysis` command) for local scans.
+  These are skill names invoked via the Skill tool, not shell commands.
 
 ## Dual ESLint config — `.eslintrc.json` is read by Codacy and CodeRabbit
 

--- a/.context/review-and-ci.md
+++ b/.context/review-and-ci.md
@@ -50,10 +50,11 @@ a command, and do not `npm install`/`npx` the CLI per scan. Verify presence with
   `codacy-analysis init --remote gh lbruton StakTrakr`, then re-relativize the two paths and
   commit (path-agnostic, runs on macOS and Linux):
   `perl -i -pe 's#("localConfigurationFile":\s*")[^"]*/(\.markdownlint\.json|eslint\.config\.cjs)"#$1$2"#g' .codacy/codacy.config.json`
-- **Cloud state is authoritative via the Cloud CLI, not the dashboard UI.** Before
-  claiming a Codacy tool toggle or pattern suppression is done, confirm it with the
-  Codacy Cloud CLI (`/codacy-skills:codacy-cloud-cli`) — the dashboard UI and backend
-  can diverge, and a UI-only check has been wrong repeatedly in a single session. The
+- **Cloud state is authoritative via the `codacy` command (the Codacy Cloud CLI), not the
+  dashboard UI.** Before claiming a Codacy tool toggle or pattern suppression is done, confirm
+  it by running the `codacy` command — invoked through the `codacy-cloud-cli` skill (Skill
+  tool) — because the dashboard UI and backend can diverge, and a UI-only check has been wrong
+  repeatedly in a single session. The
   Codacy MCP server is retired; use the `codacy-skills` plugin **skills** — the
   `codacy-cloud-cli` skill (which drives the `codacy` command) for cloud state, and the
   `codacy-analysis-cli` skill (which drives the `codacy-analysis` command) for local scans.


### PR DESCRIPTION
## Why

Companion to the spec-template fix (DocVault `6a03087`). Root cause of the recurring **per-job Codacy npm reinstall**: instruction sources referred to `codacy-analysis-cli` — which is a **skill** name (and, confusingly, the name of the *deprecated Gen-1 package*) — as if it were a command. Agents tried to run/find `codacy-analysis-cli`, failed (the real command is `codacy-analysis`, already installed machine-wide), and `npm i -g`'d it on every spec/worktree.

## What changed (`.context/review-and-ci.md`)

- **Pre-PR scan intro**: state plainly that `codacy-analysis` is *already installed machine-wide*; `codacy-analysis-cli` is the **skill** name, not a command/package; never run it as a command or `npm install`/`npx` per task — verify with `command -v codacy-analysis`, install only if that fails.
- **Cloud-CLI bullet**: relabel the `codacy-skills` entries as **skills** (invoked via the Skill tool) that drive the `codacy` / `codacy-analysis` commands — not shell commands.

## Scope

Docs-only chore (`.context/`). No runtime code, version bump, or spot bundle. The `codacy-review`/`coderabbit-review` labels are intentionally omitted (trivial chore); required Codacy Static + CodeQL run regardless.

Memory note `project-codacy-gen3-migration` and the project `settings.local.json` (stale retired-MCP perms) were updated in the same session.