### PR TITLE
fix(source): replace raw NUL bytes with hex escapes (STRK-280)

### DIFF
--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -3576,8 +3576,8 @@ function _mergeTagData(remoteTagData) {
       var unionedRemoved = _unionTags(localRemoved[uuid], remoteRemoved[uuid]);
       var canonicalLocalTags = _unionTags(localTags[uuid], []);
       var canonicalLocalRemoved = _unionTags(localRemoved[uuid], []);
-      var tagsChanged = unionedTags.join(" ") !== canonicalLocalTags.join(" ");
-      var removedChanged = unionedRemoved.join(" ") !== canonicalLocalRemoved.join(" ");
+      var tagsChanged = unionedTags.join("\x00") !== canonicalLocalTags.join("\x00");
+      var removedChanged = unionedRemoved.join("\x00") !== canonicalLocalRemoved.join("\x00");
 
       if (unionedTags.length > 0) mergedTags[uuid] = unionedTags;
       else delete mergedTags[uuid];

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -3576,8 +3576,8 @@ function _mergeTagData(remoteTagData) {
       var unionedRemoved = _unionTags(localRemoved[uuid], remoteRemoved[uuid]);
       var canonicalLocalTags = _unionTags(localTags[uuid], []);
       var canonicalLocalRemoved = _unionTags(localRemoved[uuid], []);
-      var tagsChanged = unionedTags.join("\x00") !== canonicalLocalTags.join("\x00");
-      var removedChanged = unionedRemoved.join("\x00") !== canonicalLocalRemoved.join("\x00");
+      const tagsChanged = unionedTags.join("\x00") !== canonicalLocalTags.join("\x00");
+      const removedChanged = unionedRemoved.join("\x00") !== canonicalLocalRemoved.join("\x00");
 
       if (unionedTags.length > 0) mergedTags[uuid] = unionedTags;
       else delete mergedTags[uuid];

--- a/js/priceHistory.js
+++ b/js/priceHistory.js
@@ -415,7 +415,7 @@ const _normalizeItemPriceEntry = (entry) => {
  * @returns {string} Deterministic fingerprint string
  */
 const _itemPriceEntryFingerprint = (entry) =>
-  [entry.ts, entry.itemName, entry.retail, entry.spot, entry.melt].join(" ");
+  [entry.ts, entry.itemName, entry.retail, entry.spot, entry.melt].join("\x00");
 
 /**
  * Full-fingerprint comparator: sorts by ts, then itemName, retail, spot, melt.

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.65-b1785009258";
+const CACHE_NAME = "staktrakr-v3.35.65-b1785011367";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@ importScripts("sw-router.js");
 
 const DEV_MODE = false; // Set to true during development — bypasses all caching
 
-const CACHE_NAME = "staktrakr-v3.35.65-b1784990448";
+const CACHE_NAME = "staktrakr-v3.35.65-b1785009258";
 
 // Offline fallback for navigation requests when all cache/network strategies fail
 const OFFLINE_HTML =

--- a/tests/unit/strk-280-no-raw-control-bytes.test.js
+++ b/tests/unit/strk-280-no-raw-control-bytes.test.js
@@ -77,6 +77,30 @@ const isDisallowedControlByte = (byte) =>
   (byte < 0x20 && !ALLOWED_CONTROL_BYTES.has(byte)) || byte === 0x7f;
 
 /**
+ * Runs `git ls-files`, failing loudly rather than degrading.
+ *
+ * A filesystem walk is deliberately NOT used as a fallback: it would descend
+ * into node_modules and gitignored build output, where control bytes are common
+ * and expected, turning this guard into either a false alarm or a meaningless
+ * pass. If git is unavailable the correct outcome is a clear error.
+ *
+ * @returns {string} NUL-delimited tracked paths
+ * @throws {Error} When git is missing or this is not a git checkout
+ */
+const gitListFiles = () => {
+  try {
+    return execFileSync("git", ["ls-files", "-z"], {
+      cwd: REPO_ROOT,
+      maxBuffer: 32 * 1024 * 1024,
+    }).toString("utf8");
+  } catch (error) {
+    throw new Error(
+      `STRK-280 guard needs "git ls-files"; run it from a git checkout. Cause: ${error.message}`
+    );
+  }
+};
+
+/**
  * Lists tracked text files, excluding vendored third-party bundles.
  * Uses git rather than a directory walk so untracked scratch files and
  * gitignored build output are never scanned.
@@ -84,8 +108,7 @@ const isDisallowedControlByte = (byte) =>
  * @returns {string[]} Repository-relative paths
  */
 const listTrackedTextFiles = () =>
-  execFileSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, maxBuffer: 32 * 1024 * 1024 })
-    .toString("utf8")
+  gitListFiles()
     .split("\0")
     .filter(Boolean)
     .filter((rel) => TEXT_EXTENSIONS.has(path.extname(rel).toLowerCase()))
@@ -135,8 +158,7 @@ describe("STRK-280 no raw control bytes in tracked source", () => {
     assert.equal(
       offenders.length,
       0,
-      `Raw control bytes found in tracked source. Replace each with an escape ` +
-        `sequence (${HEX_NUL_ESCAPE} for NUL):\n${report}`
+      `Raw control bytes in tracked source. Use an escape (${HEX_NUL_ESCAPE} for NUL):\n${report}`
     );
   });
 
@@ -155,8 +177,14 @@ describe("STRK-280 no raw control bytes in tracked source", () => {
     // fingerprint collision surface for tag and price-history comparisons.
     for (const rel of ["js/cloud-sync.js", "js/priceHistory.js"]) {
       const source = readFileSync(path.join(REPO_ROOT, rel), "utf8");
+      // Both quote styles are accepted so the assertion pins the contract (the
+      // separator is U+0000) rather than incidental formatting. Prettier settles
+      // on double quotes here, but a single-quoted refactor is equally correct.
+      const joinsOnNul =
+        source.includes(`join("${HEX_NUL_ESCAPE}")`) ||
+        source.includes(`join('${HEX_NUL_ESCAPE}')`);
       assert.ok(
-        source.includes(`join("${HEX_NUL_ESCAPE}")`),
+        joinsOnNul,
         `${rel} must still join on U+0000, written as the ${HEX_NUL_ESCAPE} escape`
       );
     }

--- a/tests/unit/strk-280-no-raw-control-bytes.test.js
+++ b/tests/unit/strk-280-no-raw-control-bytes.test.js
@@ -1,0 +1,175 @@
+// Unit tests for STRK-280: tracked first-party source must not contain raw
+// control bytes.
+//
+// js/cloud-sync.js and js/priceHistory.js carried literal NUL (0x00) bytes
+// inside string literals, used as a join separator for comparison fingerprints.
+// NUL is a legitimate separator choice — the defect is that it was stored as a
+// raw control byte in the source file rather than as an escape sequence.
+//
+// Blast radius observed before the fix: CodeGraphContext stores a variable's
+// initializer text as a graph property, FalkorDB cannot serialize a NUL inside
+// a query parameter, so the write hard-failed and aborted the entire repository
+// index. StakTrakr's code graph therefore held zero real application source
+// from ~2026-06-17 until this was found — structural queries (callers, call
+// chains, dead code) were silently answered from a stale snapshot.
+//
+// The escape used is the hex form (backslash-x-0-0) rather than the unicode
+// form (backslash-u-0-0-0-0). Both denote U+0000 and are runtime-identical, but
+// the unicode form is itself hazardous to handle: tooling that decodes
+// backslash-u escapes round-trips it straight back into a raw NUL, which is the
+// failure mode this issue exists to remove. The hex form is not subject to that
+// decoding, so it survives edit tooling intact.
+//
+// This test is the recurrence guard requested by the issue's third acceptance
+// criterion. It is deliberately a repo-wide sweep, not two hardcoded paths, so
+// a NUL introduced anywhere in first-party source fails the suite.
+//
+// Run: npm run test:unit
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// Extensions we treat as text. Anything else (png, woff2, ico) is binary by
+// nature and control bytes there are expected, not a defect.
+const TEXT_EXTENSIONS = new Set([
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".json",
+  ".css",
+  ".html",
+  ".md",
+  ".sh",
+  ".yml",
+  ".yaml",
+  ".csv",
+  ".toml",
+  ".txt",
+  ".svg",
+]);
+
+// Third-party minified bundles are not ours to reformat, and minifiers do emit
+// control bytes inside string tables (jszip carries 0x01-0x07). Excluded so the
+// guard stays actionable.
+const EXCLUDED_PREFIXES = ["vendor/"];
+
+// Tab, line feed, carriage return are legitimate in text files.
+const ALLOWED_CONTROL_BYTES = new Set([0x09, 0x0a, 0x0d]);
+
+// Built from a char code so this file never contains the escape it asserts on.
+const BACKSLASH = String.fromCharCode(92);
+const HEX_NUL_ESCAPE = `${BACKSLASH}x00`;
+
+/**
+ * Reports whether a byte is a control byte disallowed in tracked text source.
+ * Covers the C0 range minus tab/LF/CR, plus DEL.
+ *
+ * @param {number} byte - Byte value, 0-255
+ * @returns {boolean} True when the byte must not appear in text source
+ */
+const isDisallowedControlByte = (byte) =>
+  (byte < 0x20 && !ALLOWED_CONTROL_BYTES.has(byte)) || byte === 0x7f;
+
+/**
+ * Lists tracked text files, excluding vendored third-party bundles.
+ * Uses git rather than a directory walk so untracked scratch files and
+ * gitignored build output are never scanned.
+ *
+ * @returns {string[]} Repository-relative paths
+ */
+const listTrackedTextFiles = () =>
+  execFileSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, maxBuffer: 32 * 1024 * 1024 })
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .filter((rel) => TEXT_EXTENSIONS.has(path.extname(rel).toLowerCase()))
+    .filter((rel) => !EXCLUDED_PREFIXES.some((prefix) => rel.startsWith(prefix)))
+    .filter((rel) => {
+      // A tracked path can be absent in a partial checkout or mid-rebase state.
+      try {
+        return statSync(path.join(REPO_ROOT, rel)).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+/**
+ * Finds every disallowed control byte in a file, with line numbers, so a
+ * failure message points at the offending location instead of just the file.
+ *
+ * @param {string} rel - Repository-relative path
+ * @returns {Array<{line: number, byte: string}>} One entry per occurrence
+ */
+const findControlBytes = (rel) => {
+  const data = readFileSync(path.join(REPO_ROOT, rel));
+  const found = [];
+  let line = 1;
+  for (const byte of data) {
+    if (byte === 0x0a) {
+      line += 1;
+      continue;
+    }
+    if (isDisallowedControlByte(byte)) {
+      found.push({ line, byte: `0x${byte.toString(16).padStart(2, "0")}` });
+    }
+  }
+  return found;
+};
+
+describe("STRK-280 no raw control bytes in tracked source", () => {
+  it("finds no disallowed control byte in any tracked first-party text file", () => {
+    const offenders = listTrackedTextFiles()
+      .map((rel) => ({ rel, hits: findControlBytes(rel) }))
+      .filter((entry) => entry.hits.length > 0);
+
+    const report = offenders
+      .map(({ rel, hits }) => `${rel}: ${hits.map((h) => `line ${h.line} ${h.byte}`).join(", ")}`)
+      .join("\n");
+
+    assert.equal(
+      offenders.length,
+      0,
+      `Raw control bytes found in tracked source. Replace each with an escape ` +
+        `sequence (${HEX_NUL_ESCAPE} for NUL):\n${report}`
+    );
+  });
+
+  it("scans a meaningful number of files, so a broken filter cannot pass vacuously", () => {
+    // Without this, a bad extension filter or a git failure would yield an empty
+    // list and the sweep above would report success having checked nothing.
+    assert.ok(
+      listTrackedTextFiles().length > 100,
+      "expected the tracked-text-file sweep to cover a substantial part of the repo"
+    );
+  });
+
+  it("keeps the NUL separator semantics in the two files that used one", () => {
+    // The fix must not change the separator, only how it is spelled in source.
+    // A "fix" that swapped NUL for a comma or pipe would silently alter the
+    // fingerprint collision surface for tag and price-history comparisons.
+    for (const rel of ["js/cloud-sync.js", "js/priceHistory.js"]) {
+      const source = readFileSync(path.join(REPO_ROOT, rel), "utf8");
+      assert.ok(
+        source.includes(`join("${HEX_NUL_ESCAPE}")`),
+        `${rel} must still join on U+0000, written as the ${HEX_NUL_ESCAPE} escape`
+      );
+    }
+  });
+
+  it("still treats a raw NUL as disallowed even though vendor bundles are skipped", () => {
+    // Guards the exclusion list itself: broadening EXCLUDED_PREFIXES to silence
+    // a real finding would otherwise go unnoticed.
+    assert.equal(isDisallowedControlByte(0x00), true);
+    assert.equal(isDisallowedControlByte(0x09), false);
+    assert.equal(isDisallowedControlByte(0x0a), false);
+    assert.equal(isDisallowedControlByte(0x0d), false);
+    assert.equal(isDisallowedControlByte(0x7f), true);
+    assert.deepEqual(EXCLUDED_PREFIXES, ["vendor/"]);
+  });
+});


### PR DESCRIPTION
Closes STRK-280.

## Problem

`js/cloud-sync.js` (4 bytes) and `js/priceHistory.js` (1 byte) contained literal
NUL (`0x00`) control bytes inside string literals, used as a `join()` separator
for comparison fingerprints:

| File | Line | Construct |
|---|---|---|
| `js/cloud-sync.js` | 3579–3580 | `unionedTags.join(NUL) !== canonicalLocalTags.join(NUL)` |
| `js/priceHistory.js` | 418 | `[ts, itemName, retail, spot, melt].join(NUL)` |

Introduced 2026-06-05 in `5e190546` (STRK-155 convergent tag merge).

NUL is a perfectly good separator — the defect is that it was stored as a **raw
control byte in tracked source** rather than as an escape sequence.

## Why it mattered

CodeGraphContext stores a variable's initializer text as a graph property.
FalkorDB cannot serialize a NUL inside a query parameter, so the write
hard-failed and **aborted the entire repository index**. StakTrakr's code graph
consequently held *zero* real application source from ~2026-06-17 — structural
queries (callers, call chains, dead code) were being answered from a stale,
since-deleted worktree snapshot of v3.35.25, with no error surfacing.

The indexer crashing on valid-if-unusual source is a CGC bug and is tracked
separately in Devops. This PR is the short-term unblock plus a genuine
source-quality improvement.

## Fix

Each raw NUL becomes the hex escape `\x00`.

**Deviation from the issue, flagged deliberately.** The issue specified the
unicode escape (backslash-u-0-0-0-0). Both spellings denote U+0000 and are
runtime-identical, but the unicode form is *itself* hazardous to handle:
tooling that decodes backslash-u escapes round-trips it straight back into a
raw NUL — which is precisely the failure this issue exists to remove. That was
reproduced repeatedly while making this change (including one attempt where the
escape decoded inside a shell argument and was rejected outright). The hex form
is not subject to that decoding, so it survives edit tooling intact.

Verified equivalence: `"\x00".length === 1`, `charCodeAt(0) === 0`, identical to
`String.fromCharCode(0)`, and join-parity holds. Behaviour is unchanged; only
the spelling of the separator differs.

## Recurrence guard (third acceptance criterion)

`tests/unit/strk-280-no-raw-control-bytes.test.js` — a repo-wide sweep of
tracked first-party text files rejecting C0 control bytes (minus tab/LF/CR) and
DEL, rather than two hardcoded paths, so a NUL introduced anywhere in
first-party source fails the suite. Four cases:

1. the sweep itself
2. a non-vacuity check (a broken extension filter or a failed `git ls-files`
   would otherwise pass having scanned nothing)
3. a semantics check — both files must still join on U+0000, so a "fix" that
   swapped NUL for a comma or pipe (silently altering the fingerprint collision
   surface) fails
4. a guard on the exclusion list itself

`vendor/` is excluded: minified third-party bundles legitimately carry control
bytes in string tables (`jszip.min.js` has `0x01`–`0x07`).

A pre-commit hook was considered instead. The unit test was preferred because
hooks are opt-in per clone, and this runs in `test:unit` / `test:all` where
reviewers can see it. Happy to add a hook as a follow-up if you'd rather have
both.

## Acceptance criteria

- [x] `js/cloud-sync.js` and `js/priceHistory.js` contain zero `0x00` bytes
- [x] Tag-merge and price-history comparison behaviour unchanged — existing
      cloud-sync and goldback suites still pass
- [x] Recurrence guard added

## Verification

| Gate | Result |
|---|---|
| `npm run test:unit` | **480/480** (was 476; +4 new) |
| `npm test` (core) | **408/408** |
| `npm run lint` | clean |
| `npx prettier --check` (changed files) | clean |
| Committed blob byte-check | 0 NUL, 5 single-backslash escapes, 0 doubled |

Pre-existing `prettier --check .` warnings in `devops/pollers/shared/*.test.mjs`
reproduce on an untouched `dev` checkout and are out of scope.

No version bump — consistent with STRK-255/256/257/264/275/276. `sw.js`
`CACHE_NAME` is auto-stamped by the pre-commit hook because `js/` changed, so
existing clients pick up the corrected files.

No coverage-map row: the map tracks the Playwright inventory, and no unit test
holds a first-column row.
