### PR TITLE
chore(docs): scope en-CA date rule to local dates, add UTC-key inverse case

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ For UI work touching `index.html`, `css/styles.css`, modal/view rendering, or in
 - `events.js` top-level code cannot call `safeGetElement`; use `document.getElementById` for parse-time event wiring.
 - `state.js` variables declared with `let` need `Object.defineProperty` exposure when tests or modules require `window.X`.
 - Use Canadian English locale formatting with `toLocaleDateString('en-CA')` for local user-facing `yyyy-mm-dd` dates; do not use `toISOString().slice(0, 10)` for those.
-- For UTC-keyed data values (publisher feed business days, chart time keys), keep the UTC calendar date via the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`.
+- For UTC-keyed data values (publisher feed business days, chart time keys), keep the UTC calendar date via the feed row's ISO timestamp field (`row.t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`.
 - Do not mix local Date construction with UTC formatting unless the conversion is deliberate and commented at the call site.
 - StakTrakr has four CSS themes: `light`, `dark`, `slate`, and `sepia`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,8 @@ For UI work touching `index.html`, `css/styles.css`, modal/view rendering, or in
 - `events.js` top-level code cannot call `safeGetElement`; use `document.getElementById` for parse-time event wiring.
 - `state.js` variables declared with `let` need `Object.defineProperty` exposure when tests or modules require `window.X`.
 - Use Canadian English locale formatting with `toLocaleDateString('en-CA')` for local user-facing `yyyy-mm-dd` dates; do not use `toISOString().slice(0, 10)` for those.
-- For UTC-keyed data values (publisher feed business days, chart time keys), keep the UTC calendar date via the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`; never mix local Date construction with UTC formatting.
+- For UTC-keyed data values (publisher feed business days, chart time keys), keep the UTC calendar date via the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`.
+- Do not mix local Date construction with UTC formatting unless the conversion is deliberate and commented at the call site.
 - StakTrakr has four CSS themes: `light`, `dark`, `slate`, and `sepia`.
 
 ## Release And Pre-Commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ For UI work touching `index.html`, `css/styles.css`, modal/view rendering, or in
 - `showAppConfirm`, `showAppAlert`, and `showAppPrompt` are custom Document Object Model (DOM) modals, not native browser dialogs.
 - `events.js` top-level code cannot call `safeGetElement`; use `document.getElementById` for parse-time event wiring.
 - `state.js` variables declared with `let` need `Object.defineProperty` exposure when tests or modules require `window.X`.
-- Use Canadian English locale formatting with `toLocaleDateString('en-CA')` for local `yyyy-mm-dd` dates; do not use `toISOString().slice(0, 10)`.
+- Use Canadian English locale formatting with `toLocaleDateString('en-CA')` for local user-facing `yyyy-mm-dd` dates; do not use `toISOString().slice(0, 10)` for those.
+- For UTC-keyed data values (publisher feed business days, chart time keys), keep the UTC calendar date via the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`; never mix local Date construction with UTC formatting.
 - StakTrakr has four CSS themes: `light`, `dark`, `slate`, and `sepia`.
 
 ## Release And Pre-Commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,10 @@ Do not fall back to Python/subprocess file writes as a workaround.
 
 ### Date formatting — Canadian English locale
 
-Use `toLocaleDateString('en-CA')` (Canadian English) to produce local dates in year-month-day format.
-Do not use `toISOString().slice(0, 10)`; it returns a UTC date and causes off-by-one errors for users in negative UTC offsets.
+Use `toLocaleDateString('en-CA')` (Canadian English) to produce **local, user-facing** dates in year-month-day format (form defaults, filenames, display).
+Do not use `toISOString().slice(0, 10)` for those; it returns a UTC date and shifts a day for users in negative UTC offsets.
+**Inverse case — UTC-keyed data values** (publisher feed business days, chart time keys): keep the UTC calendar date via the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`; local `en-CA` there shifts a day for users in positive UTC offsets.
+Never mix frames (for example, local `new Date(y, m, d)` construction followed by `toISOString()` formatting).
 
 ### Theme count — four themes, not three
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,8 +172,10 @@ Do not fall back to Python/subprocess file writes as a workaround.
 
 Use `toLocaleDateString('en-CA')` (Canadian English) to produce **local, user-facing** dates in year-month-day format (form defaults, filenames, display).
 Do not use `toISOString().slice(0, 10)` for those; it returns a UTC date and shifts a day for users in negative UTC offsets.
-**Inverse case — UTC-keyed data values** (publisher feed business days, chart time keys): keep the UTC calendar date via the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`; local `en-CA` there shifts a day for users in positive UTC offsets.
-Never mix frames (for example, local `new Date(y, m, d)` construction followed by `toISOString()` formatting).
+**Inverse case — UTC-keyed data values** (publisher feed business days, chart time keys): keep the UTC calendar date.
+Derive it from the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`.
+Local `en-CA` on a UTC-stamped key shifts a day for users in positive UTC offsets.
+Do not mix frames (local `new Date(y, m, d)` construction followed by `toISOString()` formatting) unless the conversion is deliberate and commented at the call site.
 
 ### Theme count — four themes, not three
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Do not fall back to Python/subprocess file writes as a workaround.
 Use `toLocaleDateString('en-CA')` (Canadian English) to produce **local, user-facing** dates in year-month-day format (form defaults, filenames, display).
 Do not use `toISOString().slice(0, 10)` for those; it returns a UTC date and shifts a day for users in negative UTC offsets.
 **Inverse case — UTC-keyed data values** (publisher feed business days, chart time keys): keep the UTC calendar date.
-Derive it from the ISO substring (`t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`.
+Derive it from the feed row's ISO timestamp field (`row.t.split("T")[0]`) or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`.
 Local `en-CA` on a UTC-stamped key shifts a day for users in positive UTC offsets.
 Do not mix frames (local `new Date(y, m, d)` construction followed by `toISOString()` formatting) unless the conversion is deliberate and commented at the call site.
 


### PR DESCRIPTION
## Summary

Instruction-file-only chore (CLAUDE.md + AGENTS.md twins, kept in sync). No runtime code touched.

The **Date formatting — Canadian English locale** rule was accurate for its original scope (user-facing local dates) but never stated its boundary. During STRK-260 design review, the ambiguity nearly steered the implementation toward applying local `en-CA` formatting to UTC-keyed data values (publisher daily-history business days, chart time keys) — the mirror-image bug of the one the rule was written to prevent (shifts a day for positive-UTC-offset users instead of negative).

## Changes

- **CLAUDE.md** — scope the rule to local, user-facing dates; add the UTC-keyed inverse case (`t.split("T")[0]` or `toLocaleDateString('en-CA', { timeZone: 'UTC' })`); ban mixed-frame construction/formatting.
- **AGENTS.md** — matching twin update (two bullets).

## Verification

- `npx agentlinter --local` — zero criticals (only pre-existing acronym tips).
- Markdown lint + prettier passed via pre-commit hooks.
- All six existing `en-CA` call sites remain compliant under the clarified rule; `market-charts.js:173` UTC substring is now explicitly sanctioned rather than a contradiction.