### PR TITLE
chore(dates): remove unreachable European fallback in parseDate

### DIFF
--- a/js/utils-format.js
+++ b/js/utils-format.js
@@ -192,14 +192,7 @@ function parseDate(dateStr) {
     }
     // Both numbers <= 12, ambiguous - default to US format (MM/DD/YYYY)
     else if (first <= 12 && second <= 12) {
-      // Try US format first
-      let date = new Date(year, first - 1, second);
-      if (!isNaN(date) && date.toString() !== "Invalid Date") {
-        return localIsoDate(date);
-      }
-
-      // Fallback to European format
-      date = new Date(year, second - 1, first);
+      const date = new Date(year, first - 1, second);
       if (!isNaN(date) && date.toString() !== "Invalid Date") {
         return localIsoDate(date);
       }

--- a/js/utils-format.js
+++ b/js/utils-format.js
@@ -183,15 +183,9 @@ function parseDate(dateStr) {
         return localIsoDate(date);
       }
     }
-    // If second number > 12, it must be MM/DD/YYYY (US)
-    else if (second > 12 && first <= 12) {
-      const date = new Date(year, first - 1, second);
-      if (!isNaN(date) && date.toString() !== "Invalid Date") {
-        return localIsoDate(date);
-      }
-    }
-    // Both numbers <= 12, ambiguous - default to US format (MM/DD/YYYY)
-    else if (first <= 12 && second <= 12) {
+    // Otherwise treat as MM/DD/YYYY (US) — unambiguous when second > 12,
+    // and the default when both numbers are <= 12 (ambiguous)
+    else if (first <= 12) {
       const date = new Date(year, first - 1, second);
       if (!isNaN(date) && date.toString() !== "Invalid Date") {
         return localIsoDate(date);

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.64-b1784910217";
+const CACHE_NAME = "staktrakr-v3.35.64-b1784913145";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.64-b1784913145";
+const CACHE_NAME = "staktrakr-v3.35.64-b1784913451";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =


### PR DESCRIPTION
## Summary

Removes confirmed-dead code in `parseDate()` (`js/utils-format.js`), flagged by Codacy as an outside-diff note during PR #1362 review.

In the ambiguous both-numbers-<=12 branch, the US-format attempt `new Date(year, first - 1, second)` can never produce Invalid Date for integers 1–12 — the Date constructor rolls over out-of-range values instead of failing — so the subsequent European-format fallback never executed. This deletes the fallback and its comment; behavior is byte-identical.

`sw.js` cache-name delta is the automatic pre-commit stamp hook.

## Testing

- `npm run test:unit` — 400/400 pass, including the covering spec `tests/unit/parse-date-local-frame.test.js` (STRK-266 local-frame matrix)
- `npm run lint` — clean

No version bump, no coverage-map row (no Playwright change) — /gsd-sized chore per repo policy.