### PR TITLE
fix(sw): make providers.json network-first (STRK-264)

### DIFF
--- a/sw-router.js
+++ b/sw-router.js
@@ -90,12 +90,20 @@ const FAMILY_TABLE = [
     hasEnvelope: true,
   },
   {
+    // Network-first despite the slow-moving data (STRK-264). Cache-first meant
+    // a provider_vendors change — a new coin, or a yearly-dated product URL
+    // rolling over — could take the full 24h floor to reach a browser that
+    // already held a SW-cached copy, and a hard refresh does not clear that.
+    // The price feed is networkFirst, so the UI would show a current price
+    // behind a stale vendor link. floor is retained for the error-fallback
+    // path and to stay consistent with the other realtime families.
     family: "providers",
     test: function (p) {
       return p === "/v2/providers.json";
     },
     floor: 86400,
     hasEnvelope: true,
+    networkFirst: true,
   },
   {
     // Matches /data/spot-history-YYYY.json (local origin) and /spot-history-YYYY.json (API root)

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.65-b1784962182";
+const CACHE_NAME = "staktrakr-v3.35.65-b1784965568";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/helpers/load-sw-router.js
+++ b/tests/unit/helpers/load-sw-router.js
@@ -1,0 +1,26 @@
+// Shared loader for sw-router.js in Node unit tests.
+//
+// sw-router.js is a plain importScripts-compatible script, not an ES module, so
+// it is evaluated with a synthetic CommonJS module context to trip its export
+// guard — no ESM refactor of the production script required.
+//
+// Centralised here because three suites need it (STRK-249 routing matrix,
+// STRK-256 cache fallback, STRK-264 providers strategy).
+
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+
+/**
+ * Evaluate sw-router.js with a synthetic CJS context and return its exports.
+ *
+ * The source is a first-party repo file read from disk and passed verbatim;
+ * no external or caller-supplied string is interpolated into the function body.
+ *
+ * @returns {Record<string, any>} sw-router.js's CommonJS exports.
+ */
+export function loadSwRouter() {
+  const routerCode = readFileSync(new URL("../../../sw-router.js", import.meta.url), "utf-8");
+  const swModule = { exports: {} };
+  new Function("module", "exports", routerCode)(swModule, swModule.exports);
+  return swModule.exports;
+}

--- a/tests/unit/strk-256-sw-cache-fallback.test.js
+++ b/tests/unit/strk-256-sw-cache-fallback.test.js
@@ -17,13 +17,10 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { URL } from "node:url";
 
-const routerCode = readFileSync(new URL("../../sw-router.js", import.meta.url), "utf-8");
-const _module = { exports: {} };
-new Function("module", "exports", routerCode)(_module, _module.exports);
-const { shouldFallBackToCache } = _module.exports;
+import { loadSwRouter } from "./helpers/load-sw-router.js";
+
+const { shouldFallBackToCache } = loadSwRouter();
 
 /**
  * Build a minimal stand-in for a fetch Response.

--- a/tests/unit/strk-264-providers-network-first.test.js
+++ b/tests/unit/strk-264-providers-network-first.test.js
@@ -1,0 +1,85 @@
+// Unit tests for STRK-264: providers.json must be network-first.
+//
+// The `providers` family was cache-first with a 24h floor while its siblings
+// (spot-latest, goldback-latest, retail-latest) were networkFirst. Because
+// classifiedFetch returns a cached hit without ever touching the network while
+// the entry is inside its TTL, any change to provider_vendors could take up to
+// 24h to reach a browser that already had a Service-Worker-cached copy — and a
+// hard refresh does not clear it, only unregistering the SW does.
+//
+// Found 2026-07-24 onboarding STRK-261/262/263: the new coins' prices appeared
+// correctly (served by the networkFirst retail-latest/manifest families) but
+// clicking a price cell opened the vendor's homepage instead of the product
+// page, because window.retailProviders was still built from a 24h-old
+// providers.json. A fresh browser context resolved the links immediately,
+// which localised the fault to the SW cache layer rather than the export.
+//
+// The durable case is vendor-URL rollover: when a yearly-dated coin's product
+// page is superseded, the price feed updates at once while the URL behind it
+// can lag a day — the UI then shows a current price under a stale link.
+//
+// Run: npm run test:unit
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { URL } from "node:url";
+
+const routerCode = readFileSync(new URL("../../sw-router.js", import.meta.url), "utf-8");
+const _module = { exports: {} };
+new Function("module", "exports", routerCode)(_module, _module.exports);
+const { classifyEndpoint, FAMILY_TABLE } = _module.exports;
+
+const API1 = "https://api.staktrakr.com";
+const API2 = "https://api2.staktrakr.com";
+const SELF = "https://staktrakr.com";
+
+describe("STRK-264 providers is network-first", () => {
+  it("emits networkFirst:true on both API hosts", () => {
+    for (const host of [API1, API2]) {
+      const r = classifyEndpoint(`${host}/v2/providers.json`, SELF);
+      assert.equal(r.family, "providers");
+      assert.equal(r.networkFirst, true, `${host} must classify providers as network-first`);
+    }
+  });
+
+  it("also applies to the production /data/v2 path shape", () => {
+    // Production API endpoints are served under a /data prefix (STRK-190), so
+    // the real request shape must get the same strategy as the bare one.
+    const r = classifyEndpoint(`${API1}/data/v2/providers.json`, SELF);
+    assert.equal(r.family, "providers");
+    assert.equal(r.networkFirst, true);
+  });
+
+  it("leaves the TTL floor and envelope flag untouched", () => {
+    // Only the strategy changes. floor is unused on the networkFirst path (it
+    // skips matchWithAgeCheck entirely) but is left alone so the entry stays
+    // consistent with its realtime siblings, which also keep their floors.
+    const entry = FAMILY_TABLE.find((e) => e.family === "providers");
+    assert.equal(entry.floor, 86400);
+    assert.equal(entry.hasEnvelope, true);
+  });
+
+  it("matches the descriptor shape of the other realtime families", () => {
+    const providers = classifyEndpoint(`${API1}/v2/providers.json`, SELF);
+    const spotLatest = classifyEndpoint(`${API1}/v2/spot/latest.json`, SELF);
+    assert.deepEqual(Object.keys(providers).sort(), Object.keys(spotLatest).sort());
+  });
+
+  it("does not make every family network-first", () => {
+    // Guard against a blanket flag: the genuinely slow-moving families must
+    // still be cache-first, or every page load pays a network round trip.
+    for (const path of [
+      "/v2/manifest.json",
+      "/v2/retail/apmex/history-30d.json",
+      "/v2/spot/xau/2026/05/15.json",
+    ]) {
+      const r = classifyEndpoint(API1 + path, SELF);
+      assert.equal(
+        Object.prototype.hasOwnProperty.call(r, "networkFirst"),
+        false,
+        `${path} must remain cache-first`
+      );
+    }
+  });
+});

--- a/tests/unit/strk-264-providers-network-first.test.js
+++ b/tests/unit/strk-264-providers-network-first.test.js
@@ -8,11 +8,16 @@
 // hard refresh does not clear it, only unregistering the SW does.
 //
 // Found 2026-07-24 onboarding STRK-261/262/263: the new coins' prices appeared
-// correctly (served by the networkFirst retail-latest/manifest families) but
-// clicking a price cell opened the vendor's homepage instead of the product
-// page, because window.retailProviders was still built from a 24h-old
-// providers.json. A fresh browser context resolved the links immediately,
-// which localised the fault to the SW cache layer rather than the export.
+// correctly (served by the networkFirst retail-latest family) but clicking a
+// price cell opened the vendor's homepage instead of the product page, because
+// window.retailProviders was still built from a 24h-old providers.json. A fresh
+// browser context resolved the links immediately, which localised the fault to
+// the SW cache layer rather than the export pipeline.
+//
+// Note: `manifest` is NOT network-first (floor 1800, cache-first). The issue
+// description groups it with retail-latest as though it were; only
+// retail-latest carries the flag. Corrected here so this file does not
+// propagate that.
 //
 // The durable case is vendor-URL rollover: when a yearly-dated coin's product
 // page is superseded, the price feed updates at once while the URL behind it
@@ -22,13 +27,10 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { URL } from "node:url";
 
-const routerCode = readFileSync(new URL("../../sw-router.js", import.meta.url), "utf-8");
-const _module = { exports: {} };
-new Function("module", "exports", routerCode)(_module, _module.exports);
-const { classifyEndpoint, FAMILY_TABLE } = _module.exports;
+import { loadSwRouter } from "./helpers/load-sw-router.js";
+
+const { classifyEndpoint, FAMILY_TABLE } = loadSwRouter();
 
 const API1 = "https://api.staktrakr.com";
 const API2 = "https://api2.staktrakr.com";
@@ -74,7 +76,7 @@ describe("STRK-264 providers is network-first", () => {
       "/v2/retail/apmex/history-30d.json",
       "/v2/spot/xau/2026/05/15.json",
     ]) {
-      const r = classifyEndpoint(API1 + path, SELF);
+      const r = classifyEndpoint(`${API1}${path}`, SELF);
       assert.equal(
         Object.prototype.hasOwnProperty.call(r, "networkFirst"),
         false,

--- a/tests/unit/sw-router.test.js
+++ b/tests/unit/sw-router.test.js
@@ -319,14 +319,18 @@ describe("classifyEndpoint — networkFirst on realtime families (STRK-249)", ()
     "annual-spot-history": "/spot-history-2025.json",
   };
 
-  const REALTIME_FAMILIES = ["spot-latest", "goldback-latest", "retail-latest"];
+  // `providers` moved from NON_REALTIME to REALTIME in STRK-264. It is not
+  // realtime data, but cache-first let a provider_vendors change sit behind a
+  // 24h SW-cached copy while the price feed updated immediately, so the UI
+  // could show a current price under a stale vendor URL. Dedicated coverage
+  // lives in tests/unit/strk-264-providers-network-first.test.js.
+  const REALTIME_FAMILIES = ["spot-latest", "goldback-latest", "retail-latest", "providers"];
   const NON_REALTIME_FAMILIES = [
     "manifest",
     "spot-history-daily",
     "retail-intraday",
     "retail-history-short",
     "retail-history-long",
-    "providers",
     "annual-spot-history",
   ];
 

--- a/tests/unit/sw-router.test.js
+++ b/tests/unit/sw-router.test.js
@@ -1,20 +1,16 @@
 // Unit tests for sw-router.js using Node built-in test runner.
 // Run: npm run test:unit  (node --test tests/unit/sw-router.test.js)
 //
-// sw-router.js is a plain script file (importScripts-compatible, no ESM syntax).
-// We load it via new Function() with a synthetic CJS module context so the CJS
-// export guard fires and exports FAMILY_TABLE / classifyEndpoint without requiring
-// ESM refactoring of the production script.
+// sw-router.js is a plain script file (importScripts-compatible, no ESM syntax),
+// so it is loaded through the shared synthetic-CJS helper — see
+// ./helpers/load-sw-router.js for why and how.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { URL } from "node:url";
 
-const routerCode = readFileSync(new URL("../../sw-router.js", import.meta.url), "utf-8");
-const _module = { exports: {} };
-new Function("module", "exports", routerCode)(_module, _module.exports);
-const { FAMILY_TABLE, classifyEndpoint, parseGeneratedAtSeconds } = _module.exports;
+import { loadSwRouter } from "./helpers/load-sw-router.js";
+
+const { FAMILY_TABLE, classifyEndpoint, parseGeneratedAtSeconds } = loadSwRouter();
 
 const API1 = "https://api.staktrakr.com";
 const API2 = "https://api2.staktrakr.com";


### PR DESCRIPTION
Closes STRK-264.

## Problem

The `providers` family was cache-first with a 24h floor while its siblings — `spot-latest`, `goldback-latest`, `retail-latest` — were `networkFirst`. `classifiedFetch` returns a cached hit **without contacting the network at all** while the entry is inside its TTL, so any `provider_vendors` change could take the full 24h to reach a browser holding a SW-cached copy. A hard refresh does not clear that; only unregistering the SW or clearing Cache Storage does.

## How it surfaced

Onboarding STRK-261/262/263, the new coins' prices displayed correctly — those come via the `retail-latest` family, which *is* network-first (note: `manifest` is **not** — the issue description groups them, but only `retail-latest` carries the flag; corrected after Copilot caught it) — but clicking a price cell opened the vendor's **homepage** instead of the product page. `window.retailProviders` is built by flattening `providers.json` (`_flattenV2Providers` in `js/retail.js`), and that was still the pre-onboarding map.

A brand-new browser context with no prior SW registration resolved the links immediately. That's what localised the fault to the client-side cache layer rather than the export pipeline — the server had been correct the whole time.

## Why it matters beyond that incident

Vendor-URL rollover. When a yearly-dated coin's product page is superseded (2025 → 2026), the price feed updates immediately while the URL behind it can lag a day. The UI then shows a **current price under a stale link** — worse than showing nothing, because it looks right.

## Fix

Add `networkFirst: true` to the `providers` entry, matching the realtime families.

`floor: 86400` is **retained**. It's unused on the network-first path (which skips `matchWithAgeCheck` entirely) but still governs the error-fallback path, and the other realtime families keep their floors too — `spot-latest` keeps 1200. Removing it would be an unrelated inconsistency.

## A superseded assertion, flagged deliberately

The STRK-249 matrix asserted `providers` must **not** carry `networkFirst` — precisely the behaviour this reverses. `providers` is moved from `NON_REALTIME_FAMILIES` to `REALTIME_FAMILIES` with the supersession noted inline, rather than the assertion being quietly deleted. Same handling as STRK-257 vs STRK-250 earlier today.

Calling it out because "don't edit a test to make it pass" is the right default; this is a spec change carried by an approved issue.

## Tests

5 new unit tests:
- `networkFirst: true` on both API hosts
- the production `/data/v2/providers.json` path shape (STRK-190 prefix), not just the bare one
- descriptor-shape parity with `spot-latest`
- `floor`/`hasEnvelope` unchanged — only the strategy moves
- a guard that `manifest`, `retail-history-long` and `spot-history-daily` stay cache-first, so this can't silently become a blanket flag

**Unit 476 passed. Core 406 passed. Extended service-worker 11 passed.** Lint and prettier clean.

## Notes for the reviewer

- No version bump — consistent with STRK-256 and the recent poller PRs.
- No coverage-map row — unit tests only, Playwright inventory unchanged.
- `sw.js` appears in the diff solely because the `stamp-sw-cache` pre-commit hook re-stamped `CACHE_NAME` (`sw-router.js` is in its watched set). That's load-bearing here: the new cache name purges old caches on activate, so existing clients pick up the corrected strategy rather than waiting out their old entry.
- Every `networkFirst` family is API-host only and `page.route()` cannot intercept SW-originated fetches, so this is verified at the classification level rather than end-to-end — same constraint documented in the SW spec header and in STRK-256.