### PR TITLE
docs(context): fix stray tildes rendering the --warning gotcha as struck-through

### DIFF
--- a/.context/implementation-gotchas.md
+++ b/.context/implementation-gotchas.md
@@ -25,9 +25,9 @@ Missing the corner tier causes data cells to paint over the frozen header corner
 
 ## `--warning` color — accessibility fail on small text in light/sepia
 
-`--warning` (oklch L≈0.666) on `--bg-secondary` produces ~1.4:1 contrast in light (L≈0.96) and sepia (L≈0.892) themes.
+`--warning` (oklch L≈0.666) on `--bg-secondary` produces ≈1.4:1 contrast in light (L≈0.96) and sepia (L≈0.892) themes.
 That fails WCAG level AA for small text.
-Use a darker custom amber (~`oklch(0.55 0.15 60)`) for ticker or `font-size-xs` contexts in these themes.
+Use a darker custom amber (≈`oklch(0.55 0.15 60)`) for ticker or `font-size-xs` contexts in these themes.
 
 ## `_isMarketItemEnabled` guard — apply on both tab paths
 


### PR DESCRIPTION
Two-character docs fix in `.context/implementation-gotchas.md`. Pre-existing content bug, not a regression.

## The bug

Lines 28 and 30 each used a bare `~` to mean "approximately". In GFM a single tilde opens strikethrough, so **the two tildes paired with each other** and everything between them rendered as a `<del>` span.

Verified against GitHub's own GFM render API (`POST /markdown`, `mode: gfm`) — the file on `dev` today returns exactly **one `<del>` element**, containing:

> 1.4:1 contrast in light (L≈0.96) and sepia (L≈0.892) themes.
> That fails WCAG level AA for small text.
> Use a darker custom amber (

That swallows **"That fails WCAG level AA for small text."** — the warning the section exists to deliver. Strikethrough conventionally reads as *retracted / no longer applies*, so the gotcha has been rendering as though it were withdrawn, in both GitHub and Obsidian.

## The fix

Replaced both `~` with `≈` — the character the file **already uses for exactly this purpose on these very lines** (`L≈0.666`, `L≈0.96`, `L≈0.892`). The stray tildes were inconsistencies with the doc's own convention, so this aligns them rather than escaping around the problem (`\~` would also work but reads worse and matches nothing else in the file).

```diff
-`--warning` (oklch L≈0.666) on `--bg-secondary` produces ~1.4:1 contrast in light (L≈0.96) and sepia (L≈0.892) themes.
+`--warning` (oklch L≈0.666) on `--bg-secondary` produces ≈1.4:1 contrast in light (L≈0.96) and sepia (L≈0.892) themes.
 That fails WCAG level AA for small text.
-Use a darker custom amber (~`oklch(0.55 0.15 60)`) for ticker or `font-size-xs` contexts in these themes.
+Use a darker custom amber (≈`oklch(0.55 0.15 60)`) for ticker or `font-size-xs` contexts in these themes.
```

## How it surfaced

The prettier 3.8.4 → 3.9.4 bump (#1349, `d4c91045`). 3.9.4's markdown parser models this span and canonicalizes it to the explicit `~~` form; 3.8.3 did not flag the file at all. So `npm run format` under 3.9.4 would have **written the strikethrough in permanently** as `~~`, turning a latent rendering bug into committed content.

Worth noting the upgrade did its job here: it surfaced a real latent bug rather than creating one.

## Verification

| Check | Before | After |
|---|---|---|
| GitHub GFM `<del>` elements | 1 | **0** |
| `prettier@3.9.4 --check` on the file | fails | **passes** |
| Tildes remaining in file | 2 | **0** |

## Scope

Docs-only, single file — lightweight chore per CLAUDE.md, so no Plane issue or version lock.

Deliberately **not** included: `npm run format:check` still fails on 10 files under `devops/pollers/shared/*.test.mjs`. That is separate pre-existing debt that predates the prettier bump and is unrelated to this fix.