### PR TITLE
fix(dates): parseDate rejects impossible calendar dates via rollover (STRK-267)

### DIFF
--- a/js/utils-format.js
+++ b/js/utils-format.js
@@ -121,6 +121,36 @@ const localIsoDate = (date) => {
 };
 
 /**
+ * Constructs a local-midnight Date from numeric components and verifies they
+ * round-trip unchanged. The Date constructor silently rolls impossible
+ * calendar dates (Feb 31 → Mar 2/3), so a component mismatch means the input
+ * date does not exist on the calendar (STRK-267).
+ *
+ * @param {number} year - Full 4-digit year
+ * @param {number} monthIndex - Zero-based month (0-11)
+ * @param {number} day - Day of month
+ * @returns {Date|null} The validated Date, or null if the components rolled
+ */
+const validatedLocalDate = (year, monthIndex, day) => {
+  const date = new Date(year, monthIndex, day);
+  const roundTrips =
+    date.getFullYear() === year && date.getMonth() === monthIndex && date.getDate() === day;
+  return roundTrips ? date : null;
+};
+
+/**
+ * Logs a parse-failure warning and returns the em-dash sentinel — the shared
+ * tail for every parseDate rejection path.
+ *
+ * @param {string} dateStr - The original unparseable input
+ * @returns {string} The "—" sentinel
+ */
+const warnUnparseableDate = (dateStr) => {
+  console.warn(`Could not parse date: "${dateStr}", returning '—'`);
+  return "—";
+};
+
+/**
  * Parses various date formats into standard YYYY-MM-DD format
  *
  * Handles:
@@ -137,6 +167,11 @@ const localIsoDate = (date) => {
  * day back for positive-UTC-offset users (STRK-266). Strict YYYY-MM-DD input
  * is returned verbatim after validation.
  *
+ * Every numeric branch validates components via validatedLocalDate() and
+ * rejects impossible calendar dates like Feb 31 with "—" (STRK-267) — both
+ * the Date constructor and V8's string parsers would otherwise silently roll
+ * them into the next month.
+ *
  * @param {string} dateStr - Date string in any supported format
  * @returns {string} Date in YYYY-MM-DD format, or '—' if parsing fails
  */
@@ -146,12 +181,15 @@ function parseDate(dateStr) {
   // Clean the input string
   const cleanDateStr = dateStr.trim();
 
-  // Try ISO format (YYYY-MM-DD) first - most reliable
+  // Try ISO format (YYYY-MM-DD) first - most reliable. Impossible dates are
+  // rejected outright: V8 rolls new Date("2024-02-31") to Mar 1 rather than
+  // producing Invalid Date, so string-construction validity cannot be trusted.
   if (/^\d{4}-\d{2}-\d{2}$/.test(cleanDateStr)) {
-    const date = new Date(cleanDateStr);
-    if (!isNaN(date) && date.toString() !== "Invalid Date") {
+    const [year, month, day] = cleanDateStr.split("-").map(Number);
+    if (validatedLocalDate(year, month - 1, day)) {
       return cleanDateStr;
     }
+    return warnUnparseableDate(dateStr);
   }
 
   // Try YYYY/MM/DD format (unambiguous)
@@ -161,12 +199,12 @@ function parseDate(dateStr) {
     const month = parseInt(ymdMatch[2], 10) - 1;
     const day = parseInt(ymdMatch[3], 10);
 
-    if (month >= 0 && month <= 11 && day >= 1 && day <= 31) {
-      const date = new Date(year, month, day);
-      if (!isNaN(date) && date.toString() !== "Invalid Date") {
-        return localIsoDate(date);
-      }
+    const date = validatedLocalDate(year, month, day);
+    if (date) {
+      return localIsoDate(date);
     }
+    // Reject directly — the generic fallback also rolls "2026/02/31" → Mar 3.
+    return warnUnparseableDate(dateStr);
   }
 
   // Handle ambiguous MM/DD/YYYY vs DD/MM/YYYY formats
@@ -178,19 +216,22 @@ function parseDate(dateStr) {
 
     // If first number > 12, it must be DD/MM/YYYY (European)
     if (first > 12 && second <= 12) {
-      const date = new Date(year, second - 1, first);
-      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+      const date = validatedLocalDate(year, second - 1, first);
+      if (date) {
         return localIsoDate(date);
       }
     }
     // Otherwise treat as MM/DD/YYYY (US) — unambiguous when second > 12,
     // and the default when both numbers are <= 12 (ambiguous)
     else if (first <= 12) {
-      const date = new Date(year, first - 1, second);
-      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+      const date = validatedLocalDate(year, first - 1, second);
+      if (date) {
         return localIsoDate(date);
       }
     }
+    // Matched a numeric shape but no interpretation survived validation —
+    // reject directly so the rolling generic parser never sees the string.
+    return warnUnparseableDate(dateStr);
   }
 
   // Try parsing as a general date string (fallback)
@@ -204,8 +245,7 @@ function parseDate(dateStr) {
   }
 
   // If all parsing fails, return '—'
-  console.warn(`Could not parse date: "${dateStr}", returning '—'`);
-  return "—";
+  return warnUnparseableDate(dateStr);
 }
 
 /**

--- a/js/utils-format.js
+++ b/js/utils-format.js
@@ -117,7 +117,9 @@ const formatTimeOnly = (date) => {
  * @returns {string} Local calendar date in YYYY-MM-DD format
  */
 const localIsoDate = (date) => {
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  // padStart keeps four-digit years below 0100 (e.g. 0099) zero-padded.
+  const year = String(date.getFullYear()).padStart(4, "0");
+  return `${year}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
 };
 
 /**
@@ -132,7 +134,10 @@ const localIsoDate = (date) => {
  * @returns {Date|null} The validated Date, or null if the components rolled
  */
 const validatedLocalDate = (year, monthIndex, day) => {
-  const date = new Date(year, monthIndex, day);
+  // setFullYear sets all three components atomically — the Date constructor
+  // would map years 0-99 to 1900-1999 and break the round-trip check.
+  const date = new Date(2000, 0, 1);
+  date.setFullYear(year, monthIndex, day);
   const roundTrips =
     date.getFullYear() === year && date.getMonth() === monthIndex && date.getDate() === day;
   return roundTrips ? date : null;

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.64-b1784913451";
+const CACHE_NAME = "staktrakr-v3.35.64-b1784914446";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.64-b1784914446";
+const CACHE_NAME = "staktrakr-v3.35.64-b1784914961";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/parse-date-local-frame.test.js
+++ b/tests/unit/parse-date-local-frame.test.js
@@ -1,4 +1,4 @@
-// Unit tests for parseDate (js/utils-format.js) — STRK-266.
+// Unit tests for parseDate (js/utils-format.js) — STRK-266 + STRK-267.
 // Run: npm run test:unit  (node --test tests/unit/parse-date-local-frame.test.js)
 //
 // Bug under test: parseDate constructed `new Date(year, month, day)` (LOCAL
@@ -22,8 +22,9 @@ import { sliceArrowConst, sliceFunctionDecl } from "./test-helpers.js";
 
 const src = readFileSync(new URL("../../js/utils-format.js", import.meta.url), "utf8");
 
-// parseDate depends on localIsoDate, which depends on pad2 — slice all three so
-// the eval runs the REAL production chain.
+// parseDate depends on localIsoDate (→ pad2), validatedLocalDate, and
+// warnUnparseableDate — slice the whole chain so the eval runs the REAL
+// production code.
 const pad2Match = src.match(/^const pad2 = .*;$/m);
 assert.ok(pad2Match, "could not locate the pad2 declaration in source");
 
@@ -33,6 +34,8 @@ const parseDate = new Function(
   [
     pad2Match[0],
     sliceArrowConst(src, "const localIsoDate = ("),
+    sliceArrowConst(src, "const validatedLocalDate = ("),
+    sliceArrowConst(src, "const warnUnparseableDate = ("),
     sliceFunctionDecl(src, "function parseDate("),
     "return parseDate;",
   ].join("\n")
@@ -90,14 +93,55 @@ describe("parseDate — local-frame output (STRK-266)", () => {
     assert.equal(parseDate("2026-01-05T23:00:00Z"), "2026-01-06");
   });
 
-  it("day-overflow rolls over in the LOCAL frame (documented Date behavior)", () => {
-    // new Date(2026, 1, 31) rolls Feb 31 → Mar 3; the output must be that
-    // rolled LOCAL date, not its UTC rendering (which was Mar 2 pre-fix).
-    assert.equal(parseDate("2026/02/31"), "2026-03-03");
-  });
-
   it("empty and unparseable inputs still return the em-dash sentinel", () => {
     assert.equal(parseDate(""), "—");
     assert.equal(parseDate("not a date"), "—");
+  });
+});
+
+// STRK-267: the Date constructor silently rolls impossible calendar dates
+// (Feb 31 → Mar 2/3), so every numeric branch must verify the constructed
+// Date's components round-trip before formatting. A matched-but-impossible
+// numeric shape returns the sentinel DIRECTLY — V8's legacy string parser
+// also rolls "2026/02/31" → Mar 3, so falling through to the generic
+// new Date(string) fallback would resurrect the corruption. This supersedes
+// the STRK-266 test that documented the rollover as expected behavior.
+describe("parseDate — impossible calendar dates rejected (STRK-267)", () => {
+  it("strict ISO shape with an impossible day is rejected, not returned verbatim", () => {
+    // V8 rolls new Date("2024-02-31") to Mar 1 (NOT Invalid Date), so the
+    // pre-fix ISO branch handed the impossible string back unchanged.
+    assert.equal(parseDate("2024-02-31"), "—");
+  });
+
+  it("YYYY/MM/DD with an impossible day is rejected, not rolled", () => {
+    assert.equal(parseDate("2026/02/31"), "—");
+  });
+
+  it("YYYY/M/D (non-padded) impossible day does not reach the rolling generic parser", () => {
+    // new Date("2026/2/31") rolls to Mar 3 in the legacy parser — the ymd
+    // branch must short-circuit with the sentinel instead of falling through.
+    assert.equal(parseDate("2026/2/31"), "—");
+  });
+
+  it("unambiguous US MM/DD/YYYY (second > 12) with an impossible day is rejected", () => {
+    assert.equal(parseDate("02/31/2024"), "—");
+  });
+
+  it("unambiguous European DD/MM/YYYY (first > 12) with an impossible day is rejected", () => {
+    assert.equal(parseDate("31/04/2024"), "—");
+  });
+
+  it("both components > 12 matches no numeric format and is rejected", () => {
+    assert.equal(parseDate("13/13/2024"), "—");
+  });
+
+  it("leap day is accepted in a leap year", () => {
+    assert.equal(parseDate("2024-02-29"), "2024-02-29");
+    assert.equal(parseDate("2024/02/29"), "2024-02-29");
+  });
+
+  it("leap day is rejected in a non-leap year", () => {
+    assert.equal(parseDate("2023-02-29"), "—");
+    assert.equal(parseDate("2023/02/29"), "—");
   });
 });

--- a/tests/unit/parse-date-local-frame.test.js
+++ b/tests/unit/parse-date-local-frame.test.js
@@ -144,4 +144,16 @@ describe("parseDate — impossible calendar dates rejected (STRK-267)", () => {
     assert.equal(parseDate("2023-02-29"), "—");
     assert.equal(parseDate("2023/02/29"), "—");
   });
+
+  it("four-digit years below 0100 survive validation and keep their padding", () => {
+    // The Date constructor maps years 0-99 to 1900-1999; validatedLocalDate
+    // must set components via setFullYear so 0099 round-trips as 0099, and
+    // localIsoDate must zero-pad the year on the formatting side.
+    assert.equal(parseDate("0099-02-28"), "0099-02-28");
+    assert.equal(parseDate("0099/02/28"), "0099-02-28");
+  });
+
+  it("impossible day in a sub-0100 year is still rejected", () => {
+    assert.equal(parseDate("0099-02-30"), "—");
+  });
 });


### PR DESCRIPTION
## Summary

`parseDate()` in `js/utils-format.js` accepted impossible calendar dates because JavaScript silently rolls them instead of failing: `"02/31/2024"` parsed to `2024-03-02`. Flagged by Codacy AI review on PR #1363. Plane: **STRK-267**.

Two distinct rollover mechanisms were involved:

- **Component constructor** — `new Date(2024, 1, 31)` rolls Feb 31 → Mar 2, affecting the YYYY/MM/DD, European DD/MM/YYYY, and US MM/DD/YYYY branches.
- **V8 string parsers** — `new Date("2024-02-31")` rolls to Mar 1 (not Invalid Date), so the strict-ISO branch returned the impossible string **verbatim**; the legacy parser rolls `"2026/02/31"` → Mar 3, so the generic fallback would resurrect any rollover a numeric branch tried to reject.

## Fix

- New `validatedLocalDate(year, monthIndex, day)` helper constructs the local Date and verifies `getFullYear/getMonth/getDate` round-trip against the parsed components.
- Every numeric branch (strict ISO, YYYY/MM/DD, European, US, ambiguous US-default) validates before returning `localIsoDate(...)`.
- A matched-but-impossible numeric shape returns the `"—"` sentinel **directly** — it must not fall through to the generic `new Date(string)` fallback, which would re-roll the same string.
- Shared `warnUnparseableDate()` tail replaces the duplicated warn-and-return.

## Behavior change

Impossible dates that previously rolled (or passed through verbatim in the ISO branch) now return the `"—"` sentinel, which all four callers in `js/inventory-import.js` already handle as a normal parse-failure outcome. The STRK-266 unit case that documented rollover as expected behavior (`"2026/02/31"` → `"2026-03-03"`) is superseded by a rejection case.

## Tests (TDD)

- Extended `tests/unit/parse-date-local-frame.test.js` with a STRK-267 block: rejection across all four numeric branches, non-padded shapes, both-components>12, and a leap-year pair (`2024-02-29` accepted, `2023-02-29` rejected).
- RED verified before the fix: 6 assertion failures, all pre-existing STRK-266 cases green.
- No Playwright inventory change (unit-only coverage) — no coverage-map row.

## Verification

- `npm run test:unit` — 407/407 pass
- `npm test` (core Playwright) — 391/391 pass (7.5 m)
- `npm run lint` — clean