### PR TITLE
docs(infisical): cite project UUID in secrets pre-flight, not the slug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Full detail (routing table, throttle, false positives) in `.context/review-and-c
 - Version-bump PRs: ensure Tailscale is active.
 - `dev → main` shipping: invoke `/ship` only on explicit user approval.
 - Cloud or infrastructure claims: read the matching Foundation doc before speculating.
-- Fly.io or home poller secret claims: verify through Infisical for project `stak-trakr-94m4`, env `dev`.
+- Fly.io or home poller secret claims: verify through Infisical with `projectId` = UUID `319a1db5-207d-49d0-a61d-3f3e6b440ded`, env `dev`. Pass the UUID, not the slug `stak-trakr-94m4` (slug → `404 "bot lookup"`); `list-projects` is 422-broken.
 - Cron schedule claims: grep `devops/pollers/home-poller/docker-entrypoint.sh`.
 
 ## Commit And PR Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ Read `.context/review-and-ci.md` before Codacy CLI scans, agentlint runs, pre-PR
 - **Before writing any JavaScript** → read `Foundation/coding-standards.md` (DocVault).
 - **Before any feed/poller/API/data-path diagnosis** → invoke `/api-infrastructure` and `/retail-poller` first.
 - **Before speculating on infra failure mode** → read matching Foundation doc.
-- **Before claiming what env/secret is set on Fly.io or home poller** → `mcp__infisical__get-secret` (project `stak-trakr-94m4`, env `dev`).
+- **Before claiming what env/secret is set on Fly.io or home poller** → `mcp__infisical__get-secret` with `projectId` = UUID `319a1db5-207d-49d0-a61d-3f3e6b440ded`, env `dev`. Pass the UUID, not the slug `stak-trakr-94m4` (slug → `404 "bot lookup"`); `list-projects` is 422-broken, so discovery is unavailable.
 - **Before any version-bump PR**:
   - Run `/update-spot-bundle`.
   - Ensure Tailscale is active.


### PR DESCRIPTION
## What

Update the Fly.io / home-poller **secrets pre-flight** in both instruction twins (`CLAUDE.md`, `AGENTS.md`) to reference the Infisical project by its **UUID** instead of the human-facing slug.

## Why

`mcp__infisical__get-secret` / `list-secrets` take `projectId` = the **UUID**. The pre-flight documented the **slug** `stak-trakr-94m4`, so every caller passed the slug and got:

```
404 "Project with ID 'stak-trakr-94m4' not found during bot lookup"
```

Normally you'd call `list-projects` to translate slug → UUID, but that endpoint is **broken (HTTP 422)** — so callers had no way to self-correct, and the whole MCP got mislabeled "broken." In reality only `list-projects` is down; secret **read and write** work fine when given the UUID.

## Change

Both twins now cite `projectId = 319a1db5-207d-49d0-a61d-3f3e6b440ded`, warn that the slug 404s, and note the `list-projects` 422.

## Verification

- Live: `get-secret(projectId=319a1db5-…, env=dev, secretName=SQLD_URL)` → `http://192.168.1.81:8080` ✅
- `npx agentlinter --local`: zero criticals; neither edited line (`CLAUDE.md:200`, `AGENTS.md:138`) is flagged.
- Diff is exactly 2 lines across 2 files.

## Scope

Lightweight config/instruction chore — no Plane issue, no version bump, no runtime code touched.
