### PR TITLE
STRK-325: hybrid stock rule — page-scrape MintBuilder items with ambiguous feed stock

### DIFF
--- a/devops/pollers/shared/price-extract-mintbuilder-feed.js
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.js
@@ -95,6 +95,26 @@ export function selectFeedPrice(product) {
 }
 
 /**
+ * Decide whether the feed's tier data is a trustworthy in-stock signal
+ * (STRK-325). `tiers[].qty_max` tracks live sellable inventory — validated
+ * 2026-08-01 against 119 product pages: every product with max(qty_max) > 1
+ * across its tiers was InStock on-page (25/25 control, zero inverse
+ * anomalies), while products capped at 1 split 80 OOS / 14 genuine
+ * single-unit listings. A cap of 1 is therefore inherently ambiguous
+ * (zero-floored vs last unit) and callers must verify stock another way —
+ * the vendor module page-scrapes those items. Max is taken across ALL tiers:
+ * some in-stock products lead with a qty-1 discount tier (e.g. the 1 oz Gold
+ * Eagle's "1 - 1" first-coin tier ahead of a "2+" tier with real headroom).
+ *
+ * @param {{tiers?: Array<{qty_max?: unknown}>}} product - Feed product entry.
+ * @returns {boolean} True when the tiers show inventory headroom (> 1).
+ */
+export function feedStockIsConfident(product) {
+  const maxQty = Math.max(0, ...(product?.tiers ?? []).map((t) => Number(t?.qty_max) || 0));
+  return maxQty > 1;
+}
+
+/**
  * Fetch and index the full MintBuilder feed. Always resolves to a FeedState —
  * never throws — so a cached failure cannot fan out unhandled rejections:
  *   { ok: true, byId: Map, byUrl: Map, fetchedAt }
@@ -213,8 +233,11 @@ export function getFeedIndex({
  * the feed links. Callers treat "unavailable"/"miss" as fall-back-to-scrape.
  *
  * @param {object} opts - { url, hints, apiKey?, fetchImpl?, log?, warn?, retryDelayMs? }.
- * @returns {Promise<object>} {status:"hit", product:{productId, price, link, title}}
- *   | {status:"miss", reason} | {status:"unavailable", reason}.
+ * @returns {Promise<object>} {status:"hit", product:{productId, price, link,
+ *   title, stockConfident}} | {status:"miss", reason} |
+ *   {status:"unavailable", reason}. `stockConfident: false` means the tier
+ *   data cannot distinguish sold-out from last-unit (STRK-325) — the caller
+ *   should verify availability via the page scrape.
  */
 export async function lookupMintbuilderProduct({
   url,
@@ -253,6 +276,7 @@ export async function lookupMintbuilderProduct({
       price,
       link: product.link ?? null,
       title: product.title ?? null,
+      stockConfident: feedStockIsConfident(product),
     },
   };
 }

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.js
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.js
@@ -106,11 +106,20 @@ export function selectFeedPrice(product) {
  * some in-stock products lead with a qty-1 discount tier (e.g. the 1 oz Gold
  * Eagle's "1 - 1" first-coin tier ahead of a "2+" tier with real headroom).
  *
+ * Defensive against malformed external JSON: a non-array `tiers` value or
+ * non-finite `qty_max` entries (NaN, Infinity, "9e999") count as no signal —
+ * never throw, never fake headroom.
+ *
  * @param {{tiers?: Array<{qty_max?: unknown}>}} product - Feed product entry.
  * @returns {boolean} True when the tiers show inventory headroom (> 1).
  */
 export function feedStockIsConfident(product) {
-  const maxQty = Math.max(0, ...(product?.tiers ?? []).map((t) => Number(t?.qty_max) || 0));
+  const tiers = Array.isArray(product?.tiers) ? product.tiers : [];
+  let maxQty = 0;
+  for (const tier of tiers) {
+    const qty = Number(tier?.qty_max);
+    if (Number.isFinite(qty) && qty > maxQty) maxQty = qty;
+  }
   return maxQty > 1;
 }
 

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
@@ -249,6 +249,48 @@ test("feedStockIsConfident trusts stock only when some tier shows real inventory
     false,
     "tiers without usable qty_max → no stock signal"
   );
+
+  // External JSON can be malformed — the predicate must never throw and must
+  // never let non-finite values fake inventory headroom (PR #1416 review).
+  for (const malformed of [{ tiers: {} }, { tiers: "1+" }, { tiers: 7 }, { tiers: null }]) {
+    assert.equal(
+      feedStockIsConfident(malformed),
+      false,
+      `non-array tiers must mean no stock signal: ${JSON.stringify(malformed)}`
+    );
+  }
+  for (const bogus of ["Infinity", Infinity, -5, "9e999"]) {
+    assert.equal(
+      feedStockIsConfident({ tiers: [{ qty_max: bogus }] }),
+      false,
+      `non-finite/negative qty_max must not count as headroom: ${String(bogus)}`
+    );
+  }
+});
+
+test("a hit on a product with malformed tiers resolves stockConfident=false without throwing", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(
+    okResponse(
+      feedPayload({
+        707: {
+          title: "Malformed tiers product",
+          link: "https://mintbuilder.com/products/malformed-tiers",
+          price: 25.5,
+          tiers: {},
+        },
+      })
+    )
+  );
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/malformed-tiers",
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.equal(result.status, "hit", "malformed tiers must not crash the lookup");
+  assert.equal(result.product.stockConfident, false, "malformed tiers → unverified stock");
 });
 
 // ---------------------------------------------------------------------------

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
@@ -47,6 +47,8 @@ const feedPayload = (products) => ({
   },
 });
 
+// Tier shapes mirror the live feed (verified 2026-08-01): qty_range/qty_min/
+// qty_max plus per-payment-method prices. qty_max tracks live inventory.
 const PRODUCTS = {
   101: {
     title: "1 oz Silver Buffalo Round",
@@ -54,7 +56,10 @@ const PRODUCTS = {
     image: "https://mintbuilder.com/img/101.jpg",
     price: "38.42",
     retail: "44.99",
-    tiers: [{ qty: 1, check_wire: "38.42" }],
+    tiers: [
+      { qty_range: "1 - 20", qty_min: 1, qty_max: 20, check_wire: 38.42, bitcoin: 39.79, card: 40.79 },
+      { qty_range: "21+", qty_min: 21, qty_max: 5179, check_wire: 38.12, bitcoin: 38.49, card: 40.48 },
+    ],
     premium: "Over Spot",
   },
   202: {
@@ -63,7 +68,7 @@ const PRODUCTS = {
     image: "https://mintbuilder.com/img/202.jpg",
     price: 412.77,
     retail: 449.0,
-    tiers: [{ qty: 1, check_wire: 412.77 }],
+    tiers: [{ qty_range: "1+", qty_min: 1, qty_max: 9604, check_wire: 412.77, bitcoin: 415.79, card: 429.79 }],
     premium: null,
   },
   303: {
@@ -73,6 +78,15 @@ const PRODUCTS = {
     retail: null,
     tiers: [],
     premium: null,
+  },
+  // The observed OOS signature: an unbounded "1+" label capped at qty_max 1.
+  505: {
+    title: "Sold Out Kangaroo",
+    link: "https://mintbuilder.com/products/sold-out-kangaroo",
+    price: 61.16,
+    retail: 61.16,
+    tiers: [{ qty_range: "1+", qty_min: 1, qty_max: 1, check_wire: 61.16, bitcoin: 61.79, card: 63.79 }],
+    premium: "Over Spot",
   },
 };
 
@@ -200,6 +214,44 @@ test("selectFeedPrice accepts finite positive prices only", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// feedStockIsConfident (STRK-325)
+//
+// Validated 2026-08-01 against 119 product pages: every product with
+// max(qty_max) > 1 across tiers was InStock on-page (25/25 control); products
+// capped at 1 split 80 OOS / 14 true single-unit inventory — inherently
+// ambiguous, so the vendor module page-scrapes those instead of trusting the
+// feed for stock.
+// ---------------------------------------------------------------------------
+
+test("feedStockIsConfident trusts stock only when some tier shows real inventory headroom", async () => {
+  const { feedStockIsConfident } = await import(feedModuleUrl);
+
+  assert.equal(feedStockIsConfident(PRODUCTS[101]), true, "multi-tier with thousands available");
+  assert.equal(feedStockIsConfident(PRODUCTS[202]), true, "single healthy tier");
+  // The 1 oz Gold Eagle shape: a qty-1 discount tier first, real headroom after —
+  // the max must be taken across ALL tiers, not the first.
+  assert.equal(
+    feedStockIsConfident({
+      tiers: [
+        { qty_range: "1 - 1", qty_min: 1, qty_max: 1, check_wire: 4080.46 },
+        { qty_range: "2+", qty_min: 2, qty_max: 912, check_wire: 4090.46 },
+      ],
+    }),
+    true,
+    "a qty-1 first tier with headroom behind it is in stock"
+  );
+
+  assert.equal(feedStockIsConfident(PRODUCTS[505]), false, "degenerate 1+/max-1 is ambiguous");
+  assert.equal(feedStockIsConfident(PRODUCTS[303]), false, "no tiers → no stock signal");
+  assert.equal(feedStockIsConfident({}), false, "missing tiers → no stock signal");
+  assert.equal(
+    feedStockIsConfident({ tiers: [{ qty_range: "1+", qty_min: 1, check_wire: 5 }] }),
+    false,
+    "tiers without usable qty_max → no stock signal"
+  );
+});
+
+// ---------------------------------------------------------------------------
 // lookupMintbuilderProduct — matching
 // ---------------------------------------------------------------------------
 
@@ -222,12 +274,32 @@ test("lookup matches a stored URL to a feed product across normalization drift",
       price: 38.42,
       link: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
       title: "1 oz Silver Buffalo Round",
+      stockConfident: true,
     },
   });
   assert.equal(fetchImpl.calls.length, 1);
   assert.ok(
     fetchImpl.calls[0].url.includes("mintbuilder=all"),
     "feed request should ask for the full catalog"
+  );
+});
+
+test("a hit on a degenerate-tier product carries stockConfident=false (STRK-325)", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  const result = await feed.lookupMintbuilderProduct({
+    url: "https://mintbuilder.com/products/sold-out-kangaroo",
+    apiKey: "test-key",
+    fetchImpl,
+  });
+
+  assert.equal(result.status, "hit", "ambiguous stock is still a price hit");
+  assert.equal(result.product.price, 61.16, "the feed price is still selected");
+  assert.equal(
+    result.product.stockConfident,
+    false,
+    "max(qty_max) <= 1 must flag the stock as unverified"
   );
 });
 

--- a/devops/pollers/shared/price-extract-vendor-mintbuilder.js
+++ b/devops/pollers/shared/price-extract-vendor-mintbuilder.js
@@ -74,6 +74,18 @@ export const vendor = {
     });
 
     if (resolved.status === "hit") {
+      // STRK-325 hybrid stock rule: the feed's tier data proves availability
+      // only when some tier shows inventory headroom (max qty_max > 1 —
+      // validated against 119 product pages). A degenerate cap of 1 cannot
+      // distinguish sold-out from last-unit, so those items fall through to
+      // the page scrape, whose JSON-LD availability is authoritative.
+      if (!resolved.product.stockConfident) {
+        log(
+          `[mintbuilder] feed stock unverified (max qty_max <= 1) for ${context.coinSlug} — ` +
+            "page-scrape fallback for authoritative availability"
+        );
+        return context.scrapeGeneric(context);
+      }
       return {
         price: resolved.product.price,
         inStock: true,

--- a/devops/pollers/shared/price-extract-vendor-mintbuilder.js
+++ b/devops/pollers/shared/price-extract-vendor-mintbuilder.js
@@ -81,7 +81,7 @@ export const vendor = {
       // the page scrape, whose JSON-LD availability is authoritative.
       if (!resolved.product.stockConfident) {
         log(
-          `[mintbuilder] feed stock unverified (max qty_max <= 1) for ${context.coinSlug} — ` +
+          `[mintbuilder] feed shows no tier inventory headroom for ${context.coinSlug} — ` +
             "page-scrape fallback for authoritative availability"
         );
         return context.scrapeGeneric(context);

--- a/devops/pollers/shared/price-extract-vendors.test.mjs
+++ b/devops/pollers/shared/price-extract-vendors.test.mjs
@@ -223,6 +223,7 @@ test("STRK-321: a feed hit returns mintbuilder-api and skips the page scrape", a
         price: 38.42,
         link: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
         title: "1 oz Silver Buffalo Round",
+        stockConfident: true,
       },
     }),
   });
@@ -255,7 +256,7 @@ test("STRK-321: the feed lookup receives the row URL and hints", async () => {
       observed = args;
       return {
         status: "hit",
-        product: { productId: "202", price: 412.77, link: null, title: null },
+        product: { productId: "202", price: 412.77, link: null, title: null, stockConfident: true },
       };
     },
   });
@@ -300,6 +301,41 @@ test("STRK-321: an unavailable feed falls back to the page scrape", async () => 
     assert.equal(calls.generic, 1, `${reason} must fall back to the page scraper`);
     assert.equal(result.source, "playwright-direct:jsonLd", `${reason} fallback result returned`);
   }
+});
+
+test("STRK-325: a hit with unverified stock page-scrapes instead of trusting the feed", async () => {
+  const registry = await import(new URL("./price-extract-vendors.js", import.meta.url));
+  const { context, calls } = mintbuilderContext({
+    mbFeedLookup: async () => ({
+      status: "hit",
+      product: {
+        productId: "1105",
+        price: 61.16,
+        link: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+        title: "Sold Out Kangaroo",
+        stockConfident: false,
+      },
+    }),
+  });
+
+  const result = await registry.scrapeVendor(context);
+
+  assert.equal(
+    calls.generic,
+    1,
+    "ambiguous feed stock (max qty_max <= 1) must fall through to the page scrape"
+  );
+  // The page scrape's result is authoritative for BOTH price and availability
+  // here — its JSON-LD availability check is what the feed cannot provide.
+  assert.deepEqual(result, {
+    price: 39.99,
+    inStock: false,
+    source: "playwright-direct:jsonLd",
+    ok: true,
+    error: null,
+    url: "https://mintbuilder.com/products/1oz-silver-buffalo-round",
+  });
+  assert.equal(calls.genericContext.config.waitUntil, "domcontentloaded");
 });
 
 test("registry returns migrated modules for completed Vendor migrations", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1415. The MintBuilder feed retains sold-out listings (empirically confirmed: kangaroo-silver #1105 and maple-gold #1072 are OOS on-page yet in the feed with prices), so the STRK-321 behavior of `inStock: true` on every feed hit misreports those items.

**Validated stock signal**: `tiers[].qty_max` tracks live sellable inventory. Swept all 94 products with `max(qty_max) <= 1` plus a 25-product control against page JSON-LD availability:

- `max(qty_max) > 1` → **25/25 InStock, zero inverse anomalies** — fully trustworthy.
- `max(qty_max) <= 1` → 80 OOS / 14 genuine single-unit listings — inherently ambiguous (zero-floored vs last unit).

**Hybrid rule**: new `feedStockIsConfident()` predicate in the feed client (max across ALL tiers — some in-stock products lead with a qty-1 discount tier, e.g. the 1 oz Gold Eagle) and a `stockConfident` flag on the hit projection. The vendor module trusts confident hits as before; ambiguous hits fall through to the page scrape, whose JSON-LD availability is authoritative for both price and stock. Cost today: 2 of 14 tracked SKUs page-scrape; everything else stays on the single feed GET. Degrades gracefully to pre-feed behavior.

## Testing

- Feed client: 21 tests (3 new — predicate table incl. the Gold Eagle multi-tier shape, ambiguous-hit projection, realistic tier fixtures).
- Vendor dispatch: 27 tests (1 new — ambiguous hit page-scrapes with the resolved context, STRK-314 rule preserved).
- Full poller suite sweep green; `npm run lint` green. No version bump (devops-only), no Playwright changes.

If MintBuilder later adds an explicit availability field (requested), the predicate is the single place to consume it.

Closes STRK-325 (Plane).