### PR TITLE
chore: context-drift fixes — api-reference v2-first, health-checks v2 script

### DIFF
--- a/.context/deep-dives/api-reference.md
+++ b/.context/deep-dives/api-reference.md
@@ -4,7 +4,7 @@ project: StakTrakr
 audience: agent
 canonical: .context/deep-dives/api-reference.md
 source: "DocVault/Projects/StakTrakr/Foundation/Deep Dives/API Reference.md" # migrated 2026-08-12
-updated: "2026-06-28"
+updated: "2026-08-12"
 ---
 
 # API Reference
@@ -16,281 +16,25 @@ updated: "2026-06-28"
 
 ## Overview
 
-All endpoints are static JSON files served via Cloud - GitHub Pages from the `api` branch of `lbruton/StakTrakrApi`. Feed generation code lives in `devops/pollers/` in the `StakTrakr` repo; `StakTrakrApi` hosts the `api` branch for GitHub Pages serving. There is no dynamic server — `serve.js` on Cloud - Fly.io port 8080 is a redundancy proxy serving the same files.
+All endpoints are static JSON files served via GitHub Pages from the `api` branch of
+`lbruton/StakTrakrApi`. Feed generation code lives in `devops/pollers/` in the `StakTrakr`
+repo; `StakTrakrApi` hosts the `api` branch for GitHub Pages serving. There is no dynamic
+server — `serve.js` on Fly.io port 8080 is a redundancy proxy serving the same files.
 
-**Update cadence:** Every 15 minutes via `run-publish.sh` (cron `8,23,38,53 * * * *`).
+**v2 is the sole API layer consumed by the frontend.** v2 (STAK-503) shipped as default in
+STAK-506 and v1 was removed from frontend code in STAK-509 (v3.33.92) — all frontend
+fetches target `data/v2/`. The v1 exporter (`api-export.js`) still _writes_ `data/api/`
+files each publish cycle for external/legacy consumers, but nothing in the app reads them
+(see Legacy v1 API below).
 
----
-
-## Global Endpoints
-
-| Endpoint                      | Description                                                       | Updated      |
-| ----------------------------- | ----------------------------------------------------------------- | ------------ |
-| `data/api/manifest.json`      | Index: coin list, latest window, endpoint templates               | Every 15 min |
-| `data/api/latest.json`        | All coins' current median/lowest prices                           | Every 15 min |
-| `data/api/providers.json`     | Vendor to product URL mapping per coin (auto-generated from sqld) | Every 15 min |
-| `data/api/goldback-spot.json` | Goldback G1 rate + denomination multipliers                       | Every 15 min |
-
-### manifest.json Schema
-
-```json
-{
-  "generated_at": "2026-02-25T19:08:01.756Z",
-  "latest_window": "2026-02-25T19:00:00Z",
-  "window_count": 96,
-  "coin_count": 11,
-  "coins": ["age", "ape", "ase", "..."],
-  "coins_meta": { ... },
-  "endpoints": {
-    "latest": "api/latest.json",
-    "slug_latest": "api/{slug}/latest.json",
-    "history_7d": "api/{slug}/history-7d.json",
-    "history_30d": "api/{slug}/history-30d.json",
-    "providers": "api/providers.json"
-  }
-}
-```
-
-> `coins_meta` is an optional object containing per-coin metadata (display name, metal, weight). Present when the exporter has metadata available from the provider database.
-
-### latest.json Schema
-
-```json
-{
-  "window_start": "2026-02-25T19:00:00Z",
-  "generated_at": "2026-02-25T19:08:01.756Z",
-  "coin_count": 11,
-  "coins": {
-    "ase": {
-      "window_start": "2026-02-25T19:00:00Z",
-      "median_price": 36.42,
-      "lowest_price": 35.19,
-      "vendor_count": 7
-    }
-  }
-}
-```
-
-### goldback-spot.json Schema
-
-```json
-{
-  "date": "2026-02-25",
-  "scraped_at": "2026-02-25T19:08:01.756Z",
-  "g1_usd": 10.43,
-  "denominations": {
-    "g1": 10.43,
-    "g5": 52.15,
-    "g10": 104.3,
-    "g25": 260.75,
-    "g50": 521.5
-  },
-  "source": "goldback.com",
-  "confidence": "high"
-}
-```
+**Update cadence:** Every 15 minutes via `run-publish.sh` (cron `8,23,38,53 * * * *`) —
+it runs `api-export.js` (legacy v1) then `api-export-v2.js` (v2, non-fatal on error).
 
 ---
 
-## Per-Coin Endpoints
+## v2 API (primary)
 
-**Manifest-driven bullion coin slugs** (currently 15+ as of 2026-03-22, dynamically generated from Turso/provider data via `data/api/manifest.json`). Each coin has three endpoint files:
-
-| Endpoint Pattern                   | Description                                                               | Updated      |
-| ---------------------------------- | ------------------------------------------------------------------------- | ------------ |
-| `data/api/{slug}/latest.json`      | Per-vendor prices, confidence, availability, 24h time series (96 windows) | Every 15 min |
-| `data/api/{slug}/history-7d.json`  | Daily aggregates, last 7 days                                             | Every 15 min |
-| `data/api/{slug}/history-30d.json` | Daily aggregates, last 30 days                                            | Every 15 min |
-
-### Example Coin Slugs
-
-The slug catalog is manifest-driven and grows as coins/vendors are enabled in the provider database. Representative slugs include:
-
-**Silver (1 oz):** `ase`, `maple-silver`, `britannia-silver`, `krugerrand-silver`, `generic-silver-round`
-**Silver (10 oz):** `generic-silver-bar-10oz`
-**Gold (1 oz):** `age`, `buffalo`, `maple-gold`, `krugerrand-gold`
-**Platinum (1 oz):** `ape`
-**Goldback:** `goldback-oklahoma-g1`, `goldback-utah-g50`, `goldback-wyoming-g5`, `goldback-wyoming-g50`, and others as enabled
-
-### Planned/Future: Goldback Per-State Matrix
-
-The following Goldback slugs are scaffolded but **not yet in the committed manifest**:
-
-**Goldback (deprecated -- backward compat):** `goldback-g1`, `goldback-g2`, `goldback-g5`, `goldback-g10`, `goldback-g25`, `goldback-g50`
-**Goldback (per-state -- STAK-335):** `goldback-{state}-g{denom}` where state is one of `utah`, `nevada`, `wyoming`, `new-hampshire`, `south-dakota`, `arizona`, `oklahoma`, `dc` and denom is `ghalf`, `g1`, `g2`, `g5`, `g10`, `g25`, `g50` (56 slugs total). These endpoints will populate as vendors are enabled in the database.
-
-### Per-Coin latest.json Schema
-
-```json
-{
-  "slug": "ase",
-  "window_start": "2026-02-25T19:00:00Z",
-  "median_price": 36.42,
-  "lowest_price": 35.19,
-  "vendors": {
-    "jmbullion": {
-      "price": 35.19,
-      "confidence": 99,
-      "source": "firecrawl+vision",
-      "inStock": true
-    },
-    "apmex": {
-      "price": 36.99,
-      "confidence": 80,
-      "source": "firecrawl",
-      "inStock": true
-    }
-  },
-  "availability_by_site": {
-    "jmbullion": true,
-    "apmex": true
-  },
-  "last_known_price_by_site": {},
-  "last_available_date_by_site": {},
-  "windows_24h": [
-    {
-      "window": "2026-02-24T19:15:00Z",
-      "median": 36.5,
-      "low": 35.2,
-      "vendors": { "jmbullion": 35.2, "apmex": 37.01 }
-    }
-  ]
-}
-```
-
-**Vendor source values:**
-
-| Source             | Meaning                                                                                 |
-| ------------------ | --------------------------------------------------------------------------------------- |
-| `firecrawl+vision` | Both Firecrawl and Gemini Vision agreed (<=3% diff) — 99 confidence                     |
-| `firecrawl`        | Firecrawl text extraction only                                                          |
-| `vision`           | Gemini Vision screenshot extraction only                                                |
-| `turso_last_known` | T4 fallback — most recent in-stock price from database history (includes `stale: true`) |
-
-**Confidence tiers:**
-
-| Range | Meaning                            |
-| ----- | ---------------------------------- |
-| 90-99 | Firecrawl + Vision cross-validated |
-| 60-89 | Single source, agrees with median  |
-| 30-59 | Single source, moderate deviation  |
-| 0-29  | Outlier or disagreement            |
-
----
-
-## Spot Price Endpoints
-
-| Endpoint Pattern                  | Description                                                                               | Updated                                   |
-| --------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `data/hourly/YYYY/MM/DD/HH.json`  | Hourly spot prices (4 metals) — overwritten each poll                                     | 4x/hr (remote at `0,30`, home at `15,45`) |
-| `data/15min/YYYY/MM/DD/HHMM.json` | Immutable 15-min spot snapshots                                                           | Per poll (immutable)                      |
-| `data/spot-history-YYYY.json`     | Annual daily spot history (legacy seed — no longer actively written by `spot-extract.js`) | Legacy                                    |
-
-### Hourly File Schema
-
-```json
-[
-  {
-    "spot": 2945.12,
-    "metal": "Gold",
-    "source": "hourly",
-    "provider": "StakTrakr",
-    "timestamp": "2026-02-25 19:05:00"
-  },
-  {
-    "spot": 33.41,
-    "metal": "Silver",
-    "source": "hourly",
-    "provider": "StakTrakr",
-    "timestamp": "2026-02-25 19:05:00"
-  }
-]
-```
-
-**Metals:** Gold (XAU), Silver (XAG), Platinum (XPT), Palladium (XPD)
-**Data source:** MetalPriceAPI (`metalpriceapi.com`)
-**Rate conversion:** Conditional — `rate >= 1` uses value directly; `rate < 1` inverts (`1 / rate`) to get USD per troy oz
-
----
-
-## Goldback-Specific Endpoints
-
-### Active
-
-| Endpoint                      | Description                                | Updated                                                                                                                                                                                                                                                                                                                                                                                                    |
-| ----------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data/api/goldback-spot.json` | G1 USD rate + all denomination multipliers | Home cron `5 * * * *` (hourly at :05, STRK-58) via `node goldback-scraper.js` writes `goldback-g1` to sqld; `api-export.js` regenerates the file **every publish cycle** (4×/hr) from the cached sqld row with a fresh `generated_at`. goldback.com's upstream rate (`data.t`) can lag the scrape, so `g1_usd` may repeat across publishes. Conditionally written when `coinSlugs` includes `goldback-g1`. |
-| `data/goldback-YYYY.json`     | Rolling annual history log (newest first)  | Regenerated by `api-export.js` each publish cycle from the sqld `goldback-g1` rows.                                                                                                                                                                                                                                                                                                                        |
-
-> **Note (post-STAK-491):** Goldback data flows through sqld, not a direct git-commit path. `run-goldback.sh` on Fly.io is **disabled** (`GOLDBACK_ENABLED=0`) — the home poller's `goldback-scraper.js` writes `goldback-g1` to sqld hourly (`5 * * * *`, STRK-58), and Fly.io's `api-export.js` reads that row during its normal publish cycle to generate `goldback-spot.json`. No scraper commits directly to the `api` branch anymore.
-
-### Planned/Future: Per-State Goldback Endpoints
-
-The following endpoint families are scaffolded but **not yet populated** — `goldback-g1` is not in the committed manifest, and per-state slugs have no enabled vendors:
-
-| Endpoint                                              | Description                                            |
-| ----------------------------------------------------- | ------------------------------------------------------ |
-| `data/api/goldback-g1/latest.json`                    | Mixed-state G1 vendor prices (legacy, backward compat) |
-| `data/api/goldback-g{N}/latest.json`                  | Mixed-state denomination prices (legacy)               |
-| `data/api/goldback-{state}-g{denom}/latest.json`      | Per-vendor prices for a specific state + denomination  |
-| `data/api/goldback-{state}-g{denom}/history-7d.json`  | 7-day daily aggregates                                 |
-| `data/api/goldback-{state}-g{denom}/history-30d.json` | 30-day daily aggregates                                |
-
-**8 states x 7 denominations = 56 per-state slugs**, each with 3 endpoint files = **168 potential endpoint files** (only populated when vendors are enabled in the database).
-
----
-
-## Vendor Reference
-
-7 primary vendors tracked across all bullion coins:
-
-| Vendor ID          | Name              | Notes                                |
-| ------------------ | ----------------- | ------------------------------------ |
-| `jmbullion`        | JM Bullion        | JS-heavy (Next.js), 10s render wait  |
-| `apmex`            | APMEX             | Standard extraction                  |
-| `sdbullion`        | SD Bullion        | Standard extraction                  |
-| `monumentmetals`   | Monument Metals   | React Native Web SPA, 7s render wait |
-| `herobullion`      | Hero Bullion      | 6s render wait                       |
-| `bullionexchanges` | Bullion Exchanges | React/Magento SPA, 8s render wait    |
-| `summitmetals`     | Summit Metals     | ASE only                             |
-
-Goldback-specific vendors: `goldback` (official exchange rate)
-
----
-
-## HTTP Server Details
-
-`serve.js` runs on Cloud - Fly.io port 8080 as a redundancy endpoint:
-
-- **CORS:** `Access-Control-Allow-Origin: *`
-- **Cache:** `Cache-Control: public, max-age=300` (5 minutes)
-- **Methods:** GET and OPTIONS only
-- **Security:** Directory traversal (`..`) rejected
-- **Content types:** `.json` → `application/json`, `.db` → `application/x-sqlite3`
-
----
-
-## Best Practices Audit
-
-**Strengths:**
-
-- Static file serving — zero dynamic attack surface
-- Proper CORS configuration with preflight handling
-- Cache-Control headers appropriate for 15-min update cycle
-- sqld as single source of truth for retail data
-- Dual-source verification (Firecrawl + Vision) with confidence scoring
-
-**Recommendations:**
-
-1. _(Aspirational)_ Add `/_health` endpoint returning `{"status":"ok","generated_at":"..."}` for Fly.io health checks
-2. Add `Last-Modified` header from `stat.mtime` for conditional caching (`If-Modified-Since`)
-3. Consider adding `schema_version` to `manifest.json` for client-side breaking change detection
-
----
-
-## v2 API (STAK-503)
-
-> **Status:** v2 publisher (`devops/pollers/shared/api-export-v2.js`) generates endpoints alongside v1. Frontend migration behind `USE_V2_API` feature flag (default `false`). v2 pipeline is non-fatal — v1 continues to publish regardless of v2 outcome.
+Publisher: `devops/pollers/shared/api-export-v2.js`.
 
 ### Endpoint Tree
 
@@ -310,16 +54,6 @@ All v2 endpoints live under `data/v2/`:
 | `data/v2/goldback/{slug}/latest.json`    | Per-state goldback vendor prices                                                          | Every 15 min        |
 | `data/v2/providers.json`                 | Vendor to product URL mapping per coin (reference data — stable)                          | Every 15 min        |
 
-### Stale Thresholds (per endpoint type)
-
-| Type      | `stale_after` (seconds)                              |
-| --------- | ---------------------------------------------------- |
-| Spot      | 1200 (20 min)                                        |
-| Retail    | 1800 (30 min)                                        |
-| Goldback  | 7200 (2 h) — was 90000 (25 h) before STRK-248        |
-| Manifest  | 1800 (30 min)                                        |
-| Providers | 86400 (24 h) — vendor URLs are stable reference data |
-
 ### v2 Envelope Format
 
 Every v2 endpoint returns a self-describing envelope:
@@ -337,6 +71,20 @@ Every v2 endpoint returns a self-describing envelope:
 - `generated_at` — ISO 8601 UTC publish timestamp
 - `stale_after` — seconds after `generated_at` before this endpoint should be considered stale
 - `data` — payload (varies by endpoint type)
+
+Health logic reads `stale_after` from the envelope — no hardcoded thresholds in the
+frontend (see Health Checks deep dive). Per STRK-331, data paths and the health badge
+resolve freshness from the freshest `generated_at` per feed across serving endpoints.
+
+### Stale Thresholds (per endpoint type)
+
+| Type      | `stale_after` (seconds)                              |
+| --------- | ---------------------------------------------------- |
+| Spot      | 1200 (20 min)                                        |
+| Retail    | 1800 (30 min)                                        |
+| Goldback  | 7200 (2 h) — was 90000 (25 h) before STRK-248        |
+| Manifest  | 1800 (30 min)                                        |
+| Providers | 86400 (24 h) — vendor URLs are stable reference data |
 
 ### Dual Timestamps
 
@@ -390,11 +138,272 @@ Time-series data includes OHLCA aggregates per window:
 }
 ```
 
+### Coin Slugs
+
+The slug catalog is manifest-driven and grows as coins/vendors are enabled in the provider
+database. Representative slugs include:
+
+**Silver (1 oz):** `ase`, `maple-silver`, `britannia-silver`, `krugerrand-silver`, `generic-silver-round`
+**Silver (10 oz):** `generic-silver-bar-10oz`
+**Gold (1 oz):** `age`, `buffalo`, `maple-gold`, `krugerrand-gold`
+**Platinum (1 oz):** `ape`
+**Goldback:** `goldback-oklahoma-g1`, `goldback-utah-g50`, `goldback-wyoming-g5`, `goldback-wyoming-g50`, and others as enabled
+
+#### Planned/Future: Goldback Per-State Matrix
+
+**Goldback (per-state — STAK-335):** `goldback-{state}-g{denom}` where state is one of
+`utah`, `nevada`, `wyoming`, `new-hampshire`, `south-dakota`, `arizona`, `oklahoma`, `dc`
+and denom is `ghalf`, `g1`, `g2`, `g5`, `g10`, `g25`, `g50` (56 slugs total, 8 states ×
+7 denominations). These endpoints populate as vendors are enabled in the database.
+
+### Vendor Source Values (retail `latest.json`)
+
+| Source             | Meaning                                                                                 |
+| ------------------ | --------------------------------------------------------------------------------------- |
+| `firecrawl+vision` | Both Firecrawl and Gemini Vision agreed (<=3% diff) — 99 confidence                     |
+| `firecrawl`        | Firecrawl text extraction only                                                          |
+| `vision`           | Gemini Vision screenshot extraction only                                                |
+| `turso_last_known` | T4 fallback — most recent in-stock price from database history (includes `stale: true`) |
+
+### Confidence Tiers
+
+| Range | Meaning                            |
+| ----- | ---------------------------------- |
+| 90-99 | Firecrawl + Vision cross-validated |
+| 60-89 | Single source, agrees with median  |
+| 30-59 | Single source, moderate deviation  |
+| 0-29  | Outlier or disagreement            |
+
+---
+
+## Raw Spot Pipeline Paths
+
+These are writer-side paths (still actively written), not part of the v2 serving contract:
+
+| Endpoint Pattern                  | Description                                                                               | Updated                                   |
+| --------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `data/hourly/YYYY/MM/DD/HH.json`  | Hourly spot prices (4 metals) — overwritten each poll                                     | 4x/hr (remote at `0,30`, home at `15,45`) |
+| `data/15min/YYYY/MM/DD/HHMM.json` | Immutable 15-min spot snapshots                                                           | Per poll (immutable)                      |
+| `data/spot-history-YYYY.json`     | Annual daily spot history (legacy seed — no longer actively written by `spot-extract.js`) | Legacy                                    |
+
+### Hourly File Schema
+
+```json
+[
+  {
+    "spot": 2945.12,
+    "metal": "Gold",
+    "source": "hourly",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-25 19:05:00"
+  },
+  {
+    "spot": 33.41,
+    "metal": "Silver",
+    "source": "hourly",
+    "provider": "StakTrakr",
+    "timestamp": "2026-02-25 19:05:00"
+  }
+]
+```
+
+**Metals:** Gold (XAU), Silver (XAG), Platinum (XPT), Palladium (XPD)
+**Data source:** MetalPriceAPI (`metalpriceapi.com`)
+**Rate conversion:** Conditional — `rate >= 1` uses value directly; `rate < 1` inverts (`1 / rate`) to get USD per troy oz
+
+---
+
+## Goldback Data Flow
+
+> **Post-STAK-491:** Goldback data flows through sqld, not a direct git-commit path.
+> `run-goldback.sh` on Fly.io is **disabled** (`GOLDBACK_ENABLED=0`) — the home poller's
+> `goldback-scraper.js` writes `goldback-g1` to sqld hourly (`5 * * * *`, STRK-58), and
+> Fly.io's exporters read that row during the normal publish cycle. goldback.com's
+> upstream rate (`data.t`) can lag the scrape, so `g1_usd` may repeat across publishes.
+
+Serving endpoints are the v2 goldback rows in the table above. `data/goldback-YYYY.json`
+(rolling annual history, newest first) is also regenerated each publish cycle from the
+sqld `goldback-g1` rows.
+
+---
+
+## Vendor Reference
+
+7 primary vendors tracked across all bullion coins:
+
+| Vendor ID          | Name              | Notes                                |
+| ------------------ | ----------------- | ------------------------------------ |
+| `jmbullion`        | JM Bullion        | JS-heavy (Next.js), 10s render wait  |
+| `apmex`            | APMEX             | Standard extraction                  |
+| `sdbullion`        | SD Bullion        | Standard extraction                  |
+| `monumentmetals`   | Monument Metals   | React Native Web SPA, 7s render wait |
+| `herobullion`      | Hero Bullion      | 6s render wait                       |
+| `bullionexchanges` | Bullion Exchanges | React/Magento SPA, 8s render wait    |
+| `summitmetals`     | Summit Metals     | ASE only                             |
+
+Goldback-specific vendors: `goldback` (official exchange rate)
+
+> The live vendor map has grown beyond this original seven (e.g. `mintbuilder` via the
+> MintBuilder API feed, STRK-321) — `data/v2/providers.json` and the four vendor maps in
+> `js/retail.js`/`VENDOR_META` are the authoritative roster.
+
+---
+
+## HTTP Server Details
+
+`serve.js` runs on Fly.io port 8080 as a redundancy endpoint:
+
+- **CORS:** `Access-Control-Allow-Origin: *`
+- **Cache:** `Cache-Control: public, max-age=300` (5 minutes)
+- **Methods:** GET and OPTIONS only
+- **Security:** Directory traversal (`..`) rejected
+- **Content types:** `.json` → `application/json`, `.db` → `application/x-sqlite3`
+
+---
+
+## Legacy v1 API (`data/api/` — still published, not consumed)
+
+> **Status:** v1 endpoints are still written by `api-export.js` every publish cycle for
+> external/legacy consumers, but **no frontend code reads them** (removed in STAK-509,
+> v3.33.92). Do not build new features against v1. Schemas below are kept for pipeline
+> diagnostics and external-consumer reference only.
+
+| Endpoint                                               | Description                                                       | Updated      |
+| ------------------------------------------------------ | ----------------------------------------------------------------- | ------------ |
+| `data/api/manifest.json`                               | Index: coin list, latest window, endpoint templates               | Every 15 min |
+| `data/api/latest.json`                                 | All coins' current median/lowest prices                           | Every 15 min |
+| `data/api/providers.json`                              | Vendor to product URL mapping per coin (auto-generated from sqld) | Every 15 min |
+| `data/api/goldback-spot.json`                          | Goldback G1 rate + denomination multipliers                       | Every 15 min |
+| `data/api/{slug}/latest.json`                          | Per-vendor prices, confidence, availability, 24h series           | Every 15 min |
+| `data/api/{slug}/history-7d.json` / `history-30d.json` | Daily aggregates                                                  | Every 15 min |
+
+### v1 manifest.json Schema
+
+```json
+{
+  "generated_at": "2026-02-25T19:08:01.756Z",
+  "latest_window": "2026-02-25T19:00:00Z",
+  "window_count": 96,
+  "coin_count": 11,
+  "coins": ["age", "ape", "ase", "..."],
+  "coins_meta": { ... },
+  "endpoints": {
+    "latest": "api/latest.json",
+    "slug_latest": "api/{slug}/latest.json",
+    "history_7d": "api/{slug}/history-7d.json",
+    "history_30d": "api/{slug}/history-30d.json",
+    "providers": "api/providers.json"
+  }
+}
+```
+
+> `coins_meta` is an optional object containing per-coin metadata (display name, metal,
+> weight). Present when the exporter has metadata available from the provider database.
+
+### v1 latest.json Schema
+
+```json
+{
+  "window_start": "2026-02-25T19:00:00Z",
+  "generated_at": "2026-02-25T19:08:01.756Z",
+  "coin_count": 11,
+  "coins": {
+    "ase": {
+      "window_start": "2026-02-25T19:00:00Z",
+      "median_price": 36.42,
+      "lowest_price": 35.19,
+      "vendor_count": 7
+    }
+  }
+}
+```
+
+### v1 goldback-spot.json Schema
+
+```json
+{
+  "date": "2026-02-25",
+  "scraped_at": "2026-02-25T19:08:01.756Z",
+  "g1_usd": 10.43,
+  "denominations": {
+    "g1": 10.43,
+    "g5": 52.15,
+    "g10": 104.3,
+    "g25": 260.75,
+    "g50": 521.5
+  },
+  "source": "goldback.com",
+  "confidence": "high"
+}
+```
+
+### v1 Per-Coin latest.json Schema
+
+```json
+{
+  "slug": "ase",
+  "window_start": "2026-02-25T19:00:00Z",
+  "median_price": 36.42,
+  "lowest_price": 35.19,
+  "vendors": {
+    "jmbullion": {
+      "price": 35.19,
+      "confidence": 99,
+      "source": "firecrawl+vision",
+      "inStock": true
+    },
+    "apmex": {
+      "price": 36.99,
+      "confidence": 80,
+      "source": "firecrawl",
+      "inStock": true
+    }
+  },
+  "availability_by_site": {
+    "jmbullion": true,
+    "apmex": true
+  },
+  "last_known_price_by_site": {},
+  "last_available_date_by_site": {},
+  "windows_24h": [
+    {
+      "window": "2026-02-24T19:15:00Z",
+      "median": 36.5,
+      "low": 35.2,
+      "vendors": { "jmbullion": 35.2, "apmex": 37.01 }
+    }
+  ]
+}
+```
+
+### Deprecated Goldback Compat Slugs
+
+`goldback-g1` … `goldback-g50` (mixed-state, backward compat) are scaffolded v1-era slugs,
+not in the committed manifest.
+
+---
+
+## Best Practices Audit
+
+**Strengths:**
+
+- Static file serving — zero dynamic attack surface
+- Proper CORS configuration with preflight handling
+- Cache-Control headers appropriate for 15-min update cycle
+- sqld as single source of truth for retail data
+- Dual-source verification (Firecrawl + Vision) with confidence scoring
+- v2 self-describing envelopes — thresholds travel with the data
+
+**Recommendations:**
+
+1. _(Aspirational)_ Add `/_health` endpoint returning `{"status":"ok","generated_at":"..."}` for Fly.io health checks
+2. Add `Last-Modified` header from `stat.mtime` for conditional caching (`If-Modified-Since`)
+3. Retire the v1 exporter once external consumers (if any) confirm migration — dual-publishing doubles the publish surface for no frontend benefit
+
 ---
 
 ## Related
 
-- Architecture — system diagram, repo boundaries
+- Architecture — system diagram, repo boundaries, v1-vs-v2 status
+- Health Checks — envelope-driven staleness, diagnostic script
 - Remote Poller — scraping pipeline, Firecrawl, tiered recovery
-- Cloud - GitHub Pages — hosting for static JSON feeds
-- Cloud - Fly.io — container that produces the feeds

--- a/.context/deep-dives/health-checks.md
+++ b/.context/deep-dives/health-checks.md
@@ -4,52 +4,50 @@ project: StakTrakr
 audience: agent
 canonical: .context/deep-dives/health-checks.md
 source: "DocVault/Projects/StakTrakr/Foundation/Deep Dives/Health Checks.md" # migrated 2026-08-12
-updated: "2026-06-28"
+updated: "2026-08-12"
 ---
 
 # Health & Diagnostics
 
-> **Last verified:** 2026-03-22
+> **Last verified:** 2026-08-12 — v2 endpoints, envelope-driven staleness (STAK-509: v1 no longer consumed)
 
 ---
 
 ## Quick Health Check
 
+v2 envelopes carry their own `stale_after`, so the script needs no hardcoded thresholds
+(goldback resolves to 7200 s = 120 min):
+
 ```python
 python3 << 'EOF'
-import urllib.request, json, re
-from datetime import datetime, timezone, timedelta
+import urllib.request, json
+from datetime import datetime, timezone
 
-def age_min(ts):
-    ts = ts.strip()
-    if not re.search(r'[zZ]$|[+-]\d{2}:?\d{2}$', ts):
-        ts = ts.replace(' ', 'T') + 'Z'
-    return (datetime.now(timezone.utc) - datetime.fromisoformat(ts.replace('Z','+00:00'))).total_seconds()/60
+BASE = 'https://api.staktrakr.com/data/v2'
 
-def fetch(url):
-    with urllib.request.urlopen(url, timeout=10) as r: return json.load(r)
+def fetch(path):
+    with urllib.request.urlopen(f"{BASE}/{path}", timeout=10) as r: return json.load(r)
 
-print(f"API Health — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}\n")
-try:
-    d = fetch('https://api.staktrakr.com/data/api/manifest.json')
-    age = age_min(d['generated_at'])
-    print(f"Market   {'OK' if age<=30 else 'WARN'}  {age:.0f}m ago  ({len(d.get('coins',[]))} coins)")
-except Exception as e: print(f"Market   FAIL  {e}")
-try:
-    now = datetime.now(timezone.utc)
-    def url(dt): return f"https://api.staktrakr.com/data/hourly/{dt.year}/{dt.month:02d}/{dt.day:02d}/{dt.hour:02d}.json"
-    try: d = fetch(url(now))
-    except: d = fetch(url(now - timedelta(hours=1)))
-    age = age_min(d[-1]['timestamp'])
-    print(f"Spot     {'OK' if age<=75 else 'WARN'}  {age:.0f}m ago")
-except Exception as e: print(f"Spot     FAIL  {e}")
-try:
-    d = fetch('https://api.staktrakr.com/data/api/goldback-spot.json')
-    age = age_min(d['scraped_at'])
-    print(f"Goldback {'OK' if age<=1500 else 'WARN'}  {age/60:.1f}h ago  (${d.get('g1_usd')} G1)")
-except Exception as e: print(f"Goldback FAIL  {e}")
+def check(name, path, detail=lambda d: ''):
+    try:
+        env = fetch(path)
+        gen = datetime.fromisoformat(env['generated_at'].replace('Z', '+00:00'))
+        age = (datetime.now(timezone.utc) - gen).total_seconds()
+        limit = env.get('stale_after', 1800)
+        state = 'OK' if age <= limit else 'STALE'
+        print(f"{name:9s}{state:6s}{age/60:5.0f}m ago  (stale_after {limit//60}m){detail(env['data'])}")
+    except Exception as e:
+        print(f"{name:9s}FAIL  {e}")
+
+print(f"API Health (v2) — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}\n")
+check('Manifest', 'manifest.json', lambda d: f"  ({d.get('coin_count', '?')} coins)")
+check('Spot', 'spot/latest.json')
+check('Goldback', 'goldback/latest.json', lambda d: f"  (${d.get('g1_usd')} G1)")
 EOF
 ```
+
+> Raw pipeline paths (`data/hourly/`, `data/15min/`) are still written 4×/hr and can be
+> spot-checked directly when diagnosing the writers rather than the serving layer.
 
 ---
 
@@ -116,8 +114,8 @@ Expected: rows from `home` (retail), `home-spot` (spot from home poller), and `f
 
 | Symptom                               | Likely cause                                                                  | Action                                                                                                            |
 | ------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `manifest.json` > 30 min stale        | Home poller `run-home.sh` missed cycle or Fly.io `run-publish.sh` not running | Check home poller logs via Portainer dashboard; `fly logs --app staktrakr \| grep publish`                        |
-| `manifest.json` > 4h stale            | Home poller or Fly.io container down                                          | Check home poller container in Portainer; `fly status --app staktrakr`                                            |
+| `v2/manifest.json` > 30 min stale     | Home poller `run-home.sh` missed cycle or Fly.io `run-publish.sh` not running | Check home poller logs via Portainer dashboard; `fly logs --app staktrakr \| grep publish`                        |
+| `v2/manifest.json` > 4h stale         | Home poller or Fly.io container down                                          | Check home poller container in Portainer; `fly status --app staktrakr`                                            |
 | Spot hourly > 75 min stale            | `METAL_PRICE_API_KEY` expired or quota exceeded                               | Check MetalPriceAPI dashboard                                                                                     |
 | Goldback > 2h stale (STRK-248)        | Home poller `goldback-scraper.js` failed                                      | Check home poller logs via Portainer dashboard (goldback runs on home only, not Fly.io)                           |
 | Only 1-2 vendors per coin             | Home poller down or OOS                                                       | Check home poller container; verify sqld has recent rows (home is sole retail scraper)                            |
@@ -205,7 +203,7 @@ Each endpoint type declares its own `stale_after` value (in seconds):
 | Goldback | 7200          | 2 h (was 90000 / 25 h before STRK-248) |
 | Manifest | 1800          | 30 min                                 |
 
-The v2 manifest also publishes these thresholds in `data.stale_thresholds`, so the frontend can use a single source of truth for both v1 and v2 health badge logic. When `USE_V2_API` is enabled, `api-health.js` reads `stale_after` from the v2 envelope rather than using the hardcoded `API_HEALTH_*_STALE_MIN` constants.
+The v2 manifest also publishes these thresholds in `data.stale_thresholds`. Since STAK-506/509 (`USE_V2_API` flag shipped as default, then removed — v2 is the sole consumed layer), `api-health.js` always reads `stale_after` from the v2 envelope; the hardcoded `API_HEALTH_*_STALE_MIN` era is over. Per STRK-331, both the data paths and the badge resolve freshness from the **freshest `generated_at` per feed** across serving endpoints.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the two content-drift items deliberately deferred from the `.context/` migration ([#1441](https://github.com/lbruton/StakTrakr/pull/1441)), which was fidelity-preserving by design. Both were flagged by Codacy AI review on that PR and are now fixed after verification against source.

### api-reference.md — v2 promoted to primary
- Verified: `USE_V2_API` is gone from `js/constants.js` (shipped default STAK-506, removed STAK-509 / v3.33.92); frontend fetches only `data/v2/` (`js/constants.js:563`, `js/api-health.js:156`; zero `data/api/` refs in `js/`).
- Nuance vs. the reviewer's suggested prompt: `run-publish.sh:51` still runs the v1 exporter, so v1 is **still published, not removed** — the doc now says exactly that in a demoted "Legacy v1 API" section.
- Raw spot paths (`data/hourly/`, `data/15min/`) kept as writer-side pipeline paths (still written 4×/hr).

### health-checks.md — envelope-driven diagnostic script
- Script rewritten to fetch `data/v2/` endpoints and compute staleness from each envelope's own `stale_after` (verified live: goldback envelope carries `stale_after: 7200` = 120 min, `data.g1_usd`). Replaces the obsolete 25-hour `scraped_at` gate.
- `USE_V2_API` phrasing updated post-STAK-509; STRK-331 freshest-`generated_at` rule noted.

Drift report: `DocVault/Projects/StakTrakr/drift-reports/2026-08-12-context.md` (pending /vault-sweep).

Docs-only chore — no version bump, no review labels. Test inventory delta: +0 -0 tests, +0 -0 files.