### PR TITLE
fix(poller): stuck-run watchdog + Playwright vendor budget (STRK-255)

### DIFF
--- a/.agents/skills/retail-poller/SKILL.md
+++ b/.agents/skills/retail-poller/SKILL.md
@@ -207,9 +207,15 @@ After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPric
 | `vendor`       | TEXT    | Provider id (e.g. `apmex`)                 |
 | `price`        | REAL    | null if scrape failed                      |
 | `source`       | TEXT    | `firecrawl` \| `playwright` \| `fbp`       |
-| `in_stock`     | INTEGER | 0 if OOS patterns matched                  |
+| `confidence`   | INTEGER | Score from `scoreVendorPrice()`; nullable  |
 | `is_failed`    | INTEGER | 1 if price is null                         |
-| `poller_id`    | TEXT    | `api` (Fly.io) or `home` (home VM)         |
+| `in_stock`     | INTEGER | 0 if OOS patterns matched                  |
+
+> **No `poller_id` column on `price_snapshots`.** `POLLER_ID` is an env var used for
+> run bookkeeping and retry backoff, and it _is_ a real column on `poller_runs` and
+> `spot_prices` — but not here. Schema of record: `initSqldSchema()` in
+> `devops/pollers/shared/sqld-client.js`. Do not write queries that group
+> `price_snapshots` by `poller_id` (STRK-255).
 
 **Window floor:** every scrape is bucketed to the nearest 15-min UTC floor. The 24h history chart uses 96 windows.
 

--- a/.claude/skills/retail-poller/SKILL.md
+++ b/.claude/skills/retail-poller/SKILL.md
@@ -207,9 +207,15 @@ After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPric
 | `vendor`       | TEXT    | Provider id (e.g. `apmex`)                 |
 | `price`        | REAL    | null if scrape failed                      |
 | `source`       | TEXT    | `firecrawl` \| `playwright` \| `fbp`       |
-| `in_stock`     | INTEGER | 0 if OOS patterns matched                  |
+| `confidence`   | INTEGER | Score from `scoreVendorPrice()`; nullable  |
 | `is_failed`    | INTEGER | 1 if price is null                         |
-| `poller_id`    | TEXT    | `api` (Fly.io) or `home` (home VM)         |
+| `in_stock`     | INTEGER | 0 if OOS patterns matched                  |
+
+> **No `poller_id` column on `price_snapshots`.** `POLLER_ID` is an env var used for
+> run bookkeeping and retry backoff, and it _is_ a real column on `poller_runs` and
+> `spot_prices` — but not here. Schema of record: `initSqldSchema()` in
+> `devops/pollers/shared/sqld-client.js`. Do not write queries that group
+> `price_snapshots` by `poller_id` (STRK-255).
 
 **Window floor:** every scrape is bucketed to the nearest 15-min UTC floor. The 24h history chart uses 96 windows.
 

--- a/devops/pollers/home-poller/Dockerfile
+++ b/devops/pollers/home-poller/Dockerfile
@@ -87,6 +87,9 @@ RUN npm ci --omit=dev
 # Cache-bust: change this value to force rebuild of JS layer
 ARG CACHE_BUST=2026-03-19a
 COPY shared/*.js ./
+# Shared shell helpers (run-lock.sh) are sourced by run-home.sh at runtime.
+# Without this the source fails and `set -e` aborts the whole run (STRK-255).
+COPY shared/*.sh ./
 COPY shared/.env.example ./.env.example
 
 # Spot-poller Python source + deps

--- a/devops/pollers/home-poller/run-home.sh
+++ b/devops/pollers/home-poller/run-home.sh
@@ -6,16 +6,20 @@
 
 set -e
 
-# Lockfile guard — skip if previous run is still active
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Lockfile guard with stuck-run watchdog (STRK-255).
+# Cron here is hourly (30 * * * *). With a 5400s budget the first contended
+# tick (age 3600s) still skips — a slow run gets 90 minutes of headroom — and
+# the second (age 7200s) kills the wedged process tree and proceeds. Without
+# this a single Playwright stall froze retail data until the container
+# restarted ~3.5h later.
 LOCKFILE=/tmp/retail-poller.lock
-if [ -f "$LOCKFILE" ]; then
-  echo "[$(date -u +%H:%M:%S)] Previous run still active, skipping"
+RETAIL_RUN_MAX_SECONDS="${RETAIL_RUN_MAX_SECONDS:-5400}"
+. "$SCRIPT_DIR/run-lock.sh"
+if ! acquire_run_lock "$LOCKFILE" "$RETAIL_RUN_MAX_SECONDS"; then
   exit 0
 fi
-touch $LOCKFILE
-trap 'rm -f "$LOCKFILE"' EXIT
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Load .env if present (home poller stores Turso creds, Firecrawl URL, etc.)
 if [ -f "$SCRIPT_DIR/.env" ]; then

--- a/devops/pollers/home-poller/run-home.sh
+++ b/devops/pollers/home-poller/run-home.sh
@@ -14,9 +14,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # the second (age 7200s) kills the wedged process tree and proceeds. Without
 # this a single Playwright stall froze retail data until the container
 # restarted ~3.5h later.
+#
+# The helper sits next to this script inside the image (both land in /app) but
+# lives in ../shared/ in the repo, so resolve both layouts.
 LOCKFILE=/tmp/retail-poller.lock
 RETAIL_RUN_MAX_SECONDS="${RETAIL_RUN_MAX_SECONDS:-5400}"
-. "$SCRIPT_DIR/run-lock.sh"
+if [ -f "$SCRIPT_DIR/run-lock.sh" ]; then
+  . "$SCRIPT_DIR/run-lock.sh"
+else
+  . "$SCRIPT_DIR/../shared/run-lock.sh"
+fi
 if ! acquire_run_lock "$LOCKFILE" "$RETAIL_RUN_MAX_SECONDS"; then
   exit 0
 fi

--- a/devops/pollers/remote-poller/Dockerfile
+++ b/devops/pollers/remote-poller/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     make \
     g++ \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Tailscale (kept for diagnostics — free, no harm)

--- a/devops/pollers/remote-poller/Dockerfile
+++ b/devops/pollers/remote-poller/Dockerfile
@@ -49,6 +49,10 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN npm install --omit=dev
 
 COPY shared/*.js ./
+# Shared shell helpers (run-lock.sh). run-local.sh is not shipped in this slim
+# image today, but keeping the helper present means re-enabling it cannot
+# silently reintroduce the STRK-255 wedge.
+COPY shared/*.sh ./
 
 # Remote-specific scripts (spot + publish + cleanup)
 COPY remote-poller/run-spot.sh remote-poller/run-publish.sh remote-poller/cleanup-export.sh ./

--- a/devops/pollers/remote-poller/Dockerfile.full
+++ b/devops/pollers/remote-poller/Dockerfile.full
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gnupg \
     lsb-release \
+    procps \
     # Chromium dependencies for Playwright service
     libnss3 \
     libnspr4 \
@@ -198,6 +199,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
     && python3 -m pip install --no-cache-dir --break-system-packages "requests>=2.32.4" python-dotenv
 
 COPY shared/*.js ./
+# Shared shell helpers (run-lock.sh). This image both copies and crons
+# run-local.sh, which sources the helper — without this the source fails and
+# `set -e` aborts every retail run, so a rollback to this image could not
+# scrape at all (STRK-255).
+COPY shared/*.sh ./
 
 # Spot-poller Python source
 COPY shared/spot-poller/ /app/spot-poller/

--- a/devops/pollers/remote-poller/run-local.sh
+++ b/devops/pollers/remote-poller/run-local.sh
@@ -5,13 +5,23 @@
 
 set -e
 
-# Lockfile guard — skip if previous run is still active
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Lockfile guard with stuck-run watchdog (STRK-255).
+# At a 15-minute cadence a 1500s budget means the first contended tick (age
+# 900s) skips and the second (age 1800s) kills the wedged tree — matching the
+# home poller's "reclaim on the second consecutive contended tick" behaviour
+# while leaving a legitimately slow scrape 25 minutes of headroom.
+#
+# NOTE: this script is currently neither COPYed into the slim Fly.io image nor
+# scheduled by docker-entrypoint-slim.sh — retail scraping runs on the home
+# poller. It is kept in sync so re-enabling it does not reintroduce the wedge.
 LOCKFILE=/tmp/retail-poller.lock
-if [ -f "$LOCKFILE" ]; then
-  echo "[$(date -u +%H:%M:%S)] Previous run still active, skipping"
+RETAIL_RUN_MAX_SECONDS="${RETAIL_RUN_MAX_SECONDS:-1500}"
+. "$SCRIPT_DIR/run-lock.sh"
+if ! acquire_run_lock "$LOCKFILE" "$RETAIL_RUN_MAX_SECONDS"; then
   exit 0
 fi
-touch $LOCKFILE
 
 DATE=$(date -u +%Y-%m-%d)
 echo "[$(date -u +%H:%M:%S)] Starting retail price run for $DATE"
@@ -28,7 +38,9 @@ POLLER_ID="${POLLER_ID:-api}"
 
 # Use the persistent volume clone — no temp dir, no clone overhead
 API_EXPORT_DIR="${API_EXPORT_DIR:-/data/staktrakr-api-export}"
-trap 'rm -f "$LOCKFILE"' EXIT
+# The release trap is armed by acquire_run_lock at acquire time. It used to be
+# registered here, ~17 lines after the lock was taken, so any failure in between
+# leaked the lock permanently.
 
 if [ ! -d "$API_EXPORT_DIR/.git" ]; then
   echo "[$(date -u +%H:%M:%S)] ERROR: $API_EXPORT_DIR is not a git repo. Is volume mounted?"

--- a/devops/pollers/remote-poller/run-local.sh
+++ b/devops/pollers/remote-poller/run-local.sh
@@ -16,9 +16,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # NOTE: this script is currently neither COPYed into the slim Fly.io image nor
 # scheduled by docker-entrypoint-slim.sh — retail scraping runs on the home
 # poller. It is kept in sync so re-enabling it does not reintroduce the wedge.
+#
+# The helper sits next to this script inside the image (both land in /app) but
+# lives in ../shared/ in the repo, so resolve both layouts.
 LOCKFILE=/tmp/retail-poller.lock
 RETAIL_RUN_MAX_SECONDS="${RETAIL_RUN_MAX_SECONDS:-1500}"
-. "$SCRIPT_DIR/run-lock.sh"
+if [ -f "$SCRIPT_DIR/run-lock.sh" ]; then
+  . "$SCRIPT_DIR/run-lock.sh"
+else
+  . "$SCRIPT_DIR/../shared/run-lock.sh"
+fi
 if ! acquire_run_lock "$LOCKFILE" "$RETAIL_RUN_MAX_SECONDS"; then
   exit 0
 fi

--- a/devops/pollers/shared/playwright-budget.js
+++ b/devops/pollers/shared/playwright-budget.js
@@ -1,0 +1,123 @@
+// Hard time budgets for the Playwright fallback path (STRK-255).
+//
+// `page.goto({ timeout })` bounds navigation only. Everything else in a vendor
+// attempt — `chromium.launch()`, `page.evaluate()`, and above all
+// `browser.close()` — is unbounded. On 2026-07-19 a jmbullion navigation timed
+// out, the error was caught and logged ("… — falling back"), and the run then
+// wedged in the `finally` awaiting `browser.close()`. The scrape never returned,
+// the run lock was never released, and retail data froze for ~3.5h.
+//
+// These helpers put a ceiling on a whole vendor attempt and guarantee browser
+// teardown terminates, escalating to a process kill when the graceful close
+// itself hangs.
+
+/** Default ceiling for one vendor's Playwright attempt, in milliseconds. */
+export const DEFAULT_VENDOR_BUDGET_MS = 90_000;
+
+/** Default ceiling for a graceful `browser.close()`, in milliseconds. */
+export const DEFAULT_CLOSE_TIMEOUT_MS = 10_000;
+
+/** Sentinel resolved by {@link withDeadline} when the budget is exhausted. */
+export const DEADLINE_EXCEEDED = Symbol("deadline-exceeded");
+
+/**
+ * Race a promise against a deadline without leaving a dangling timer.
+ *
+ * Resolves to {@link DEADLINE_EXCEEDED} rather than rejecting, so callers can
+ * treat a blown budget as "this vendor produced nothing" and continue to the
+ * next one instead of aborting the run.
+ *
+ * The losing promise is not cancelled — JavaScript cannot cancel a pending
+ * promise — so a rejection arriving after the deadline is swallowed here to
+ * avoid an unhandled rejection taking down the process.
+ *
+ * @param {Promise<T>} promise - Work to bound.
+ * @param {number} ms - Budget in milliseconds.
+ * @returns {Promise<T | typeof DEADLINE_EXCEEDED>} Result, or the sentinel.
+ * @template T
+ */
+export function withDeadline(promise, ms) {
+  let timer;
+  const deadline = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(DEADLINE_EXCEEDED), ms);
+    // Do not hold the event loop open purely for this timer.
+    if (typeof timer.unref === "function") timer.unref();
+  });
+
+  return Promise.race([promise, deadline]).finally(() => {
+    clearTimeout(timer);
+    // The loser may still settle later; a late rejection with no handler would
+    // terminate the process under Node's default unhandledRejection policy.
+    Promise.resolve(promise).catch(() => {});
+  });
+}
+
+/**
+ * Close a Playwright browser, guaranteeing the call returns.
+ *
+ * A graceful `close()` is attempted first. If it does not settle within
+ * `timeoutMs` the underlying browser process is killed outright — leaking a
+ * Chromium process is strictly better than wedging the poller forever.
+ *
+ * @param {{close: Function, process?: Function}} browser - Playwright browser.
+ * @param {object} [opts] - Options.
+ * @param {number} [opts.timeoutMs] - Graceful close budget.
+ * @param {(msg: string) => void} [opts.log] - Logger for the escalation path.
+ * @returns {Promise<"closed"|"killed"|"failed">} How teardown resolved.
+ */
+export async function closeBrowserSafely(browser, opts = {}) {
+  const { timeoutMs = DEFAULT_CLOSE_TIMEOUT_MS, log = () => {} } = opts;
+  if (!browser) return "closed";
+
+  let closePromise;
+  try {
+    closePromise = Promise.resolve(browser.close());
+  } catch {
+    // A synchronous throw from close() still leaves the process to reap.
+    closePromise = Promise.reject(new Error("close threw synchronously"));
+  }
+
+  const outcome = await withDeadline(
+    closePromise.then(
+      () => "closed",
+      () => "failed"
+    ),
+    timeoutMs
+  );
+
+  if (outcome !== DEADLINE_EXCEEDED) return outcome;
+
+  log(`  (playwright) browser.close() exceeded ${timeoutMs}ms — killing browser process`);
+  try {
+    const proc = typeof browser.process === "function" ? browser.process() : null;
+    if (proc && typeof proc.kill === "function") {
+      proc.kill("SIGKILL");
+      return "killed";
+    }
+  } catch {
+    /* fall through — nothing more we can do */
+  }
+  return "failed";
+}
+
+/**
+ * Resolve the per-vendor Playwright budget from the environment.
+ *
+ * @param {Record<string, string|undefined>} [env] - Environment to read.
+ * @returns {number} Budget in milliseconds.
+ */
+export function resolveVendorBudgetMs(env = process.env) {
+  const raw = Number(env.PLAYWRIGHT_VENDOR_BUDGET_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_VENDOR_BUDGET_MS;
+}
+
+/**
+ * Resolve the graceful browser-close budget from the environment.
+ *
+ * @param {Record<string, string|undefined>} [env] - Environment to read.
+ * @returns {number} Budget in milliseconds.
+ */
+export function resolveCloseTimeoutMs(env = process.env) {
+  const raw = Number(env.PLAYWRIGHT_CLOSE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CLOSE_TIMEOUT_MS;
+}

--- a/devops/pollers/shared/playwright-budget.js
+++ b/devops/pollers/shared/playwright-budget.js
@@ -11,6 +11,8 @@
 // teardown terminates, escalating to a process kill when the graceful close
 // itself hangs.
 
+import { execFileSync } from "node:child_process";
+
 /** Default ceiling for one vendor's Playwright attempt, in milliseconds. */
 export const DEFAULT_VENDOR_BUDGET_MS = 90_000;
 
@@ -48,29 +50,61 @@ export function withDeadline(promise, ms) {
     clearTimeout(timer);
     // The loser may still settle later; a late rejection with no handler would
     // terminate the process under Node's default unhandledRejection policy.
-    Promise.resolve(promise).catch(() => {});
+    // Optional call so a non-promise argument cannot throw here.
+    promise?.catch?.(() => {});
   });
+}
+
+/**
+ * List the direct child pids of a process.
+ *
+ * Used to identify the browser Chromium spawns, because Playwright's `Browser`
+ * gives no handle on it (see {@link closeBrowserSafely}).
+ *
+ * @param {number} [parentPid] - Parent to inspect; defaults to this process.
+ * @returns {number[]} Child pids, or an empty array if they cannot be listed.
+ */
+export function listChildPids(parentPid = process.pid) {
+  try {
+    return execFileSync("pgrep", ["-P", String(parentPid)], { encoding: "utf8" })
+      .split("\n")
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  } catch {
+    // No children, or pgrep unavailable. Either way there is nothing to kill.
+    return [];
+  }
 }
 
 /**
  * Close a Playwright browser, guaranteeing the call returns.
  *
  * A graceful `close()` is attempted first. If it does not settle within
- * `timeoutMs` the underlying browser process is killed outright — leaking a
- * Chromium process is strictly better than wedging the poller forever.
+ * `timeoutMs` the browser is killed outright — leaking a Chromium process is
+ * strictly better than wedging the poller forever.
+ *
+ * Killing is deliberately two-pronged. Playwright exposes `process()` on
+ * `BrowserServer` and `ElectronApplication` only — **not** on the `Browser`
+ * returned by `chromium.launch()` — so for the poller's launch-based path that
+ * accessor is always absent and `fallbackPids` is what actually does the work.
+ * The caller records the pids Chromium spawned under, because once this Node
+ * process exits they are reparented to init and no longer reachable from the
+ * run-lock watchdog's process-tree walk.
  *
  * @param {{close: Function, process?: Function}} browser - Playwright browser.
  * @param {object} [opts] - Options.
  * @param {number} [opts.timeoutMs] - Graceful close budget.
  * @param {(msg: string) => void} [opts.log] - Logger for the escalation path.
+ * @param {number[]} [opts.fallbackPids] - Pids to SIGKILL when close() hangs.
  * @returns {Promise<"closed"|"killed"|"failed">} How teardown resolved.
  */
 export async function closeBrowserSafely(browser, opts = {}) {
-  const { timeoutMs = DEFAULT_CLOSE_TIMEOUT_MS, log = () => {} } = opts;
+  const { timeoutMs = DEFAULT_CLOSE_TIMEOUT_MS, log = () => {}, fallbackPids = [] } = opts;
   if (!browser) return "closed";
 
   let closePromise;
   try {
+    // close() may legitimately return undefined, so normalize before chaining.
     closePromise = Promise.resolve(browser.close());
   } catch {
     // A synchronous throw from close() still leaves the process to reap.
@@ -88,6 +122,8 @@ export async function closeBrowserSafely(browser, opts = {}) {
   if (outcome !== DEADLINE_EXCEEDED) return outcome;
 
   log(`  (playwright) browser.close() exceeded ${timeoutMs}ms — killing browser process`);
+
+  // BrowserServer / ElectronApplication path.
   try {
     const proc = typeof browser.process === "function" ? browser.process() : null;
     if (proc && typeof proc.kill === "function") {
@@ -95,7 +131,22 @@ export async function closeBrowserSafely(browser, opts = {}) {
       return "killed";
     }
   } catch {
-    /* fall through — nothing more we can do */
+    /* fall through to the pid path */
+  }
+
+  // chromium.launch() path: no process handle exists, so kill the recorded pids.
+  let killed = 0;
+  for (const pid of fallbackPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+      killed += 1;
+    } catch {
+      // Already gone — nothing to do.
+    }
+  }
+  if (killed > 0) {
+    log(`  (playwright) SIGKILLed ${killed} orphaned browser process(es)`);
+    return "killed";
   }
   return "failed";
 }

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -27,6 +27,13 @@ import { getCFClearanceCookie } from "./cf-clearance.js";
 import { loadWebscaleCookie, looksLikeWebscaleChallenge } from "./webscale-cookies.js";
 import { shouldBypassFirecrawlPreferredForPhase0 } from "./price-extract-vendor-goldback.js";
 import {
+  DEADLINE_EXCEEDED,
+  closeBrowserSafely,
+  resolveCloseTimeoutMs,
+  resolveVendorBudgetMs,
+  withDeadline,
+} from "./playwright-budget.js";
+import {
   FIRECRAWL_PREFERRED_PROVIDERS,
   FIRECRAWL_TABLE_PARSE_PROVIDERS,
   PLAYWRIGHT_ONLY_PROVIDERS,
@@ -605,13 +612,14 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     log(`  (playwright-direct) ${providerId} failed: ${err.message.slice(0, 100)} — falling back`);
     return null;
   } finally {
-    if (browser) {
-      try {
-        await browser.close();
-      } catch {
-        /* ignore */
-      }
-    }
+    // `browser.close()` has no timeout of its own. On 2026-07-19 it hung here
+    // *after* the navigation error had already been caught and logged, wedging
+    // the run and freezing retail data for ~3.5h (STRK-255). Teardown must
+    // always return, escalating to a process kill if the graceful close stalls.
+    await closeBrowserSafely(browser, {
+      timeoutMs: resolveCloseTimeoutMs(),
+      log,
+    });
   }
 }
 
@@ -689,7 +697,21 @@ async function scrapeGenericTarget(context) {
       tableParseProviderIds: FIRECRAWL_TABLE_PARSE_PROVIDERS,
     });
   if (!PLAYWRIGHT_ONLY_PROVIDERS.has(provider.id) && !fcPreferredForTarget && PLAYWRIGHT_LAUNCH) {
-    const directResult = await scrapeWithPlaywrightDirect(urls[0], provider.id, coin);
+    // Total-attempt ceiling on top of the per-call navigation timeout, so one
+    // hostile vendor cannot hang the whole run in an unbounded launch/evaluate/
+    // teardown step. A blown budget is treated as "no result" and falls through
+    // to Firecrawl rather than aborting the poll (STRK-255).
+    const budgetMs = resolveVendorBudgetMs();
+    const budgeted = await withDeadline(
+      scrapeWithPlaywrightDirect(urls[0], provider.id, coin),
+      budgetMs
+    );
+    if (budgeted === DEADLINE_EXCEEDED) {
+      warn(
+        `  (playwright-direct) ${provider.id} exceeded ${budgetMs}ms vendor budget — abandoning and falling back`
+      );
+    }
+    const directResult = budgeted === DEADLINE_EXCEEDED ? null : budgeted;
     if (directResult !== null) {
       price = directResult.price;
       source = directResult.source;

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -29,6 +29,7 @@ import { shouldBypassFirecrawlPreferredForPhase0 } from "./price-extract-vendor-
 import {
   DEADLINE_EXCEEDED,
   closeBrowserSafely,
+  listChildPids,
   resolveCloseTimeoutMs,
   resolveVendorBudgetMs,
   withDeadline,
@@ -475,11 +476,20 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
   const { chromium } = await import("playwright-core");
   let browser;
 
+  // Playwright's `Browser` (unlike `BrowserServer`) exposes no handle on the
+  // Chromium it spawned, so record the pids that appear across launch. If
+  // teardown later wedges, these are the only way to reap the browser — once
+  // this Node process exits they are reparented to init and the run-lock
+  // watchdog's tree walk can no longer see them (STRK-255).
+  const pidsBeforeLaunch = new Set(listChildPids());
+  let browserPids = [];
+
   try {
     browser = await chromium.launch({
       headless: true,
       args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
     });
+    browserPids = listChildPids().filter((pid) => !pidsBeforeLaunch.has(pid));
 
     // Webscale-protected vendors (jmbullion, providentmetals): if an operator
     // has stashed a solved wspc cookie for this host, inject it with the UA it
@@ -619,6 +629,7 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     await closeBrowserSafely(browser, {
       timeoutMs: resolveCloseTimeoutMs(),
       log,
+      fallbackPids: browserPids,
     });
   }
 }

--- a/devops/pollers/shared/run-lock.sh
+++ b/devops/pollers/shared/run-lock.sh
@@ -45,20 +45,59 @@ _run_lock_pid_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
-# _run_lock_kill_tree <pid> <signal>
+# _run_lock_children <pid>
 #
-# Signal a process and all of its descendants, children first, so a dying
-# parent cannot spawn replacements before it goes. The poller's wedge is
-# typically Chromium under node under bash, so killing only the recorded shell
-# PID would orphan the browser and leak memory on the host.
-_run_lock_kill_tree() {
+# List the direct children of a pid. `pgrep` comes from procps, which is not
+# installed in every poller image, so fall back to parsing `ps` rather than
+# silently degrading to a parent-only kill.
+_run_lock_children() {
   local pid="$1"
-  local sig="$2"
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -P "$pid" 2>/dev/null || true
+  else
+    ps -eo pid=,ppid= 2>/dev/null | awk -v p="$pid" '$2 == p { print $1 }' || true
+  fi
+}
+
+# _run_lock_collect_tree <pid>
+#
+# Print pid and every descendant, deepest first.
+#
+# The tree must be captured *before* any signal is sent: once the holding shell
+# exits, its children are reparented to init and can no longer be found by
+# walking down from the holder, so a second pass would miss exactly the
+# long-lived Chromium process the kill exists to reap.
+_run_lock_collect_tree() {
+  local pid="$1"
   local child
-  for child in $(pgrep -P "$pid" 2>/dev/null); do
-    _run_lock_kill_tree "$child" "$sig"
+  for child in $(_run_lock_children "$pid"); do
+    _run_lock_collect_tree "$child"
   done
-  kill "-$sig" "$pid" 2>/dev/null || true
+  echo "$pid"
+}
+
+# _run_lock_signal_pids <signal> <pid...>
+#
+# Send a signal to each pid, ignoring those that have already exited.
+_run_lock_signal_pids() {
+  local sig="$1"
+  shift
+  local pid
+  for pid in "$@"; do
+    kill "-$sig" "$pid" 2>/dev/null || true
+  done
+}
+
+# _run_lock_survivors <pid...>
+#
+# Print the subset of pids that are still alive.
+_run_lock_survivors() {
+  local pid
+  for pid in "$@"; do
+    if _run_lock_pid_alive "$pid"; then
+      echo "$pid"
+    fi
+  done
 }
 
 # _run_lock_release
@@ -74,21 +113,28 @@ _run_lock_release() {
 
 # _run_lock_claim <lockfile>
 #
-# Atomically create the lockfile containing "<pid> <start-epoch>". `noclobber`
-# makes the create-or-fail a single operation; the previous check-then-touch
-# left a window where two ticks could both believe they held the lock.
+# Atomically publish a lockfile already containing "<pid> <start-epoch>".
+#
+# The owner record is written to a private temp file first and then hard-linked
+# into place. `ln` fails if the target exists, so the create-or-fail decision
+# stays atomic, and — unlike a `noclobber` redirect — the lockfile is never
+# observable in a zero-byte state. That window mattered: a redirect creates the
+# file before `printf` fills it, so a competing tick could read an empty owner,
+# classify a live lock as malformed, delete it, and run concurrently.
 #
 # Returns 0 when this shell now owns the lock, 1 when another shell won.
 _run_lock_claim() {
   local lockfile="$1"
-  if (
-    set -o noclobber
-    printf '%s %s\n' "$$" "$(date -u +%s)" >"$lockfile"
-  ) 2>/dev/null; then
+  local tmp="${lockfile}.$$.tmp"
+
+  printf '%s %s\n' "$$" "$(date -u +%s)" >"$tmp" 2>/dev/null || return 1
+  if ln "$tmp" "$lockfile" 2>/dev/null; then
+    rm -f "$tmp"
     RUN_LOCK_FILE="$lockfile"
     trap _run_lock_release EXIT
     return 0
   fi
+  rm -f "$tmp"
   return 1
 }
 
@@ -115,6 +161,21 @@ _run_lock_force_claim() {
 acquire_run_lock() {
   local lockfile="$1"
   local max_age="${2:-$RUN_LOCK_DEFAULT_MAX_SECONDS}"
+
+  # A non-numeric budget (typo'd RETAIL_RUN_MAX_SECONDS, unexpanded variable)
+  # would make the `-lt` comparison below emit "integer expression expected" and
+  # return non-zero, aborting the whole tick under `set -e`. Fall back to the
+  # default rather than letting a config typo stop the poller.
+  case "$max_age" in
+    "" | *[!0-9]*)
+      _run_lock_log "WATCHDOG: ignoring non-numeric run budget '$max_age' — using ${RUN_LOCK_DEFAULT_MAX_SECONDS}s"
+      max_age="$RUN_LOCK_DEFAULT_MAX_SECONDS"
+      ;;
+    0)
+      _run_lock_log "WATCHDOG: ignoring zero run budget — using ${RUN_LOCK_DEFAULT_MAX_SECONDS}s"
+      max_age="$RUN_LOCK_DEFAULT_MAX_SECONDS"
+      ;;
+  esac
 
   if _run_lock_claim "$lockfile"; then
     return 0
@@ -153,14 +214,29 @@ acquire_run_lock() {
     return 1
   fi
 
-  _run_lock_log "WATCHDOG: run pid $holder_pid exceeded ${max_age}s budget (${age}s) — killing process tree"
-  _run_lock_kill_tree "$holder_pid" TERM
+  # Snapshot the whole tree up front. The holding shell usually dies on the
+  # first SIGTERM, which reparents its children to init — after that they can no
+  # longer be reached by walking down from the holder, and the wedged Chromium
+  # (the process actually worth reaping) would survive as an orphan.
+  local tree
+  tree="$(_run_lock_collect_tree "$holder_pid")"
+  # shellcheck disable=SC2086 # word splitting is intended: one pid per line
+  set -- $tree
+
+  _run_lock_log "WATCHDOG: run pid $holder_pid exceeded ${max_age}s budget (${age}s) — killing process tree ($# pid(s): $*)"
+  _run_lock_signal_pids TERM "$@"
   sleep "$RUN_LOCK_KILL_GRACE_SECONDS"
-  if _run_lock_pid_alive "$holder_pid"; then
-    _run_lock_log "WATCHDOG: pid $holder_pid survived SIGTERM — escalating to SIGKILL"
-    _run_lock_kill_tree "$holder_pid" KILL
+
+  local survivors
+  survivors="$(_run_lock_survivors "$@")"
+  if [ -n "$survivors" ]; then
+    # shellcheck disable=SC2086 # word splitting is intended: one pid per line
+    set -- $survivors
+    _run_lock_log "WATCHDOG: $# pid(s) survived SIGTERM ($*) — escalating to SIGKILL"
+    _run_lock_signal_pids KILL "$@"
     sleep 1
   fi
+
   _run_lock_log "WATCHDOG: reclaimed $lockfile — proceeding with this run"
   _run_lock_force_claim "$lockfile"
   return $?

--- a/devops/pollers/shared/run-lock.sh
+++ b/devops/pollers/shared/run-lock.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# StakTrakr poller run lock + stuck-run watchdog (STRK-255).
+#
+# Sourced by run-home.sh (home VM) and run-local.sh (Fly.io) to serialize poll
+# runs without letting a wedged run freeze the pipeline indefinitely.
+#
+# Background: the previous guard was `[ -f "$LOCKFILE" ] && exit 0` plus a bare
+# `touch`. It could not distinguish a healthy in-flight run from a hung one, and
+# a run killed without its EXIT trap (OOM, SIGKILL, container stop) left the
+# lock behind forever. On 2026-07-19 a Playwright stall on jmbullion froze
+# retail data for ~3.5h while every tick logged "Previous run still active".
+#
+# The lockfile now holds "<pid> <start-epoch>", which supports three outcomes:
+#   1. holder is alive and within budget  -> skip this tick (normal contention)
+#   2. holder is gone                     -> stale lock, reclaim  (WATCHDOG)
+#   3. holder is alive but over budget    -> kill tree, reclaim   (WATCHDOG)
+#
+# shellcheck shell=bash
+
+# Path of the lock currently held by this shell; consumed by the EXIT trap.
+RUN_LOCK_FILE=""
+
+# Default budget (seconds) before a live holder is considered wedged. Callers
+# should pass an explicit value sized to their cron interval; see acquire_run_lock.
+RUN_LOCK_DEFAULT_MAX_SECONDS="${RUN_LOCK_DEFAULT_MAX_SECONDS:-3600}"
+
+# Seconds to wait after SIGTERM before escalating to SIGKILL.
+RUN_LOCK_KILL_GRACE_SECONDS="${RUN_LOCK_KILL_GRACE_SECONDS:-5}"
+
+# _run_lock_log <message...>
+#
+# Emit a timestamped line matching the surrounding run-script log format so
+# watchdog events are greppable in /data/logs/retail-poller.log without exec.
+_run_lock_log() {
+  echo "[$(date -u +%H:%M:%S)] $*"
+}
+
+# _run_lock_pid_alive <pid>
+#
+# Return 0 when the process exists and is signalable by this user. Signal 0
+# performs the permission and existence check without delivering a signal.
+_run_lock_pid_alive() {
+  local pid="$1"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+# _run_lock_kill_tree <pid> <signal>
+#
+# Signal a process and all of its descendants, children first, so a dying
+# parent cannot spawn replacements before it goes. The poller's wedge is
+# typically Chromium under node under bash, so killing only the recorded shell
+# PID would orphan the browser and leak memory on the host.
+_run_lock_kill_tree() {
+  local pid="$1"
+  local sig="$2"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    _run_lock_kill_tree "$child" "$sig"
+  done
+  kill "-$sig" "$pid" 2>/dev/null || true
+}
+
+# _run_lock_release
+#
+# EXIT-trap handler. Removes only the lock this shell actually acquired, so a
+# shell that skipped on contention never deletes the live holder's lock.
+_run_lock_release() {
+  if [ -n "$RUN_LOCK_FILE" ]; then
+    rm -f "$RUN_LOCK_FILE"
+    RUN_LOCK_FILE=""
+  fi
+}
+
+# _run_lock_claim <lockfile>
+#
+# Atomically create the lockfile containing "<pid> <start-epoch>". `noclobber`
+# makes the create-or-fail a single operation; the previous check-then-touch
+# left a window where two ticks could both believe they held the lock.
+#
+# Returns 0 when this shell now owns the lock, 1 when another shell won.
+_run_lock_claim() {
+  local lockfile="$1"
+  if (
+    set -o noclobber
+    printf '%s %s\n' "$$" "$(date -u +%s)" >"$lockfile"
+  ) 2>/dev/null; then
+    RUN_LOCK_FILE="$lockfile"
+    trap _run_lock_release EXIT
+    return 0
+  fi
+  return 1
+}
+
+# _run_lock_force_claim <lockfile>
+#
+# Replace a lock that has been judged stale. Not atomic against a competing
+# watchdog, which is acceptable: both would be reclaiming the same dead holder,
+# and cron ticks for a given poller are an hour (home) or 15 minutes (Fly) apart.
+_run_lock_force_claim() {
+  local lockfile="$1"
+  rm -f "$lockfile"
+  _run_lock_claim "$lockfile"
+}
+
+# acquire_run_lock <lockfile> [max_run_seconds]
+#
+# Acquire the poller run lock, reclaiming it from a dead or overrunning holder.
+#
+# max_run_seconds should exceed one cron interval so a normally-slow run is
+# never killed by the very next tick — the watchdog is meant to fire on the
+# second consecutive contended tick, not the first.
+#
+# Returns 0 when the caller should proceed with the run, 1 when it should skip.
+acquire_run_lock() {
+  local lockfile="$1"
+  local max_age="${2:-$RUN_LOCK_DEFAULT_MAX_SECONDS}"
+
+  if _run_lock_claim "$lockfile"; then
+    return 0
+  fi
+
+  local holder_pid=""
+  local holder_epoch=""
+  read -r holder_pid holder_epoch <"$lockfile" 2>/dev/null || true
+
+  # A lockfile with no parseable PID predates this helper (bare `touch`) or was
+  # truncated by an unclean shutdown. Either way nothing owns it.
+  case "$holder_pid" in
+    "" | *[!0-9]*)
+      _run_lock_log "WATCHDOG: stale lock at $lockfile (no owner recorded) — reclaiming"
+      _run_lock_force_claim "$lockfile"
+      return $?
+      ;;
+  esac
+
+  if ! _run_lock_pid_alive "$holder_pid"; then
+    _run_lock_log "WATCHDOG: stale lock at $lockfile (pid $holder_pid is gone) — reclaiming"
+    _run_lock_force_claim "$lockfile"
+    return $?
+  fi
+
+  local now
+  now="$(date -u +%s)"
+  local age=0
+  case "$holder_epoch" in
+    "" | *[!0-9]*) age="$max_age" ;;
+    *) age=$((now - holder_epoch)) ;;
+  esac
+
+  if [ "$age" -lt "$max_age" ]; then
+    _run_lock_log "Previous run still active, skipping (pid $holder_pid, ${age}s elapsed)"
+    return 1
+  fi
+
+  _run_lock_log "WATCHDOG: run pid $holder_pid exceeded ${max_age}s budget (${age}s) — killing process tree"
+  _run_lock_kill_tree "$holder_pid" TERM
+  sleep "$RUN_LOCK_KILL_GRACE_SECONDS"
+  if _run_lock_pid_alive "$holder_pid"; then
+    _run_lock_log "WATCHDOG: pid $holder_pid survived SIGTERM — escalating to SIGKILL"
+    _run_lock_kill_tree "$holder_pid" KILL
+    sleep 1
+  fi
+  _run_lock_log "WATCHDOG: reclaimed $lockfile — proceeding with this run"
+  _run_lock_force_claim "$lockfile"
+  return $?
+}

--- a/tests/unit/strk-255-playwright-budget.test.js
+++ b/tests/unit/strk-255-playwright-budget.test.js
@@ -11,16 +11,38 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 
 import {
   withDeadline,
   closeBrowserSafely,
+  listChildPids,
   resolveVendorBudgetMs,
   resolveCloseTimeoutMs,
   DEADLINE_EXCEEDED,
   DEFAULT_VENDOR_BUDGET_MS,
   DEFAULT_CLOSE_TIMEOUT_MS,
 } from "../../devops/pollers/shared/playwright-budget.js";
+
+/**
+ * Resolve once a spawned child has exited and been reaped.
+ *
+ * @param {import("node:child_process").ChildProcess} child - Process to await.
+ * @param {number} timeoutMs - Maximum wait in milliseconds.
+ * @returns {Promise<boolean>} True when the child exited before the deadline.
+ */
+function waitForExit(child, timeoutMs = 10000) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
 
 /**
  * Build a promise that never settles, standing in for a wedged browser call.
@@ -137,10 +159,59 @@ describe("STRK-255 closeBrowserSafely", () => {
     assert.equal(await closeBrowserSafely(browser), "failed");
   });
 
-  it("does not hang when close() wedges and no process handle exists", async () => {
-    // browserless/CDP-connected browsers expose no local process to kill.
+  it("does not hang when close() wedges and nothing can be killed", async () => {
+    // CDP-connected browsers expose neither a local process nor known pids.
     const browser = { close: () => neverSettles() };
     assert.equal(await closeBrowserSafely(browser, { timeoutMs: 20 }), "failed");
+  });
+
+  it("kills recorded pids when close() hangs and no process handle exists", async () => {
+    // This is the poller's real shape. Playwright exposes process() on
+    // BrowserServer and ElectronApplication only — NOT on the Browser that
+    // chromium.launch() returns — so the handle path never fires here and the
+    // recorded pids are the only way to reap a wedged Chromium.
+    const victim = spawn("sleep", ["60"], { stdio: "ignore" });
+    const browser = { close: () => neverSettles() };
+
+    const logs = [];
+    const outcome = await closeBrowserSafely(browser, {
+      timeoutMs: 20,
+      log: (m) => logs.push(m),
+      fallbackPids: [victim.pid],
+    });
+
+    assert.equal(outcome, "killed");
+    assert.match(logs.join("\n"), /orphaned browser process/);
+    assert.equal(await waitForExit(victim), true);
+  });
+
+  it("reports failed when every recorded pid is already gone", async () => {
+    const ghost = spawn("sleep", ["60"], { stdio: "ignore" });
+    const ghostPid = ghost.pid;
+    ghost.kill("SIGKILL");
+    await waitForExit(ghost);
+
+    const outcome = await closeBrowserSafely(
+      { close: () => neverSettles() },
+      { timeoutMs: 20, fallbackPids: [ghostPid] }
+    );
+    assert.equal(outcome, "failed");
+  });
+});
+
+describe("STRK-255 listChildPids", () => {
+  it("finds a spawned child of this process", async () => {
+    const child = spawn("sleep", ["30"], { stdio: "ignore" });
+    const pids = listChildPids();
+    assert.ok(pids.includes(child.pid), `expected ${child.pid} in ${JSON.stringify(pids)}`);
+    child.kill("SIGKILL");
+    await waitForExit(child);
+  });
+
+  it("returns an empty array when there are no children to list", () => {
+    // Must degrade quietly — pgrep exits non-zero when nothing matches, and on
+    // images without procps it is absent entirely.
+    assert.deepEqual(listChildPids(999999), []);
   });
 });
 

--- a/tests/unit/strk-255-playwright-budget.test.js
+++ b/tests/unit/strk-255-playwright-budget.test.js
@@ -1,0 +1,173 @@
+// Unit tests for the Playwright vendor time budget (STRK-255).
+//
+// The 2026-07-19 freeze was not a navigation timeout — `page.goto` was already
+// bounded at 15s and it fired correctly, logging "… — falling back". The run
+// then wedged in the `finally` block awaiting `browser.close()`, which has no
+// timeout of its own. These tests pin the two guarantees that prevent a repeat:
+// a whole vendor attempt cannot outlive its budget, and browser teardown always
+// returns, escalating to SIGKILL when a graceful close hangs.
+//
+// Run: npm run test:unit
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  withDeadline,
+  closeBrowserSafely,
+  resolveVendorBudgetMs,
+  resolveCloseTimeoutMs,
+  DEADLINE_EXCEEDED,
+  DEFAULT_VENDOR_BUDGET_MS,
+  DEFAULT_CLOSE_TIMEOUT_MS,
+} from "../../devops/pollers/shared/playwright-budget.js";
+
+/**
+ * Build a promise that never settles, standing in for a wedged browser call.
+ *
+ * @returns {Promise<never>} A forever-pending promise.
+ */
+function neverSettles() {
+  return new Promise(() => {});
+}
+
+/**
+ * Sleep for a given duration.
+ *
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("STRK-255 withDeadline", () => {
+  it("passes through a value that arrives in time", async () => {
+    const result = await withDeadline(Promise.resolve("ok"), 1000);
+    assert.equal(result, "ok");
+  });
+
+  it("resolves to the sentinel instead of hanging forever", async () => {
+    const result = await withDeadline(neverSettles(), 25);
+    assert.equal(result, DEADLINE_EXCEEDED);
+  });
+
+  it("resolves to the sentinel rather than rejecting, so the run continues", async () => {
+    // A blown budget must not abort the poll — the remaining vendors still
+    // need to be scraped. This is why the helper resolves rather than throws.
+    const result = await withDeadline(
+      delay(50).then(() => "late"),
+      10
+    );
+    assert.equal(result, DEADLINE_EXCEEDED);
+  });
+
+  it("swallows a rejection that lands after the deadline", async () => {
+    const leaked = [];
+    const onUnhandled = (err) => leaked.push(err);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const slowFailure = delay(20).then(() => {
+        throw new Error("late boom");
+      });
+      const result = await withDeadline(slowFailure, 5);
+      assert.equal(result, DEADLINE_EXCEEDED);
+      await delay(60);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+
+    // Node's default policy for an unhandled rejection is to terminate. A
+    // browser call that rejects after we stopped waiting must not kill the run.
+    assert.deepEqual(leaked, []);
+  });
+
+  it("propagates a rejection that arrives before the deadline", async () => {
+    await assert.rejects(() => withDeadline(Promise.reject(new Error("boom")), 1000), /boom/);
+  });
+});
+
+describe("STRK-255 closeBrowserSafely", () => {
+  it("reports a clean close", async () => {
+    const browser = { close: async () => {} };
+    assert.equal(await closeBrowserSafely(browser), "closed");
+  });
+
+  it("tolerates a null browser", async () => {
+    assert.equal(await closeBrowserSafely(null), "closed");
+  });
+
+  it("kills the browser process when close() hangs", async () => {
+    const signals = [];
+    const browser = {
+      close: () => neverSettles(),
+      process: () => ({
+        kill: (sig) => signals.push(sig),
+      }),
+    };
+
+    const logs = [];
+    const outcome = await closeBrowserSafely(browser, {
+      timeoutMs: 20,
+      log: (m) => logs.push(m),
+    });
+
+    // This is the exact 2026-07-19 wedge: close() never returns.
+    assert.equal(outcome, "killed");
+    assert.deepEqual(signals, ["SIGKILL"]);
+    assert.match(logs.join("\n"), /killing browser process/);
+  });
+
+  it("returns rather than throwing when close() rejects", async () => {
+    const browser = {
+      close: async () => {
+        throw new Error("already closed");
+      },
+    };
+    assert.equal(await closeBrowserSafely(browser), "failed");
+  });
+
+  it("returns rather than throwing when close() throws synchronously", async () => {
+    const browser = {
+      close: () => {
+        throw new Error("sync boom");
+      },
+    };
+    assert.equal(await closeBrowserSafely(browser), "failed");
+  });
+
+  it("does not hang when close() wedges and no process handle exists", async () => {
+    // browserless/CDP-connected browsers expose no local process to kill.
+    const browser = { close: () => neverSettles() };
+    assert.equal(await closeBrowserSafely(browser, { timeoutMs: 20 }), "failed");
+  });
+});
+
+describe("STRK-255 budget resolution", () => {
+  it("falls back to defaults when unset", () => {
+    assert.equal(resolveVendorBudgetMs({}), DEFAULT_VENDOR_BUDGET_MS);
+    assert.equal(resolveCloseTimeoutMs({}), DEFAULT_CLOSE_TIMEOUT_MS);
+  });
+
+  it("honours valid overrides", () => {
+    assert.equal(resolveVendorBudgetMs({ PLAYWRIGHT_VENDOR_BUDGET_MS: "45000" }), 45000);
+    assert.equal(resolveCloseTimeoutMs({ PLAYWRIGHT_CLOSE_TIMEOUT_MS: "3000" }), 3000);
+  });
+
+  it("ignores junk and non-positive overrides", () => {
+    // A typo'd env var must not silently disable the budget.
+    assert.equal(
+      resolveVendorBudgetMs({ PLAYWRIGHT_VENDOR_BUDGET_MS: "abc" }),
+      DEFAULT_VENDOR_BUDGET_MS
+    );
+    assert.equal(
+      resolveVendorBudgetMs({ PLAYWRIGHT_VENDOR_BUDGET_MS: "0" }),
+      DEFAULT_VENDOR_BUDGET_MS
+    );
+    assert.equal(
+      resolveVendorBudgetMs({ PLAYWRIGHT_VENDOR_BUDGET_MS: "-1" }),
+      DEFAULT_VENDOR_BUDGET_MS
+    );
+  });
+});

--- a/tests/unit/strk-255-poller-watchdog.test.js
+++ b/tests/unit/strk-255-poller-watchdog.test.js
@@ -232,10 +232,112 @@ describe("STRK-255 retail poller run lock", () => {
     assert.match(res.stdout, /WATCHDOG:/);
   });
 
-  it("acquires atomically rather than checking then writing", () => {
-    // noclobber makes create-or-fail a single operation; the original
-    // `[ -f ]` then `touch` left a window where two ticks could both proceed.
+  it("SIGKILLs a descendant that ignores SIGTERM after its parent dies", async () => {
+    const lockfile = join(workDir, "poller.lock");
+    const pidFile = join(workDir, "grandchild.pid");
+
+    // Holder shell -> child shell -> grandchild that traps SIGTERM, standing in
+    // for a Chromium that does not die politely. The holder exits on the first
+    // TERM, reparenting the grandchild to init; escalation must still reach it,
+    // which only works if the tree was captured before signalling.
+    const holder = spawn(
+      "bash",
+      ["-c", `bash -c 'trap "" TERM; echo $$ > "${pidFile}"; sleep 120' & sleep 120`],
+      { stdio: "ignore" }
+    );
+    // Give the grandchild time to register its pid.
+    execFileSync("sleep", ["0.5"]);
+    const grandchildPid = Number(readFileSync(pidFile, "utf8").trim());
+    assert.ok(grandchildPid > 0);
+    assert.equal(isAlive(grandchildPid), true);
+
+    const staleEpoch = Math.floor(Date.now() / 1000) - 100;
+    writeFileSync(lockfile, `${holder.pid} ${staleEpoch}\n`);
+
+    const res = runAcquire(lockfile, SHORT_MAX_AGE);
+
+    assert.match(res.stdout, /ACQUIRED/);
+    assert.match(res.stdout, /survived SIGTERM/);
+    assert.equal(isAlive(grandchildPid), false, "TERM-ignoring descendant must be SIGKILLed");
+
+    await waitForExit(holder);
+  });
+
+  it("lets exactly one of many concurrent acquirers win", () => {
+    const lockfile = join(workDir, "poller.lock");
+    const CONTENDERS = 12;
+
+    // Publishing the lock must be atomic *with its contents*. A `noclobber`
+    // redirect creates the file before the PID is written, so a competing tick
+    // could read an empty owner, judge the live lock malformed, delete it, and
+    // run concurrently. Hard-linking a pre-filled temp file closes that window.
+    const script = `
+      for i in $(seq 1 ${CONTENDERS}); do
+        (
+          . "${LOCK_HELPER}"
+          if acquire_run_lock "${lockfile}" 600; then
+            echo WON
+            sleep 0.3
+          fi
+        ) &
+      done
+      wait
+    `;
+    const stdout = execFileSync("bash", ["-c", script], { encoding: "utf8" });
+    const wins = stdout.split("\n").filter((l) => l.trim() === "WON").length;
+
+    assert.equal(wins, 1, `expected exactly one winner, got ${wins}`);
+  });
+
+  it("never exposes a lockfile without an owner record", () => {
+    const lockfile = join(workDir, "poller.lock");
+    // Poll the lock while a run holds it; it must never be observed empty.
+    const script = `
+      . "${LOCK_HELPER}"
+      acquire_run_lock "${lockfile}" 600 >/dev/null
+      for i in $(seq 1 40); do
+        if [ -f "${lockfile}" ] && [ ! -s "${lockfile}" ]; then echo EMPTY_SEEN; fi
+        sleep 0.01
+      done
+      echo DONE
+    `;
+    const stdout = execFileSync("bash", ["-c", script], { encoding: "utf8" });
+
+    assert.doesNotMatch(stdout, /EMPTY_SEEN/);
+    assert.match(stdout, /DONE/);
+  });
+
+  it("falls back to the default budget instead of aborting on a junk budget", () => {
+    const lockfile = join(workDir, "poller.lock");
+    const holder = spawnStandIn(30);
+    writeFileSync(lockfile, `${holder.pid} ${Math.floor(Date.now() / 1000)}\n`);
+
+    // `[ "$age" -lt "abc" ]` emits "integer expression expected" and returns
+    // non-zero, which under `set -e` would kill the whole tick.
+    const res = runAcquire(lockfile, "abc");
+
+    assert.equal(res.status, 0, "a junk budget must not abort the run");
+    assert.match(res.stdout, /non-numeric run budget/);
+    assert.match(res.stdout, /Previous run still active, skipping/);
+
+    holder.kill("SIGKILL");
+  });
+
+  it("can enumerate children without pgrep", () => {
+    // procps is absent from some poller images; the helper must not silently
+    // degrade to a parent-only kill there.
     const helper = readFileSync(LOCK_HELPER, "utf8");
-    assert.match(helper, /noclobber/);
+    assert.match(helper, /command -v pgrep/);
+    assert.match(helper, /ps -eo pid=,ppid=/);
+  });
+
+  it("captures the process tree before signalling, not after", () => {
+    // Once the holding shell dies its children are reparented to init and can
+    // no longer be found by walking down from the holder.
+    const helper = readFileSync(LOCK_HELPER, "utf8");
+    const collectAt = helper.indexOf('_run_lock_collect_tree "$holder_pid"');
+    const signalAt = helper.indexOf("_run_lock_signal_pids TERM");
+    assert.ok(collectAt > 0 && signalAt > 0);
+    assert.ok(collectAt < signalAt, "tree must be captured before the first signal");
   });
 });

--- a/tests/unit/strk-255-poller-watchdog.test.js
+++ b/tests/unit/strk-255-poller-watchdog.test.js
@@ -1,0 +1,241 @@
+// Unit tests for the retail poller stuck-run watchdog (STRK-255).
+//
+// Regression coverage for a silent 3.5h retail-data freeze on 2026-07-19: the
+// home poller's hourly run hung mid-scrape inside the Playwright fallback
+// (jmbullion, Webscale interstitial). The lockfile guard in run-home.sh was a
+// bare `touch` with no PID and no age, so every subsequent tick printed
+// "Previous run still active, skipping" and no-opped. Nothing could tell a
+// genuinely-running poll from a wedged one, and nothing could reclaim the lock
+// — it was only cleared when the container restarted hours later.
+//
+// The fix is a shared `acquire_run_lock` helper that records `PID EPOCH`,
+// detects both dead holders (crash / OOM-kill, where the EXIT trap never ran)
+// and live-but-overrunning holders, kills the stale process tree, and proceeds.
+//
+// Run: npm run test:unit
+//
+// These tests drive the real bash helper via a temp lockfile and short-lived
+// `sleep` processes. Nothing touches /tmp/retail-poller.lock or the poller.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const LOCK_HELPER = join(REPO_ROOT, "devops", "pollers", "shared", "run-lock.sh");
+
+/** Seconds a held lock may live before the watchdog reclaims it, in tests. */
+const SHORT_MAX_AGE = 2;
+
+let workDir;
+
+/**
+ * Run `acquire_run_lock` in a fresh bash process against a given lockfile.
+ *
+ * The helper is sourced rather than executed so the caller keeps the EXIT trap
+ * semantics the real run scripts rely on.
+ *
+ * @param {string} lockfile - Path to the lockfile under test.
+ * @param {number} maxAge - Max age in seconds before a live holder is killed.
+ * @param {string} [body] - Extra bash to run after a successful acquire.
+ * @returns {{status: number, stdout: string}} Exit status and combined output.
+ */
+function runAcquire(lockfile, maxAge, body = "") {
+  const script = `
+    set -e
+    # Shorten the SIGTERM grace so the kill path does not dominate suite time.
+    # The grace duration itself is not under test.
+    export RUN_LOCK_KILL_GRACE_SECONDS=1
+    . "${LOCK_HELPER}"
+    if acquire_run_lock "${lockfile}" ${maxAge}; then
+      echo "ACQUIRED"
+      ${body}
+    else
+      echo "SKIPPED"
+      exit 0
+    fi
+  `;
+  try {
+    const stdout = execFileSync("bash", ["-c", script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+/**
+ * Spawn a long-running process to stand in for a wedged poll.
+ *
+ * The ChildProcess handle is deliberately retained so Node reaps the process
+ * when it dies. An unreaped child lingers as a zombie, and a zombie PID still
+ * answers `kill -0` — which would make the helper read a dead holder as alive.
+ *
+ * @param {number} seconds - How long the stand-in should live.
+ * @returns {import("node:child_process").ChildProcess} The spawned process.
+ */
+function spawnStandIn(seconds) {
+  return spawn("sleep", [String(seconds)], { stdio: "ignore" });
+}
+
+/**
+ * Report whether a PID is alive and not a zombie.
+ *
+ * @param {number} pid - Process id to check.
+ * @returns {boolean} True when the process exists in a non-zombie state.
+ */
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+  try {
+    const stat = execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
+      encoding: "utf8",
+    }).trim();
+    return stat.length > 0 && !stat.startsWith("Z");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve once a spawned child has fully exited and been reaped by Node.
+ *
+ * @param {import("node:child_process").ChildProcess} child - Process to await.
+ * @param {number} timeoutMs - Maximum wait in milliseconds.
+ * @returns {Promise<boolean>} True when the child exited before the deadline.
+ */
+function waitForExit(child, timeoutMs = 15000) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+describe("STRK-255 retail poller run lock", () => {
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "strk255-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("acquires a free lock and records PID and start epoch", () => {
+    const lockfile = join(workDir, "poller.lock");
+    const res = runAcquire(lockfile, 60, `cat "${lockfile}"`);
+
+    assert.equal(res.status, 0);
+    assert.match(res.stdout, /ACQUIRED/);
+    // Lockfile contents must be "<pid> <epoch>" so a later tick can both probe
+    // liveness and compute age. A bare touch() is what caused STRK-255.
+    assert.match(res.stdout, /^\d+ \d{10}$/m);
+  });
+
+  it("releases the lock on normal exit", () => {
+    const lockfile = join(workDir, "poller.lock");
+    runAcquire(lockfile, 60);
+    assert.equal(existsSync(lockfile), false);
+  });
+
+  it("releases the lock when the run fails under set -e", () => {
+    const lockfile = join(workDir, "poller.lock");
+    const res = runAcquire(lockfile, 60, "false");
+
+    assert.notEqual(res.status, 0);
+    // The trap must be armed at acquire time, not after later setup steps —
+    // run-local.sh armed it ~17 lines late, leaking the lock on early failure.
+    assert.equal(existsSync(lockfile), false);
+  });
+
+  it("skips when a live holder is still within its budget", async () => {
+    const lockfile = join(workDir, "poller.lock");
+    const holder = spawnStandIn(30);
+    writeFileSync(lockfile, `${holder.pid} ${Math.floor(Date.now() / 1000)}\n`);
+
+    const res = runAcquire(lockfile, 600);
+
+    assert.match(res.stdout, /Previous run still active, skipping/);
+    assert.doesNotMatch(res.stdout, /ACQUIRED/);
+    assert.equal(isAlive(holder.pid), true, "a healthy run must not be killed");
+    // The skipping shell must not delete the live holder's lock on its way out.
+    assert.equal(existsSync(lockfile), true);
+
+    holder.kill("SIGKILL");
+    await waitForExit(holder);
+  });
+
+  it("reclaims a lock whose holder is dead (crash or OOM-kill)", async () => {
+    const lockfile = join(workDir, "poller.lock");
+    const holder = spawnStandIn(30);
+    const deadPid = holder.pid;
+    holder.kill("SIGKILL");
+    // Await the exit event, not just the signal: until Node reaps the child it
+    // stays a zombie, and a zombie PID still answers `kill -0`.
+    assert.equal(await waitForExit(holder), true);
+
+    writeFileSync(lockfile, `${deadPid} ${Math.floor(Date.now() / 1000)}\n`);
+    const res = runAcquire(lockfile, 600);
+
+    // This is the OOM / SIGKILL case: the EXIT trap never ran, so the lock
+    // outlived its owner. Age alone would not catch it.
+    assert.match(res.stdout, /ACQUIRED/);
+    assert.match(res.stdout, /WATCHDOG:/);
+    assert.match(res.stdout, /stale/i);
+  });
+
+  it("kills a live holder that has overrun its budget and proceeds", async () => {
+    const lockfile = join(workDir, "poller.lock");
+    const holder = spawnStandIn(60);
+    const stuckPid = holder.pid;
+    const staleEpoch = Math.floor(Date.now() / 1000) - SHORT_MAX_AGE * 10;
+    writeFileSync(lockfile, `${stuckPid} ${staleEpoch}\n`);
+
+    const res = runAcquire(lockfile, SHORT_MAX_AGE);
+
+    assert.match(res.stdout, /ACQUIRED/, "the current tick must proceed");
+    assert.match(res.stdout, /WATCHDOG:/);
+    assert.equal(
+      await waitForExit(holder),
+      true,
+      "the wedged process tree must actually be killed, not just unlocked"
+    );
+    assert.equal(isAlive(stuckPid), false);
+  });
+
+  it("reclaims a malformed or truncated lockfile", () => {
+    const lockfile = join(workDir, "poller.lock");
+    writeFileSync(lockfile, "");
+
+    const res = runAcquire(lockfile, 600);
+
+    // A bare `touch`-era lockfile has no PID at all; it must not wedge the
+    // poller forever after an upgrade.
+    assert.match(res.stdout, /ACQUIRED/);
+    assert.match(res.stdout, /WATCHDOG:/);
+  });
+
+  it("acquires atomically rather than checking then writing", () => {
+    // noclobber makes create-or-fail a single operation; the original
+    // `[ -f ]` then `touch` left a window where two ticks could both proceed.
+    const helper = readFileSync(LOCK_HELPER, "utf8");
+    assert.match(helper, /noclobber/);
+  });
+});


### PR DESCRIPTION
Closes STRK-255.

## Problem

A Playwright stall on jmbullion froze retail data for ~3.5h on 2026-07-19. Two independent defects combined.

**1. The lock could not tell a wedged run from a healthy one.**

```bash
if [ -f "$LOCKFILE" ]; then echo "Previous run still active, skipping"; exit 0; fi
touch $LOCKFILE
```

An empty lockfile carries no identity and no age, so every subsequent tick no-opped until the container restarted. Three failure modes fall out of this:

- a wedged run holds the lock forever;
- a run killed without its EXIT trap (OOM / SIGKILL) leaks the lock permanently, since `touch` leaves nothing to expire;
- `[ -f ]` then `touch` is not atomic.

In `run-local.sh` the trap was additionally registered ~17 lines *after* the lock was taken, so any failure in between leaked it.

**2. `browser.close()` has no timeout.**

The navigation timeout fired and was handled correctly — the log line in the issue (`… — falling back`) is the *catch* branch. The run then wedged in the `finally` awaiting teardown, after the error had already been logged. `page.goto({timeout})` bounds navigation only; `chromium.launch()`, `page.evaluate()` and `browser.close()` are all unbounded. A longer `goto` timeout would have changed nothing.

## Fix

**`devops/pollers/shared/run-lock.sh`** — records `<pid> <epoch>`, acquires atomically via `noclobber`, and reclaims the lock from either a **dead** holder (liveness probe, catches OOM/SIGKILL) or an **overrunning** one (age budget). These cover different failure modes, so both are needed. The process tree is killed children-first (TERM, then KILL after a grace) so a wedged Chromium is not orphaned, and every event logs a greppable `WATCHDOG:` line.

Budgets are sized so the first contended tick still skips and the second reclaims:

| Poller | Cadence | Budget | Behaviour |
|---|---|---|---|
| home | hourly | 5400s | T+3600 skip → T+7200 reclaim |
| remote | 15 min | 1500s | T+900 skip → T+1800 reclaim |

**`devops/pollers/shared/playwright-budget.js`** — a per-vendor deadline around the whole attempt, and a teardown that escalates to SIGKILL when the graceful close hangs. A blown budget resolves to "no result" and falls through to Firecrawl rather than aborting the poll, so one hostile vendor cannot end the run. Late rejections from the abandoned promise are swallowed — under Node's default policy an unhandled rejection would terminate the process.

**Both Dockerfiles copied only `shared/*.js`.** The new helper would never have reached either image, and sourcing a missing file under `set -e` would have broken the poller outright. `COPY shared/*.sh` added to both.

## Verification

- 22 new unit tests; full suite **448 passed / 0 failed**, poller `.test.mjs` **14 passed / 0 failed**.
- End-to-end simulation with real processes: tick 1 wedges, tick 2 `SKIPPED` (healthy holder untouched), tick 3 fires `WATCHDOG:`, kills the shell **and its descendant**, and `COMPLETED`. Lock released.
- `bash -n` clean on all three shell scripts; prettier and eslint clean.

Requirement 3 (surface watchdog events) needs no new code: `dashboard.js` already tails `/data/logs/retail-poller.log` via `readLog()`, which is where cron redirects this output.

## Also in scope

Corrects retail-poller skill doc drift flagged in the issue, in both the `.claude/` and `.agents/` twins: `price_snapshots` has **no** `poller_id` column (verified against `initSqldSchema()`); that column exists on `poller_runs` and `spot_prices`. The table also omitted the real `confidence` column.

## Notes for the reviewer

- No version bump — matches the STRK-277 poller precedent (PR #1366).
- No coverage-map row — these are `node --test` unit tests, not Playwright.
- `run-local.sh` is currently neither copied into the slim Fly.io image nor scheduled; retail scraping is home-only today. It is fixed in step anyway so re-enabling it cannot reintroduce the wedge.
- Out of scope, noted in passing: `run-goldback.sh` still uses the old `touch`-guard pattern. It uses a separate lock path and is currently unscheduled, so it is not part of this fix.