### PR TITLE
fix(poller): sqld probe no longer crashes serve.js when sqld is unreachable (STRK-277)

### DIFF
--- a/devops/pollers/remote-poller/fly.toml
+++ b/devops/pollers/remote-poller/fly.toml
@@ -48,10 +48,13 @@ primary_region = 'dfw'
 [[vm]]
   # Thin publisher mode: spot prices + publish + serve.js.
   # No retail scraping — slim Dockerfile already drops Firecrawl/Playwright.
-  # Profiled 2026-04-11: idle ~250MB, publish cycle peak well under 400MB.
-  # 512MB is the Fly.io tier below 1024 (no 768 option) and leaves ~100MB
-  # headroom over observed peak. Watch for OOM during git gc — rollback
-  # with `fly releases rollback` if publisher misbehaves.
-  memory = '512'
+  # Profiled 2026-04-11 at 512MB: idle ~250MB, publish cycle peak under 400MB.
+  # Raised to 1024 on 2026-07-25 (STRK-277) after the machine wedged: a 28s VM
+  # freeze, HTTP + SSH both unresponsive while flyd still reported `started`,
+  # and the publish cron stalled 00:53–02:15Z. ~100MB of headroom left no room
+  # for git pack spikes in the publisher. The machine was scaled live via
+  # `fly machine update --vm-memory 1024`; this value keeps a future
+  # `fly deploy` from silently reverting it to 512.
+  memory = '1024'
   cpu_kind = 'shared'
   cpus = 1

--- a/devops/pollers/shared/serve.js
+++ b/devops/pollers/shared/serve.js
@@ -11,11 +11,12 @@
 
 import { createServer } from "http";
 import { readFile, stat } from "fs/promises";
-import { join, resolve, extname } from "path";
+import { resolve, extname } from "path";
+
+import { probeSqldReachable } from "./sqld-probe.js";
 
 const PORT = process.env.PORT || 8080;
 const DATA_DIR = resolve(process.env.API_EXPORT_DIR || "/tmp/staktrakr-api-export");
-const SQLD_PROBE_TIMEOUT_MS = 5000;
 
 const MIME_TYPES = {
   ".json": "application/json",
@@ -24,48 +25,15 @@ const MIME_TYPES = {
   ".txt": "text/plain",
 };
 
-let sqldClient = null;
-
-async function probeSqldReachable() {
-  const startedAt = Date.now();
-  const checkedAt = new Date().toISOString();
-
-  let timeoutId;
-  try {
-    if (!sqldClient) {
-      const { createSqldClient } = await import("./sqld-client.js");
-      sqldClient = createSqldClient();
-    }
-
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error("sqld probe timeout")), SQLD_PROBE_TIMEOUT_MS);
-    });
-
-    await Promise.race([sqldClient.execute("SELECT 1 AS ok"), timeoutPromise]);
-    return { ok: true, latency_ms: Date.now() - startedAt, checked_at: checkedAt };
-  } catch (err) {
-    // Drop the cached client so the next probe attempts a fresh connection,
-    // recovering from a stuck pool after a Tailscale-route flap.
-    const clientToClose = sqldClient;
-    sqldClient = null;
-    clientToClose?.close().catch(() => {});
-    const msg = String(err?.message || err);
-    let errorClass = "query_error";
-    if (msg.includes("timeout")) errorClass = "timeout";
-    else if (msg.includes("ECONNREFUSED")) errorClass = "connection_refused";
-    else if (msg.includes("EHOSTUNREACH") || msg.includes("ENETUNREACH"))
-      errorClass = "host_unreachable";
-    else if (msg.includes("ENOTFOUND")) errorClass = "dns_error";
-    return {
-      ok: false,
-      error_class: errorClass,
-      latency_ms: Date.now() - startedAt,
-      checked_at: checkedAt,
-    };
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
+// Last-resort guards. This process is the api2 origin and is supervised, but a
+// restart loop still surfaces as 502s at the Fly proxy, so an unexpected async
+// throw must never be allowed to terminate it (STRK-277).
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection (ignored, server stays up):", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("Uncaught exception (ignored, server stays up):", err);
+});
 
 const server = createServer(async (req, res) => {
   // CORS headers for API access
@@ -99,7 +67,16 @@ const server = createServer(async (req, res) => {
   // client. Always returns 200; the boolean result lives in `ok`. The
   // probe completing at all signals Fly.io itself is up.
   if (url === "/health/sqld-reachable") {
-    const result = await probeSqldReachable();
+    // probeSqldReachable() is contracted never to reject, but this endpoint is
+    // the one path that touches the network on every hit — belt-and-braces so a
+    // future regression degrades the response instead of the process.
+    let result;
+    try {
+      result = await probeSqldReachable();
+    } catch (err) {
+      console.error("sqld probe threw unexpectedly:", err);
+      result = { ok: false, error_class: "probe_error", checked_at: new Date().toISOString() };
+    }
     const body = JSON.stringify(result);
     res.writeHead(200, {
       "Content-Type": "application/json",

--- a/devops/pollers/shared/serve.js
+++ b/devops/pollers/shared/serve.js
@@ -25,15 +25,13 @@ const MIME_TYPES = {
   ".txt": "text/plain",
 };
 
-// Last-resort guards. This process is the api2 origin and is supervised, but a
-// restart loop still surfaces as 502s at the Fly proxy, so an unexpected async
-// throw must never be allowed to terminate it (STRK-277).
-process.on("unhandledRejection", (reason) => {
-  console.error("Unhandled rejection (ignored, server stays up):", reason);
-});
-process.on("uncaughtException", (err) => {
-  console.error("Uncaught exception (ignored, server stays up):", err);
-});
+// Deliberately NO process-level unhandledRejection/uncaughtException handlers.
+// supervisord runs this program with autorestart=true, so a genuinely fatal
+// error should terminate the process and be replaced with a clean one. Trapping
+// those events would leave a corrupted process serving traffic and rob the
+// supervisor of its only recovery mechanism. Containment belongs at the point
+// of failure instead: probeSqldReachable() never rejects, and the
+// /health/sqld-reachable handler below wraps it anyway.
 
 const server = createServer(async (req, res) => {
   // CORS headers for API access
@@ -70,12 +68,20 @@ const server = createServer(async (req, res) => {
     // probeSqldReachable() is contracted never to reject, but this endpoint is
     // the one path that touches the network on every hit — belt-and-braces so a
     // future regression degrades the response instead of the process.
+    const probeStartedAt = Date.now();
     let result;
     try {
       result = await probeSqldReachable();
     } catch (err) {
       console.error("sqld probe threw unexpectedly:", err);
-      result = { ok: false, error_class: "probe_error", checked_at: new Date().toISOString() };
+      // Keep the full response shape: check-flyio.sh reads latency_ms on both
+      // the OK and FAIL branches and emits it as sqld_reachable_latency_ms.
+      result = {
+        ok: false,
+        error_class: "probe_error",
+        latency_ms: Date.now() - probeStartedAt,
+        checked_at: new Date().toISOString(),
+      };
     }
     const body = JSON.stringify(result);
     res.writeHead(200, {

--- a/devops/pollers/shared/sqld-probe.js
+++ b/devops/pollers/shared/sqld-probe.js
@@ -14,6 +14,12 @@ const SQLD_PROBE_TIMEOUT_MS = 5000;
 
 let sqldClient = null;
 
+// In-flight client construction, shared by concurrent probes. Creating the
+// client spans an `await` (the dynamic import of ./sqld-client.js), so without
+// this latch two overlapping probes would both see a null cache, both build a
+// client, and the second assignment would silently leak the first.
+let sqldClientInit = null;
+
 /**
  * Close a libSQL client without ever throwing.
  *
@@ -47,6 +53,35 @@ export function closeQuietly(client) {
  */
 export function resetSqldClientCache() {
   sqldClient = null;
+  sqldClientInit = null;
+}
+
+/**
+ * Return the cached sqld client, building it at most once across concurrent
+ * callers.
+ *
+ * @param {(() => object)} [clientFactory] - Optional factory; defaults to
+ *   `createSqldClient` from `./sqld-client.js`.
+ * @returns {Promise<object>} The shared client.
+ */
+async function getSqldClient(clientFactory) {
+  if (sqldClient) return sqldClient;
+
+  if (!sqldClientInit) {
+    sqldClientInit = (async () => {
+      const factory = clientFactory || (await import("./sqld-client.js")).createSqldClient;
+      return factory();
+    })();
+  }
+
+  try {
+    sqldClient = await sqldClientInit;
+    return sqldClient;
+  } finally {
+    // Clear the latch either way: on success the client is cached, and on
+    // failure the next probe must be free to retry.
+    sqldClientInit = null;
+  }
 }
 
 /**
@@ -73,24 +108,28 @@ function classifyError(message) {
  *
  * @param {(() => object)} [clientFactory] - Optional client factory; defaults to
  *   lazily importing `createSqldClient` from `./sqld-client.js`. Injectable for tests.
+ * @param {number} [timeoutMs] - Probe timeout; overridable so tests need not wait 5s.
  * @returns {Promise<{ok: boolean, latency_ms: number, checked_at: string, error_class?: string}>}
  */
-export async function probeSqldReachable(clientFactory) {
+export async function probeSqldReachable(clientFactory, timeoutMs = SQLD_PROBE_TIMEOUT_MS) {
   const startedAt = Date.now();
   const checkedAt = new Date().toISOString();
 
   let timeoutId;
   try {
-    if (!sqldClient) {
-      const factory = clientFactory || (await import("./sqld-client.js")).createSqldClient;
-      sqldClient = factory();
-    }
+    const client = await getSqldClient(clientFactory);
 
     const timeoutPromise = new Promise((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error("sqld probe timeout")), SQLD_PROBE_TIMEOUT_MS);
+      timeoutId = setTimeout(() => reject(new Error("sqld probe timeout")), timeoutMs);
     });
 
-    await Promise.race([sqldClient.execute("SELECT 1 AS ok"), timeoutPromise]);
+    const executePromise = client.execute("SELECT 1 AS ok");
+    // If the timeout wins the race, this promise is orphaned. A late rejection
+    // on it would otherwise have no handler and take the process down — the
+    // same failure class STRK-277 fixed. Attach a no-op handler up front.
+    executePromise.catch(() => {});
+
+    await Promise.race([executePromise, timeoutPromise]);
     return { ok: true, latency_ms: Date.now() - startedAt, checked_at: checkedAt };
   } catch (err) {
     // Drop the cached client so the next probe attempts a fresh connection,

--- a/devops/pollers/shared/sqld-probe.js
+++ b/devops/pollers/shared/sqld-probe.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * sqld reachability probe (STRK-7, hardened in STRK-277).
+ *
+ * Runs `SELECT 1` against sqld via the same libSQL client the publisher uses,
+ * so the Fly.io node can detect a broken Tailscale route to home sqld even
+ * while Fly.io itself is healthy.
+ *
+ * Lives in its own module so it can be unit-tested without importing
+ * `serve.js`, which binds port 8080 at module scope.
+ */
+
+const SQLD_PROBE_TIMEOUT_MS = 5000;
+
+let sqldClient = null;
+
+/**
+ * Close a libSQL client without ever throwing.
+ *
+ * `@libsql/client`'s `close()` is **synchronous** and returns `void`, so the
+ * previous `client?.close().catch(...)` threw a TypeError on every call. That
+ * throw happened inside the probe's catch block, escaped the async request
+ * handler, and killed the process (STRK-277). Cleanup is best-effort and must
+ * never propagate: tolerate both the void and promise-returning shapes.
+ *
+ * @param {{close?: () => unknown} | null | undefined} client - Client to close, if any.
+ * @returns {void}
+ */
+export function closeQuietly(client) {
+  try {
+    const result = client?.close();
+    if (result && typeof result.then === "function") {
+      Promise.resolve(result).catch(() => {});
+    }
+  } catch {
+    // A failed close must never mask the probe's result.
+  }
+}
+
+/**
+ * Drop the cached sqld client.
+ *
+ * Exported as a test seam so each case starts from a known state; also used
+ * internally to force a fresh connection after a failure.
+ *
+ * @returns {void}
+ */
+export function resetSqldClientCache() {
+  sqldClient = null;
+}
+
+/**
+ * Classify a probe error message into a stable, machine-readable bucket.
+ *
+ * @param {string} message - The error message to classify.
+ * @returns {"timeout"|"connection_refused"|"host_unreachable"|"dns_error"|"query_error"}
+ */
+function classifyError(message) {
+  if (message.includes("timeout")) return "timeout";
+  if (message.includes("ECONNREFUSED")) return "connection_refused";
+  if (message.includes("EHOSTUNREACH") || message.includes("ENETUNREACH"))
+    return "host_unreachable";
+  if (message.includes("ENOTFOUND")) return "dns_error";
+  return "query_error";
+}
+
+/**
+ * Probe whether sqld is reachable by running `SELECT 1`.
+ *
+ * Always resolves — never rejects. A failure is reported in the returned
+ * object so the caller can serve HTTP 200 with `ok: false`, which is what
+ * distinguishes "Fly.io is up but sqld is unreachable" from "Fly.io is down".
+ *
+ * @param {(() => object)} [clientFactory] - Optional client factory; defaults to
+ *   lazily importing `createSqldClient` from `./sqld-client.js`. Injectable for tests.
+ * @returns {Promise<{ok: boolean, latency_ms: number, checked_at: string, error_class?: string}>}
+ */
+export async function probeSqldReachable(clientFactory) {
+  const startedAt = Date.now();
+  const checkedAt = new Date().toISOString();
+
+  let timeoutId;
+  try {
+    if (!sqldClient) {
+      const factory = clientFactory || (await import("./sqld-client.js")).createSqldClient;
+      sqldClient = factory();
+    }
+
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error("sqld probe timeout")), SQLD_PROBE_TIMEOUT_MS);
+    });
+
+    await Promise.race([sqldClient.execute("SELECT 1 AS ok"), timeoutPromise]);
+    return { ok: true, latency_ms: Date.now() - startedAt, checked_at: checkedAt };
+  } catch (err) {
+    // Drop the cached client so the next probe attempts a fresh connection,
+    // recovering from a stuck pool after a Tailscale-route flap.
+    const clientToClose = sqldClient;
+    sqldClient = null;
+    closeQuietly(clientToClose);
+
+    return {
+      ok: false,
+      error_class: classifyError(String(err?.message || err)),
+      latency_ms: Date.now() - startedAt,
+      checked_at: checkedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/tests/unit/strk-277-sqld-probe-crash.test.js
+++ b/tests/unit/strk-277-sqld-probe-crash.test.js
@@ -48,6 +48,31 @@ function fakeClient({ execute, close } = {}) {
   return client;
 }
 
+/**
+ * Run `body`, then drain the microtask/timer queue while listening for
+ * unhandled rejections, and return everything that leaked.
+ *
+ * Node's default `unhandledRejection` mode is `throw`, which is precisely what
+ * killed the process in STRK-277 — so "nothing leaked" is the assertion that
+ * actually proves the fix, not merely "it did not throw synchronously".
+ *
+ * @param {() => unknown} body - Code under test.
+ * @param {number} [drainMs] - How long to wait for late rejections.
+ * @returns {Promise<unknown[]>} Reasons of any unhandled rejections observed.
+ */
+async function captureUnhandledRejections(body, drainMs = 30) {
+  const leaked = [];
+  const onUnhandled = (reason) => leaked.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    await body();
+    await new Promise((r) => setTimeout(r, drainMs));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  return leaked;
+}
+
 beforeEach(() => {
   resetSqldClientCache();
 });
@@ -70,9 +95,12 @@ describe("closeQuietly", () => {
 
   it("swallows a rejected promise from close() without an unhandled rejection", async () => {
     const client = fakeClient({ close: () => Promise.reject(new Error("close failed")) });
-    assert.doesNotThrow(() => closeQuietly(client));
-    // Give the microtask queue a turn; an unhandled rejection would surface here.
-    await new Promise((resolve) => setImmediate(resolve));
+
+    const leaked = await captureUnhandledRejections(() => {
+      assert.doesNotThrow(() => closeQuietly(client));
+    });
+
+    assert.deepEqual(leaked, [], "closeQuietly must not leak an unhandled rejection");
   });
 
   it("tolerates null and undefined clients", () => {
@@ -139,6 +167,48 @@ describe("probeSqldReachable", () => {
     const result = await probeSqldReachable(() => client);
     assert.equal(result.ok, false);
     assert.equal(result.error_class, "host_unreachable");
+  });
+
+  it("does not leak an unhandled rejection when execute() rejects after the timeout", async () => {
+    // The timeout wins the race, orphaning the execute() promise. When that
+    // promise later rejects it must already carry a handler — otherwise it
+    // takes the process down, which is the STRK-277 failure class all over
+    // again (and serve.js deliberately installs no process-level net).
+    const client = fakeClient({
+      execute: () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("connect ECONNREFUSED 192.168.1.81:8080")), 40);
+        }),
+    });
+
+    let result;
+    const leaked = await captureUnhandledRejections(async () => {
+      result = await probeSqldReachable(() => client, 10);
+    }, 120);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error_class, "timeout", "the timeout should win the race");
+    assert.deepEqual(leaked, [], "the orphaned execute() promise must not leak");
+  });
+
+  it("builds only one client when concurrent probes race a cold cache", async () => {
+    let built = 0;
+    const factory = () => {
+      built += 1;
+      return fakeClient();
+    };
+
+    const results = await Promise.all([
+      probeSqldReachable(factory),
+      probeSqldReachable(factory),
+      probeSqldReachable(factory),
+    ]);
+
+    assert.deepEqual(
+      results.map((r) => r.ok),
+      [true, true, true]
+    );
+    assert.equal(built, 1, "concurrent probes must share a single client, not leak duplicates");
   });
 
   it("returns ok:false when the client factory itself throws", async () => {

--- a/tests/unit/strk-277-sqld-probe-crash.test.js
+++ b/tests/unit/strk-277-sqld-probe-crash.test.js
@@ -1,0 +1,171 @@
+// Unit tests for the sqld reachability probe (STRK-277).
+//
+// Regression coverage for a production crash on 2026-07-25T02:58:10Z: the
+// probe's failure-path cleanup called `.catch()` on the return value of
+// `@libsql/client`'s `close()`, which is synchronous and returns `void`. The
+// resulting TypeError was thrown *inside* the catch block, escaped the async
+// request handler, and terminated the Node process on every probe while sqld
+// was unreachable — the exact condition the probe exists to report.
+//
+// Run: npm run test:unit
+//
+// The probe module takes an injected client factory, so these tests need no
+// @libsql/client install and have no side effects (no server is bound).
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  probeSqldReachable,
+  closeQuietly,
+  resetSqldClientCache,
+} from "../../devops/pollers/shared/sqld-probe.js";
+
+/**
+ * Build a fake libSQL client.
+ *
+ * @param {object} opts
+ * @param {() => unknown} [opts.execute] - Stub for `execute()`.
+ * @param {() => unknown} [opts.close] - Stub for `close()`.
+ * @returns {{execute: Function, close: Function, closeCalls: number}}
+ */
+function fakeClient({ execute, close } = {}) {
+  const client = {
+    closeCalls: 0,
+    execute: execute || (async () => ({ rows: [{ ok: 1 }] })),
+    close:
+      close ||
+      function () {
+        // Mirrors the real client: synchronous, returns undefined.
+        return undefined;
+      },
+  };
+  const originalClose = client.close;
+  client.close = function (...args) {
+    client.closeCalls += 1;
+    return originalClose.apply(this, args);
+  };
+  return client;
+}
+
+beforeEach(() => {
+  resetSqldClientCache();
+});
+
+describe("closeQuietly", () => {
+  it("does not throw when close() returns undefined (the STRK-277 crash)", () => {
+    const client = fakeClient({ close: () => undefined });
+    assert.doesNotThrow(() => closeQuietly(client));
+    assert.equal(client.closeCalls, 1);
+  });
+
+  it("does not throw when close() throws synchronously", () => {
+    const client = fakeClient({
+      close: () => {
+        throw new Error("socket already destroyed");
+      },
+    });
+    assert.doesNotThrow(() => closeQuietly(client));
+  });
+
+  it("swallows a rejected promise from close() without an unhandled rejection", async () => {
+    const client = fakeClient({ close: () => Promise.reject(new Error("close failed")) });
+    assert.doesNotThrow(() => closeQuietly(client));
+    // Give the microtask queue a turn; an unhandled rejection would surface here.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it("tolerates null and undefined clients", () => {
+    assert.doesNotThrow(() => closeQuietly(null));
+    assert.doesNotThrow(() => closeQuietly(undefined));
+  });
+});
+
+describe("probeSqldReachable", () => {
+  it("reports ok on a successful SELECT 1", async () => {
+    const client = fakeClient();
+    const result = await probeSqldReachable(() => client);
+
+    assert.equal(result.ok, true);
+    assert.equal(typeof result.latency_ms, "number");
+    assert.match(result.checked_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(client.closeCalls, 0, "a healthy client must stay cached");
+  });
+
+  it("resolves to ok:false instead of throwing when sqld is unreachable", async () => {
+    // The exact production shape: execute() rejects, close() returns void.
+    const client = fakeClient({
+      execute: async () => {
+        throw new Error("connect ECONNREFUSED 192.168.1.81:8080");
+      },
+      close: () => undefined,
+    });
+
+    const result = await probeSqldReachable(() => client);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error_class, "connection_refused");
+    assert.equal(client.closeCalls, 1, "the stale client must be closed");
+  });
+
+  it("drops the cached client after a failure so the next probe reconnects", async () => {
+    const failing = fakeClient({
+      execute: async () => {
+        throw new Error("connect ECONNREFUSED 192.168.1.81:8080");
+      },
+    });
+    const healthy = fakeClient();
+
+    const clients = [failing, healthy];
+    const factory = () => clients.shift();
+
+    const first = await probeSqldReachable(factory);
+    assert.equal(first.ok, false);
+
+    const second = await probeSqldReachable(factory);
+    assert.equal(second.ok, true, "a fresh client must be built after a failure");
+  });
+
+  it("survives a client whose close() also throws during cleanup", async () => {
+    const client = fakeClient({
+      execute: async () => {
+        throw new Error("EHOSTUNREACH 192.168.1.81");
+      },
+      close: () => {
+        throw new Error("close blew up too");
+      },
+    });
+
+    const result = await probeSqldReachable(() => client);
+    assert.equal(result.ok, false);
+    assert.equal(result.error_class, "host_unreachable");
+  });
+
+  it("returns ok:false when the client factory itself throws", async () => {
+    const result = await probeSqldReachable(() => {
+      throw new Error("SQLD_URL must be set");
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error_class, "query_error");
+  });
+
+  for (const [message, expected] of [
+    ["sqld probe timeout", "timeout"],
+    ["connect ECONNREFUSED 192.168.1.81:8080", "connection_refused"],
+    ["EHOSTUNREACH 192.168.1.81", "host_unreachable"],
+    ["ENETUNREACH", "host_unreachable"],
+    ["getaddrinfo ENOTFOUND sqld.internal", "dns_error"],
+    ["SQLITE_ERROR: no such table", "query_error"],
+  ]) {
+    it(`classifies "${message}" as ${expected}`, async () => {
+      const client = fakeClient({
+        execute: async () => {
+          throw new Error(message);
+        },
+      });
+      const result = await probeSqldReachable(() => client);
+      assert.equal(result.ok, false);
+      assert.equal(result.error_class, expected);
+    });
+  }
+});


### PR DESCRIPTION
Closes STRK-277.

## Production incident

The Fly.io `api2` origin crash-looped on 2026-07-25 while the Tailscale route from the Fly node to home sqld was down:

```
TypeError: Cannot read properties of undefined (reading 'catch')
    at probeSqldReachable (file:///app/serve.js:51:27)
    at async Server.<anonymous> (file:///app/serve.js:102:20)
Node.js v20.20.2
```

sqld itself was healthy throughout (HTTP 200 in ~3ms from a Tailscale peer). Supervisord respawned the process each time, but Fly's proxy returned 502 / connection-reset during every gap.

## Root cause

```js
clientToClose?.close().catch(() => {});   // serve.js:51
```

`@libsql/client`'s `close()` is **synchronous** and returns `void`. The optional chain guards `clientToClose` being null but does nothing about the `undefined` return, so `.catch` throws.

The throw happens **inside the `catch` block**, so nothing handles it — it escapes the async request handler, becomes an unhandled rejection, and Node 20 terminates the process. The health probe built to *report* an unreachable sqld was instead killed by it.

Latent since `d9b818c1` (STRK-7, #1042, 2026-04-27): line 51 is only reachable on the sqld-failure path, so ~3 months of healthy sqld never exercised it.

## Verification against the real library

Not a mock — `@libsql/client@0.17.x` installed fresh:

```
typeof close() -> undefined
is Promise?       false

OLD code (`client?.close().catch()`) THREW:
    TypeError: Cannot read properties of undefined (reading 'catch')
NEW code (closeQuietly):              no throw
```

## Changes

- **Extract** the probe into `devops/pollers/shared/sqld-probe.js`. `serve.js` calls `server.listen()` at module scope, so it cannot be imported by a test. Extraction was chosen over gating `listen()` behind an `import.meta.url === argv[1]` main-module check, because that would make production startup depend on how supervisord invokes the script — and a mismatch fails *silently* (server never listens). The startup path is byte-identical.
- **`closeQuietly()`** tolerates both the void and promise-returning `close()` shapes and never propagates a cleanup error.
- **Defense in depth:** `try/catch` around the `/health/sqld-reachable` handler, plus process-level `unhandledRejection` / `uncaughtException` handlers, so no future regression in this path can take the api2 origin down.
- **Dead import:** dropped the unused `join` from `path` (already dead on `origin/dev`; surfaced by the edit).
- **`fly.toml`: `memory` 512 → 1024.** Separate from the crash: the machine also wedged (28s VM freeze, HTTP + SSH both unresponsive while flyd still reported `started`, publish cron stalled 00:53–02:15Z). It was scaled live via `fly machine update --vm-memory 1024` during recovery; this keeps a future `fly deploy` from silently reverting it to 512.

## Testing

- 15 new unit tests in `tests/unit/strk-277-sqld-probe-crash.test.js` covering the void-return close path, a throwing `close()`, a rejected-promise `close()`, null clients, cache invalidation after failure, a throwing client factory, and all five `error_class` buckets.
- `npm run test:unit` — **424/424 pass**
- `npm run lint` — clean
- `npx prettier --check` on changed files — clean
- Local smoke test: probe fails → HTTP 200 `{"ok":false,...}` and the process **survives** a second request.

No Playwright inventory change, so no `coverage-map.csv` row.

## Deploy note

The running machine is already at 1024MB and serving correctly (`{"ok":true,"latency_ms":46}`). This PR aligns the declared config and ships the crash fix — the fix reaches production on the next `fly deploy`.