### PR TITLE
docs(readme): refresh What's New for v3.35.64

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ A powerful, privacy-first portfolio tracker for Silver, Gold, Platinum, Palladiu
 
 ## What's New in v3.35.64
 
-- **Retail price reliability** — Summit Metals prices restored after a related-products carousel false-flagged the whole vendor out of stock; goldback's stale-data warning now fires correctly during feed outages instead of silently showing hours-old prices (STRK-251, STRK-250)
+- **Retail price reliability** — Summit Metals prices restored after a related-products carousel false-flagged the whole vendor out of stock; Goldback's stale-data warning now fires correctly during feed outages instead of silently showing hours-old prices (STRK-251, STRK-250)
 - **Goldback intraday pricing** — new hourly price feed covering the last 72 hours, honest scrape-time timestamps instead of a daily placeholder, and a 2-hour freshness budget (STRK-248)
-- **Realtime price freshness** — spot, goldback, and retail prices load fresh on every visit instead of a stale cached copy, with automatic failover to the backup API (STRK-249)
+- **Real-time price freshness** — spot, Goldback, and retail prices load fresh on every visit instead of a stale cached copy, with automatic failover to the backup API (STRK-249)
 - **Constitutional (junk) silver** — lot pricing by denomination, bulk Type→Goldback conversion, custom-purity field reset on type changes, and value-chart history capture for valuation-only edits (STRK-242, STRK-244, STRK-245, STRK-246, STRK-247)
 
 Full details in the [Changelog](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ A powerful, privacy-first portfolio tracker for Silver, Gold, Platinum, Palladiu
 
 ---
 
-## What's New in v3.35.0
+## What's New in v3.35.64
 
-- **Trade linking** — bidirectional links between disposed-traded items and received inventory with editable provenance, spot-derived trade values, undo support, and cloud-sync visibility (STRK-123)
-- **Cloud sync hardening** — tag merge on sync, conflict-loop fix after accepting remote changes, Bullion Exchanges content-quality retry (STRK-106, STRK-107, STRK-108)
-- **Retail & autocomplete fixes** — SDB/BE spot-ticker sidebar leak patched, autocomplete field name casing corrected (STRK-99, STRK-114)
-- **Test infrastructure** — full Playwright suite consolidation from 7 scattered spec tiers into compact domain suites with archived historical coverage (STRK-97 → STRK-122)
+- **Retail price reliability** — Summit Metals prices restored after a related-products carousel false-flagged the whole vendor out of stock; goldback's stale-data warning now fires correctly during feed outages instead of silently showing hours-old prices (STRK-251, STRK-250)
+- **Goldback intraday pricing** — new hourly price feed covering the last 72 hours, honest scrape-time timestamps instead of a daily placeholder, and a 2-hour freshness budget (STRK-248)
+- **Realtime price freshness** — spot, goldback, and retail prices load fresh on every visit instead of a stale cached copy, with automatic failover to the backup API (STRK-249)
+- **Constitutional (junk) silver** — lot pricing by denomination, bulk Type→Goldback conversion, custom-purity field reset on type changes, and value-chart history capture for valuation-only edits (STRK-242, STRK-244, STRK-245, STRK-246, STRK-247)
 
 Full details in the [Changelog](CHANGELOG.md).
 


### PR DESCRIPTION
## Summary
- README's "What's New" section still read "What's New in v3.35.0" (the Trade Linking release, last touched in the v3.35.56 timeframe) — refreshed to summarize the 8 patches shipped since (v3.35.57-3.35.64).

## Test plan
- Docs-only change; markdown lint + prettier passed via pre-commit hooks.