### PR TITLE
chore(deps): bump js-yaml 4.1.1 → 4.3.0 on dev (replaces #1352)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -892,10 +892,20 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
Replaces #1352, landing the same fix on `dev` instead of `main`.

## Why #1352 targeted `main`

Not a config bug. `.github/dependabot.yml` correctly sets `target-branch: dev` for both ecosystems, but this is a **security** update, and per [GitHub's docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) *"security updates always use the default branch for the repository"* — `target-branch` applies to version updates only. This will recur for every future Dependabot security PR; nothing to fix in the config.

Merging #1352 as-is would put `main` ahead of `dev` and invite the severed-ancestry situation `/ship` has to heal with `-s ours`. This PR takes the normal `dev → main` path instead.

## Risk: low

[GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — quadratic-complexity DoS in YAML merge-key handling, **moderate** (CVSS 5.3, CWE-407), affects `>=4.0.0 <=4.1.1`.

js-yaml is a **dev-only transitive** dependency:

```
staktrakr@3.35.64
`-- eslint@9.39.2
  `-- @eslint/eslintrc@3.3.3
    `-- js-yaml@4.1.1
```

StakTrakr ships no YAML parsing to the browser, so there is no production exposure — exploiting this would require linting a hostile YAML file locally.

## Change

Lockfile-only, via `npm audit fix --package-lock-only`. Only the `js-yaml` block moves; `eslint` stays on **9.39.2** and no other package resolves differently.

## Verification

- `npm audit` → **0 vulnerabilities** (was 1 moderate)
- `npm run lint` → passes (exit 0)
- `npm run test:unit` → **388/388 pass**
- `npm ci` from this lockfile installs js-yaml 4.3.0, eslint 9.39.2, no drift

## Related

- **STRK-253** tracks the ESLint 9 → 10 migration. That upgrade drops `@eslint/eslintrc` — the only thing pulling js-yaml in — so it will dissolve this dependency entirely and make this pin unnecessary.
- #1350 (eslint 10) closed and deferred; Codacy still ships only ESLint9.