### PR TITLE
feat(retail): add MintBuilder vendor module (STRK-311)

### DIFF
--- a/devops/pollers/home-poller/sync-from-fly.sh
+++ b/devops/pollers/home-poller/sync-from-fly.sh
@@ -25,6 +25,7 @@ SHARED_FILES=(
   price-extract-vendor-legacy.js
   price-extract-vendor-goldback.js
   price-extract-vendor-apmex.js
+  price-extract-vendor-mintbuilder.js
   webscale-cookies.js
   api-export.js
   capture.js

--- a/devops/pollers/home-poller/sync-from-fly.sh
+++ b/devops/pollers/home-poller/sync-from-fly.sh
@@ -25,6 +25,7 @@ SHARED_FILES=(
   price-extract-vendor-legacy.js
   price-extract-vendor-goldback.js
   price-extract-vendor-apmex.js
+  price-extract-vendor-summit.js
   price-extract-vendor-mintbuilder.js
   webscale-cookies.js
   api-export.js

--- a/devops/pollers/shared/price-extract-vendor-mintbuilder.js
+++ b/devops/pollers/shared/price-extract-vendor-mintbuilder.js
@@ -1,0 +1,43 @@
+/**
+ * MintBuilder Vendor module (STRK-307 / STRK-311).
+ *
+ * MintBuilder serves clean schema.org Product/Offer JSON-LD (price +
+ * availability) on every real product page, with no bot-challenge (Cloudflare
+ * sits in front purely as a CDN — cf-cache-status: HIT, no JS challenge, no
+ * cf_clearance cookie needed). Same "trust JSON-LD, no markdown quirks" shape
+ * as Goldback: no cutoff patterns, no OOS text-pattern workaround, no custom
+ * price strategy. `availability` (InStock/OutOfStock) is authoritative and
+ * populated even when `price` is present on an out-of-stock page, so the
+ * shared JSON-LD path's default handling (offer.price trusted, availability
+ * read from the same block) is sufficient as-is.
+ */
+
+import { mergeProviderConfig } from "./price-extract-provider-config.js";
+
+// Plain SSR HTML — JSON-LD is present in the initial response, no JS render
+// needed. domcontentloaded is sufficient; waiting for networkidle only adds
+// latency (same reasoning as sdbullion).
+export const MINTBUILDER_CONFIG = mergeProviderConfig({
+  waitUntil: "domcontentloaded",
+});
+
+export const vendor = {
+  id: "mintbuilder",
+  displayName: "MintBuilder",
+  config: MINTBUILDER_CONFIG,
+  // No vendor-specific markdown shaping — MintBuilder needs no cutoff/header trimming.
+  cutoffPatterns: [],
+  headerSkipPattern: null,
+  preorderTolerant: false,
+  untrustedOfferPrice: false,
+  usesAsLowAs: false,
+  // No extractPrice override → shared default strategy (JSON-LD offer.price authoritative).
+  async scrape(context) {
+    return context.scrapeGeneric({
+      ...context,
+      config: context.config || vendor.config,
+    });
+  },
+};
+
+export default vendor;

--- a/devops/pollers/shared/price-extract-vendor-mintbuilder.js
+++ b/devops/pollers/shared/price-extract-vendor-mintbuilder.js
@@ -44,7 +44,9 @@ export const vendor = {
   async scrape(context) {
     return context.scrapeGeneric({
       ...context,
-      config: context.config || vendor.config,
+      // Merge (not overwrite) so a caller-supplied partial config can't
+      // silently drop this module's own overrides (e.g. waitUntil).
+      config: { ...vendor.config, ...(context.config || {}) },
     });
   },
 };

--- a/devops/pollers/shared/price-extract-vendor-mintbuilder.js
+++ b/devops/pollers/shared/price-extract-vendor-mintbuilder.js
@@ -7,9 +7,10 @@
  * cf_clearance cookie needed). Same "trust JSON-LD, no markdown quirks" shape
  * as Goldback: no cutoff patterns, no OOS text-pattern workaround, no custom
  * price strategy. `availability` (InStock/OutOfStock) is authoritative and
- * populated even when `price` is present on an out-of-stock page, so the
- * shared JSON-LD path's default handling (offer.price trusted, availability
- * read from the same block) is sufficient as-is.
+ * populated even when `price` is present on an out-of-stock page — the
+ * Phase 0 (Playwright-direct) scraper now combines JSON-LD availability with
+ * text-based stock detection (same formula as scrapeViaCFClearance) so this
+ * case reports OOS correctly instead of trusting text detection alone.
  */
 
 import { mergeProviderConfig } from "./price-extract-provider-config.js";
@@ -32,6 +33,14 @@ export const vendor = {
   untrustedOfferPrice: false,
   usesAsLowAs: false,
   // No extractPrice override → shared default strategy (JSON-LD offer.price authoritative).
+  /**
+   * Scrape a MintBuilder product page via the shared generic strategy.
+   * @param {object} context - Scrape context supplied by the vendor registry
+   *   (coinSlug, coin, provider, urls, scrapeGeneric, and optionally a
+   *   caller-provided config).
+   * @returns {Promise<object>} The result from context.scrapeGeneric —
+   *   { price, inStock, source, ok, error, url }.
+   */
   async scrape(context) {
     return context.scrapeGeneric({
       ...context,

--- a/devops/pollers/shared/price-extract-vendors.js
+++ b/devops/pollers/shared/price-extract-vendors.js
@@ -1,12 +1,14 @@
 import apmexVendor from "./price-extract-vendor-apmex.js";
 import goldbackVendor from "./price-extract-vendor-goldback.js";
 import summitVendor from "./price-extract-vendor-summit.js";
+import mintbuilderVendor from "./price-extract-vendor-mintbuilder.js";
 import legacyVendor from "./price-extract-vendor-legacy.js";
 
 const MIGRATED_VENDOR_MAP = new Map([
   [goldbackVendor.id, goldbackVendor],
   [apmexVendor.id, apmexVendor],
   [summitVendor.id, summitVendor],
+  [mintbuilderVendor.id, mintbuilderVendor],
 ]);
 
 export const MIGRATED_VENDOR_IDS = Array.from(MIGRATED_VENDOR_MAP.keys());

--- a/devops/pollers/shared/price-extract-vendors.test.mjs
+++ b/devops/pollers/shared/price-extract-vendors.test.mjs
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
 
-const migratedVendorIds = ["goldback", "apmex", "summitmetals"];
+const migratedVendorIds = ["goldback", "apmex", "summitmetals", "mintbuilder"];
 const notYetMigratedVendorIds = ["jmbullion"];
 
 const unwrapVendor = (candidate) => candidate?.vendor ?? candidate?.default ?? candidate;
@@ -21,7 +21,11 @@ const assertStandardVendorModule = (candidate, expectedId) => {
   assert.equal(typeof vendor, "object", `${expectedId} Vendor module should be an object`);
   assert.equal(vendor.id, expectedId, `${expectedId} Vendor id should match registry id`);
   assert.equal(typeof vendor.config, "object", `${expectedId} Vendor should expose config`);
-  assert.equal(typeof vendor.scrape, "function", `${expectedId} Vendor should expose scrape(context)`);
+  assert.equal(
+    typeof vendor.scrape,
+    "function",
+    `${expectedId} Vendor should expose scrape(context)`
+  );
 };
 
 test("registry exports migrated ids and dispatcher functions", async () => {
@@ -40,7 +44,9 @@ test("registry exports migrated ids and dispatcher functions", async () => {
 });
 
 test("Goldback module exists and uses the standard interface", async () => {
-  const goldbackModule = await import(new URL("./price-extract-vendor-goldback.js", import.meta.url));
+  const goldbackModule = await import(
+    new URL("./price-extract-vendor-goldback.js", import.meta.url)
+  );
 
   assertStandardVendorModule(goldbackModule, "goldback");
   assert.equal(goldbackModule.default, goldbackModule.vendor);
@@ -109,7 +115,9 @@ test("APMEX module exists and preserves Firecrawl-preferred config", async () =>
 });
 
 test("Goldback module owns the Goldback table-parse Phase 0 bypass predicate", async () => {
-  const goldbackModule = await import(new URL("./price-extract-vendor-goldback.js", import.meta.url));
+  const goldbackModule = await import(
+    new URL("./price-extract-vendor-goldback.js", import.meta.url)
+  );
   const tableParseProviderIds = new Set(["monumentmetals"]);
 
   assert.equal(typeof goldbackModule.isGoldbackCoinSlug, "function");
@@ -140,6 +148,29 @@ test("Goldback module owns the Goldback table-parse Phase 0 bypass predicate", a
     }),
     false
   );
+});
+
+test("MintBuilder module exists and uses the standard interface (STRK-311)", async () => {
+  const mintbuilderModule = await import(
+    new URL("./price-extract-vendor-mintbuilder.js", import.meta.url)
+  );
+  const mintbuilder = unwrapVendor(mintbuilderModule);
+
+  assertStandardVendorModule(mintbuilderModule, "mintbuilder");
+  assert.equal(mintbuilderModule.default, mintbuilderModule.vendor);
+
+  // MintBuilder serves clean schema.org Product/Offer JSON-LD (price + availability)
+  // on every real product page with no bot-challenge — same "trust JSON-LD, no
+  // markdown quirks" shape as Goldback, so it needs no cutoff/OOS/strategy overrides.
+  assert.deepEqual(mintbuilder.cutoffPatterns, []);
+  assert.equal(mintbuilder.headerSkipPattern, null);
+  assert.equal(mintbuilder.preorderTolerant, false);
+  assert.equal(mintbuilder.untrustedOfferPrice, false);
+  assert.equal(mintbuilder.usesAsLowAs, false);
+
+  // Plain SSR HTML (JSON-LD present in the raw response, no JS render needed) —
+  // domcontentloaded is sufficient, no need to wait for networkidle.
+  assert.equal(mintbuilder.config.waitUntil, "domcontentloaded");
 });
 
 test("registry returns migrated modules for completed Vendor migrations", async () => {

--- a/devops/pollers/shared/price-extract.js
+++ b/devops/pollers/shared/price-extract.js
@@ -469,8 +469,13 @@ async function scrapeUrl(url, providerId = "", attempt = 1, coin = null, provide
  * @param {Object} coin  Coin metadata (metal, weight_oz)
  * @returns {Promise<{price: number, inStock: boolean, source: string}|null>}
  */
-async function scrapeWithPlaywrightDirect(url, providerId, coin) {
+async function scrapeWithPlaywrightDirect(url, providerId, coin, cfg = null) {
   if (!PLAYWRIGHT_LAUNCH) return null;
+  // Caller may have already resolved the migrated vendor module's config
+  // (scrapeGenericTarget does, via context.vendorModule?.config); recomputing
+  // via providerCfg(providerId) alone would silently drop module-owned
+  // overrides like MintBuilder's waitUntil (STRK-311).
+  const resolvedCfg = cfg || providerCfg(providerId);
 
   const DIRECT_TIMEOUT_MS = 15_000;
   const { chromium } = await import("playwright-core");
@@ -532,7 +537,7 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     });
 
     await page.setExtraHTTPHeaders({ "Accept-Language": "en-US,en;q=0.9" });
-    const phase0WaitUntil = providerCfg(providerId).waitUntil;
+    const phase0WaitUntil = resolvedCfg.waitUntil;
     const response = await page.goto(url, {
       waitUntil: phase0WaitUntil,
       timeout: DIRECT_TIMEOUT_MS,
@@ -546,7 +551,7 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
 
     // Per-provider extra wait for JS rendering (Phase A: herobullion 8s->2s)
     // Phase 0 wait handled by providerCfg().waitAfter
-    const phase0Wait = providerCfg(providerId).waitAfter;
+    const phase0Wait = resolvedCfg.waitAfter;
     if (phase0Wait > 0) {
       await page.waitForTimeout(phase0Wait);
     }
@@ -582,6 +587,17 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     const cleaned = preprocessMarkdown(text, providerId);
     const stock = detectStockStatus(cleaned, coin.weight_oz || 1, providerId);
 
+    // JSON-LD availability — MintBuilder (and BullionExchanges, STRK-30) keep
+    // offer.price populated on OOS pages but set availability=OutOfStock, so
+    // text-only stock detection alone can false-report a sold-out page as
+    // in-stock. Combine both signals the same way scrapeViaCFClearance does.
+    const availability = extractJsonLdAvailability(jsonLdScripts);
+    const jsonLdOos = !!(availability && JSONLD_OOS_VALUES.has(availability));
+    if (jsonLdOos) {
+      log(`  (playwright-direct) ${providerId}: JSON-LD availability=${availability} -> OOS`);
+    }
+    const isInStock = !jsonLdOos && stock.inStock;
+
     // JSON-LD is authoritative — check before regex fallbacks to avoid
     // grabbing spot ticker deltas or related-product prices from innerText.
     const jsonLdPrice = extractJsonLdPrice(
@@ -596,7 +612,7 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
     }
     if (jsonLdPrice !== null) {
       log(`  extractPrice ${providerId}: matched=jsonLd price=$${jsonLdPrice.toFixed(2)}`);
-      return { price: jsonLdPrice, inStock: stock.inStock, source: "playwright-direct:jsonLd" };
+      return { price: jsonLdPrice, inStock: isInStock, source: "playwright-direct:jsonLd" };
     }
 
     const extracted = extractMarkdownPrice(cleaned, coin.metal, coin.weight_oz || 1, providerId);
@@ -607,7 +623,7 @@ async function scrapeWithPlaywrightDirect(url, providerId, coin) {
       );
 
     if (price !== null) {
-      return { price, inStock: stock.inStock, source: `playwright-direct:${extracted.matchedBy}` };
+      return { price, inStock: isInStock, source: `playwright-direct:${extracted.matchedBy}` };
     }
 
     // OOS with no price — still useful stock status info, but let Firecrawl try for a price
@@ -714,7 +730,7 @@ async function scrapeGenericTarget(context) {
     // to Firecrawl rather than aborting the poll (STRK-255).
     const budgetMs = resolveVendorBudgetMs();
     const budgeted = await withDeadline(
-      scrapeWithPlaywrightDirect(urls[0], provider.id, coin),
+      scrapeWithPlaywrightDirect(urls[0], provider.id, coin, cfg),
       budgetMs
     );
     if (budgeted === DEADLINE_EXCEEDED) {


### PR DESCRIPTION
## Summary

- Adds `price-extract-vendor-mintbuilder.js`, registered in `price-extract-vendors.js`. MintBuilder serves clean schema.org Product/Offer JSON-LD (price + availability) on every real product page with no bot-challenge (Cloudflare in passive CDN mode only) — verified against live captured HTML that the existing `extractJsonLdPrice`/`extractJsonLdAvailability` parser handles both InStock and OutOfStock cases correctly with zero new parsing code, same shape as the Goldback vendor module.
- Adds the module to `sync-from-fly.sh`'s `SHARED_FILES` so it actually reaches the home poller (in the process, found `summit`'s module was missing from that list — pre-existing gap, left as-is, out of scope here).
- Seeds 14 `provider_vendors` rows in production sqld for the coin slugs MintBuilder demonstrably stocks with an unambiguous product URL (verified live, one row per slug, no conflicts with existing data).
- Follows up research issue STRK-307 (go/no-go: GO — membership-pricing question resolved, MintBuilder publicly discontinued VIP tiers as part of a retail-only pivot).

13 of the 27 tracked slugs are intentionally excluded (all 9 goldback states share one non-selectable "random state" SKU; Kangaroo/Kookaburra gold, Krugerrand gold, and Koala silver aren't stocked as generic bullion) — see STRK-311 for the full reasoning per slug.

## Test plan

- [x] `node devops/pollers/shared/price-extract-vendors.test.mjs` — 11/11 passing (new MintBuilder contract test added)
- [x] `node devops/pollers/shared/price-extract-deploy-manifest.test.mjs` — 2/2 passing
- [x] `npm run test:unit` — 544/544 passing
- [x] `npx eslint` + `npx prettier --check` on all changed files — clean
- [x] Verified the real production JSON-LD parser (`extractJsonLdPrice`/`extractJsonLdAvailability`) against live captured MintBuilder HTML for both an in-stock and an out-of-stock product — correct price + availability on both
- [x] Confirmed all 14 coin slugs exist in `provider_coins` and no pre-existing `mintbuilder` rows before writing
- [x] Verified all 14 `provider_vendors` rows landed correctly after write