### PR TITLE
docs(.context): document --success non-text contrast gap (STRK-291)

### DIFF
--- a/.context/implementation-gotchas.md
+++ b/.context/implementation-gotchas.md
@@ -29,6 +29,18 @@ Missing the corner tier causes data cells to paint over the frozen header corner
 That fails WCAG level AA for small text.
 Use a darker custom amber (≈`oklch(0.55 0.15 60)`) for ticker or `font-size-xs` contexts in these themes.
 
+## `--success` color — non-text contrast fail on sepia icons
+
+Sibling of the `--warning` gotcha above, at a different WCAG bar.
+Sepia `--success` (`oklch(0.603 0.117 130.4)`) on the sepia spot-card surface (`oklch(0.892 0.032 89.1)`) measures **2.72:1** — under the WCAG 1.4.11 Non-text Contrast bar of **3:1** for icons and graphical objects.
+STRK-291 fixed it in `css/styles.css` with a same-hue, lower-lightness override: `[data-theme="sepia"] .spot-sync-icon--fresh { color: oklch(0.52 0.13 130.4) }`, measured at 3.83:1.
+Light `--success` measures 3.35:1 — passing, but with little margin. Dark and slate are 5.6–5.8:1 and fine.
+
+Two method notes, both of which cost real debugging time in STRK-291:
+
+- **Judge icon strokes and borders at 3:1, not 4.5:1.** Non-text Contrast (1.4.11) governs icons and graphical objects; the 4.5:1 small-text bar implied by the `--warning` entry above does not apply to them.
+- **Never parse `oklch(...)` numbers as RGB.** `getComputedStyle` returns these tokens verbatim as `oklch(...)` strings, and treating the three components as RGB yields silently wrong ratios — during STRK-291 that mistake reported all four themes as failing, including ones that were fine. Resolve to sRGB by painting the colour into a 1×1 canvas and reading the pixel back; working implementation is `__resolveRgb` in `tests/playwright/core/strk-189-spot-freshness.spec.js`.
+
 ## `_isMarketItemEnabled` guard — apply on both tab paths
 
 In `_renderVendorTable()`, apply the `_isMarketItemEnabled` filter on **both** the All-tab code path and the per-metal-tab `else` branch.

--- a/.context/implementation-gotchas.md
+++ b/.context/implementation-gotchas.md
@@ -39,7 +39,7 @@ Light `--success` measures 3.35:1 — passing, but with little margin. Dark and 
 Two method notes, both of which cost real debugging time in STRK-291:
 
 - **Judge icon strokes and borders at 3:1, not 4.5:1.** Non-text Contrast (1.4.11) governs icons and graphical objects; the 4.5:1 small-text bar implied by the `--warning` entry above does not apply to them.
-- **Never parse `oklch(...)` numbers as RGB.** `getComputedStyle` returns these tokens verbatim as `oklch(...)` strings, and treating the three components as RGB yields silently wrong ratios — during STRK-291 that mistake reported all four themes as failing, including ones that were fine. Resolve to sRGB by painting the colour into a 1×1 canvas and reading the pixel back; working implementation is `__resolveRgb` in `tests/playwright/core/strk-189-spot-freshness.spec.js`.
+- **Never parse `oklch(...)` numbers as RGB.** `getComputedStyle` returns these tokens verbatim as `oklch(...)` strings, and treating the three components as RGB yields silently wrong ratios — during STRK-291 that mistake reported all four themes as failing, including ones that were fine. Resolve to sRGB by painting the color into a 1×1 canvas and reading the pixel back; working implementation is `__resolveRgb` in `tests/playwright/core/strk-189-spot-freshness.spec.js`.
 
 ## `_isMarketItemEnabled` guard — apply on both tab paths
 


### PR DESCRIPTION
## Summary

Adds one section to `.context/implementation-gotchas.md` recording a contrast gap found during STRK-291 (shipped in v3.35.88, #1410) that was documented nowhere.

The file already covers `--warning` failing the small-text bar in light/sepia. This is the sibling case at a **different** WCAG bar — the new entry cross-references that one rather than contradicting it.

## What the entry records

- Sepia `--success` (`oklch(0.603 0.117 130.4)`) measures **2.72:1** against the sepia spot-card surface (`oklch(0.892 0.032 89.1)`) — under the WCAG 1.4.11 Non-text Contrast bar of 3:1 for icons and graphical objects.
- The shipped fix: `[data-theme="sepia"] .spot-sync-icon--fresh { color: oklch(0.52 0.13 130.4) }` — same hue, lower lightness, 3.83:1.
- Light is 3.35:1 (passes, little margin); dark and slate are 5.6–5.8:1.

Plus two method notes that each cost real debugging time:

1. Icon strokes and borders are judged at **3:1** (1.4.11), not the 4.5:1 small-text bar.
2. `getComputedStyle` returns these tokens verbatim as `oklch(...)`. Parsing those three numbers as RGB gives silently wrong ratios — that mistake reported all four themes as failing, including ones that were fine. Resolve to sRGB via a 1x1 canvas; working implementation is `__resolveRgb` in `tests/playwright/core/strk-189-spot-freshness.spec.js`.

## Scope

Docs only — one file, +12 lines, no runtime code touched. Per CLAUDE.md, `.context/` edits are config/tooling, so this is a lightweight chore PR to `dev`: no Plane issue, no version lock, no spot bundle. Every number was verified against the shipped `css/styles.css` on `dev` before writing.