### PR TITLE
chore: deny EnterWorktree; require git-based worktrees off origin/dev

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "permissions": {
+    "deny": ["EnterWorktree"],
     "allow": [
       "Skill(*)",
       "WebFetch",

--- a/.context/git-topology.md
+++ b/.context/git-topology.md
@@ -25,9 +25,16 @@ Loaded on demand by `/release`, `/start-patch`, `/finishing-a-development-branch
 - After creation, run `cp CLAUDE.md .worktrees/<name>/`.
 - Then run `npm install --no-audit --no-fund`.
 - Pushing fixes to an open PR → commit from existing PR worktree, not a new branch.
-- **`EnterWorktree` caveat (harness tool):** its default base-ref `fresh` branches from `origin/main` (the GitHub default branch), **not** `origin/dev`. A `dev`-targeted PR from such a branch inherits an ancient merge-base, so GitHub's three-dot diff balloons into thousands of lines of false "scope creep" (Copilot/Codacy flag it as unrelated tickets).
-  - Preferred: create on the correct base, then enter by path — `git fetch origin dev && git worktree add .claude/worktrees/<branch> -b <branch> origin/dev`, then call `EnterWorktree` with `path: ".claude/worktrees/<branch>"`.
-  - Fallback: right after `EnterWorktree` with `name:` and **before any edits**, run `git fetch origin && git reset --hard origin/dev`.
+- **`EnterWorktree` is denied in this repo.** `.claude/settings.json` carries a bare-name deny rule, which removes the tool from the agent's context entirely. Create worktrees with git, always naming `origin/dev` as the base:
+
+  ```bash
+  git fetch origin dev
+  git worktree add .claude/worktrees/<name> -b <branch> origin/dev
+  ```
+
+  - **Why it is blocked:** `worktree.baseRef` accepts only `"fresh"` (the remote default branch — `main` here) and `"head"` (the main checkout's current `HEAD`). It **cannot** be set to a branch name, so the tool has no setting that expresses a `dev`-based worktree. `"head"` is the worse failure of the two: the base silently depends on wherever the main checkout is parked, so it is right some days and a full release behind on others.
+  - **Symptom when the base is wrong:** a `dev`-targeted PR inherits an ancient merge-base, so GitHub's three-dot diff balloons into thousands of lines of false "scope creep" (Copilot/Codacy flag it as unrelated tickets).
+  - **Fetch before you search.** In a stale worktree, `grep` for code that exists on `dev` returns nothing, which is indistinguishable from "this identifier was never written." Always `git fetch origin dev` before trusting a negative search result.
   - Always verify before opening the PR: `git merge-base origin/dev HEAD` must equal `git rev-parse origin/dev`.
 
 ## Merge Strategy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ UUIDs are convenience references. Re-fetch via `mcp__plane__list_states` if a se
 - **Every change to `dev` needs a PR — no exceptions.** The `Protect Dev` ruleset (required `Codacy Static Code Analysis` + CodeQL checks, signed commits, no bypass actors) blocks direct pushes of any file type, instruction files included.
 - Config/tooling edits (`.claude/`, `.Codex/`, `.opencode/`, `.agents/`, `CLAUDE.md`, `AGENTS.md`, `.geminiignore`, `.gitignore`, skill files, devops config) are still **lightweight** — a small chore PR to `dev`, no Plane issue or version lock required.
 - Runtime code (`js/`, `css/`, `index.html`, `data/`, `pollers/`, tests) requires the **full discipline**: Plane issue → worktree → PR to `dev`.
-- **`EnterWorktree` base-ref caveat:** it branches from `origin/main`, but PRs target `dev` — create the worktree on `origin/dev` first. Full caveat (commands + merge-base verification) in `.context/git-topology.md`.
+- **`EnterWorktree` is denied in this repo** (`.claude/settings.json`) — it cannot be based on `dev`. Create worktrees with git: `git fetch origin dev && git worktree add .claude/worktrees/<name> -b <branch> origin/dev`. Rationale + merge-base verification in `.context/git-topology.md`.
+- **Fetch `origin/dev` before searching a worktree.** A stale worktree makes `grep` return empty for code that exists on `dev` — a false negative that reads exactly like "this identifier does not exist."
 - `devops/version.lock` is gitignored — it exists only in the main checkout, never in a worktree. Claim the version lock by writing to `<main-checkout>/devops/version.lock`, not the worktree path.
 - **Full rules:** `.context/git-topology.md` — merge strategy, worktree naming, spot bundle, branch staleness, sketch overrides.
 


### PR DESCRIPTION
## Why

`EnterWorktree` cannot honor this repo's `feature/* → dev → main` topology, and repeated sessions have based worktrees on stale `main` commits as a result. Most recently a worktree started **27 commits behind `dev`** (the full v3.35.83–88 span), which made `grep` return false negatives for code that exists on `dev`.

Per the [Claude Code worktrees docs](https://code.claude.com/docs/en/worktrees#choose-the-base-branch):

> You can't set `worktree.baseRef` to a branch name. To start a worktree from a specific existing branch, create it with git directly.

`worktree.baseRef` accepts only:

- `"fresh"` — the remote's default branch, i.e. `main`. Wrong base for a `dev`-targeted PR.
- `"head"` — the main checkout's current `HEAD`. This is what is set globally, and it's the worse of the two: the base silently depends on wherever the main checkout happens to be parked, so it's correct some days and a full release behind on others.

There is no third option. The tool encodes trunk-based development, where the default branch *is* the integration branch; here the integration branch is deliberately not the default branch.

## What changed

- **`.claude/settings.json`** — bare-name deny rule for `EnterWorktree`. Per the [permissions docs](https://code.claude.com/docs/en/permissions), a bare tool name *"removes the tool from Claude's context entirely, so Claude never sees it"* — this is removal, not a prompt-and-refuse, so there's no judgment call left to get wrong.
- **`.context/git-topology.md`** — replaced the now-dead base-ref caveat (which described an `EnterWorktree` workflow that no longer exists) with the git recipe, the rationale, and the merge-base verification step.
- **`CLAUDE.md`** — same replacement in the Git Topology summary.

Both docs gain a **fetch-before-search** rule: in a stale worktree, `grep` returning nothing is indistinguishable from "this identifier was never written."

## The replacement recipe

```bash
git fetch origin dev
git worktree add .claude/worktrees/<name> -b <branch> origin/dev
```

This is what `.context/git-topology.md` line 24 already prescribed — the deny rule just makes it the only available path.

## Scope

Config + docs only, three files, no runtime code. Lightweight chore per CLAUDE.md: no Plane issue, no version lock, no spot bundle. JSON validated; no sibling copies of the caveat exist in `AGENTS.md` or the other harness dirs.

## Note

Takes effect for the main checkout once merged and pulled. Global `~/.claude/settings.json` is untouched — other projects keep `EnterWorktree`.