### PR TITLE
chore(deps): security lockfile bumps — js-yaml 4.3.1 + brace-expansion 1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -774,9 +774,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,9 +312,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Lands two **dev-only transitive** security fixes on `dev`, clearing both open `npm audit` high-severity findings. Replaces Dependabot [#1435](https://github.com/lbruton/StakTrakr/pull/1435) (which targeted `main` directly, against our dev-first topology).

## Fixes
| Package | Bump | Advisory | Path |
|---------|------|----------|------|
| js-yaml | 4.3.0 → 4.3.1 | GHSA-5p4m-2wfm-xmqj (**HIGH**, CVE-2026-59870, quadratic-CPU DoS in `!!omap`) — Dependabot alert #30 | eslint → @eslint/eslintrc → js-yaml |
| brace-expansion | 1.1.16 → 1.1.18 | GHSA-rgw5-rvv9-x895 + GHSA-mh99-v99m-4gvg (**HIGH**, unbounded-expansion DoS) | transitive via glob/minimatch |

## Scope & verification
- **Lockfile-only** (`--package-lock-only`), 6 lines total. No `package.json` changes (both transitive).
- Both confined to the lint/build toolchain — not shipped to the static app.
- `npm audit` → **0 vulnerabilities** after both bumps.

Closes the `dev`-side gap so the next `dev → main` ship carries the fixes and cannot re-introduce the vulnerable versions. Dependabot alert #30 auto-closes once 4.3.1 is in the tree.