### PR TITLE
STRK-321: MintBuilder direct API feed — feed-first vendor with page-scrape fallback

### DIFF
--- a/devops/pollers/.env.home.example
+++ b/devops/pollers/.env.home.example
@@ -30,6 +30,11 @@ FIRECRAWL_BASE_URL=http://firecrawl-api:3002
 VISION_ENABLED=0
 GEMINI_API_KEY=
 
+# MintBuilder direct price feed (STRK-321, optional — unset falls back to page
+# scraping). First-party vendor API key; keep it out of provider URLs and any
+# published JSON. Must also stay declared in docker-compose.home.yml.
+MB_API_KEY=
+
 # Fly.io health check
 FLYIO_TAILSCALE_IP=100.90.171.110
 FLYIO_HTTP_URL=https://api2.staktrakr.com/data/retail/providers.json

--- a/devops/pollers/docker-compose.home.yml
+++ b/devops/pollers/docker-compose.home.yml
@@ -35,6 +35,13 @@ services:
       - FIRECRAWL_BASE_URL=${FIRECRAWL_BASE_URL:-http://firecrawl-api:3002}
       - VISION_ENABLED=${VISION_ENABLED:-0}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      # MintBuilder direct price feed (STRK-321). Key lives ONLY in the stack
+      # env — never in provider URLs or published JSON. Unset = page scraping.
+      # MUST be listed here or compose drops it (the stack env array alone is
+      # not enough). Cron additionally needs the run-home.sh re-export hop;
+      # missing either produces "works from dashboard retry, falls back under
+      # cron" (or the inverse).
+      - MB_API_KEY=${MB_API_KEY:-}
       - FLYIO_TAILSCALE_IP=${FLYIO_TAILSCALE_IP:-100.90.171.110}
       - FLYIO_HTTP_URL=${FLYIO_HTTP_URL:-https://api2.staktrakr.com/data/retail/providers.json}
       - CF_CLEARANCE_SCRAPER_URL=${CF_CLEARANCE_SCRAPER_URL:-http://byparr:8191}

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -1313,6 +1313,12 @@ if (log) log.scrollTop = log.scrollHeight;
 // Provider editor page (GET /providers)
 // ---------------------------------------------------------------------------
 
+// Vendors fed by a first-party price API instead of page scraping (STRK-321).
+// Presentation-only: drives the "Direct API" badge in the By Vendor view. Row
+// URLs stay the human product pages (they feed matching + published Buy
+// links); the API key lives only in the container env, never in row data.
+const API_FED_VENDOR_IDS = new Set(["mintbuilder"]);
+
 function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups) {
   const coins = providers.coins || {};
   const coinEntries = Object.entries(coins);
@@ -1363,7 +1369,11 @@ function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, ve
 
       return `<div style="margin-bottom:12px;" class="vendor-section" data-vendor="${escAttr(vg.vendorId)}">
       <div style="display:flex;justify-content:space-between;align-items:center;padding:8px 12px;background:var(--surface2);border-radius:6px;cursor:pointer;margin-bottom:4px;" class="vendor-section-header">
-        <span style="font-weight:600;font-size:13px;">${escHtml(vg.vendorName)}</span>
+        <span style="font-weight:600;font-size:13px;">${escHtml(vg.vendorName)}${
+          API_FED_VENDOR_IDS.has(vg.vendorId)
+            ? ' <span style="font-size:9px;text-transform:uppercase;letter-spacing:0.5px;padding:2px 6px;border:1px solid var(--border);border-radius:4px;color:var(--muted);vertical-align:middle;" title="Prices come from this vendor&#39;s direct API feed (one call per run). Product URLs below still drive feed matching and Buy links — add/remove items exactly like scraped vendors.">Direct API</span>'
+            : ""
+        }</span>
         <span style="font-size:11px;color:var(--muted);">${statsText}</span>
       </div>
       <div class="vendor-section-body" style="display:none;">${itemRows}</div>

--- a/devops/pollers/home-poller/run-home.sh
+++ b/devops/pollers/home-poller/run-home.sh
@@ -37,13 +37,16 @@ fi
 
 # STRK-230: cron runs `. /etc/environment` before this script, but plain
 # assignments sourced that way are NOT exported, so this child script (→ node)
-# never sees them. Re-export ONLY the WEBSCALE_* cookie vars from the container
-# env so price-extract.js can inject the wspc cookie for JM/Provident. Scoped to
-# WEBSCALE_* deliberately, to leave every other var's behavior untouched.
+# never sees them. Re-export ONLY the WEBSCALE_* cookie vars (wspc cookie for
+# JM/Provident) plus MB_API_KEY (STRK-321 MintBuilder direct feed) from the
+# container env. Scoped deliberately, to leave every other var's behavior
+# untouched. Without the MB_API_KEY hop the feed silently falls back to page
+# scraping under cron while the dashboard retry (which inherits the Docker
+# env) still uses the feed — a confusing half-state.
 if [ -f /etc/environment ]; then
   while IFS= read -r _line; do
     case "$_line" in
-      WEBSCALE_*=*) export "${_line}" ;;
+      WEBSCALE_*=* | MB_API_KEY=*) export "${_line}" ;;
     esac
   done < /etc/environment
 fi
@@ -59,7 +62,9 @@ fi
 # Providers loaded from Turso at runtime (STAK-348)
 POLLER_ID="${POLLER_ID:-home}"
 
-# Run Firecrawl extraction (with Playwright fallback) — writes results to Turso
+# Run Firecrawl extraction (with Playwright fallback) — writes results to Turso.
+# MB_API_KEY passed inline as belt-and-braces alongside the re-export above
+# (STRK-321): either hop alone suffices, both make the cron path robust.
 echo "[$(date -u +%H:%M:%S)] Running price extraction..."
 DATA_DIR="${DATA_DIR:-$SCRIPT_DIR/data}" \
 FIRECRAWL_BASE_URL="${FIRECRAWL_BASE_URL:-http://localhost:3002}" \
@@ -67,6 +72,7 @@ BROWSER_MODE=local \
 PLAYWRIGHT_LAUNCH=1 \
 PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-/usr/local/share/playwright}" \
 POLLER_ID="$POLLER_ID" \
+MB_API_KEY="${MB_API_KEY:-}" \
 node "$SCRIPT_DIR/price-extract.js"
 
 # T3 queue status — log failure count, warn if rate looks systemic

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.js
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.js
@@ -1,0 +1,251 @@
+/**
+ * MintBuilder direct price feed client (STRK-321).
+ *
+ * MintBuilder granted StakTrakr first-party API access — the first vendor with
+ * a direct feed. One GET of /feed/api/prices?key=…&mintbuilder=all returns
+ * every active product as an id-keyed map ({ title, link, price, retail,
+ * tiers, premium }), so the poll loop's per-target lookups are served from a
+ * per-process memoized index: exactly one feed request per run, N cache hits.
+ *
+ * Matching: a feed product's `link` is its public product-page URL — the same
+ * URL stored in provider_vendors.url — so rows match by canonicalized URL
+ * comparison. A row can pin an exact product with {"mbProductId": "…"} in its
+ * free-form `hints` column (dashboard gear row) when the URL drifts.
+ *
+ * Key hygiene: MB_API_KEY is read at CALL time (import purity — this module
+ * sits in price-extract.js's import graph) and the request URL is never
+ * logged. provider_vendors.url must keep the human product URL; it is
+ * republished into public JSON and rendered as Buy links.
+ */
+
+export const MINTBUILDER_FEED_URL = "https://mintbuilder.com/feed/api/prices";
+// Mirrors the goldback-scraper.js feed timeout; no shared constant exists yet.
+export const FEED_TIMEOUT_MS = 15_000;
+const FEED_RETRY_DELAY_MS = 2_000;
+
+// Per-process feed memo. Promise-valued so concurrent lookups share one
+// in-flight request; fingerprinted by key so a rotated key refetches.
+let _feedState = null;
+let _feedFingerprint = null;
+
+/** Sleep helper for the single transient-failure retry. */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Canonicalize a product URL for feed↔row matching.
+ *
+ * Collapses the differences that show up between stored rows and feed links
+ * without changing product identity: protocol (http/https), host case and a
+ * leading "www.", path case, query string, fragment, and a trailing slash.
+ * Root URLs normalize to the bare host.
+ *
+ * @param {unknown} raw - URL string to canonicalize.
+ * @returns {string|null} "host/path" canonical form, or null when unparseable.
+ */
+export function normalizeProductUrl(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  let parsed;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  let path = parsed.pathname.toLowerCase();
+  if (path.endsWith("/")) path = path.slice(0, -1);
+  return `${host}${path}`;
+}
+
+/**
+ * Read the optional {"mbProductId": "…"} pin from a provider row's free-form
+ * hints column. Defensive by design: the dashboard JSON-validates hints on
+ * save, but rows can predate that validation or be edited directly in sqld,
+ * and the column is shared with other free-form uses.
+ *
+ * @param {unknown} hintsText - Raw provider_vendors.hints value.
+ * @param {(msg: string) => void} [warn] - Warn sink for malformed JSON.
+ * @returns {string|null} The pinned product id, or null when absent/unusable.
+ */
+export function parseHintsProductId(hintsText, warn = console.warn) {
+  if (typeof hintsText !== "string" || hintsText.trim() === "") return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(hintsText);
+  } catch {
+    warn("[mintbuilder-feed] unparseable hints JSON — ignoring the mbProductId pin");
+    return null;
+  }
+  const id = parsed?.mbProductId;
+  if (typeof id === "number" && Number.isFinite(id)) return String(id);
+  if (typeof id === "string" && id.trim() !== "") return id.trim();
+  return null;
+}
+
+/**
+ * Select the price to record from a feed product. The feed's `price` field is
+ * the lowest quantity tier (check/wire); this seam exists so a tier-selection
+ * change (e.g. preferring the qty-1 tier) stays confined to one function.
+ *
+ * @param {{price?: unknown}} product - Feed product entry.
+ * @returns {number|null} A finite positive price, or null when unusable.
+ */
+export function selectFeedPrice(product) {
+  const price = Number(product?.price);
+  return Number.isFinite(price) && price > 0 ? price : null;
+}
+
+/**
+ * Fetch and index the full MintBuilder feed. Always resolves to a FeedState —
+ * never throws — so a cached failure cannot fan out unhandled rejections:
+ *   { ok: true, byId: Map, byUrl: Map, fetchedAt }
+ *   { ok: false, reason: "no_key"|"bad_key"|"fetch_failed"|"bad_payload" }
+ *
+ * @param {object} opts - Fetch collaborators (apiKey, fetchImpl, log, warn, retryDelayMs).
+ * @returns {Promise<object>} The resolved FeedState.
+ */
+async function buildFeedState({ apiKey, fetchImpl, log, warn, retryDelayMs }) {
+  if (!apiKey) {
+    warn("[mintbuilder-feed] MB_API_KEY not set — mintbuilder targets fall back to page scrape");
+    return { ok: false, reason: "no_key" };
+  }
+
+  // The key travels only in the request itself — never log this URL.
+  const requestUrl = `${MINTBUILDER_FEED_URL}?key=${encodeURIComponent(apiKey)}&mintbuilder=all`;
+  let response = null;
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      response = await fetchImpl(requestUrl, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "StakTrakr/1.0 mintbuilder-feed",
+        },
+        signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
+      });
+    } catch (err) {
+      warn(`[mintbuilder-feed] feed request failed (attempt ${attempt}/2): ${err.message}`);
+      response = null;
+    }
+
+    if (response && response.status === 401) {
+      warn("[mintbuilder-feed] feed rejected the API key (HTTP 401) — falling back to page scrape");
+      return { ok: false, reason: "bad_key" };
+    }
+    if (response && response.ok) break;
+    if (response) {
+      warn(`[mintbuilder-feed] feed HTTP ${response.status} (attempt ${attempt}/2)`);
+      response = null;
+    }
+    if (attempt === 1 && retryDelayMs > 0) await sleep(retryDelayMs);
+  }
+
+  if (!response) return { ok: false, reason: "fetch_failed" };
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    warn("[mintbuilder-feed] feed body is not valid JSON");
+    return { ok: false, reason: "bad_payload" };
+  }
+
+  const products = payload?.data?.products;
+  if (typeof products !== "object" || products === null || Array.isArray(products)) {
+    warn("[mintbuilder-feed] feed payload has no data.products map");
+    return { ok: false, reason: "bad_payload" };
+  }
+
+  const byId = new Map();
+  const byUrl = new Map();
+  for (const [productId, product] of Object.entries(products)) {
+    byId.set(String(productId), product);
+    const urlKey = normalizeProductUrl(product?.link);
+    if (urlKey) byUrl.set(urlKey, { productId: String(productId), product });
+  }
+
+  log(`[mintbuilder-feed] indexed ${byId.size} products from the direct feed`);
+  return { ok: true, byId, byUrl, fetchedAt: new Date().toISOString() };
+}
+
+/**
+ * Memoized accessor for the feed index. The first caller in a process fetches
+ * the full catalog; every later caller (the poll loop runs one coin×vendor
+ * target at a time) shares the same resolved state. The memo is fingerprinted
+ * by API key so a rotated key builds a fresh index.
+ *
+ * @param {object} [opts] - apiKey (default: process.env.MB_API_KEY read at
+ *   call time), fetchImpl (default: global fetch), log/warn sinks, retryDelayMs.
+ * @returns {Promise<object>} The (possibly cached) FeedState.
+ */
+export function getFeedIndex({
+  apiKey,
+  fetchImpl = fetch,
+  log = console.log,
+  warn = console.warn,
+  retryDelayMs = FEED_RETRY_DELAY_MS,
+} = {}) {
+  const key = apiKey !== undefined ? apiKey : process.env.MB_API_KEY;
+  const fingerprint = key || "";
+  if (_feedState && _feedFingerprint === fingerprint) return _feedState;
+  _feedFingerprint = fingerprint;
+  _feedState = buildFeedState({ apiKey: key, fetchImpl, log, warn, retryDelayMs });
+  return _feedState;
+}
+
+/**
+ * Resolve one provider row against the feed. Never throws.
+ *
+ * Match order: a hints {"mbProductId"} pin (when present in the feed) beats
+ * URL matching; otherwise the row URL is canonicalized and looked up against
+ * the feed links. Callers treat "unavailable"/"miss" as fall-back-to-scrape.
+ *
+ * @param {object} opts - { url, hints, apiKey?, fetchImpl?, log?, warn?, retryDelayMs? }.
+ * @returns {Promise<object>} {status:"hit", product:{productId, price, link, title}}
+ *   | {status:"miss", reason} | {status:"unavailable", reason}.
+ */
+export async function lookupMintbuilderProduct({
+  url,
+  hints = null,
+  apiKey,
+  fetchImpl,
+  log = console.log,
+  warn = console.warn,
+  retryDelayMs,
+} = {}) {
+  const state = await getFeedIndex({ apiKey, fetchImpl, log, warn, retryDelayMs });
+  if (!state.ok) return { status: "unavailable", reason: state.reason };
+
+  let productId = null;
+  let product = null;
+
+  const pinnedId = parseHintsProductId(hints, warn);
+  if (pinnedId && state.byId.has(pinnedId)) {
+    productId = pinnedId;
+    product = state.byId.get(pinnedId);
+  } else {
+    const urlKey = normalizeProductUrl(url);
+    const match = urlKey ? state.byUrl.get(urlKey) : undefined;
+    if (match) ({ productId, product } = match);
+  }
+
+  if (!product) return { status: "miss", reason: "not_in_feed" };
+
+  const price = selectFeedPrice(product);
+  if (price === null) return { status: "miss", reason: "invalid_price" };
+
+  return {
+    status: "hit",
+    product: {
+      productId,
+      price,
+      link: product.link ?? null,
+      title: product.title ?? null,
+    },
+  };
+}
+
+/** Reset the per-process feed memo (test hook). */
+export function _resetFeedCacheForTests() {
+  _feedState = null;
+  _feedFingerprint = null;
+}

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.js
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.js
@@ -109,8 +109,12 @@ async function buildFeedState({ apiKey, fetchImpl, log, warn, retryDelayMs }) {
     return { ok: false, reason: "no_key" };
   }
 
-  // The key travels only in the request itself — never log this URL.
+  // The key travels only in the request itself — never log this URL. Error
+  // messages are redacted too: some fetch implementations echo the full
+  // request URL (key included) into err.message.
   const requestUrl = `${MINTBUILDER_FEED_URL}?key=${encodeURIComponent(apiKey)}&mintbuilder=all`;
+  const redactKey = (text) =>
+    String(text).replaceAll(apiKey, "***").replaceAll(encodeURIComponent(apiKey), "***");
   let response = null;
 
   for (let attempt = 1; attempt <= 2; attempt++) {
@@ -123,7 +127,9 @@ async function buildFeedState({ apiKey, fetchImpl, log, warn, retryDelayMs }) {
         signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
       });
     } catch (err) {
-      warn(`[mintbuilder-feed] feed request failed (attempt ${attempt}/2): ${err.message}`);
+      warn(
+        `[mintbuilder-feed] feed request failed (attempt ${attempt}/2): ${redactKey(err.message)}`
+      );
       response = null;
     }
 
@@ -133,7 +139,14 @@ async function buildFeedState({ apiKey, fetchImpl, log, warn, retryDelayMs }) {
     }
     if (response && response.ok) break;
     if (response) {
-      warn(`[mintbuilder-feed] feed HTTP ${response.status} (attempt ${attempt}/2)`);
+      // Only 5xx is treated as transient; other non-OK statuses (403, 404,
+      // 429, …) are terminal for this run — retrying them wastes a request.
+      const transient = response.status >= 500;
+      warn(
+        `[mintbuilder-feed] feed HTTP ${response.status}` +
+          (transient ? ` (attempt ${attempt}/2)` : " — not retrying")
+      );
+      if (!transient) return { ok: false, reason: "fetch_failed" };
       response = null;
     }
     if (attempt === 1 && retryDelayMs > 0) await sleep(retryDelayMs);

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/**
+ * TDD contract tests for the MintBuilder direct price feed client (STRK-321).
+ *
+ * The feed client wraps GET mintbuilder.com/feed/api/prices?key=…&mintbuilder=all
+ * behind a per-process memoized index so the poll loop (one target per
+ * coin×vendor) costs exactly one feed request per run. These tests pin:
+ *   - URL canonicalization used to match feed `link` values to stored
+ *     provider_vendors.url rows,
+ *   - the hints {"mbProductId"} override parse,
+ *   - lookup semantics (hit / miss / unavailable — never throws),
+ *   - single-fetch memoization incl. cached failures and key-rotation refetch,
+ *   - retry policy (401 never retries, 5xx/network retries once),
+ *   - key hygiene (the API key never appears in log/warn output),
+ *   - import purity (the module enters price-extract.js's import graph).
+ *
+ * Run with:
+ *   node devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+const feedModuleUrl = new URL("./price-extract-mintbuilder-feed.js", import.meta.url);
+
+/** Import the feed module fresh state via its test-reset hook before each fetch test. */
+const loadFeed = async () => {
+  const mod = await import(feedModuleUrl);
+  mod._resetFeedCacheForTests();
+  return mod;
+};
+
+/** Build a data.products fixture keyed by product id, in the documented feed shape. */
+const feedPayload = (products) => ({
+  data: {
+    products,
+    metals: { silver: { price: 38.1, change: 0.2 } },
+    spot_version: "0f6e2c5f",
+    timestamp: "2026-08-01T14:00:00Z",
+  },
+});
+
+const PRODUCTS = {
+  101: {
+    title: "1 oz Silver Buffalo Round",
+    link: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    image: "https://mintbuilder.com/img/101.jpg",
+    price: "38.42",
+    retail: "44.99",
+    tiers: [{ qty: 1, check_wire: "38.42" }],
+    premium: "Over Spot",
+  },
+  202: {
+    title: "1/10 oz Gold Eagle",
+    link: "https://www.mintbuilder.com/products/tenth-oz-gold-eagle/",
+    image: "https://mintbuilder.com/img/202.jpg",
+    price: 412.77,
+    retail: 449.0,
+    tiers: [{ qty: 1, check_wire: 412.77 }],
+    premium: null,
+  },
+  303: {
+    title: "Broken price product",
+    link: "https://mintbuilder.com/products/broken",
+    price: "N/A",
+    retail: null,
+    tiers: [],
+    premium: null,
+  },
+};
+
+/** fetch double: returns queued results in order (an Error entry throws). Records calls. */
+const makeFetch = (...results) => {
+  const calls = [];
+  const impl = async (url, opts) => {
+    calls.push({ url, opts });
+    const next = results.length > 1 ? results.shift() : results[0];
+    if (next instanceof Error) throw next;
+    return next;
+  };
+  impl.calls = calls;
+  return impl;
+};
+
+const okResponse = (json) => ({ ok: true, status: 200, json: async () => json });
+const errResponse = (status) => ({ ok: false, status, json: async () => ({}) });
+
+/** Capture log/warn lines for assertion (and key-leak scanning). */
+const makeSpy = () => {
+  const lines = [];
+  const fn = (...args) => lines.push(args.join(" "));
+  fn.lines = lines;
+  return fn;
+};
+
+// ---------------------------------------------------------------------------
+// Import purity — the vendor module imports this client, which puts it in the
+// price-extract.js import graph pinned by price-extract-imports.test.mjs.
+// ---------------------------------------------------------------------------
+
+test("feed module imports with zero side effects and no env reads at import time", () => {
+  const script = `
+    const sideEffects = [];
+    console.log = (...a) => sideEffects.push("log:" + a.join(" "));
+    console.warn = (...a) => sideEffects.push("warn:" + a.join(" "));
+    console.error = (...a) => sideEffects.push("error:" + a.join(" "));
+    const mod = await import(${JSON.stringify(feedModuleUrl.href)});
+    process.stdout.write(JSON.stringify({
+      sideEffects,
+      lookup: typeof mod.lookupMintbuilderProduct,
+      getFeedIndex: typeof mod.getFeedIndex,
+      normalizeProductUrl: typeof mod.normalizeProductUrl,
+    }) + "\\n");
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: __dirname,
+    env: { PATH: process.env.PATH || "", HOME: process.env.HOME || "" },
+    encoding: "utf8",
+    timeout: 3_000,
+  });
+
+  assert.equal(result.status, 0, `import probe failed:\n${result.stdout}\n${result.stderr}`);
+  const probe = JSON.parse(result.stdout.trim().split("\n").filter(Boolean).at(-1));
+  assert.deepEqual(probe.sideEffects, [], "importing the feed client must not log or warn");
+  assert.equal(probe.lookup, "function");
+  assert.equal(probe.getFeedIndex, "function");
+  assert.equal(probe.normalizeProductUrl, "function");
+});
+
+// ---------------------------------------------------------------------------
+// normalizeProductUrl
+// ---------------------------------------------------------------------------
+
+test("normalizeProductUrl canonicalizes equivalent product URLs", async () => {
+  const { normalizeProductUrl } = await import(feedModuleUrl);
+  const canonical = "mintbuilder.com/products/1oz-silver-buffalo-round";
+
+  // https/http, www, trailing slash, query, fragment, and case all collapse.
+  assert.equal(
+    normalizeProductUrl("https://www.MintBuilder.com/Products/1oz-Silver-Buffalo-Round/?aff=reddit#top"),
+    canonical
+  );
+  assert.equal(normalizeProductUrl("http://mintbuilder.com/products/1oz-silver-buffalo-round"), canonical);
+  assert.equal(normalizeProductUrl("https://mintbuilder.com/products/1oz-silver-buffalo-round/"), canonical);
+
+  // Root URLs normalize to the bare host.
+  assert.equal(normalizeProductUrl("https://mintbuilder.com/"), "mintbuilder.com");
+  assert.equal(normalizeProductUrl("https://mintbuilder.com"), "mintbuilder.com");
+
+  // Garbage in → null out (never throws).
+  for (const bad of [null, undefined, "", "not a url", "products/relative", 42]) {
+    assert.equal(normalizeProductUrl(bad), null, `expected null for ${String(bad)}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// parseHintsProductId
+// ---------------------------------------------------------------------------
+
+test("parseHintsProductId reads the mbProductId pin defensively", async () => {
+  const { parseHintsProductId } = await import(feedModuleUrl);
+
+  const quiet = makeSpy();
+  assert.equal(parseHintsProductId('{"mbProductId":"12345"}', quiet), "12345");
+  assert.equal(parseHintsProductId('{"mbProductId":12345}', quiet), "12345", "numbers coerce");
+  assert.equal(parseHintsProductId('{"mbProductId":"  678 "}', quiet), "678", "trimmed");
+  // Absent/empty/no-key inputs are the normal case — silent null.
+  assert.equal(parseHintsProductId(null, quiet), null);
+  assert.equal(parseHintsProductId("", quiet), null);
+  assert.equal(parseHintsProductId('{"selector":".price"}', quiet), null);
+  assert.equal(parseHintsProductId('{"mbProductId":{}}', quiet), null, "non-scalar ignored");
+  assert.equal(parseHintsProductId('{"mbProductId":"   "}', quiet), null, "blank ignored");
+  assert.equal(quiet.lines.length, 0, "no warns for absent/no-key hints");
+
+  // Malformed JSON warns (rows can predate dashboard validation) but never throws.
+  const noisy = makeSpy();
+  assert.equal(parseHintsProductId("{not json", noisy), null);
+  assert.equal(noisy.lines.length, 1, "malformed hints should warn exactly once");
+});
+
+// ---------------------------------------------------------------------------
+// selectFeedPrice
+// ---------------------------------------------------------------------------
+
+test("selectFeedPrice accepts finite positive prices only", async () => {
+  const { selectFeedPrice } = await import(feedModuleUrl);
+
+  assert.equal(selectFeedPrice({ price: "38.42" }), 38.42, "string prices coerce");
+  assert.equal(selectFeedPrice({ price: 412.77 }), 412.77);
+  for (const bad of [{ price: 0 }, { price: -3 }, { price: "N/A" }, { price: null }, {}]) {
+    assert.equal(selectFeedPrice(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// lookupMintbuilderProduct — matching
+// ---------------------------------------------------------------------------
+
+test("lookup matches a stored URL to a feed product across normalization drift", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  const result = await feed.lookupMintbuilderProduct({
+    // Stored row URL differs from the feed link by case, www, slash, and query.
+    url: "https://WWW.mintbuilder.com/Products/1oz-Silver-Buffalo-Round/?utm_source=stak",
+    hints: null,
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, {
+    status: "hit",
+    product: {
+      productId: "101",
+      price: 38.42,
+      link: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+      title: "1 oz Silver Buffalo Round",
+    },
+  });
+  assert.equal(fetchImpl.calls.length, 1);
+  assert.ok(
+    fetchImpl.calls[0].url.includes("mintbuilder=all"),
+    "feed request should ask for the full catalog"
+  );
+});
+
+test("lookup matches www-carrying feed links from a bare stored URL", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/tenth-oz-gold-eagle",
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.equal(result.status, "hit");
+  assert.equal(result.product.productId, "202");
+  assert.equal(result.product.price, 412.77);
+});
+
+test("a hints mbProductId pin beats URL matching", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round", // would match 101
+    hints: '{"mbProductId":"202"}',
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.equal(result.status, "hit");
+  assert.equal(result.product.productId, "202", "the pinned id must win over the URL match");
+});
+
+test("lookup misses cleanly when the product is not in the feed", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/discontinued-item",
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, { status: "miss", reason: "not_in_feed" });
+});
+
+test("lookup reports invalid_price when the matched product price is unusable", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/broken",
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, { status: "miss", reason: "invalid_price" });
+});
+
+// ---------------------------------------------------------------------------
+// lookupMintbuilderProduct — availability + retry policy
+// ---------------------------------------------------------------------------
+
+test("missing key short-circuits without fetching and warns once per process", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+  const warn = makeSpy();
+
+  const first = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "",
+    fetchImpl,
+    warn,
+  });
+  const second = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/tenth-oz-gold-eagle",
+    apiKey: "",
+    fetchImpl,
+    warn,
+  });
+
+  assert.deepEqual(first, { status: "unavailable", reason: "no_key" });
+  assert.deepEqual(second, { status: "unavailable", reason: "no_key" });
+  assert.equal(fetchImpl.calls.length, 0, "no key must mean no network traffic");
+  assert.equal(warn.lines.length, 1, "the missing-key warn must fire once, not per target");
+  assert.match(warn.lines[0], /MB_API_KEY/);
+});
+
+test("HTTP 401 reports bad_key without retrying", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(errResponse(401));
+  const warn = makeSpy();
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "revoked-key",
+    fetchImpl,
+    warn,
+  });
+
+  assert.deepEqual(result, { status: "unavailable", reason: "bad_key" });
+  assert.equal(fetchImpl.calls.length, 1, "401 is not transient — never retry it");
+});
+
+test("HTTP 5xx retries once then reports fetch_failed", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(errResponse(503), errResponse(503));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "test-key",
+    fetchImpl,
+    warn: makeSpy(),
+    retryDelayMs: 0,
+  });
+
+  assert.deepEqual(result, { status: "unavailable", reason: "fetch_failed" });
+  assert.equal(fetchImpl.calls.length, 2, "one retry, no more");
+});
+
+test("network errors retry once then report fetch_failed", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(new Error("ECONNRESET"), new Error("ECONNRESET"));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "test-key",
+    fetchImpl,
+    warn: makeSpy(),
+    retryDelayMs: 0,
+  });
+
+  assert.deepEqual(result, { status: "unavailable", reason: "fetch_failed" });
+  assert.equal(fetchImpl.calls.length, 2);
+});
+
+test("a payload without data.products reports bad_payload without retrying", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse({ hello: "world" }));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "test-key",
+    fetchImpl,
+    warn: makeSpy(),
+  });
+
+  assert.deepEqual(result, { status: "unavailable", reason: "bad_payload" });
+  assert.equal(fetchImpl.calls.length, 1, "a well-formed non-feed response is not transient");
+});
+
+// ---------------------------------------------------------------------------
+// Memoization
+// ---------------------------------------------------------------------------
+
+test("the feed is fetched once per process across many lookups", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  for (const url of [
+    "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    "https://mintbuilder.com/products/tenth-oz-gold-eagle",
+    "https://mintbuilder.com/products/not-in-feed",
+  ]) {
+    await feed.lookupMintbuilderProduct({ url, apiKey: "test-key", fetchImpl });
+  }
+
+  assert.equal(fetchImpl.calls.length, 1, "the poll loop must cost one feed GET per run");
+
+  feed._resetFeedCacheForTests();
+  await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "test-key",
+    fetchImpl,
+  });
+  assert.equal(fetchImpl.calls.length, 2, "reset must allow a fresh fetch");
+});
+
+test("a failed fetch is cached — later targets fall back without re-fetching", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(errResponse(503), errResponse(503));
+
+  const first = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "test-key",
+    fetchImpl,
+    warn: makeSpy(),
+    retryDelayMs: 0,
+  });
+  const second = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/tenth-oz-gold-eagle",
+    apiKey: "test-key",
+    fetchImpl,
+    warn: makeSpy(),
+    retryDelayMs: 0,
+  });
+
+  assert.equal(first.status, "unavailable");
+  assert.deepEqual(second, first, "the cached failure must be reused");
+  assert.equal(fetchImpl.calls.length, 2, "attempt + one retry — nothing more for the whole run");
+});
+
+test("a changed API key invalidates the memoized feed", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "key-a",
+    fetchImpl,
+  });
+  await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: "key-b",
+    fetchImpl,
+  });
+
+  assert.equal(fetchImpl.calls.length, 2, "key rotation must not serve the stale index");
+});
+
+// ---------------------------------------------------------------------------
+// Key hygiene
+// ---------------------------------------------------------------------------
+
+test("the API key never appears in log or warn output", async () => {
+  const feed = await loadFeed();
+  const secret = "sekret-key-do-not-log";
+  const log = makeSpy();
+  const warn = makeSpy();
+
+  // Happy path, then a 401 path — the two chattiest branches.
+  await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: secret,
+    fetchImpl: makeFetch(okResponse(feedPayload(PRODUCTS))),
+    log,
+    warn,
+  });
+  feed._resetFeedCacheForTests();
+  await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: secret,
+    fetchImpl: makeFetch(errResponse(401)),
+    log,
+    warn,
+  });
+
+  for (const line of [...log.lines, ...warn.lines]) {
+    assert.ok(!line.includes(secret), `output leaked the API key: ${line}`);
+  }
+});
+
+let passed = 0;
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    await fn();
+    console.log(`  ok  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL ${name}`);
+    console.log(`    ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
@@ -364,6 +364,24 @@ test("network errors retry once then report fetch_failed", async () => {
   assert.equal(fetchImpl.calls.length, 2);
 });
 
+test("non-transient 4xx statuses (403/404) report fetch_failed without retrying", async () => {
+  for (const status of [403, 404]) {
+    const feed = await loadFeed();
+    const fetchImpl = makeFetch(errResponse(status));
+
+    const result = await feed.lookupMintbuilderProduct({
+      url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+      apiKey: "test-key",
+      fetchImpl,
+      warn: makeSpy(),
+      retryDelayMs: 0,
+    });
+
+    assert.deepEqual(result, { status: "unavailable", reason: "fetch_failed" });
+    assert.equal(fetchImpl.calls.length, 1, `HTTP ${status} is not transient — never retry it`);
+  }
+});
+
 test("a payload without data.products reports bad_payload without retrying", async () => {
   const feed = await loadFeed();
   const fetchImpl = makeFetch(okResponse({ hello: "world" }));
@@ -473,6 +491,21 @@ test("the API key never appears in log or warn output", async () => {
     fetchImpl: makeFetch(errResponse(401)),
     log,
     warn,
+  });
+
+  // Network-error path: some fetch implementations embed the full request URL
+  // (key included) in the error message — the client must redact it.
+  feed._resetFeedCacheForTests();
+  const urlLeakingError = new Error(
+    `fetch failed for https://mintbuilder.com/feed/api/prices?key=${secret}&mintbuilder=all`
+  );
+  await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    apiKey: secret,
+    fetchImpl: makeFetch(urlLeakingError, urlLeakingError),
+    log,
+    warn,
+    retryDelayMs: 0,
   });
 
   for (const line of [...log.lines, ...warn.lines]) {

--- a/devops/pollers/shared/price-extract-vendor-mintbuilder.js
+++ b/devops/pollers/shared/price-extract-vendor-mintbuilder.js
@@ -1,6 +1,15 @@
 /**
- * MintBuilder Vendor module (STRK-307 / STRK-311).
+ * MintBuilder Vendor module (STRK-307 / STRK-311 / STRK-321).
  *
+ * STRK-321: MintBuilder granted StakTrakr direct API access — the first
+ * vendor with a first-party price feed. scrape() is now FEED-FIRST: it
+ * resolves the row against the memoized feed index
+ * (price-extract-mintbuilder-feed.js, one GET per process) and only falls
+ * back to the page scrape on a miss or when the feed is unavailable
+ * (MB_API_KEY unset, HTTP failure, bad payload). Unsetting MB_API_KEY
+ * therefore rolls the vendor back to pure scraping with no code change.
+ *
+ * The page-scrape fallback is the pre-STRK-321 behavior and stays healthy:
  * MintBuilder serves clean schema.org Product/Offer JSON-LD (price +
  * availability) on every real product page, with no bot-challenge (Cloudflare
  * sits in front purely as a CDN — cf-cache-status: HIT, no JS challenge, no
@@ -14,6 +23,7 @@
  */
 
 import { mergeProviderConfig } from "./price-extract-provider-config.js";
+import { lookupMintbuilderProduct } from "./price-extract-mintbuilder-feed.js";
 
 // Plain SSR HTML — JSON-LD is present in the initial response, no JS render
 // needed. domcontentloaded is sufficient; waiting for networkidle only adds
@@ -34,15 +44,57 @@ export const vendor = {
   usesAsLowAs: false,
   // No extractPrice override → shared default strategy (JSON-LD offer.price authoritative).
   /**
-   * Scrape a MintBuilder product page via the shared generic strategy.
+   * Resolve a MintBuilder target feed-first, page-scrape as fallback (STRK-321).
+   *
+   * A feed hit records `source: "mintbuilder-api"` with `inStock: true` (the
+   * feed carries no stock field; presence in the all-active-products payload
+   * is the availability signal) and always reports the row's product-page URL
+   * — never the feed endpoint. A miss or an unavailable feed falls back to
+   * `context.scrapeGeneric`, which decides both price and OOS from the page.
+   *
    * @param {object} context - Scrape context supplied by the vendor registry
-   *   (coinSlug, coin, provider, urls, scrapeGeneric), carrying a config
-   *   already merged as provider defaults → this module's config →
-   *   caller-explicit overrides (STRK-314).
-   * @returns {Promise<object>} The result from context.scrapeGeneric —
-   *   { price, inStock, source, ok, error, url }.
+   *   (coinSlug, coin, provider, urls, scrapeGeneric, optional mbFeedLookup
+   *   test seam), carrying a config already merged as provider defaults →
+   *   this module's config → caller-explicit overrides (STRK-314). The
+   *   fallback passes this context through untouched — config is never
+   *   re-derived or merged here.
+   * @returns {Promise<object>} { price, inStock, source, ok, error, url }.
    */
   async scrape(context) {
+    const log = context.log || console.log;
+    const warn = context.warn || console.warn;
+    const lookup = context.mbFeedLookup || lookupMintbuilderProduct;
+    const targetUrl = context.url || context.urls?.[0] || context.provider?.url || null;
+
+    const resolved = await lookup({
+      url: targetUrl,
+      hints: context.provider?.hints ?? null,
+      log,
+      warn,
+    });
+
+    if (resolved.status === "hit") {
+      return {
+        price: resolved.product.price,
+        inStock: true,
+        source: "mintbuilder-api",
+        ok: true,
+        error: null,
+        url: targetUrl,
+      };
+    }
+
+    if (resolved.status === "miss") {
+      warn(
+        `[mintbuilder] feed miss (${resolved.reason}) for ${context.coinSlug} @ ${targetUrl} — ` +
+          'page-scrape fallback (pin {"mbProductId": "…"} in the row hints to fix a URL drift)'
+      );
+    } else {
+      log(
+        `[mintbuilder] feed unavailable (${resolved.reason}) for ${context.coinSlug} — page-scrape fallback`
+      );
+    }
+
     return context.scrapeGeneric(context);
   },
 };

--- a/devops/pollers/shared/price-extract-vendors.test.mjs
+++ b/devops/pollers/shared/price-extract-vendors.test.mjs
@@ -169,8 +169,137 @@ test("MintBuilder module exists and uses the standard interface (STRK-311)", asy
   assert.equal(mintbuilder.usesAsLowAs, false);
 
   // Plain SSR HTML (JSON-LD present in the raw response, no JS render needed) —
-  // domcontentloaded is sufficient, no need to wait for networkidle.
+  // domcontentloaded is sufficient, no need to wait for networkidle. Since
+  // STRK-321 scrape() is feed-first; these flags still govern the page-scrape
+  // fallback path, so they remain pinned.
   assert.equal(mintbuilder.config.waitUntil, "domcontentloaded");
+});
+
+// ---------------------------------------------------------------------------
+// STRK-321 — MintBuilder feed-first dispatch
+//
+// scrape() consults the direct price feed before scraping. The feed lookup is
+// injectable through the context (scrapeVendor spreads the caller context), so
+// these tests pin the dispatch contract without any network traffic.
+// ---------------------------------------------------------------------------
+
+/** Base MintBuilder dispatch context with silent loggers and a scrapeGeneric probe. */
+const mintbuilderContext = (overrides = {}) => {
+  const calls = { generic: 0, genericContext: null };
+  const context = {
+    provider: {
+      id: "mintbuilder",
+      url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+      hints: null,
+    },
+    coinSlug: "silver-buffalo-1oz",
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+    log: () => {},
+    warn: () => {},
+    scrapeGeneric: async (ctx) => {
+      calls.generic++;
+      calls.genericContext = ctx;
+      return {
+        price: 39.99,
+        inStock: false,
+        source: "playwright-direct:jsonLd",
+        ok: true,
+        error: null,
+        url: ctx.url,
+      };
+    },
+    ...overrides,
+  };
+  return { context, calls };
+};
+
+test("STRK-321: a feed hit returns mintbuilder-api and skips the page scrape", async () => {
+  const registry = await import(new URL("./price-extract-vendors.js", import.meta.url));
+  const { context, calls } = mintbuilderContext({
+    mbFeedLookup: async () => ({
+      status: "hit",
+      product: {
+        productId: "101",
+        price: 38.42,
+        link: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+        title: "1 oz Silver Buffalo Round",
+      },
+    }),
+  });
+
+  const result = await registry.scrapeVendor(context);
+
+  assert.deepEqual(result, {
+    price: 38.42,
+    inStock: true,
+    source: "mintbuilder-api",
+    ok: true,
+    error: null,
+    // The row's product-page URL — never the feed link or endpoint.
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+  });
+  assert.equal(calls.generic, 0, "a feed hit must not touch the page scraper");
+});
+
+test("STRK-321: the feed lookup receives the row URL and hints", async () => {
+  const registry = await import(new URL("./price-extract-vendors.js", import.meta.url));
+  let observed = null;
+  const { context } = mintbuilderContext({
+    provider: {
+      id: "mintbuilder",
+      url: "https://mintbuilder.com/products/tenth-oz-gold-eagle",
+      hints: '{"mbProductId":"202"}',
+    },
+    url: "https://mintbuilder.com/products/tenth-oz-gold-eagle",
+    mbFeedLookup: async (args) => {
+      observed = args;
+      return {
+        status: "hit",
+        product: { productId: "202", price: 412.77, link: null, title: null },
+      };
+    },
+  });
+
+  await registry.scrapeVendor(context);
+
+  assert.equal(observed.url, "https://mintbuilder.com/products/tenth-oz-gold-eagle");
+  assert.equal(observed.hints, '{"mbProductId":"202"}', "the hints pin must reach the lookup");
+});
+
+test("STRK-321: a feed miss falls back to the page scrape with the resolved context", async () => {
+  const registry = await import(new URL("./price-extract-vendors.js", import.meta.url));
+  const { context, calls } = mintbuilderContext({
+    mbFeedLookup: async () => ({ status: "miss", reason: "not_in_feed" }),
+  });
+
+  const result = await registry.scrapeVendor(context);
+
+  assert.equal(calls.generic, 1, "a miss must fall back to the page scraper");
+  assert.deepEqual(result, {
+    price: 39.99,
+    inStock: false,
+    source: "playwright-direct:jsonLd",
+    ok: true,
+    error: null,
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+  });
+  // STRK-314: the fallback must reuse the context scrapeVendor resolved —
+  // module-owned config intact, not re-derived inside the module.
+  assert.equal(calls.genericContext.config.waitUntil, "domcontentloaded");
+});
+
+test("STRK-321: an unavailable feed falls back to the page scrape", async () => {
+  const registry = await import(new URL("./price-extract-vendors.js", import.meta.url));
+  for (const reason of ["no_key", "bad_key", "fetch_failed", "bad_payload"]) {
+    const { context, calls } = mintbuilderContext({
+      mbFeedLookup: async () => ({ status: "unavailable", reason }),
+    });
+
+    const result = await registry.scrapeVendor(context);
+
+    assert.equal(calls.generic, 1, `${reason} must fall back to the page scraper`);
+    assert.equal(result.source, "playwright-direct:jsonLd", `${reason} fallback result returned`);
+  }
 });
 
 test("registry returns migrated modules for completed Vendor migrations", async () => {


### PR DESCRIPTION
## Summary

MintBuilder reached out after finding the Reddit post and granted StakTrakr **first-party API access** — the first vendor with a direct price feed. This PR switches the `mintbuilder` vendor from HTML scraping to the feed, with automatic fallback to the existing (healthy) JSON-LD page scrape.

- **New feed client** `devops/pollers/shared/price-extract-mintbuilder-feed.js`: one memoized GET of `/feed/api/prices?mintbuilder=all` per process; per-target lookups served from the cached index. Never throws; 401 never retries; 5xx/network retries once; failures cached for the run.
- **Vendor module** `price-extract-vendor-mintbuilder.js` `scrape()` is now feed-first. A hit records `source: "mintbuilder-api"`, `inStock: true`, and the row's product-page URL. Miss/unavailable falls back to `scrapeGeneric` with the context passed through untouched (STRK-314 single-merge rule).
- **Matching**: feed `link` ↔ row `url` via canonicalized-URL comparison (protocol/www/case/query/fragment/trailing-slash collapsed); optional `{"mbProductId": "…"}` pin in the row's `hints` column beats URL matching (dashboard-editable, no redeploy).
- **Env plumbing** (both hops required): `MB_API_KEY` declared in `docker-compose.home.yml` (compose drops undeclared stack env vars) AND re-exported in `run-home.sh` for the cron path (STRK-230 pattern), plus inline on the node invocation as belt-and-braces. Documented in `.env.home.example`.
- **Dashboard**: "Direct API" badge (with explanatory tooltip) on API-fed vendor sections in the By Vendor tab. Items, toggles, and URL editing unchanged — adding/removing a MintBuilder product stays the exact same flow as scraped vendors.

## Key security invariant

`provider_vendors.url` keeps the human product-page URL — that column is republished into four public JSON files and rendered as Buy links. The feed endpoint + key live only in the container env; the request URL is never logged (test-pinned: the key cannot appear in log/warn output).

## Testing

- TDD: 18 new feed-client contract tests + 4 new feed-first dispatch tests in `price-extract-vendors.test.mjs`.
- All 15 `devops/pollers/shared/*.test.mjs` suites green, including import-purity (`price-extract-imports.test.mjs`) with the feed module now in the graph.
- `npm run test:unit` green, `npm run lint` green.
- No Playwright inventory changes → no coverage-map row. No version bump (devops-only, no `js/` app code).

## Rollout (after merge)

1. Pre-rollout gate: keyed dry-run (`DRY_RUN=1`) comparing feed price vs live page price per SKU — the feed `price` is the lowest qty tier; if it diverges from the qty-1 page price, the fix is confined to `selectFeedPrice()`.
2. Portainer git redeploy of stack 7 **with the full env array including `MB_API_KEY`** (Portainer does not persist env vars across git redeploys), then `/deploy-verify`: sqld rows showing `source='mintbuilder-api'`, no bounds-guard rejections, no 401s, published JSON greps zero `key=` hits.
3. Rollback: unset `MB_API_KEY` and redeploy — the vendor reverts to pure page scraping with no code change.

## Follow-ups (separate issues, out of scope here)

1. Frontend first-class vendor registration (`RETAIL_VENDOR_NAMES/URLS/COLORS`, `VENDOR_META`).
2. Dashboard hygiene: `/app` vs `$DATA_DIR` path bug (`dashboard.js:53-54`), By Vendor `readOnly` gap.
3. Dashboard API-feed controls: dedicated "API Product ID" input, per-row feed-match indicator, vendor-level feed health line.

Closes STRK-321 (Plane).