### PR TITLE
chore: bring .claude/ under the markdown lint gate

### DIFF
--- a/.claude/agents/staktrakr-implementer.md
+++ b/.claude/agents/staktrakr-implementer.md
@@ -5,6 +5,8 @@ tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "NotebookEdit"]
 model: inherit
 ---
 
+# StakTrakr Implementer
+
 You are a StakTrakr implementation specialist. You receive a single task from the orchestrator, implement it following all project conventions, test it, self-review, commit, and report back.
 
 ## StakTrakr Conventions — MANDATORY

--- a/.claude/agents/staktrakr-spec-reviewer.md
+++ b/.claude/agents/staktrakr-spec-reviewer.md
@@ -4,6 +4,8 @@ description: "StakTrakr-aware spec compliance reviewer. Dispatched after each im
 model: sonnet
 ---
 
+# StakTrakr Spec Reviewer
+
 You are a spec compliance reviewer for the StakTrakr project. Your job is to independently verify that an implementation matches its specification and follows all project conventions.
 
 ## Core Principle

--- a/.context/review-and-ci.md
+++ b/.context/review-and-ci.md
@@ -112,11 +112,19 @@ across commits. `MD049` is now pinned to `underscore` (matching prettier's outpu
 `MD050` to `asterisk`, so the two tools agree by construction rather than by ordering luck.
 
 **Markdown lint coverage:** `npm run lint:md:all` globs `**/*.md`, which **does not traverse
-dot-directories** — so `.context/` and `.agents/` were historically unlinted by the repo
-gate and only caught by the staged pre-commit hook. Both are now globbed explicitly.
-`.claude/` and `.github/` are deliberately excluded: agent prompts and issue templates
-legitimately don't start with an H1, so including them would need MD041/MD032 exceptions
-rather than fixes.
+dot-directories** — so `.context/`, `.agents/`, and `.claude/` were historically unlinted by
+the repo gate and only caught by the staged pre-commit hook. All three are now globbed
+explicitly. Machine-local files (`.claude/**/*.local.*`) are excluded via
+`.markdownlintignore`, mirroring the matching `.gitignore` rule, because markdownlint globs
+the filesystem rather than git and would otherwise judge files the repo deliberately ignores.
+
+`.github/` stays excluded: issue templates render **into** an issue body rather than standing
+as documents, so MD041 does not apply to them.
+
+> When adding a directory to this gate, check `git ls-files` first. Lint findings on
+> untracked or ignored files are noise by construction — filtering by tracked-ness before
+> judging the findings is what turned an apparent "needs MD041/MD032 exceptions" verdict on
+> `.claude/` into two one-line heading fixes and zero exceptions.
 
 ### 75% docstring-coverage pre-merge gate (the invisible blocker)
 

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -5,8 +5,8 @@ playwright-report
 test-results
 .git
 
-# Machine-local files, mirroring .gitignore:73 (.claude/**/*.local.*). These are hook
-# message templates and personal overrides — not repo content, so the repo lint gate
-# should not judge them. markdownlint globs the filesystem rather than git, so without
-# this it would lint files git deliberately ignores.
+# Machine-local files, mirroring the matching rule in .gitignore. These are hook message
+# templates and personal overrides — not repo content, so the repo lint gate should not
+# judge them. markdownlint globs the filesystem rather than git, so without this it would
+# lint files git deliberately ignores.
 .claude/**/*.local.*

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,3 +4,9 @@ node_modules
 playwright-report
 test-results
 .git
+
+# Machine-local files, mirroring .gitignore:73 (.claude/**/*.local.*). These are hook
+# message templates and personal overrides — not repo content, so the repo lint gate
+# should not judge them. markdownlint globs the filesystem rather than git, so without
+# this it would lint files git deliberately ignores.
+.claude/**/*.local.*

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:unit": "node --test tests/unit/*.test.js",
     "lint:md": "bash devops/hooks/lint-markdown-changed.sh --staged",
     "lint:md:changed": "bash devops/hooks/lint-markdown-changed.sh --changed",
-    "lint:md:all": "npx --yes markdownlint-cli --config .markdownlint.json --ignore-path .markdownlintignore \"**/*.md\" \".context/**/*.md\" \".agents/**/*.md\"",
+    "lint:md:all": "npx --yes markdownlint-cli --config .markdownlint.json --ignore-path .markdownlintignore \"**/*.md\" \".context/**/*.md\" \".agents/**/*.md\" \".claude/**/*.md\"",
     "test": "npm run test:core",
     "test:core": "npx playwright test tests/playwright/core",
     "test:extended": "npx playwright test tests/playwright/extended --pass-with-no-tests",


### PR DESCRIPTION
## What

Closes the last dot-directory gap from #1447. **No rule exceptions were needed** — my earlier claim that `.claude/` required MD041/MD032 exceptions was wrong, and checking which files git actually *tracks* dissolved it.

## The real breakdown of the 11 findings

| File | Tracked? | Verdict |
|---|---|---|
| 3× `.claude/hookify.*.local.md` | **gitignored** (`.gitignore:73` → `.claude/**/*.local.*`) | Not repo content — hookify message templates, machine-local. They only appeared because markdownlint globs the **filesystem**, not git. |
| `.claude/agents/staktrakr-implementer.md` | tracked | One missing `#` heading |
| `.claude/agents/staktrakr-spec-reviewer.md` | tracked | One missing `#` heading |

Everything else under `.claude/` — all 11 `SKILL.md` files plus `rules/js-invariants.md` — was **already clean**.

## Changes

1. **`.markdownlintignore`** — add `.claude/**/*.local.*`, mirroring `.gitignore:73`, so the lint gate judges exactly what the repo tracks.
2. **Both agent files** — add an H1. The body is a system prompt, so a title line is harmless and reads better. Neither has an `.agents/` twin (only skills do), so no sibling update was needed.
3. **`package.json`** — add `.claude/**/*.md` to `lint:md:all`.

## Verification

- `npm run lint:md:all` exits **0** with the expanded scope.
- **`.claude/` is genuinely in scope** — injected MD001/MD012 into `.claude/skills/faq/SKILL.md` and confirmed the gate catches it:
  ```
  .claude/skills/faq/SKILL.md:111 error MD012/no-multiple-blanks
  .claude/skills/faq/SKILL.md:112 error MD001/heading-increment
  ```
  (reverted immediately)
- **The ignore rule holds** — a deliberately malformed `.claude/probe.local.md` produced zero gate findings (then removed).

## `.github/` stays excluded

Agreed with the maintainer's read: those are GitHub-authored formats we don't hand-edit, and issue templates render *into* an issue body rather than standing as documents, so MD041 genuinely doesn't apply.

## Note

`.markdownlintignore` and `.gitignore` encode overlapping intent ("not project content") in two places. This mirrors one rule across them; if more machine-local files appear, the pair is worth revisiting so they can't drift apart again.