### PR TITLE
feat(STRK-324): dashboard API-feed controls — product ID pin, match badge, feed health

### DIFF
--- a/devops/pollers/home-poller/dashboard-hygiene.test.mjs
+++ b/devops/pollers/home-poller/dashboard-hygiene.test.mjs
@@ -165,6 +165,29 @@ test("the feed health probe is bounded so a long-running dashboard refreshes (ST
   );
 });
 
+test("the feed probe stays off the /providers response path (STRK-324)", () => {
+  const handler = DASHBOARD_SRC.slice(
+    DASHBOARD_SRC.indexOf('url === "/providers"'),
+    DASHBOARD_SRC.indexOf('url === "/providers/coin-data"')
+  );
+  assert.ok(handler.length > 0, "expected a GET /providers handler");
+
+  // buildFeedState allows two 15s attempts plus a 2s retry delay. Awaiting it
+  // while rendering would stall the entire provider editor for ~32s on the
+  // first load after each cache expiry whenever the vendor endpoint hangs.
+  assert.doesNotMatch(
+    handler,
+    /probeFeedHealth\(/,
+    "the provider page must not await an external vendor endpoint; the health " +
+      "line is fetched client-side from GET /providers/feed-health"
+  );
+  assert.match(
+    DASHBOARD_SRC,
+    /url === "\/providers\/feed-health"/,
+    "expected a separate feed-health endpoint"
+  );
+});
+
 test("By Vendor URL input honors the readOnly flag (STRK-323)", () => {
   assert.match(
     renderLineFor("vendor-url-byvendor"),

--- a/devops/pollers/home-poller/dashboard-hygiene.test.mjs
+++ b/devops/pollers/home-poller/dashboard-hygiene.test.mjs
@@ -130,6 +130,32 @@ test("the product-id endpoint writes hints only, never updateVendorFields (STRK-
   );
 });
 
+test("vendor section expand/collapse resolves the body by class, not position (STRK-324)", () => {
+  const raw = DASHBOARD_SRC.slice(
+    DASHBOARD_SRC.indexOf("document.querySelectorAll('.vendor-section-header')"),
+    DASHBOARD_SRC.indexOf("document.querySelectorAll('.vendor-url-byvendor')")
+  );
+  assert.ok(raw.length > 0, "expected a .vendor-section-header click handler");
+  // Assert on code, not prose — the comment explaining the fix names the very
+  // API the guard forbids.
+  const handler = raw.replace(/\/\/[^\n]*/g, "");
+
+  // API-fed vendors render a feed health line between the header and the rows.
+  // A nextElementSibling lookup then toggles the health line and the item rows
+  // never expand — for exactly the vendor the feed controls exist to operate.
+  assert.doesNotMatch(
+    handler,
+    /nextElementSibling/,
+    "positional lookup breaks whenever anything is rendered between the header " +
+      "and .vendor-section-body"
+  );
+  assert.match(
+    handler,
+    /querySelector\(['"]\.vendor-section-body['"]\)/,
+    "the collapse target must be resolved by class"
+  );
+});
+
 test("the feed health probe is bounded so a long-running dashboard refreshes (STRK-324)", () => {
   assert.match(
     DASHBOARD_SRC,

--- a/devops/pollers/home-poller/dashboard-hygiene.test.mjs
+++ b/devops/pollers/home-poller/dashboard-hygiene.test.mjs
@@ -98,6 +98,47 @@ test("PROVIDERS_FILE resolves under DATA_DIR, not the script directory (STRK-323
   );
 });
 
+test("By Vendor API product ID input honors the readOnly flag (STRK-324)", () => {
+  assert.match(
+    renderLineFor("vendor-productid-byvendor"),
+    /readOnly \? "disabled" : ""/,
+    "the feed product ID pin is a write control and must be disabled when sqld is down"
+  );
+});
+
+test("the product-id endpoint writes hints only, never updateVendorFields (STRK-324)", () => {
+  const handler = DASHBOARD_SRC.slice(
+    DASHBOARD_SRC.indexOf('url === "/providers/vendor-product-id"'),
+    DASHBOARD_SRC.indexOf('url === "/providers/bulk-toggle"')
+  );
+  assert.ok(handler.length > 0, "expected a /providers/vendor-product-id handler");
+  assert.match(
+    handler,
+    /updateVendorHints\(/,
+    "must use the hints-only writer so the selector column survives"
+  );
+  assert.doesNotMatch(
+    handler,
+    /updateVendorFields\(/,
+    "updateVendorFields writes selector AND hints — calling it here resolves " +
+      "selector to null and silently wipes it"
+  );
+  assert.match(
+    handler,
+    /mergeHintsProductId\(/,
+    "must merge into the existing hints JSON rather than overwrite the column"
+  );
+});
+
+test("the feed health probe is bounded so a long-running dashboard refreshes (STRK-324)", () => {
+  assert.match(
+    DASHBOARD_SRC,
+    /getFeedIndex\(\{\s*maxAgeMs:/,
+    "getFeedIndex memoizes forever by default; the dashboard is a long-running " +
+      "process, so an unbounded call would freeze the health line at first page load"
+  );
+});
+
 test("By Vendor URL input honors the readOnly flag (STRK-323)", () => {
   assert.match(
     renderLineFor("vendor-url-byvendor"),

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -1384,14 +1384,7 @@ async function probeFeedHealth() {
   }
 }
 
-function renderProvidersPage(
-  providers,
-  scrapeStatus,
-  failureCount,
-  readOnly,
-  vendorGroups,
-  feedHealth
-) {
+function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups) {
   const coins = providers.coins || {};
   const coinEntries = Object.entries(coins);
   const totalCoins = coinEntries.length;
@@ -1459,10 +1452,14 @@ function renderProvidersPage(
         })
         .join("");
 
-      const feedHealthHtml =
-        isApiFed && feedHealth
-          ? `<div class="vendor-feed-health" style="padding:4px 12px 6px;font-size:11px;color:${feedHealth.ok ? "var(--green)" : "var(--red)"};" title="${escAttr(feedHealth.detail)}">${escHtml(feedHealth.label)}</div>`
-          : "";
+      // Placeholder only — the probe is fetched client-side after render. It
+      // must never sit on the HTML response path: a hanging feed endpoint
+      // costs two 15s attempts plus a 2s retry delay, which would stall the
+      // whole provider editor for ~32s on the first load after each cache
+      // expiry (STRK-324).
+      const feedHealthHtml = isApiFed
+        ? `<div class="vendor-feed-health" data-vendor="${escAttr(vg.vendorId)}" style="padding:4px 12px 6px;font-size:11px;color:var(--muted);">checking feed…</div>`
+        : "";
 
       return `<div style="margin-bottom:12px;" class="vendor-section" data-vendor="${escAttr(vg.vendorId)}">
       <div style="display:flex;justify-content:space-between;align-items:center;padding:8px 12px;background:var(--surface2);border-radius:6px;cursor:pointer;margin-bottom:4px;" class="vendor-section-header">
@@ -2111,16 +2108,38 @@ document.querySelectorAll('.vendor-productid-byvendor').forEach(function(input) 
   var orig = input.value;
   input.addEventListener('blur', async function() {
     if (input.value === orig) return;
-    const r = await fetch('/providers/vendor-product-id', {
-      method: 'POST',
-      headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ coinSlug: input.dataset.coin, vendorId: input.dataset.vendor, productId: input.value })
-    });
-    const j = await r.json();
-    showToast(j.message, r.ok);
-    if (r.ok) orig = input.value;
-    else input.value = orig;
+    try {
+      const r = await fetch('/providers/vendor-product-id', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({ coinSlug: input.dataset.coin, vendorId: input.dataset.vendor, productId: input.value })
+      });
+      const j = await r.json();
+      showToast(j.message, r.ok);
+      if (r.ok) orig = input.value;
+      else input.value = orig;
+    } catch {
+      // Without this the rejection is unhandled: no toast, and the field keeps
+      // an edit the server never received — which reads as saved on next blur.
+      showToast('Request failed — product ID not saved', false);
+      input.value = orig;
+    }
   });
+});
+
+// ── By Vendor tab: feed health, fetched after render ─────────────────────
+// Deliberately not part of the page HTML — see GET /providers/feed-health.
+document.querySelectorAll('.vendor-feed-health').forEach(async function(el) {
+  try {
+    const r = await fetch('/providers/feed-health');
+    const j = await r.json();
+    el.textContent = j.label;
+    el.style.color = j.ok ? 'var(--green)' : 'var(--red)';
+    if (j.detail) el.title = j.detail;
+  } catch {
+    el.textContent = 'feed status unavailable';
+    el.style.color = 'var(--muted)';
+  }
 });
 
 // ── By Vendor tab: toggle enabled/disabled ───────────────────────────────
@@ -2870,18 +2889,18 @@ async function handleRequest(req, res) {
   if (req.method === "GET" && url === "/providers") {
     let client = null;
     let readOnly = false;
-    let providers, scrapeStatus, failureCount, vendorGroups, feedHealth;
+    let providers, scrapeStatus, failureCount, vendorGroups;
     try {
       client = getSqldClient();
       await initProviderSchema(client);
-      // probeFeedHealth never rejects, so it cannot drag the page into the
-      // read-only fallback; it resolves to null when the probe itself errored.
-      [providers, scrapeStatus, failureCount, vendorGroups, feedHealth] = await Promise.all([
+      // The feed probe is deliberately absent here — see GET
+      // /providers/feed-health. Awaiting it would put an external vendor
+      // endpoint on this page's critical path.
+      [providers, scrapeStatus, failureCount, vendorGroups] = await Promise.all([
         getProviders(client),
         getVendorScrapeStatus(client).catch(() => null),
         getFailureCount(client),
         getProvidersByVendor(client).catch(() => []),
-        probeFeedHealth(),
       ]);
     } catch {
       readOnly = true;
@@ -2893,7 +2912,6 @@ async function handleRequest(req, res) {
       scrapeStatus = null;
       failureCount = 0;
       vendorGroups = [];
-      feedHealth = null;
     } finally {
       if (client)
         try {
@@ -2903,9 +2921,7 @@ async function handleRequest(req, res) {
         }
     }
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-    res.end(
-      renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups, feedHealth)
-    );
+    res.end(renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups));
     return;
   }
 
@@ -3082,6 +3098,18 @@ async function handleRequest(req, res) {
       res.writeHead(400, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: false, message: err.message }));
     }
+    return;
+  }
+
+  // ── GET /providers/feed-health ─────────────────────────────────────────
+  // Served separately from the provider page on purpose: this calls an
+  // external vendor endpoint, and buildFeedState allows two 15s attempts plus
+  // a 2s retry delay. On the page's critical path a hanging feed would stall
+  // the whole provider editor for ~32s after each cache expiry (STRK-324).
+  if (req.method === "GET" && url === "/providers/feed-health") {
+    const health = await probeFeedHealth();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(health || { ok: false, label: "feed status unavailable", detail: "" }));
     return;
   }
 

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -2074,7 +2074,12 @@ document.querySelectorAll('[data-provider-tab]').forEach(function(btn) {
 // ── Vendor section expand/collapse ───────────────────────────────────────
 document.querySelectorAll('.vendor-section-header').forEach(function(header) {
   header.addEventListener('click', function() {
-    var body = this.nextElementSibling;
+    // Look the body up by class rather than nextElementSibling: API-fed
+    // vendors render a feed health line between the header and the rows, and
+    // a positional lookup silently toggles whatever happens to sit next.
+    var section = this.closest('.vendor-section');
+    var body = section && section.querySelector('.vendor-section-body');
+    if (!body) return;
     body.style.display = body.style.display === 'none' ? '' : 'none';
   });
 });

--- a/devops/pollers/home-poller/dashboard.js
+++ b/devops/pollers/home-poller/dashboard.js
@@ -30,6 +30,8 @@ import {
   deleteCoin,
   deleteVendor,
   updateVendorFields,
+  getVendorHints,
+  updateVendorHints,
   getVendorScrapeStatus,
   getFailureStats,
   getFailureTrend,
@@ -47,6 +49,11 @@ import {
   clearAllChronicFailures,
   getProvidersByVendor,
 } from "./provider-db.js";
+import {
+  getFeedIndex,
+  parseHintsProductId,
+  mergeHintsProductId,
+} from "./price-extract-mintbuilder-feed.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -1335,7 +1342,56 @@ if (log) log.scrollTop = log.scrollHeight;
 // links); the API key lives only in the container env, never in row data.
 const API_FED_VENDOR_IDS = new Set(["mintbuilder"]);
 
-function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups) {
+// The source value price-extract writes for a direct feed hit (STRK-321). Any
+// other value on an API-fed row means that item fell back to page scraping.
+const FEED_SOURCE = "mintbuilder-api";
+
+// How long a feed probe is reused before /providers re-checks. The dashboard is
+// a long-running process, so getFeedIndex must be bounded or the health line
+// would freeze at whatever the first page load saw (STRK-324).
+const FEED_HEALTH_MAX_AGE_MS = 60_000;
+
+/**
+ * Summarize feed reachability for the By Vendor header. Never throws — a feed
+ * problem must not take the provider editor down with it.
+ *
+ * @returns {Promise<{ok: boolean, label: string, detail: string}|null>}
+ */
+async function probeFeedHealth() {
+  try {
+    const state = await getFeedIndex({ maxAgeMs: FEED_HEALTH_MAX_AGE_MS });
+    if (state.ok) {
+      return {
+        ok: true,
+        label: `feed OK — ${state.byId.size} products`,
+        detail: `Checked ${new Date(state.fetchedAt).toLocaleTimeString()}. Live probe from the dashboard, not the last poller run.`,
+      };
+    }
+    const reasons = {
+      no_key: "MB_API_KEY not set — every item page-scrapes",
+      bad_key: "API key rejected (HTTP 401) — every item page-scrapes",
+      fetch_failed: "feed unreachable — every item page-scrapes",
+      bad_payload: "feed returned an unexpected payload — every item page-scrapes",
+    };
+    return {
+      ok: false,
+      label: reasons[state.reason] || `feed unavailable (${state.reason})`,
+      detail: "Live probe from the dashboard. The poller falls back to page scraping.",
+    };
+  } catch (err) {
+    console.error("[dashboard] feed health probe failed:", err?.message || err);
+    return null;
+  }
+}
+
+function renderProvidersPage(
+  providers,
+  scrapeStatus,
+  failureCount,
+  readOnly,
+  vendorGroups,
+  feedHealth
+) {
   const coins = providers.coins || {};
   const coinEntries = Object.entries(coins);
   const totalCoins = coinEntries.length;
@@ -1343,6 +1399,7 @@ function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, ve
   // Build vendor-centric view HTML
   const vendorViewHtml = (vendorGroups || [])
     .map((vg) => {
+      const isApiFed = API_FED_VENDOR_IDS.has(vg.vendorId);
       const okCount = vg.items.filter((i) => {
         const key = `${i.coinSlug}:${vg.vendorId}`;
         const st = scrapeStatus?.get(key);
@@ -1373,25 +1430,50 @@ function renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, ve
               priceText = `<span style="color:var(--green);font-size:11px;">$${st.price}</span>`;
             }
           }
-          return `<div style="display:grid;grid-template-columns:auto 1fr 2fr 1fr auto;gap:8px;align-items:center;padding:5px 8px 5px 24px;border-bottom:1px solid var(--border);font-size:12px;">
+          // API-fed rows get a pin input and a per-row match indicator so an
+          // operator can see, without reading logs, whether this item actually
+          // came from the feed or quietly fell back to page scraping.
+          let apiCells = "";
+          if (isApiFed) {
+            const pinnedId = parseHintsProductId(item.hints, () => {}) || "";
+            let matchBadge =
+              '<span style="font-size:10px;color:var(--muted);" title="No price recorded for this item yet.">—</span>';
+            if (st && st.source) {
+              matchBadge =
+                st.source === FEED_SOURCE
+                  ? '<span style="font-size:10px;color:var(--green);" title="Last price came from the direct API feed.">feed</span>'
+                  : `<span style="font-size:10px;color:var(--muted);" title="Last price came from a page scrape (source: ${escAttr(st.source)}). Expected for items the feed cannot confirm in stock, or when the key is unset.">scrape</span>`;
+            }
+            apiCells = `
+        <input type="text" class="vendor-productid-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" value="${escAttr(pinnedId)}" style="width:100%;font-size:11px;" placeholder="feed id (optional)" title="Pin this row to an exact feed product ID. Leave blank to match by URL. Saved into the hints JSON without touching its other keys." ${readOnly ? "disabled" : ""}>
+        ${matchBadge}`;
+          }
+          const gridCols = isApiFed ? "auto 1fr 2fr 90px auto 1fr auto" : "auto 1fr 2fr 1fr auto";
+          return `<div style="display:grid;grid-template-columns:${gridCols};gap:8px;align-items:center;padding:5px 8px 5px 24px;border-bottom:1px solid var(--border);font-size:12px;">
         ${dot}
         <span style="font-weight:600;">${escHtml(item.coinName)} ${metalBadge(item.metal)}</span>
-        <input type="text" class="vendor-url-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" value="${escAttr(item.url || "")}" style="width:100%;font-size:11px;" placeholder="https://..." ${readOnly ? "disabled" : ""}>
+        <input type="text" class="vendor-url-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" value="${escAttr(item.url || "")}" style="width:100%;font-size:11px;" placeholder="https://..." ${readOnly ? "disabled" : ""}>${apiCells}
         ${priceText}
         <button class="btn-sm vendor-toggle-byvendor" data-coin="${escAttr(item.coinSlug)}" data-vendor="${escAttr(vg.vendorId)}" data-enabled="${item.enabled !== false ? "1" : "0"}" style="background:${item.enabled !== false ? "var(--green)" : "var(--red)"};color:#fff;font-size:10px;min-width:32px;" ${readOnly ? "disabled" : ""}>${item.enabled !== false ? "On" : "Off"}</button>
       </div>`;
         })
         .join("");
 
+      const feedHealthHtml =
+        isApiFed && feedHealth
+          ? `<div class="vendor-feed-health" style="padding:4px 12px 6px;font-size:11px;color:${feedHealth.ok ? "var(--green)" : "var(--red)"};" title="${escAttr(feedHealth.detail)}">${escHtml(feedHealth.label)}</div>`
+          : "";
+
       return `<div style="margin-bottom:12px;" class="vendor-section" data-vendor="${escAttr(vg.vendorId)}">
       <div style="display:flex;justify-content:space-between;align-items:center;padding:8px 12px;background:var(--surface2);border-radius:6px;cursor:pointer;margin-bottom:4px;" class="vendor-section-header">
         <span style="font-weight:600;font-size:13px;">${escHtml(vg.vendorName)}${
-          API_FED_VENDOR_IDS.has(vg.vendorId)
+          isApiFed
             ? ' <span style="font-size:9px;text-transform:uppercase;letter-spacing:0.5px;padding:2px 6px;border:1px solid var(--border);border-radius:4px;color:var(--muted);vertical-align:middle;" title="Prices come from this vendor&#39;s direct API feed (one call per run). Product URLs below still drive feed matching and Buy links — add/remove items exactly like scraped vendors.">Direct API</span>'
             : ""
         }</span>
         <span style="font-size:11px;color:var(--muted);">${statsText}</span>
       </div>
+      ${feedHealthHtml}
       <div class="vendor-section-body" style="display:none;">${itemRows}</div>
     </div>`;
     })
@@ -2014,6 +2096,25 @@ document.querySelectorAll('.vendor-url-byvendor').forEach(function(input) {
     const j = await r.json();
     showToast(j.message, r.ok);
     if (r.ok) orig = input.value;
+  });
+});
+
+// ── By Vendor tab: API feed product ID pin ───────────────────────────────
+// Blank clears the pin and falls back to URL matching. Saves on blur, matching
+// the URL input beside it. The server merges into the hints JSON.
+document.querySelectorAll('.vendor-productid-byvendor').forEach(function(input) {
+  var orig = input.value;
+  input.addEventListener('blur', async function() {
+    if (input.value === orig) return;
+    const r = await fetch('/providers/vendor-product-id', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ coinSlug: input.dataset.coin, vendorId: input.dataset.vendor, productId: input.value })
+    });
+    const j = await r.json();
+    showToast(j.message, r.ok);
+    if (r.ok) orig = input.value;
+    else input.value = orig;
   });
 });
 
@@ -2764,15 +2865,18 @@ async function handleRequest(req, res) {
   if (req.method === "GET" && url === "/providers") {
     let client = null;
     let readOnly = false;
-    let providers, scrapeStatus, failureCount, vendorGroups;
+    let providers, scrapeStatus, failureCount, vendorGroups, feedHealth;
     try {
       client = getSqldClient();
       await initProviderSchema(client);
-      [providers, scrapeStatus, failureCount, vendorGroups] = await Promise.all([
+      // probeFeedHealth never rejects, so it cannot drag the page into the
+      // read-only fallback; it resolves to null when the probe itself errored.
+      [providers, scrapeStatus, failureCount, vendorGroups, feedHealth] = await Promise.all([
         getProviders(client),
         getVendorScrapeStatus(client).catch(() => null),
         getFailureCount(client),
         getProvidersByVendor(client).catch(() => []),
+        probeFeedHealth(),
       ]);
     } catch {
       readOnly = true;
@@ -2784,6 +2888,7 @@ async function handleRequest(req, res) {
       scrapeStatus = null;
       failureCount = 0;
       vendorGroups = [];
+      feedHealth = null;
     } finally {
       if (client)
         try {
@@ -2793,7 +2898,9 @@ async function handleRequest(req, res) {
         }
     }
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-    res.end(renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups));
+    res.end(
+      renderProvidersPage(providers, scrapeStatus, failureCount, readOnly, vendorGroups, feedHealth)
+    );
     return;
   }
 
@@ -2969,6 +3076,43 @@ async function handleRequest(req, res) {
     } catch (err) {
       res.writeHead(400, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: false, message: err.message }));
+    }
+    return;
+  }
+
+  // ── POST /providers/vendor-product-id ──────────────────────────────────
+  // Sets or clears the {"mbProductId"} feed pin for one row. Read-modify-write
+  // on hints so unrelated keys survive, and hints-only so the selector is not
+  // collaterally nulled the way updateVendorFields would (STRK-324).
+  if (req.method === "POST" && url === "/providers/vendor-product-id") {
+    let client = null;
+    try {
+      const { coinSlug, vendorId, productId } = JSON.parse(await readBody(req));
+      if (!coinSlug || !vendorId) throw new Error("coinSlug and vendorId required");
+      client = getSqldClient();
+      const currentHints = await getVendorHints(client, coinSlug, vendorId);
+      const nextHints = mergeHintsProductId(currentHints, productId);
+      await updateVendorHints(client, coinSlug, vendorId, nextHints);
+      const cleared = !nextHints || !parseHintsProductId(nextHints, () => {});
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          ok: true,
+          message: cleared
+            ? `Cleared the feed product ID for ${vendorId}/${coinSlug}.`
+            : `Pinned ${vendorId}/${coinSlug} to feed product ${parseHintsProductId(nextHints, () => {})}.`,
+        })
+      );
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, message: err.message }));
+    } finally {
+      if (client)
+        try {
+          await client.close();
+        } catch {
+          /* ignore */
+        }
     }
     return;
   }

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.js
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.js
@@ -27,6 +27,10 @@ const FEED_RETRY_DELAY_MS = 2_000;
 // in-flight request; fingerprinted by key so a rotated key refetches.
 let _feedState = null;
 let _feedFingerprint = null;
+// Wall-clock stamp of when the current memo was started, for the optional
+// maxAgeMs bound. Set at build time rather than on resolve so concurrent
+// callers during an in-flight fetch share one request.
+let _feedBuiltAt = null;
 
 /** Sleep helper for the single transient-failure retry. */
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -79,6 +83,45 @@ export function parseHintsProductId(hintsText, warn = console.warn) {
   if (typeof id === "number" && Number.isFinite(id)) return String(id);
   if (typeof id === "string" && id.trim() !== "") return id.trim();
   return null;
+}
+
+/**
+ * Write (or clear) the {"mbProductId"} pin inside a provider row's free-form
+ * hints JSON — the inverse of parseHintsProductId, used by the dashboard's
+ * dedicated API Product ID input (STRK-324).
+ *
+ * The hints column is shared with other free-form uses, so the merge preserves
+ * every other key. Unlike the reader, this one is strict: a hints value that
+ * cannot be parsed as a JSON object throws rather than being overwritten,
+ * because silently replacing an operator's hand-written hints during an
+ * unrelated product-id edit would be data loss. They can repair the raw JSON in
+ * the gear row first.
+ *
+ * @param {unknown} hintsText - Existing provider_vendors.hints value.
+ * @param {string|number|null|undefined} productId - Pin to set; empty clears it.
+ * @returns {string|null} Hints JSON to store, or null when nothing is left.
+ * @throws {Error} When hintsText is present but is not a JSON object.
+ */
+export function mergeHintsProductId(hintsText, productId) {
+  let parsed = {};
+  if (typeof hintsText === "string" && hintsText.trim() !== "") {
+    try {
+      parsed = JSON.parse(hintsText);
+    } catch {
+      throw new Error("Existing hints are not valid JSON — fix them before setting a product ID");
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        "Existing hints are not a JSON object — fix them before setting a product ID"
+      );
+    }
+  }
+
+  const id = productId === null || productId === undefined ? "" : String(productId).trim();
+  if (id === "") delete parsed.mbProductId;
+  else parsed.mbProductId = id;
+
+  return Object.keys(parsed).length === 0 ? null : JSON.stringify(parsed);
 }
 
 /**
@@ -215,8 +258,18 @@ async function buildFeedState({ apiKey, fetchImpl, log, warn, retryDelayMs }) {
  * target at a time) shares the same resolved state. The memo is fingerprinted
  * by API key so a rotated key builds a fresh index.
  *
+ * `maxAgeMs` bounds how long a memoized state (success *or* failure) is reused.
+ * It defaults to Infinity, which is right for the poller: one process per cron
+ * run, so the memo dies with the run and a TTL would only add requests. A
+ * long-running consumer — the home-poller dashboard, which renders a feed
+ * health line — must pass a finite value, otherwise its first render pins the
+ * feed state for the life of the server and the health line reports a frozen
+ * snapshot forever (STRK-324). Bounding failures too means a rejected key or a
+ * transient outage recovers on its own once the operator fixes it.
+ *
  * @param {object} [opts] - apiKey (default: process.env.MB_API_KEY read at
- *   call time), fetchImpl (default: global fetch), log/warn sinks, retryDelayMs.
+ *   call time), fetchImpl (default: global fetch), log/warn sinks, retryDelayMs,
+ *   maxAgeMs (default: Infinity — never expire).
  * @returns {Promise<object>} The (possibly cached) FeedState.
  */
 export function getFeedIndex({
@@ -225,11 +278,14 @@ export function getFeedIndex({
   log = console.log,
   warn = console.warn,
   retryDelayMs = FEED_RETRY_DELAY_MS,
+  maxAgeMs = Infinity,
 } = {}) {
   const key = apiKey !== undefined ? apiKey : process.env.MB_API_KEY;
   const fingerprint = key || "";
-  if (_feedState && _feedFingerprint === fingerprint) return _feedState;
+  const fresh = _feedBuiltAt !== null && Date.now() - _feedBuiltAt < maxAgeMs;
+  if (_feedState && _feedFingerprint === fingerprint && fresh) return _feedState;
   _feedFingerprint = fingerprint;
+  _feedBuiltAt = Date.now();
   _feedState = buildFeedState({ apiKey: key, fetchImpl, log, warn, retryDelayMs });
   return _feedState;
 }
@@ -294,4 +350,5 @@ export async function lookupMintbuilderProduct({
 export function _resetFeedCacheForTests() {
   _feedState = null;
   _feedFingerprint = null;
+  _feedBuiltAt = null;
 }

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
@@ -627,6 +627,138 @@ test("the API key never appears in log or warn output", async () => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// maxAgeMs — bounded memo for long-running consumers (STRK-324)
+//
+// The poller is a process per cron run, so an unbounded memo is exactly right
+// there and stays the default. The dashboard is a long-running server: without
+// a TTL its first /providers load would pin the feed state for the life of the
+// process and the health line would report a frozen snapshot forever.
+// ---------------------------------------------------------------------------
+
+test("without maxAgeMs the memo never expires (poller behaviour is unchanged)", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl });
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl });
+
+  assert.equal(fetchImpl.calls.length, 1, "the unbounded memo must still fetch exactly once");
+});
+
+test("maxAgeMs=0 forces a refetch on every call", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl, maxAgeMs: 0 });
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl, maxAgeMs: 0 });
+
+  assert.equal(fetchImpl.calls.length, 2, "a zero max age means every call is stale");
+});
+
+test("a memo younger than maxAgeMs is reused", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl, maxAgeMs: 60_000 });
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl, maxAgeMs: 60_000 });
+
+  assert.equal(fetchImpl.calls.length, 1, "a fresh memo must not refetch");
+});
+
+test("a memo older than maxAgeMs refetches", async () => {
+  const feed = await loadFeed();
+  const fetchImpl = makeFetch(okResponse(feedPayload(PRODUCTS)));
+
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl, maxAgeMs: 1 });
+  await new Promise((r) => setTimeout(r, 10));
+  await feed.getFeedIndex({ apiKey: "test-key", fetchImpl, maxAgeMs: 1 });
+
+  assert.equal(fetchImpl.calls.length, 2, "an expired memo must refetch");
+});
+
+test("a cached failure is not sticky once maxAgeMs elapses", async () => {
+  const feed = await loadFeed();
+  // Same key throughout: a key rotation would refetch via the fingerprint, so
+  // this proves the TTL alone lets a transient outage recover. Two 500s
+  // exhaust the single retry and resolve to a failure state.
+  const fetchImpl = makeFetch(errResponse(500), errResponse(500), okResponse(feedPayload(PRODUCTS)));
+
+  const first = await feed.getFeedIndex({
+    apiKey: "test-key",
+    fetchImpl,
+    maxAgeMs: 0,
+    warn: makeSpy(),
+    retryDelayMs: 0,
+  });
+  assert.equal(first.ok, false, "two 500s should resolve to a failure state");
+
+  const second = await feed.getFeedIndex({
+    apiKey: "test-key",
+    fetchImpl,
+    maxAgeMs: 0,
+    warn: makeSpy(),
+    retryDelayMs: 0,
+  });
+  assert.equal(second.ok, true, "the recovered feed must replace the cached failure");
+});
+
+// ---------------------------------------------------------------------------
+// mergeHintsProductId — the write side of the {"mbProductId"} pin (STRK-324)
+//
+// The dashboard exposes the pin as a dedicated per-row input, but hints is a
+// shared free-form JSON column. Writing it must preserve every other key, and
+// must refuse rather than clobber when the existing value cannot be parsed.
+// ---------------------------------------------------------------------------
+
+test("merge writes the pin into empty hints", async () => {
+  const feed = await import(feedModuleUrl);
+  assert.equal(feed.mergeHintsProductId(null, "101"), '{"mbProductId":"101"}');
+  assert.equal(feed.mergeHintsProductId("", "101"), '{"mbProductId":"101"}');
+  assert.equal(feed.mergeHintsProductId("   ", "101"), '{"mbProductId":"101"}');
+});
+
+test("merge preserves unrelated hint keys", async () => {
+  const feed = await import(feedModuleUrl);
+  const merged = feed.mergeHintsProductId('{"asLowAs":true,"waitMs":500}', "101");
+  assert.deepEqual(JSON.parse(merged), { asLowAs: true, waitMs: 500, mbProductId: "101" });
+});
+
+test("merge overwrites an existing pin and trims/coerces the id", async () => {
+  const feed = await import(feedModuleUrl);
+  assert.deepEqual(JSON.parse(feed.mergeHintsProductId('{"mbProductId":"1"}', "  202 ")), {
+    mbProductId: "202",
+  });
+  assert.deepEqual(JSON.parse(feed.mergeHintsProductId(null, 303)), { mbProductId: "303" });
+});
+
+test("an empty id clears the pin but keeps the other keys", async () => {
+  const feed = await import(feedModuleUrl);
+  const merged = feed.mergeHintsProductId('{"asLowAs":true,"mbProductId":"101"}', "");
+  assert.deepEqual(JSON.parse(merged), { asLowAs: true });
+});
+
+test("clearing the only key yields null so the column is emptied, not left as {}", async () => {
+  const feed = await import(feedModuleUrl);
+  assert.equal(feed.mergeHintsProductId('{"mbProductId":"101"}', ""), null);
+  assert.equal(feed.mergeHintsProductId(null, ""), null);
+});
+
+test("merge refuses to clobber hints it cannot parse", async () => {
+  const feed = await import(feedModuleUrl);
+  // Losing an operator's hand-written hints to a product-id edit would be a
+  // silent data loss; surfacing the error lets them fix the raw JSON first.
+  assert.throws(() => feed.mergeHintsProductId("{not json", "101"), /valid JSON/i);
+  assert.throws(() => feed.mergeHintsProductId("[1,2,3]", "101"), /JSON object/i);
+  assert.throws(() => feed.mergeHintsProductId('"a string"', "101"), /JSON object/i);
+});
+
+test("the merge round-trips through parseHintsProductId", async () => {
+  const feed = await import(feedModuleUrl);
+  const merged = feed.mergeHintsProductId('{"asLowAs":true}', "404");
+  assert.equal(feed.parseHintsProductId(merged), "404");
+});
+
 let passed = 0;
 let failed = 0;
 for (const [name, fn] of tests) {

--- a/devops/pollers/shared/provider-db.js
+++ b/devops/pollers/shared/provider-db.js
@@ -354,16 +354,26 @@ export async function getVendorHints(client, coinSlug, vendorId) {
  * calling that one with just hints resolves selector to null and silently wipes
  * it. The dashboard's API Product ID input edits hints alone (STRK-324).
  *
+ * Throws when the UPDATE matches no row. This is a read-modify-write partner
+ * to getVendorHints, so a row deleted between the two calls would otherwise
+ * make the write vanish while the caller reports success.
+ *
  * @param {import("@libsql/client").Client} client
  * @param {string} coinSlug
  * @param {string} vendorId
  * @param {string|null} hints
+ * @returns {Promise<{rowsAffected: number}>}
+ * @throws {Error} When no provider row matched.
  */
 export async function updateVendorHints(client, coinSlug, vendorId, hints) {
-  await client.execute({
+  const result = await client.execute({
     sql: "UPDATE provider_vendors SET hints = ?, updated_at = datetime('now') WHERE coin_slug = ? AND vendor_id = ?",
     args: [hints ?? null, coinSlug, vendorId],
   });
+  if (result.rowsAffected === 0) {
+    throw new Error(`No provider row for ${vendorId}/${coinSlug} — it may have just been deleted`);
+  }
+  return { rowsAffected: result.rowsAffected };
 }
 
 /**

--- a/devops/pollers/shared/provider-db.js
+++ b/devops/pollers/shared/provider-db.js
@@ -330,17 +330,60 @@ export async function updateVendorFields(client, coinSlug, vendorId, { selector,
 }
 
 /**
- * Get the latest scrape status for every vendor.
- * Returns a Map keyed by "coinSlug:vendorId" with { price, isFailed, scrapedAt }.
+ * Read one vendor row's raw hints JSON.
  *
  * @param {import("@libsql/client").Client} client
- * @returns {Promise<Map<string, {price: number|null, isFailed: boolean, scrapedAt: string}>>}
+ * @param {string} coinSlug
+ * @param {string} vendorId
+ * @returns {Promise<string|null>} The stored hints text, or null when unset.
+ * @throws {Error} When no such provider row exists.
+ */
+export async function getVendorHints(client, coinSlug, vendorId) {
+  const result = await client.execute({
+    sql: "SELECT hints FROM provider_vendors WHERE coin_slug = ? AND vendor_id = ?",
+    args: [coinSlug, vendorId],
+  });
+  if (result.rows.length === 0) throw new Error(`No provider row for ${vendorId}/${coinSlug}`);
+  return result.rows[0].hints ?? null;
+}
+
+/**
+ * Update only a vendor's hints, leaving selector untouched.
+ *
+ * Deliberately separate from updateVendorFields, which writes both columns:
+ * calling that one with just hints resolves selector to null and silently wipes
+ * it. The dashboard's API Product ID input edits hints alone (STRK-324).
+ *
+ * @param {import("@libsql/client").Client} client
+ * @param {string} coinSlug
+ * @param {string} vendorId
+ * @param {string|null} hints
+ */
+export async function updateVendorHints(client, coinSlug, vendorId, hints) {
+  await client.execute({
+    sql: "UPDATE provider_vendors SET hints = ?, updated_at = datetime('now') WHERE coin_slug = ? AND vendor_id = ?",
+    args: [hints ?? null, coinSlug, vendorId],
+  });
+}
+
+/**
+ * Get the latest scrape status for every vendor.
+ * Returns a Map keyed by "coinSlug:vendorId" with
+ * { price, isFailed, scrapedAt, source }.
+ *
+ * `source` records how the row was obtained ("mintbuilder-api" for a direct
+ * feed hit, "firecrawl"/"playwright"/… for a page scrape). The dashboard uses
+ * it to show, per row, whether an API-fed vendor actually matched the feed or
+ * quietly fell back to scraping (STRK-324).
+ *
+ * @param {import("@libsql/client").Client} client
+ * @returns {Promise<Map<string, {price: number|null, isFailed: boolean, scrapedAt: string, source: string|null}>>}
  */
 export async function getVendorScrapeStatus(client) {
   const result = await client.execute(`
-    SELECT coin_slug, vendor, price, is_failed, scraped_at
+    SELECT coin_slug, vendor, price, is_failed, scraped_at, source
     FROM (
-      SELECT coin_slug, vendor, price, is_failed, scraped_at,
+      SELECT coin_slug, vendor, price, is_failed, scraped_at, source,
              ROW_NUMBER() OVER (PARTITION BY coin_slug, vendor ORDER BY scraped_at DESC) AS rn
       FROM price_snapshots
     ) sub
@@ -352,6 +395,7 @@ export async function getVendorScrapeStatus(client) {
       price: row.price,
       isFailed: row.is_failed === 1,
       scrapedAt: row.scraped_at,
+      source: row.source ?? null,
     });
   }
   return map;


### PR DESCRIPTION
Closes STRK-324. Poller-only — no frontend, no release artifacts, so no version bump (same shape as STRK-321 [#1415](https://github.com/lbruton/StakTrakr/pull/1415) and STRK-323 [#1421](https://github.com/lbruton/StakTrakr/pull/1421)).

Makes an API-fed vendor as self-serve from the poll dashboard as the scraped ones. The `{"mbProductId"}` pin was previously reachable only by hand-editing raw hints JSON in the gear row.

## 1. Per-row API Product ID input

Rendered only for vendors in `API_FED_VENDOR_IDS`. Reads via the feed module's existing `parseHintsProductId`; writes through a new `POST /providers/vendor-product-id`.

Two traps the write path avoids:

| Trap | Consequence if ignored | Mitigation |
|---|---|---|
| `hints` is a **shared** free-form column | a pin edit would drop `asLowAs`, `waitMs`, … | new `mergeHintsProductId` does read-modify-write preserving all other keys |
| `updateVendorFields` writes selector **and** hints | passing only hints resolves `selector ?? null` → **silently wipes the selector** | added hints-only `updateVendorHints` + a `getVendorHints` reader |

The merge also **throws rather than overwriting** hints it cannot parse — silently discarding hand-written hints during an unrelated product-id edit would be data loss. The operator repairs the raw JSON in the gear row first.

## 2. Per-row match indicator

`feed` vs `scrape`, from the latest `price_snapshots.source` (`mintbuilder-api` = feed hit). `getVendorScrapeStatus` now selects and returns that column. This surfaces the **silent fallback** case: an item still gets a price, but no longer via the feed.

## 3. Vendor-level feed health line

A **live probe** from the dashboard — product count, key status (unset / rejected / unreachable / bad payload), probe time. Labelled as a live check rather than the last poller run, because that is what it is.

That required bounding the feed memo, which is the subtle part:

> `getFeedIndex` memoizes for the life of the process. That is correct for the poller — one process per cron run — and **remains the default**. But the dashboard is long-running, so an unbounded call would pin the health line to whatever the first `/providers` load saw, forever.

Added an opt-in `maxAgeMs` (default `Infinity`, so **poller behaviour is unchanged**); the dashboard passes 60s. Bounding *failures* too means a rejected key recovers on its own once fixed, rather than staying stuck until the container restarts.

`probeFeedHealth` never rejects, so a feed outage cannot drag the provider editor into its read-only fallback. With no key set, `buildFeedState` returns without any outbound request.

`readOnly` is threaded through the new input, per STRK-323.

## Testing

**Real TDD** for the pure/unit-testable parts — 12 new cases in the feed suite, each verified red before implementing:

- `maxAgeMs`: expiry, reuse-when-fresh, the **unbounded-default** case (pins that poller behaviour did not change), and failure-recovery
- `mergeHintsProductId`: key preservation, overwrite, clearing, clearing-the-last-key → `null` (empties the column rather than storing `{}`), both refuse-to-clobber paths, and a round-trip through `parseHintsProductId`

Dashboard rendering stays **source-contract** — dashboard.js only runs inside the container (Dockerfile flattens `shared/` and `home-poller/` into `/app`; see STRK-323 for the full reasoning). New guards assert the endpoint uses `updateVendorHints` and **never** `updateVendorFields`, that it merges rather than overwrites, and that the health probe is bounded.

```
feed suite            34/34   exit 0
dashboard contract     8/8    exit 0
full poller suite     17/17   exit 0
```

`no-undef` probe (`devops/` is outside `npm run lint`'s scope) clean apart from three pre-existing `document` references inside Playwright `page.evaluate` callbacks — identical on `origin/dev`.

Verified the new import is safe: the feed module has **zero imports** and no side effects, and `COPY shared/*.js ./` places it beside `dashboard.js` in `/app`.

## Note

`probeFeedHealth()` runs on every `/providers` GET even if no API-fed vendor is present in that render. The 60s memo bounds this to at most one outbound request per minute regardless of page loads, and it is a no-op when `MB_API_KEY` is unset, so I left it unconditional rather than sequencing it behind the `vendorGroups` query.