### PR TITLE
chore(skills): retail-poller MintBuilder API-direct update + stale-claims cleanup

### DIFF
--- a/.agents/skills/retail-poller/SKILL.md
+++ b/.agents/skills/retail-poller/SKILL.md
@@ -57,7 +57,7 @@ Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
 | `devops/pollers/shared/price-extract-vendors.js`            | Vendor module registry + `scrapeVendor()` dispatch (STRK-32/314)               |
 | `devops/pollers/shared/price-extract-vendor-mintbuilder.js` | MintBuilder feed-first `scrape()` with page-scrape fallback (STRK-321/325)     |
 | `devops/pollers/shared/price-extract-mintbuilder-feed.js`   | MintBuilder feed client — memoized index, URL matching, hybrid stock predicate |
-| `devops/pollers/remote-poller/run-local.sh`                 | Full Fly.io run: extract → capture → vision → export → push                    |
+| `devops/pollers/remote-poller/run-local.sh`                 | Fly.io run wrapper — retail scraping disabled in production (STAK-478)         |
 | `devops/pollers/remote-poller/run-publish.sh`               | API export + git push to api branch                                            |
 | `devops/pollers/remote-poller/docker-entrypoint.sh`         | Container startup (creates `/data/retail/`, writes crontab, exports env)       |
 | `devops/pollers/remote-poller/Dockerfile`                   | Fly.io all-in-one container image                                              |
@@ -190,11 +190,9 @@ SDB pages show "As Low As" only in add-on accessories and carousel sections — 
 
 If Firecrawl returns no price, `scrapeWithPlaywright()` tries a browserless remote browser (`BROWSERLESS_URL` env var). `SLOW_PROVIDERS = {jmbullion, herobullion, summitmetals}` get an extra 4s wait.
 
-### FBP Gap-Fill
+### FBP Gap-Fill (REMOVED — wrapper is dead code)
 
-After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps FBP dealer names to vendor ids, writes as `source: "fbp"` to sqld.
-
-`run-fbp.sh` (the PM cron at 3pm ET) runs `PATCH_GAPS=1 node price-extract.js` to fill only today's gaps.
+The FBP fallback no longer exists in `price-extract.js`: nothing reads `PATCH_GAPS`, `extractFbpPrices()` is gone, and no path writes `source: "fbp"`. `home-poller/run-fbp.sh` still sets `PATCH_GAPS=1` but the flag is silently ignored, and no cron invokes it (`docker-entrypoint.sh` is the cron authority). `provider_coins.fbp_url` remains as a vestigial column.
 
 ---
 

--- a/.agents/skills/retail-poller/SKILL.md
+++ b/.agents/skills/retail-poller/SKILL.md
@@ -25,13 +25,16 @@ api-export.js  (sqld + vision JSON → data/api/ REST endpoints → api branch)
 
 > **Repo:** All poller scripts now live in `StakTrakr/devops/pollers/` — shared core in `shared/`, Fly.io config in `remote-poller/`, home VM config in `home-poller/`. Deploy: `cd devops/pollers && fly deploy --config remote-poller/fly.toml`. The old `StakTrakrApi/devops/fly-poller/` location is deprecated.
 
-**Fly.io container is the sole scraping pipeline — no GHA cloud fallback:**
+**Home poller is the sole retail scraper (STAK-478) — Fly.io only publishes:**
 
-| Pipeline                    | Browser                                    | Role               | Trigger                         |
-| --------------------------- | ------------------------------------------ | ------------------ | ------------------------------- |
-| **Fly.io** (`run-local.sh`) | Playwright (self-hosted, `localhost:3002`) | **Primary + only** | Every 15 min via container cron |
+| Pipeline                      | Browser                               | Role                          | Trigger                            |
+| ----------------------------- | ------------------------------------- | ----------------------------- | ---------------------------------- |
+| **Home VM** (`run-home.sh`)   | Playwright local + Firecrawl + Byparr | **Sole retail scraper**       | Hourly at `:30` via container cron |
+| **Fly.io** (`run-publish.sh`) | —                                     | Publisher (sqld → api branch) | `8,23,38,53 * * * *`               |
 
-**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). All retail scraping now runs exclusively in the Fly.io container via self-hosted Firecrawl + the Portainer VM secondary poller. Manage containers via Portainer REST API — see `home-infrastructure` skill.
+**Exception — MintBuilder is feed-first (STRK-321/325):** resolved against the direct vendor API (one memoized GET per run) with page-scrape fallback; see the Direct API Access table below.
+
+**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). Manage containers via Portainer REST API — see `home-infrastructure` skill.
 
 **Key constraint:** `providers.json` lives on the **`api` branch**, not `main` or `dev`.
 Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
@@ -42,21 +45,24 @@ Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
 
 ## File Map
 
-| File                                                | Purpose                                                                        |
-| --------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `devops/pollers/shared/price-extract.js`            | Primary scraper — Firecrawl + Playwright fallback → sqld                       |
-| `devops/pollers/shared/capture.js`                  | Screenshot capture — `BROWSER_MODE=browserless` / `browserbase` / `local`      |
-| `devops/pollers/shared/extract-vision.js`           | Gemini Vision price extraction from screenshots → per-coin JSON files          |
-| `devops/pollers/shared/api-export.js`               | sqld + vision JSON → `data/api/` static JSON endpoints with confidence scoring |
-| `devops/pollers/shared/export-providers-json.js`    | sqld → `/data/retail/providers.json` (runs every 5 min via cron)               |
-| `devops/pollers/shared/turso-client.js`             | sqld/libSQL client factory                                                     |
-| `devops/pollers/shared/provider-db.js`              | Provider CRUD + export from sqld                                               |
-| `devops/pollers/remote-poller/run-local.sh`         | Full Fly.io run: extract → capture → vision → export → push                    |
-| `devops/pollers/remote-poller/run-publish.sh`       | API export + git push to api branch                                            |
-| `devops/pollers/remote-poller/docker-entrypoint.sh` | Container startup (creates `/data/retail/`, writes crontab, exports env)       |
-| `devops/pollers/remote-poller/Dockerfile`           | Fly.io all-in-one container image                                              |
-| `devops/pollers/home-poller/run-home.sh`            | Home VM retail scrape run                                                      |
-| `devops/pollers/home-poller/docker-entrypoint.sh`   | Home container startup                                                         |
+| File                                                        | Purpose                                                                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `devops/pollers/shared/price-extract.js`                    | Primary scraper — Firecrawl + Playwright fallback → sqld                       |
+| `devops/pollers/shared/capture.js`                          | Screenshot capture — `BROWSER_MODE=browserless` / `browserbase` / `local`      |
+| `devops/pollers/shared/extract-vision.js`                   | Gemini Vision price extraction from screenshots → per-coin JSON files          |
+| `devops/pollers/shared/api-export.js`                       | sqld + vision JSON → `data/api/` static JSON endpoints with confidence scoring |
+| `devops/pollers/shared/export-providers-json.js`            | sqld → `/data/retail/providers.json` (runs every 5 min via cron)               |
+| `devops/pollers/shared/turso-client.js`                     | sqld/libSQL client factory                                                     |
+| `devops/pollers/shared/provider-db.js`                      | Provider CRUD + export from sqld                                               |
+| `devops/pollers/shared/price-extract-vendors.js`            | Vendor module registry + `scrapeVendor()` dispatch (STRK-32/314)               |
+| `devops/pollers/shared/price-extract-vendor-mintbuilder.js` | MintBuilder feed-first `scrape()` with page-scrape fallback (STRK-321/325)     |
+| `devops/pollers/shared/price-extract-mintbuilder-feed.js`   | MintBuilder feed client — memoized index, URL matching, hybrid stock predicate |
+| `devops/pollers/remote-poller/run-local.sh`                 | Full Fly.io run: extract → capture → vision → export → push                    |
+| `devops/pollers/remote-poller/run-publish.sh`               | API export + git push to api branch                                            |
+| `devops/pollers/remote-poller/docker-entrypoint.sh`         | Container startup (creates `/data/retail/`, writes crontab, exports env)       |
+| `devops/pollers/remote-poller/Dockerfile`                   | Fly.io all-in-one container image                                              |
+| `devops/pollers/home-poller/run-home.sh`                    | Home VM retail scrape run                                                      |
+| `devops/pollers/home-poller/docker-entrypoint.sh`           | Home container startup                                                         |
 
 ---
 
@@ -64,10 +70,11 @@ Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
 
 ### Direct API Access (No Scraping Needed)
 
-| Vendor         | Platform        | API                                    | Auth | Notes                                                  |
-| -------------- | --------------- | -------------------------------------- | ---- | ------------------------------------------------------ |
-| **SD Bullion** | Magento 2       | REST `/rest/V1/nfusions/cache/pricing` | None | Full catalog (6,003 SKUs), tiered pricing, cash/BTC/CC |
-| **APMEX**      | Traditional SSR | JSON-LD in HTML                        | None | `schema.org/Product` with price + availability         |
+| Vendor          | Platform        | API                                          | Auth         | Notes                                                                                                                                                                              |
+| --------------- | --------------- | -------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MintBuilder** | Custom          | `GET /feed/api/prices?key=…&mintbuilder=all` | `MB_API_KEY` | **LIVE (STRK-321/325)** — feed-first vendor module, ~314 products; `tiers[].qty_max` = live inventory; hybrid stock rule: `max(qty_max) ≤ 1` is ambiguous → that item page-scrapes |
+| **SD Bullion**  | Magento 2       | REST `/rest/V1/nfusions/cache/pricing`       | None         | Full catalog (6,003 SKUs), tiered pricing, cash/BTC/CC — documented, not wired                                                                                                     |
+| **APMEX**       | Traditional SSR | JSON-LD in HTML                              | None         | `schema.org/Product` with price + availability                                                                                                                                     |
 
 ### Cloudflare-Gated APIs (Need CF Cookie)
 
@@ -136,9 +143,9 @@ Located at `$DATA_REPO_PATH/data/retail/providers.json` on the **api branch**.
 
 **Coin fields:** `name`, `metal` (`silver`/`gold`/`platinum`/`palladium`), `weight_oz`, `fbp_url` (FindBullionPrices fallback URL)
 
-**Provider fields:** `id` (matches `FBP_DEALER_NAME_MAP` key in price-extract.js), `enabled`, `url`
+**Provider fields:** `id` (the vendor id dispatched through the `price-extract-vendors.js` registry — migrated modules or the legacy adapter), `enabled`, `url`, plus optional `selector`, `hints` (free-form JSON; carries `{"mbProductId"}` for MintBuilder feed pinning), `skipPriceBounds`
 
-To add a new vendor: add to `FBP_DEALER_NAME_MAP` in `price-extract.js` AND add to each coin's `providers[]` in `providers.json`.
+To add a new vendor: add its rows via the dashboard (`/providers`, writes sqld `provider_vendors`); write a vendor module + register it in `price-extract-vendors.js` only when it needs custom behavior. (`FBP_DEALER_NAME_MAP` no longer exists.)
 
 ---
 
@@ -185,7 +192,7 @@ If Firecrawl returns no price, `scrapeWithPlaywright()` tries a browserless remo
 
 ### FBP Gap-Fill
 
-After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps dealer names via `FBP_DEALER_NAME_MAP`, writes as `source: "fbp"` to sqld.
+After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps FBP dealer names to vendor ids, writes as `source: "fbp"` to sqld.
 
 `run-fbp.sh` (the PM cron at 3pm ET) runs `PATCH_GAPS=1 node price-extract.js` to fill only today's gaps.
 

--- a/.claude/skills/retail-poller/SKILL.md
+++ b/.claude/skills/retail-poller/SKILL.md
@@ -57,7 +57,7 @@ Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
 | `devops/pollers/shared/price-extract-vendors.js`            | Vendor module registry + `scrapeVendor()` dispatch (STRK-32/314)               |
 | `devops/pollers/shared/price-extract-vendor-mintbuilder.js` | MintBuilder feed-first `scrape()` with page-scrape fallback (STRK-321/325)     |
 | `devops/pollers/shared/price-extract-mintbuilder-feed.js`   | MintBuilder feed client — memoized index, URL matching, hybrid stock predicate |
-| `devops/pollers/remote-poller/run-local.sh`                 | Full Fly.io run: extract → capture → vision → export → push                    |
+| `devops/pollers/remote-poller/run-local.sh`                 | Fly.io run wrapper — retail scraping disabled in production (STAK-478)         |
 | `devops/pollers/remote-poller/run-publish.sh`               | API export + git push to api branch                                            |
 | `devops/pollers/remote-poller/docker-entrypoint.sh`         | Container startup (creates `/data/retail/`, writes crontab, exports env)       |
 | `devops/pollers/remote-poller/Dockerfile`                   | Fly.io all-in-one container image                                              |
@@ -190,11 +190,9 @@ SDB pages show "As Low As" only in add-on accessories and carousel sections — 
 
 If Firecrawl returns no price, `scrapeWithPlaywright()` tries a browserless remote browser (`BROWSERLESS_URL` env var). `SLOW_PROVIDERS = {jmbullion, herobullion, summitmetals}` get an extra 4s wait.
 
-### FBP Gap-Fill
+### FBP Gap-Fill (REMOVED — wrapper is dead code)
 
-After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps FBP dealer names to vendor ids, writes as `source: "fbp"` to sqld.
-
-`run-fbp.sh` (the PM cron at 3pm ET) runs `PATCH_GAPS=1 node price-extract.js` to fill only today's gaps.
+The FBP fallback no longer exists in `price-extract.js`: nothing reads `PATCH_GAPS`, `extractFbpPrices()` is gone, and no path writes `source: "fbp"`. `home-poller/run-fbp.sh` still sets `PATCH_GAPS=1` but the flag is silently ignored, and no cron invokes it (`docker-entrypoint.sh` is the cron authority). `provider_coins.fbp_url` remains as a vestigial column.
 
 ---
 

--- a/.claude/skills/retail-poller/SKILL.md
+++ b/.claude/skills/retail-poller/SKILL.md
@@ -25,13 +25,16 @@ api-export.js  (sqld + vision JSON → data/api/ REST endpoints → api branch)
 
 > **Repo:** All poller scripts now live in `StakTrakr/devops/pollers/` — shared core in `shared/`, Fly.io config in `remote-poller/`, home VM config in `home-poller/`. Deploy: `cd devops/pollers && fly deploy --config remote-poller/fly.toml`. The old `StakTrakrApi/devops/fly-poller/` location is deprecated.
 
-**Fly.io container is the sole scraping pipeline — no GHA cloud fallback:**
+**Home poller is the sole retail scraper (STAK-478) — Fly.io only publishes:**
 
-| Pipeline                    | Browser                                    | Role               | Trigger                         |
-| --------------------------- | ------------------------------------------ | ------------------ | ------------------------------- |
-| **Fly.io** (`run-local.sh`) | Playwright (self-hosted, `localhost:3002`) | **Primary + only** | Every 15 min via container cron |
+| Pipeline                      | Browser                               | Role                          | Trigger                            |
+| ----------------------------- | ------------------------------------- | ----------------------------- | ---------------------------------- |
+| **Home VM** (`run-home.sh`)   | Playwright local + Firecrawl + Byparr | **Sole retail scraper**       | Hourly at `:30` via container cron |
+| **Fly.io** (`run-publish.sh`) | —                                     | Publisher (sqld → api branch) | `8,23,38,53 * * * *`               |
 
-**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). All retail scraping now runs exclusively in the Fly.io container via self-hosted Firecrawl + the Portainer VM secondary poller. Manage containers via Portainer REST API — see `home-infrastructure` skill.
+**Exception — MintBuilder is feed-first (STRK-321/325):** resolved against the direct vendor API (one memoized GET per run) with page-scrape fallback; see the Direct API Access table below.
+
+**No GHA cloud failsafe for retail.** `retail-price-poller.yml` was deleted 2026-02-22 (was sending requests to public Firecrawl cloud API, burning paid credits — STAK-268). Manage containers via Portainer REST API — see `home-infrastructure` skill.
 
 **Key constraint:** `providers.json` lives on the **`api` branch**, not `main` or `dev`.
 Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
@@ -42,21 +45,24 @@ Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
 
 ## File Map
 
-| File                                                | Purpose                                                                        |
-| --------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `devops/pollers/shared/price-extract.js`            | Primary scraper — Firecrawl + Playwright fallback → sqld                       |
-| `devops/pollers/shared/capture.js`                  | Screenshot capture — `BROWSER_MODE=browserless` / `browserbase` / `local`      |
-| `devops/pollers/shared/extract-vision.js`           | Gemini Vision price extraction from screenshots → per-coin JSON files          |
-| `devops/pollers/shared/api-export.js`               | sqld + vision JSON → `data/api/` static JSON endpoints with confidence scoring |
-| `devops/pollers/shared/export-providers-json.js`    | sqld → `/data/retail/providers.json` (runs every 5 min via cron)               |
-| `devops/pollers/shared/turso-client.js`             | sqld/libSQL client factory                                                     |
-| `devops/pollers/shared/provider-db.js`              | Provider CRUD + export from sqld                                               |
-| `devops/pollers/remote-poller/run-local.sh`         | Full Fly.io run: extract → capture → vision → export → push                    |
-| `devops/pollers/remote-poller/run-publish.sh`       | API export + git push to api branch                                            |
-| `devops/pollers/remote-poller/docker-entrypoint.sh` | Container startup (creates `/data/retail/`, writes crontab, exports env)       |
-| `devops/pollers/remote-poller/Dockerfile`           | Fly.io all-in-one container image                                              |
-| `devops/pollers/home-poller/run-home.sh`            | Home VM retail scrape run                                                      |
-| `devops/pollers/home-poller/docker-entrypoint.sh`   | Home container startup                                                         |
+| File                                                        | Purpose                                                                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `devops/pollers/shared/price-extract.js`                    | Primary scraper — Firecrawl + Playwright fallback → sqld                       |
+| `devops/pollers/shared/capture.js`                          | Screenshot capture — `BROWSER_MODE=browserless` / `browserbase` / `local`      |
+| `devops/pollers/shared/extract-vision.js`                   | Gemini Vision price extraction from screenshots → per-coin JSON files          |
+| `devops/pollers/shared/api-export.js`                       | sqld + vision JSON → `data/api/` static JSON endpoints with confidence scoring |
+| `devops/pollers/shared/export-providers-json.js`            | sqld → `/data/retail/providers.json` (runs every 5 min via cron)               |
+| `devops/pollers/shared/turso-client.js`                     | sqld/libSQL client factory                                                     |
+| `devops/pollers/shared/provider-db.js`                      | Provider CRUD + export from sqld                                               |
+| `devops/pollers/shared/price-extract-vendors.js`            | Vendor module registry + `scrapeVendor()` dispatch (STRK-32/314)               |
+| `devops/pollers/shared/price-extract-vendor-mintbuilder.js` | MintBuilder feed-first `scrape()` with page-scrape fallback (STRK-321/325)     |
+| `devops/pollers/shared/price-extract-mintbuilder-feed.js`   | MintBuilder feed client — memoized index, URL matching, hybrid stock predicate |
+| `devops/pollers/remote-poller/run-local.sh`                 | Full Fly.io run: extract → capture → vision → export → push                    |
+| `devops/pollers/remote-poller/run-publish.sh`               | API export + git push to api branch                                            |
+| `devops/pollers/remote-poller/docker-entrypoint.sh`         | Container startup (creates `/data/retail/`, writes crontab, exports env)       |
+| `devops/pollers/remote-poller/Dockerfile`                   | Fly.io all-in-one container image                                              |
+| `devops/pollers/home-poller/run-home.sh`                    | Home VM retail scrape run                                                      |
+| `devops/pollers/home-poller/docker-entrypoint.sh`           | Home container startup                                                         |
 
 ---
 
@@ -64,10 +70,11 @@ Path on disk: `$DATA_REPO_PATH/data/retail/providers.json`
 
 ### Direct API Access (No Scraping Needed)
 
-| Vendor         | Platform        | API                                    | Auth | Notes                                                  |
-| -------------- | --------------- | -------------------------------------- | ---- | ------------------------------------------------------ |
-| **SD Bullion** | Magento 2       | REST `/rest/V1/nfusions/cache/pricing` | None | Full catalog (6,003 SKUs), tiered pricing, cash/BTC/CC |
-| **APMEX**      | Traditional SSR | JSON-LD in HTML                        | None | `schema.org/Product` with price + availability         |
+| Vendor          | Platform        | API                                          | Auth         | Notes                                                                                                                                                                              |
+| --------------- | --------------- | -------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MintBuilder** | Custom          | `GET /feed/api/prices?key=…&mintbuilder=all` | `MB_API_KEY` | **LIVE (STRK-321/325)** — feed-first vendor module, ~314 products; `tiers[].qty_max` = live inventory; hybrid stock rule: `max(qty_max) ≤ 1` is ambiguous → that item page-scrapes |
+| **SD Bullion**  | Magento 2       | REST `/rest/V1/nfusions/cache/pricing`       | None         | Full catalog (6,003 SKUs), tiered pricing, cash/BTC/CC — documented, not wired                                                                                                     |
+| **APMEX**       | Traditional SSR | JSON-LD in HTML                              | None         | `schema.org/Product` with price + availability                                                                                                                                     |
 
 ### Cloudflare-Gated APIs (Need CF Cookie)
 
@@ -136,9 +143,9 @@ Located at `$DATA_REPO_PATH/data/retail/providers.json` on the **api branch**.
 
 **Coin fields:** `name`, `metal` (`silver`/`gold`/`platinum`/`palladium`), `weight_oz`, `fbp_url` (FindBullionPrices fallback URL)
 
-**Provider fields:** `id` (matches `FBP_DEALER_NAME_MAP` key in price-extract.js), `enabled`, `url`
+**Provider fields:** `id` (the vendor id dispatched through the `price-extract-vendors.js` registry — migrated modules or the legacy adapter), `enabled`, `url`, plus optional `selector`, `hints` (free-form JSON; carries `{"mbProductId"}` for MintBuilder feed pinning), `skipPriceBounds`
 
-To add a new vendor: add to `FBP_DEALER_NAME_MAP` in `price-extract.js` AND add to each coin's `providers[]` in `providers.json`.
+To add a new vendor: add its rows via the dashboard (`/providers`, writes sqld `provider_vendors`); write a vendor module + register it in `price-extract-vendors.js` only when it needs custom behavior. (`FBP_DEALER_NAME_MAP` no longer exists.)
 
 ---
 
@@ -185,7 +192,7 @@ If Firecrawl returns no price, `scrapeWithPlaywright()` tries a browserless remo
 
 ### FBP Gap-Fill
 
-After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps dealer names via `FBP_DEALER_NAME_MAP`, writes as `source: "fbp"` to sqld.
+After primary scrapes, any coin with failures scrapes `fbp_url` (FindBullionPrices comparison table). `extractFbpPrices()` parses FBP table rows, maps FBP dealer names to vendor ids, writes as `source: "fbp"` to sqld.
 
 `run-fbp.sh` (the PM cron at 3pm ET) runs `PATCH_GAPS=1 node price-extract.js` to fill only today's gaps.
 


### PR DESCRIPTION
Trivial docs chore (skill twins only, no runtime code): documents the live MintBuilder direct feed (STRK-321/325) in the retail-poller skill, fixes the stale Fly.io-primary retail claim (home poller is sole retail scraper per STAK-478, hourly :30), removes dead FBP_DEALER_NAME_MAP references, and adds the feed-client modules to the file map. Both .claude/.agents twins updated identically (diff-verified). agentlinter --local: zero criticals.