### PR TITLE
chore: fix markdown gate conflicts — prettier before lint, pin MD049, cover .context/

### DIFF
--- a/.context/review-and-ci.md
+++ b/.context/review-and-ci.md
@@ -100,8 +100,23 @@ are easy to hit unexpectedly:
 | `stamp-sw-cache`     | stamps the service-worker cache on staged asset changes                  |
 | `check-release-sync` | release-artifact version sync (a **subset** — see `git-topology.md`)     |
 | `check-claude-md`    | verifies CLAUDE.md exists (it is tracked; restore with `git restore`)    |
-| `lint-markdown`      | markdownlint on staged Markdown                                          |
 | `lint-staged`        | prettier on staged files                                                 |
+| `lint-markdown`      | markdownlint on staged Markdown                                          |
+
+**Order matters: prettier runs before markdownlint.** Reversed (as it was until
+2026-08-13), markdownlint validated the pre-prettier content while prettier's rewrites
+landed unlinted — so a commit could pass and still leave the file failing the _next_ lint.
+The concrete symptom was emphasis style: prettier normalizes `*text*` to `_text_`, MD049
+defaulted to "consistent" and resolved to asterisk in some files, and the two ping-ponged
+across commits. `MD049` is now pinned to `underscore` (matching prettier's output) and
+`MD050` to `asterisk`, so the two tools agree by construction rather than by ordering luck.
+
+**Markdown lint coverage:** `npm run lint:md:all` globs `**/*.md`, which **does not traverse
+dot-directories** — so `.context/` and `.agents/` were historically unlinted by the repo
+gate and only caught by the staged pre-commit hook. Both are now globbed explicitly.
+`.claude/` and `.github/` are deliberately excluded: agent prompts and issue templates
+legitimately don't start with an H1, so including them would need MD041/MD032 exceptions
+rather than fixes.
 
 ### 75% docstring-coverage pre-merge gate (the invisible blocker)
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -23,5 +23,11 @@
   },
   "MD035": {
     "style": "---"
+  },
+  "MD049": {
+    "style": "underscore"
+  },
+  "MD050": {
+    "style": "asterisk"
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,15 +29,18 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-      - id: lint-markdown
-        name: Lint staged Markdown files
-        entry: bash devops/hooks/lint-markdown-changed.sh --staged
-        language: system
-        pass_filenames: false
-        files: \.md$
+      # prettier runs BEFORE lint-markdown so markdownlint validates the content that
+      # actually gets committed. Reversed, prettier's rewrites land unlinted and fail the
+      # next commit that touches the same file.
       - id: lint-staged
         name: Format staged files with prettier
         entry: npx lint-staged
         language: system
         pass_filenames: false
         always_run: true
+      - id: lint-markdown
+        name: Lint staged Markdown files
+        entry: bash devops/hooks/lint-markdown-changed.sh --staged
+        language: system
+        pass_filenames: false
+        files: \.md$

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:unit": "node --test tests/unit/*.test.js",
     "lint:md": "bash devops/hooks/lint-markdown-changed.sh --staged",
     "lint:md:changed": "bash devops/hooks/lint-markdown-changed.sh --changed",
-    "lint:md:all": "npx --yes markdownlint-cli --config .markdownlint.json --ignore-path .markdownlintignore \"**/*.md\"",
+    "lint:md:all": "npx --yes markdownlint-cli --config .markdownlint.json --ignore-path .markdownlintignore \"**/*.md\" \".context/**/*.md\" \".agents/**/*.md\"",
     "test": "npm run test:core",
     "test:core": "npx playwright test tests/playwright/core",
     "test:extended": "npx playwright test tests/playwright/extended --pass-with-no-tests",


### PR DESCRIPTION
## What

Three related defects in the markdown tooling, all surfaced while fixing docs in #1445/#1446. Config + one doc update; no runtime code.

### 1. Hook ordering — prettier now runs before markdownlint

`lint-markdown` ran **before** `lint-staged` (prettier), so markdownlint validated the *pre-prettier* content while prettier's rewrites landed **unlinted**. A commit could pass its own gate and still leave the file failing the **next** lint of that same file.

Swapped, so markdownlint validates what actually gets committed.

### 2. MD049 vs prettier ping-pong

`MD049` defaulted to `"consistent"` (first-use wins, per file) while prettier **always** normalizes emphasis to underscore. In any file whose first emphasis happened to be an asterisk, the two disagreed permanently.

This wasn't hypothetical — it happened twice in two days: `_after_` and `_skill_` in `review-and-ci.md` were converted to asterisk in #1445, silently reverted by prettier in the same commit, then failed lint again in #1446.

Pinned `MD049: underscore` (prettier's output) and `MD050: asterisk`. **Verified zero MD049/MD050 findings repo-wide under the pin** — this matches existing content rather than forcing a rewrite.

### 3. `.context/` was never linted by the repo gate

`lint:md:all` globs `**/*.md`, which **does not traverse dot-directories**. So 28 `.context/` docs and 12 `.agents/` docs were only ever checked by the *staged* pre-commit hook — which is exactly why these conflicts only ever surfaced at commit time and never in a repo-wide run.

Both are now globbed explicitly.

## Verification

- `npm run lint:md:all` — exit **0** with the expanded scope
- **Proved the gap is closed** by injecting a deliberate MD001/MD012 violation into `.context/testing.md` and confirming the gate catches it (then reverting):

```
.context/testing.md:75 error MD012/no-multiple-blanks
.context/testing.md:76 error MD001/heading-increment
```

- The MD049 pin immediately caught an asterisk in my own new prose in this PR — working as intended
- Pre-commit hooks pass in the new order (prettier → markdownlint, visible in the commit output)

## Deliberately excluded

`.claude/` and `.github/` are **not** added to the glob. They carry 11 pre-existing MD041/MD032 findings, but those are correct-as-written: agent prompts and GitHub issue templates legitimately don't open with an H1. Including them would require rule exceptions rather than fixes — a separate decision, not a silent one.

## Doc

`.context/review-and-ci.md` — the pre-commit hook table added in #1445 now reflects the new order, with the ordering rationale and the dot-directory coverage gap recorded so neither is rediscovered the hard way.

## Not in this PR

The `/vault-sweep` skill's stale precondition (hard-stops unless cwd is the DocVault root, though every command in it is `-C`-scoped so cwd is irrelevant) lives in `~/.claude/skills/` — outside this repo, so it can't ride along. Fixed separately.