### PR TITLE
chore(deps): pin better-sqlite3 to ^11 for the poller images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,27 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # better-sqlite3 is pinned to ^11 — the last line publishing prebuilt
+      # binaries usable by our poller images. Verified on linux/amd64 (PR #1377):
+      #
+      #   v13.x — engines >=22 (we run node:20-slim), and its prebuilt binary
+      #           needs glibc 2.38 while Debian bookworm ships 2.36. home-poller
+      #           has no make/g++ so the image build fails outright; remote-poller
+      #           installs cleanly and then SEGFAULTS on first use.
+      #   v12.x — no longer publishes Node 20 prebuilds, so it also fails to
+      #           install on home-poller; with a toolchain it compiles (+47s/build).
+      #
+      # Lifting this pin is infra work, not a dependency bump: it needs a trixie
+      # base image (glibc 2.41) or make/g++ added to home-poller, plus Node 22.
+      # Planned alongside the poller's move to its own repo.
+      #
+      # Scoped to semver-major deliberately. An `ignore` entry suppresses
+      # security-update PRs as well as version-update PRs (it does NOT suppress
+      # the Dependabot *alert* itself), so a blanket ignore would silence CVE
+      # fixes. Limiting it to majors means a security patch within 11.x still
+      # opens a PR automatically; only major bumps are held back — and those we
+      # cannot deploy anyway until the base image moves.
+      - dependency-name: "better-sqlite3"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,12 +53,24 @@ updates:
       # base image (glibc 2.41) or make/g++ added to home-poller, plus Node 22.
       # Planned alongside the poller's move to its own repo.
       #
-      # Scoped to semver-major deliberately. An `ignore` entry suppresses
-      # security-update PRs as well as version-update PRs (it does NOT suppress
-      # the Dependabot *alert* itself), so a blanket ignore would silence CVE
-      # fixes. Limiting it to majors means a security patch within 11.x still
-      # opens a PR automatically; only major bumps are held back — and those we
-      # cannot deploy anyway until the base image moves.
+      # Scoped to semver-major rather than a bare dependency-name ignore. Two
+      # documented facts constrain this, and they cut in opposite directions:
+      #
+      #   - `ignore` "can be configured to prevent Dependabot from opening pull
+      #     requests for version updates AND security updates" — so a bare
+      #     `dependency-name` ignore would silence CVE fix PRs.
+      #   - "`update-types` only affects version updates, not security updates."
+      #
+      # So the update-types filter narrows this to version-update noise, which is
+      # the intent. What the docs do NOT spell out is how the two combine — i.e.
+      # whether a security update needing a major bump is still proposed here.
+      # Do not treat that as settled either way.
+      #
+      # Operationally it does not matter much: we cannot deploy a major bump
+      # until the base image moves regardless. What matters is that dependabot.yml
+      # never suppresses the Dependabot *alert* itself, so a better-sqlite3
+      # advisory will still surface in the Security tab. Watch the alert rather
+      # than waiting on a PR. See STRK-297.
       - dependency-name: "better-sqlite3"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
## Summary

Closes out #1377 (better-sqlite3 11.10.0 → 13.0.1) by pinning the dependency and stopping Dependabot from re-proposing it weekly.

I tested the bump on `linux/amd64` — the production architecture — inside each poller's exact image. It breaks both, in two different ways.

| Environment | v11.10.0 (current) | v13.0.1 (proposed) |
|---|---|---|
| **home-poller** — `node:20-slim`, python3, no `make`/`g++` | ✅ installs, works | ❌ `INSTALL_EXIT=1` — Docker build fails |
| **remote-poller** — `node:20-slim` + `make`/`g++` | ✅ works | ⚠️ installs cleanly, then **segfaults** |

## Root causes

**1. `engines: { node: '>=22' }`** — v13.0.0 dropped Node 20. Both pollers are `node:20-slim`. npm only warns (`EBADENGINE`), so this alone doesn't block the install.

**2. The v13 prebuilt binary needs glibc 2.38.** Both images are Debian bookworm (glibc 2.36):

```
/lib/.../libm.so.6: version `GLIBC_2.38' not found
(required by .../prebuilds/linux-x64.node)
```

home-poller has no `make`, so npm falls back to `node-gyp` and the build dies. remote-poller installs *successfully* and then segfaults on first use — a green Docker build that crashes in production, and a segfault isn't catchable by `try`/`catch`.

This is live code, not a dormant dep: `goldback-scraper.js` → `db.js` → `better-sqlite3`, running hourly at `:05` on the home poller.

**v12 is not a middle ground.** It still lists Node 20 as supported, but no longer publishes Node 20 prebuilds (`No prebuilt binaries found (target=20.20.2 ...)`), so it also fails to install on home-poller. With a toolchain it compiles from source, adding ~47s to every image build.

## Change

One file — `.github/dependabot.yml`, poller block only:

```yaml
ignore:
  - dependency-name: "better-sqlite3"
    update-types:
      - "version-update:semver-major"
```

`package.json` already declares `^11.0.0`, so the semver range was never the gap — Dependabot proposes majors regardless of the declared range.

**Scoped to `semver-major` deliberately.** An `ignore` entry suppresses security-update PRs as well as version-update PRs (it does *not* suppress the Dependabot alert itself — [docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)). A blanket ignore would silence CVE fixes. Limiting it to majors keeps patch/minor security updates within 11.x flowing automatically, and only holds back major bumps — which we couldn't deploy anyway until the base image moves.

## Roadmap note

Lifting this pin needs a trixie base image (glibc 2.41) **or** `make`/`g++` added to home-poller, plus Node 22. Worth knowing: bumping to `node:22-slim` does **not** fix it — still bookworm, still glibc 2.36. That's deliberate infra work, planned alongside the poller's move to its own repo.

## Scope

Config only — no runtime code, no version bump.