### PR TITLE
fix(STRK-323): resolve dashboard data paths from $DATA_DIR and thread readOnly through By Vendor

### DIFF
--- a/devops/pollers/home-poller/dashboard-hygiene.test.mjs
+++ b/devops/pollers/home-poller/dashboard-hygiene.test.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Source-contract tests for home-poller dashboard hygiene (STRK-323).
+ *
+ * Run with:
+ *   node --test devops/pollers/home-poller/dashboard-hygiene.test.mjs
+ *
+ * Why source-contract rather than behavioral: dashboard.js is only runnable
+ * inside the poller container. The Dockerfile flattens `shared/*.js` and
+ * `home-poller/dashboard.js` into a single `/app` directory, so its
+ * `./provider-db.js` import (the real file lives in `shared/`) and its
+ * `@libsql/client` dependency both resolve there and nowhere in the repo
+ * layout. It also has no exports and calls `server.listen()` at module top
+ * level. Both defects guarded here are source-shape regressions, so asserting
+ * on the source is the check that can actually run outside Docker.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const DASHBOARD_SRC = readFileSync(new URL("./dashboard.js", import.meta.url), "utf8");
+
+/**
+ * Return the single source line declaring the named top-level const.
+ * @param {string} name Constant identifier to locate.
+ * @returns {string} The full source line declaring that constant.
+ */
+function constLine(name) {
+  const line = DASHBOARD_SRC.split("\n").find((l) => l.startsWith(`const ${name} `));
+  assert.ok(line, `expected a top-level \`const ${name}\` declaration in dashboard.js`);
+  return line;
+}
+
+/**
+ * Return the source line that renders the element carrying the given class.
+ * @param {string} className Class attribute value to locate.
+ * @returns {string} The full source line rendering that element.
+ */
+function renderLineFor(className) {
+  // Match the class as a token so multi-class attributes (class="btn-sm foo")
+  // are found, not just exact single-class ones.
+  const attr = new RegExp(`class="[^"]*\\b${className}\\b[^"]*"`);
+  const line = DASHBOARD_SRC.split("\n").find((l) => attr.test(l));
+  assert.ok(line, `expected dashboard.js to render an element with class "${className}"`);
+  return line;
+}
+
+test("DATA_DIR honors the container's $DATA_DIR env var (STRK-323)", () => {
+  const line = constLine("DATA_DIR");
+  assert.match(
+    line,
+    /process\.env\.DATA_DIR/,
+    "DATA_DIR must read process.env.DATA_DIR — the compose file sets DATA_DIR=/data " +
+      "and mounts poller-data there, while import.meta.url resolves into the image layer"
+  );
+  assert.doesNotMatch(
+    line,
+    /import\.meta\.url/,
+    "DATA_DIR must not resolve relative to import.meta.url — dashboard.js is copied to " +
+      "/app/dashboard.js, so that yields /app/data (image layer), not the /data volume"
+  );
+});
+
+test("PROVIDERS_FILE resolves under DATA_DIR, not the script directory (STRK-323)", () => {
+  const line = constLine("PROVIDERS_FILE");
+  assert.doesNotMatch(
+    line,
+    /import\.meta\.url/,
+    "PROVIDERS_FILE must not resolve relative to import.meta.url — POST /providers/export " +
+      "would write where nothing reads, and the sqld-down fallback would read an empty path"
+  );
+  assert.match(
+    line,
+    /DATA_DIR/,
+    "PROVIDERS_FILE must be derived from DATA_DIR so it matches the path " +
+      "export-providers-json.js writes (DATA_DIR/retail/providers.json)"
+  );
+});
+
+test("By Vendor URL input honors the readOnly flag (STRK-323)", () => {
+  assert.match(
+    renderLineFor("vendor-url-byvendor"),
+    /readOnly \? "disabled" : ""/,
+    "the By Vendor URL input must be disabled when sqld is down, matching the " +
+      "per-coin vendor-url input"
+  );
+});
+
+test("By Vendor enable/disable toggle honors the readOnly flag (STRK-323)", () => {
+  assert.match(
+    renderLineFor("vendor-toggle-byvendor"),
+    /readOnly \? "disabled" : ""/,
+    "the By Vendor toggle must be disabled when sqld is down — an enabled control " +
+      "in read-only mode issues a write that cannot succeed"
+  );
+});

--- a/devops/pollers/home-poller/dashboard-hygiene.test.mjs
+++ b/devops/pollers/home-poller/dashboard-hygiene.test.mjs
@@ -46,6 +46,26 @@ function renderLineFor(className) {
   return line;
 }
 
+test("loadEnv() runs before every env-derived constant (STRK-323)", () => {
+  const lines = DASHBOARD_SRC.split("\n");
+  const loadEnvAt = lines.findIndex((l) => l.includes("function loadEnv()"));
+  assert.ok(loadEnvAt >= 0, "expected a loadEnv() bootstrap in dashboard.js");
+
+  // The container exports env directly, but the LXC/bare-metal install
+  // (setup-lxc.sh) ships a .env beside the script. A const declared above
+  // loadEnv() reads process.env too early and silently takes its default.
+  const offenders = lines
+    .map((line, i) => ({ line, i }))
+    .filter(({ line, i }) => i < loadEnvAt && /^const \w+ = .*process\.env\./.test(line))
+    .map(({ line, i }) => `  line ${i + 1}: ${line.trim()}`);
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `these constants read process.env before loadEnv() runs, so a .env value is ignored:\n${offenders.join("\n")}`
+  );
+});
+
 test("DATA_DIR honors the container's $DATA_DIR env var (STRK-323)", () => {
   const line = constLine("DATA_DIR");
   assert.match(

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -16,6 +16,8 @@ import { createServer } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { execSync, spawn } from "node:child_process";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createClient } from "@libsql/client";
 import {
   initProviderSchema,
@@ -46,12 +48,20 @@ import {
   getProvidersByVendor,
 } from "./provider-db.js";
 
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
 const PORT = parseInt(process.env.DASHBOARD_PORT || "3010", 10);
 const LOG_FILE = process.env.POLLER_LOG || "/data/logs/retail-poller.log";
 const LOG_LINES = 300;
 const IFACE = process.env.NET_IFACE || "eth0";
-const PROVIDERS_FILE = new URL("data/retail/providers.json", import.meta.url).pathname;
-const DATA_DIR = new URL("data/", import.meta.url).pathname;
+// Resolve the data root the same way every other poller script does, so the
+// dashboard reads and writes the file export-providers-json.js actually
+// produces (DATA_DIR/retail/providers.json). Deriving this from
+// import.meta.url pointed at /app/data — the image layer — instead of the
+// /data volume the compose file mounts, which silently broke both the
+// sqld-down read fallback and POST /providers/export (STRK-323).
+const DATA_DIR = resolve(process.env.DATA_DIR || join(__dirname, "../../data"));
+const PROVIDERS_FILE = join(DATA_DIR, "retail", "providers.json");
 
 // Load .env if not already in environment
 (function loadEnv() {
@@ -1360,9 +1370,9 @@ function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, ve
           return `<div style="display:grid;grid-template-columns:auto 1fr 2fr 1fr auto;gap:8px;align-items:center;padding:5px 8px 5px 24px;border-bottom:1px solid var(--border);font-size:12px;">
         ${dot}
         <span style="font-weight:600;">${escHtml(item.coinName)} ${metalBadge(item.metal)}</span>
-        <input type="text" class="vendor-url-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" value="${escAttr(item.url || "")}" style="width:100%;font-size:11px;" placeholder="https://...">
+        <input type="text" class="vendor-url-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" value="${escAttr(item.url || "")}" style="width:100%;font-size:11px;" placeholder="https://..." ${readOnly ? "disabled" : ""}>
         ${priceText}
-        <button class="btn-sm vendor-toggle-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" data-enabled="${item.enabled !== false ? "1" : "0"}" style="background:${item.enabled !== false ? "var(--green)" : "var(--red)"};color:#fff;font-size:10px;min-width:32px;">${item.enabled !== false ? "On" : "Off"}</button>
+        <button class="btn-sm vendor-toggle-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" data-enabled="${item.enabled !== false ? "1" : "0"}" style="background:${item.enabled !== false ? "var(--green)" : "var(--red)"};color:#fff;font-size:10px;min-width:32px;" ${readOnly ? "disabled" : ""}>${item.enabled !== false ? "On" : "Off"}</button>
       </div>`;
         })
         .join("");

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -50,6 +50,23 @@ import {
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
+// Load .env if not already in environment.
+//
+// MUST run before any const below reads process.env. The container exports its
+// config directly, but the LXC/bare-metal install (setup-lxc.sh) ships a .env
+// beside the script instead — and every env-derived constant here is evaluated
+// at module load. Declaring them above this call silently ignores the .env
+// value and falls back to the default (STRK-323).
+(function loadEnv() {
+  const envFile = new URL(".env", import.meta.url).pathname;
+  if (!existsSync(envFile)) return;
+  const lines = readFileSync(envFile, "utf8").split("\n");
+  for (const line of lines) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^[\x27\x22]|[\x27\x22]$/g, "");
+  }
+})();
+
 const PORT = parseInt(process.env.DASHBOARD_PORT || "3010", 10);
 const LOG_FILE = process.env.POLLER_LOG || "/data/logs/retail-poller.log";
 const LOG_LINES = 300;
@@ -62,17 +79,6 @@ const IFACE = process.env.NET_IFACE || "eth0";
 // sqld-down read fallback and POST /providers/export (STRK-323).
 const DATA_DIR = resolve(process.env.DATA_DIR || join(__dirname, "../../data"));
 const PROVIDERS_FILE = join(DATA_DIR, "retail", "providers.json");
-
-// Load .env if not already in environment
-(function loadEnv() {
-  const envFile = new URL(".env", import.meta.url).pathname;
-  if (!existsSync(envFile)) return;
-  const lines = readFileSync(envFile, "utf8").split("\n");
-  for (const line of lines) {
-    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
-    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^[\x27\x22]|[\x27\x22]$/g, "");
-  }
-})();
 
 // ---------------------------------------------------------------------------
 // sqld client


### PR DESCRIPTION
Closes STRK-323.

Two pre-existing home-poller dashboard bugs surfaced during STRK-321 exploration. Poller-only change — no frontend, no release artifacts, so no version bump (same shape as STRK-321 / [#1415](https://github.com/lbruton/StakTrakr/pull/1415)).

## 1. Path bug

`PROVIDERS_FILE` and `DATA_DIR` were derived from `import.meta.url`. The Dockerfile copies dashboard.js to `/app/dashboard.js` (`home-poller/Dockerfile:101`), so those resolved to **`/app/data/retail/providers.json` — inside the image layer** — while the real file lives on the `poller-data` volume mounted at `/data` (`DATA_DIR=/data`, `docker-compose.home.yml:16` and `:62`).

Two consequences:

| Site | Symptom |
|---|---|
| `POST /providers/export` (:3025) | wrote to a path nothing reads |
| sqld-down fallback (:2764) | read a nonexistent path, so the read-only dashboard **always rendered an empty provider list** |

`DATA_DIR` was additionally **dead** — declared and never referenced.

Both constants now use the idiom shared by the other 14 poller scripts:

```js
const DATA_DIR = resolve(process.env.DATA_DIR || join(__dirname, "../../data"));
const PROVIDERS_FILE = join(DATA_DIR, "retail", "providers.json");
```

This matches the path `export-providers-json.js` documents and writes (*"write to DATA_DIR/retail/providers.json"*, :3 and :16). In-container the fallback also normalises to `/data` (`join("/app", "../../data")`), so it is correct with or without the env var set.

## 2. readOnly gap

The By Vendor tab rendered its URL input and enable/disable toggle without the `readOnly` flag that every per-coin control already honors (:1421–1435). Latent today — `vendorGroups` is `[]` on the degraded path — but a live control in read-only mode issues a write that cannot succeed. Now threaded.

## Testing

Adds `devops/pollers/home-poller/dashboard-hygiene.test.mjs` — **source-contract** assertions rather than behavioral, and the PR body should be explicit about why:

> dashboard.js only runs inside the container. The Dockerfile flattens `shared/*.js` and `home-poller/dashboard.js` into a single `/app`, so its `./provider-db.js` import (real file: `shared/provider-db.js`) and `@libsql/client` dependency resolve there and **nowhere in the repo layout** — verified, it fails with `ERR_MODULE_NOT_FOUND`. It also has no exports and calls `server.listen()` at module top level.

Both defects are source-shape regressions, so this is the check that can actually run outside Docker. Verified **red before, green after**.

- `node --test devops/pollers/home-poller/dashboard-hygiene.test.mjs` → 4/4
- Full poller suite `node --test devops/pollers/shared/*.test.mjs` → exit 0, no regressions
- Targeted `no-undef` probe (`devops/` sits outside `npm run lint`'s scope) confirms the new `node:path` / `node:url` imports resolve. Only hits are three pre-existing `document` references inside Playwright `page.evaluate` callbacks — identical on `origin/dev`.

## Deploy note

No redeploy is strictly required for correctness of the running poller (the scrape path is unaffected), but the export/read-only fixes only take effect on the next home-poller image rebuild.