### PR TITLE
chore: add path-scoped JS invariants rule (.claude/rules/)

### DIFF
--- a/.claude/rules/js-invariants.md
+++ b/.claude/rules/js-invariants.md
@@ -5,9 +5,10 @@ paths:
 
 # JavaScript Invariants — StakTrakr
 
-Silent-failure foot-guns in `js/`. Every entry here fails **quietly** — no exception, no
-red test — which is why they are injected at the point of edit rather than left to review.
-Full detail: `.context/coding-standards.md`, `.context/implementation-gotchas.md`.
+Foot-guns in `js/`. Most fail **silently** — no exception, no red test — which is why they
+are injected at the point of edit rather than left to review. Two throw loudly and are
+marked as such. Full detail: `.context/coding-standards.md`,
+`.context/implementation-gotchas.md`.
 
 ## Dual config store — CRITICAL, silent data loss
 
@@ -24,9 +25,16 @@ stay stale.
 
 ## All `js/` files share ONE global scope
 
-Script-tag globals — no modules, no imports. A duplicate top-level `const`/`var` across two
-files is a **SyntaxError that silently kills the second script**. Prefix new sync-related
-globals `SYNC_` / `_sync`.
+Script-tag globals — no modules, no imports. Redeclaring a top-level binding across two
+files behaves differently by keyword, and both outcomes are bad:
+
+- `const` / `let` / `class` — **SyntaxError at parse time that silently kills the second
+  script.** Nothing else on the page reports it.
+- `var` — legal. The later script silently overwrites the earlier value, so there is no
+  error at all and the symptom surfaces far from the cause.
+
+Prefix new sync-related globals `SYNC_` (precedent: `SYNC_SCOPE_KEYS`,
+`SYNC_BACKUP_PREFIX` in `js/constants.js`).
 
 Corollary: to find every reference to a global, Grep the identifier. There is no import
 graph, so semantic search under-reports call sites.
@@ -34,12 +42,13 @@ graph, so semantic search under-reports call sites.
 ## `safeGetElement` returns a partial dummy, not null
 
 A missing element yields a shim whose members no-op silently, so `if (!el)` never fires.
-Only `instanceof HTMLElement` discriminates a real element.
+Discriminate a real element with `instanceof HTMLElement` or `nodeType === 1` — the
+codebase uses both (`js/spotLookup.js:26`).
 
 `init.js` defines it and loads **after** `events.js` (both `defer`). Top-level code in
-`events.js` calling `safeGetElement` throws a silent ReferenceError — use
-`document.getElementById` for parse-time wiring. Factory closures are fine; they resolve at
-runtime.
+`events.js` calling `safeGetElement` **throws a ReferenceError** — loud, but it kills the
+rest of the script. Use `document.getElementById` for parse-time wiring. Factory closures
+are fine; they resolve at runtime.
 
 ## `loadDataSync` — swallowed errors, truthy defaults
 
@@ -50,17 +59,26 @@ runtime.
 - `saveDataSync` **re-throws** on quota errors, unlike raw `localStorage.setItem`.
   Fire-and-forget callers migrating from raw storage need a `try/catch`.
 
-## A new persisted key registers in TWO places
+## Persisted keys: `ALLOWED_STORAGE_KEYS` always, `SYNC_SCOPE_KEYS` conditionally
 
-`ALLOWED_STORAGE_KEYS` **and** `SYNC_SCOPE_KEYS` (`js/constants.js`). Registering one
-without the other yields a key that either fails restore or never syncs — both silent.
-Device-local keys are deliberately excluded from `SYNC_SCOPE_KEYS`; note that in a comment
-at the declaration (precedent: `FORM_SECTION_STATE_KEY`, STRK-301).
+Any new persisted key must be added to `ALLOWED_STORAGE_KEYS`.
+
+`SYNC_SCOPE_KEYS` (`js/constants.js`) is **not** automatic — it covers inventory data plus
+preferences meaningful _across devices_. Its contract explicitly excludes OAuth tokens,
+transient caches, server-sourced data, and device-local state. Adding a cache or a
+server-sourced value there is a bug, not an omission.
+
+When a key is deliberately device-local, say so in a comment at the declaration
+(precedent: `FORM_SECTION_STATE_KEY`, STRK-301).
 
 ## A new `js/` file registers in TWO places
 
 `index.html` **and** `CORE_ASSETS` in `sw.js`. Missing the `sw.js` half fails only offline,
-only after a cache cycle — invisible in every local test run.
+only after a cache cycle — invisible in every local test run. Keep `CORE_ASSETS` in the
+same order as the `<script>` tags for auditability.
+
+**Intentional exception:** `js/test-loader.js` is never added to `CORE_ASSETS` — it is a
+dev-only harness, gated on `hostname === "localhost"`. Do not precache dev-only scripts.
 
 ## Date frames — never mix silently
 
@@ -72,19 +90,20 @@ only after a cache cycle — invisible in every local test run.
 
 Crossing frames is allowed only when deliberate and commented at the call site.
 
-## `applyBulkEdit()` — flat assignment, shallow copy
+## `applyBulkEdit()` — preserve the current contracts
 
-- Assignment is flat (`item[fieldId] = value`). A nested path such as
-  `item.numistaData.shape` silently writes a bogus top-level key unless it has a
-  `BULK_FIELD_STORAGE_MAP` entry (precedent: STRK-91).
-- `Object.assign({}, item)` is shallow, so mutating a nested object mutates `oldItem` too
-  and change-log before/after diffs come out empty. Deep-copy before mutating.
+Both historical hazards are already solved in `js/bulkEdit.js`. Do not regress them:
+
+- **Nested paths** route through `BULK_FIELD_STORAGE_MAP` via `applyBulkFieldToItem()`.
+  A new bulk-editable field at a nested path (e.g. `item.numistaData.shape`) needs its own
+  map entry; without one, a flat write lands on a bogus top-level key (precedent: STRK-91).
+- **Change-log snapshots** use `structuredClone` for `oldItem.numistaData` and
+  `oldItem.fieldMeta`. A plain `Object.assign({}, item)` is shallow — mutating a nested
+  object would also mutate `oldItem` and the before/after diff would come out empty.
 - Grep `BULK_COLUMN_PRIORITY` for its length rather than trusting docs — reviewers have
   guessed wrong in three separate sessions.
 
-## Two smaller ones
+## `_isMarketItemEnabled` — apply on both tab paths
 
-- `_isMarketItemEnabled` must be applied on **both** the All-tab path and the per-metal
-  `else` branch of `_renderVendorTable()`, or disabled vendors surface as column headers.
-- `isGoldbackLookup` (target + unit) and `isGoldbackRetailLookup` (unit only) are different
-  predicates. Retail lookup uses unit-only.
+In `_renderVendorTable()`, apply the filter on **both** the All-tab path and the per-metal
+`else` branch, or disabled vendors surface as column headers.

--- a/.claude/rules/js-invariants.md
+++ b/.claude/rules/js-invariants.md
@@ -1,0 +1,90 @@
+---
+paths:
+  - "js/**/*.js"
+---
+
+# JavaScript Invariants — StakTrakr
+
+Silent-failure foot-guns in `js/`. Every entry here fails **quietly** — no exception, no
+red test — which is why they are injected at the point of edit rather than left to review.
+Full detail: `.context/coding-standards.md`, `.context/implementation-gotchas.md`.
+
+## Dual config store — CRITICAL, silent data loss
+
+Two unrelated localStorage stores. Confusing them was the STRK-573 root cause.
+
+| Store                             | Key                  | Read / Write                                              |
+| --------------------------------- | -------------------- | --------------------------------------------------------- |
+| Spot providers                    | `metalApiConfig`     | `loadApiConfig()` / `saveApiConfig()`                     |
+| Catalog providers (Numista, PCGS) | `catalog_api_config` | `catalogConfig.getNumistaConfig()` / `setNumistaConfig()` |
+
+`loadApiConfig().keys["numista"]` returns `undefined` — wrong store, no error raised.
+After saving a catalog key, call `catalogAPI.initializeProviders()` or provider instances
+stay stale.
+
+## All `js/` files share ONE global scope
+
+Script-tag globals — no modules, no imports. A duplicate top-level `const`/`var` across two
+files is a **SyntaxError that silently kills the second script**. Prefix new sync-related
+globals `SYNC_` / `_sync`.
+
+Corollary: to find every reference to a global, Grep the identifier. There is no import
+graph, so semantic search under-reports call sites.
+
+## `safeGetElement` returns a partial dummy, not null
+
+A missing element yields a shim whose members no-op silently, so `if (!el)` never fires.
+Only `instanceof HTMLElement` discriminates a real element.
+
+`init.js` defines it and loads **after** `events.js` (both `defer`). Top-level code in
+`events.js` calling `safeGetElement` throws a silent ReferenceError — use
+`document.getElementById` for parse-time wiring. Factory closures are fine; they resolve at
+runtime.
+
+## `loadDataSync` — swallowed errors, truthy defaults
+
+- Parse/decompression errors return the default instead of throwing. An outer `try/catch`
+  will not fire, and `console.warn` in that catch is dead code.
+- The default is `[]`, not `null` — and `[]` is truthy, so `if (!stored)` merge guards
+  silently skip. Pass `null` explicitly when the caller tests truthiness.
+- `saveDataSync` **re-throws** on quota errors, unlike raw `localStorage.setItem`.
+  Fire-and-forget callers migrating from raw storage need a `try/catch`.
+
+## A new persisted key registers in TWO places
+
+`ALLOWED_STORAGE_KEYS` **and** `SYNC_SCOPE_KEYS` (`js/constants.js`). Registering one
+without the other yields a key that either fails restore or never syncs — both silent.
+Device-local keys are deliberately excluded from `SYNC_SCOPE_KEYS`; note that in a comment
+at the declaration (precedent: `FORM_SECTION_STATE_KEY`, STRK-301).
+
+## A new `js/` file registers in TWO places
+
+`index.html` **and** `CORE_ASSETS` in `sw.js`. Missing the `sw.js` half fails only offline,
+only after a cache cycle — invisible in every local test run.
+
+## Date frames — never mix silently
+
+- User-facing local dates → `toLocaleDateString('en-CA')`.
+- Feed-keyed / UTC values → derive from the ISO field (`row.t.split("T")[0]`) or pass
+  `{ timeZone: 'UTC' }`.
+- `toISOString().slice(0, 10)` on a locally-constructed date shifts a day for users at
+  negative UTC offsets; local `en-CA` on a UTC-stamped key shifts the other way.
+
+Crossing frames is allowed only when deliberate and commented at the call site.
+
+## `applyBulkEdit()` — flat assignment, shallow copy
+
+- Assignment is flat (`item[fieldId] = value`). A nested path such as
+  `item.numistaData.shape` silently writes a bogus top-level key unless it has a
+  `BULK_FIELD_STORAGE_MAP` entry (precedent: STRK-91).
+- `Object.assign({}, item)` is shallow, so mutating a nested object mutates `oldItem` too
+  and change-log before/after diffs come out empty. Deep-copy before mutating.
+- Grep `BULK_COLUMN_PRIORITY` for its length rather than trusting docs — reviewers have
+  guessed wrong in three separate sessions.
+
+## Two smaller ones
+
+- `_isMarketItemEnabled` must be applied on **both** the All-tab path and the per-metal
+  `else` branch of `_renderVendorTable()`, or disabled vendors surface as column headers.
+- `isGoldbackLookup` (target + unit) and `isGoldbackRetailLookup` (unit only) are different
+  predicates. Retail lookup uses unit-only.


### PR DESCRIPTION
## What

Adds `.claude/rules/js-invariants.md` — a **path-scoped Claude Code rule** (`paths: js/**/*.js`) carrying the silent-failure invariants for `js/`.

No Plane issue: `.claude/` config edits are lightweight per `.context/git-topology.md`. No version lock, no runtime code touched.

## Why

`CLAUDE.md` already routes to `.context/` docs via a "Read before…" table, but that routing is an *instruction* — it depends on the agent noticing the table applies, deciding the task qualifies, and then reading the file. Three probabilistic steps, each a place it silently doesn't happen.

Rules with `paths:` frontmatter are injected by the harness when a matching file is read, collapsing that to one deterministic event. The Gotcha Index exists because these specific things kept recurring (STRK-573 dual-config-store data loss, hallucinated `contrast` theme, missing `sw.js` registration), which is the evidence that pointer-only routing leaks.

## Scope decisions

- **Selection criterion:** only invariants that fail *silently* — no exception, no failing test.
- **`.context/` is unchanged.** It stays the harness-neutral content layer readable by Codex/OpenCode/Antigravity; this rule is a Claude-only trigger layer that points back at it. No content was moved out.
- **Deliberately excluded:** CSS gotchas (`--warning`/`--success` contrast, sticky columns, four themes), the Playwright dialog pattern, `check-release-sync`, closing-task ordering. Those are `css/**`, `tests/**`, and workflow scoped — wrong trigger for this file. Separate rules if the pilot works.
- Every identifier cited (`ALLOWED_STORAGE_KEYS`, `SYNC_SCOPE_KEYS`, `CORE_ASSETS`, `BULK_COLUMN_PRIORITY`) was grepped live rather than taken from docs or memory.

## Context cost

Zero always-on. Path-scoped rules load lazily on matching reads.

Known caveat, deliberately accepted: path-scoped rules are **not re-injected after `/compact`** (root `CLAUDE.md` is). So the CRITICAL dual-config-store line stays in `CLAUDE.md` as well — duplication is correct here, since the cost of that invariant being absent is silent data loss.

## Verification

- `markdownlint-cli` — clean (exit 0)
- `agentlinter --local` — 86/100 (B+), unchanged; all findings pre-existing in `AGENTS.md`/`CLAUDE.md`
- Pre-commit hooks — all passed, commit signed
- Frontmatter format verified empirically on Claude Code v2.1.220 via a canary rule in a fresh headless session (quoted YAML-list `paths:` loads correctly; the GitHub issues claiming otherwise are ~200 patch versions stale)

## Pilot

This is a trial. The observable proxy for success is whether the recurring violations above stop appearing in review over the next few patches. If they don't, this is one file to revert.