### PR TITLE
chore: prettier-format 10 poller test files to green the format gate

### DIFF
--- a/devops/pollers/shared/price-extract-availability.test.mjs
+++ b/devops/pollers/shared/price-extract-availability.test.mjs
@@ -98,9 +98,7 @@ test("availability missing — returns null", () => {
 });
 
 test("non-Product JSON-LD — returns null", () => {
-  const av = extractJsonLdAvailability([
-    JSON.stringify({ "@type": "Organization", name: "Hero" }),
-  ]);
+  const av = extractJsonLdAvailability([JSON.stringify({ "@type": "Organization", name: "Hero" })]);
   assert.equal(av, null);
 });
 

--- a/devops/pollers/shared/price-extract-html-chrome-strip.test.mjs
+++ b/devops/pollers/shared/price-extract-html-chrome-strip.test.mjs
@@ -20,8 +20,7 @@
 
 const CHROME_OR_RAWTEXT_TAGS = new Set(["script", "style", "nav", "header", "footer"]);
 
-const isHtmlWhitespace = (c) =>
-  c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f";
+const isHtmlWhitespace = (c) => c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f";
 const collapseWhitespace = (s) => s.replace(/\s+/g, " ");
 
 function findHtmlTagEnd(html, from) {
@@ -141,25 +140,19 @@ assert(
 
 assert(
   "3. <header> content dropped (spot ticker scenario)",
-  htmlToPlainText(
-    "<header>Gold $4,520.00 Silver $75.92</header><main>1 oz Maple $77.82</main>"
-  ),
+  htmlToPlainText("<header>Gold $4,520.00 Silver $75.92</header><main>1 oz Maple $77.82</main>"),
   "1 oz Maple $77.82"
 );
 
 assert(
   "4. <nav> content dropped (mega-menu links)",
-  htmlToPlainText(
-    "<nav>Gold Silver Platinum 1/2 oz 1/4 oz</nav><main>1 oz Maple $77.82</main>"
-  ),
+  htmlToPlainText("<nav>Gold Silver Platinum 1/2 oz 1/4 oz</nav><main>1 oz Maple $77.82</main>"),
   "1 oz Maple $77.82"
 );
 
 assert(
   "5. <footer> content dropped (legal/ads area)",
-  htmlToPlainText(
-    "<main>1 oz Maple $77.82</main><footer>Spot Gold $4,520.00</footer>"
-  ),
+  htmlToPlainText("<main>1 oz Maple $77.82</main><footer>Spot Gold $4,520.00</footer>"),
   "1 oz Maple $77.82"
 );
 
@@ -271,11 +264,7 @@ assert(
   "price $77.82"
 );
 
-assert(
-  "11. <article> content preserved",
-  htmlToPlainText("<article>$77.82</article>"),
-  "$77.82"
-);
+assert("11. <article> content preserved", htmlToPlainText("<article>$77.82</article>"), "$77.82");
 
 assert(
   "12. <aside> content preserved",

--- a/devops/pollers/shared/price-extract-imports.test.mjs
+++ b/devops/pollers/shared/price-extract-imports.test.mjs
@@ -144,10 +144,11 @@ test("shared helpers provide representative parser, OOS, HTML, and JSON-LD behav
     77.82
   );
 
-  assert.deepEqual(
-    shared.detectStockStatus("This product is out of stock.", 1, "apmex"),
-    { inStock: false, reason: "out_of_stock", detectedText: "out of stock" }
-  );
+  assert.deepEqual(shared.detectStockStatus("This product is out of stock.", 1, "apmex"), {
+    inStock: false,
+    reason: "out_of_stock",
+    detectedText: "out of stock",
+  });
 
   const parsed = shared.extractMarkdownPrice(
     "| Qty | (e)Check/Wire | Card |\n| --- | ---: | ---: |\n| 1+ | $77.82 | $80.93 |",

--- a/devops/pollers/shared/price-extract-jsonld.test.mjs
+++ b/devops/pollers/shared/price-extract-jsonld.test.mjs
@@ -42,7 +42,9 @@ function extractJsonLdPrice(jsonLdScripts, metal, weightOz = 1, providerId = "")
     if (typeof method === "string")
       return method.includes("ByBankTransferInAdvance") || WIRE_METHOD_RE.test(method);
     if (method["@id"])
-      return method["@id"].includes("ByBankTransferInAdvance") || WIRE_METHOD_RE.test(method["@id"]);
+      return (
+        method["@id"].includes("ByBankTransferInAdvance") || WIRE_METHOD_RE.test(method["@id"])
+      );
     if (method.name) return WIRE_METHOD_RE.test(method.name);
     return false;
   }
@@ -144,8 +146,7 @@ assert(
             price: "895.42",
           },
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { minValue: "1", maxValue: "9" },
             price: "859.60",
           },
@@ -208,14 +209,12 @@ assert(
         price: "893.33",
         priceSpecification: [
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { minValue: "10", maxValue: "19" },
             price: "857.60",
           },
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { minValue: "50", maxValue: "10000" },
             price: "849.60",
           },
@@ -314,8 +313,7 @@ assert(
       offers: {
         price: "895.42",
         priceSpecification: {
-          appliesToPaymentMethod:
-            "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+          appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
           eligibleQuantity: { minValue: "1", maxValue: "9" },
           price: "859.60",
         },
@@ -419,8 +417,7 @@ assert(
         price: "5,350.14",
         priceSpecification: [
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { minValue: "1", maxValue: "9" },
             price: "5,200.00",
           },
@@ -442,8 +439,7 @@ assert(
         price: "895.42",
         priceSpecification: [
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             price: "859.60",
           },
         ],
@@ -536,8 +532,7 @@ assert(
         price: "895.42",
         priceSpecification: [
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { value: 1 },
             price: "859.60",
           },
@@ -559,8 +554,7 @@ assert(
         price: "893.33",
         priceSpecification: [
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { value: 10 },
             price: "857.60",
           },
@@ -649,8 +643,7 @@ assert(
         price: "78.23", // bulk in offer.price — would be picked without the fix
         priceSpecification: [
           {
-            appliesToPaymentMethod:
-              "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
+            appliesToPaymentMethod: "http://purl.org/goodrelations/v1#ByBankTransferInAdvance",
             eligibleQuantity: { minValue: "1", maxValue: "49" },
             price: "79.23", // single-unit wire — should win
           },

--- a/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
+++ b/devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
@@ -57,8 +57,22 @@ const PRODUCTS = {
     price: "38.42",
     retail: "44.99",
     tiers: [
-      { qty_range: "1 - 20", qty_min: 1, qty_max: 20, check_wire: 38.42, bitcoin: 39.79, card: 40.79 },
-      { qty_range: "21+", qty_min: 21, qty_max: 5179, check_wire: 38.12, bitcoin: 38.49, card: 40.48 },
+      {
+        qty_range: "1 - 20",
+        qty_min: 1,
+        qty_max: 20,
+        check_wire: 38.42,
+        bitcoin: 39.79,
+        card: 40.79,
+      },
+      {
+        qty_range: "21+",
+        qty_min: 21,
+        qty_max: 5179,
+        check_wire: 38.12,
+        bitcoin: 38.49,
+        card: 40.48,
+      },
     ],
     premium: "Over Spot",
   },
@@ -68,7 +82,16 @@ const PRODUCTS = {
     image: "https://mintbuilder.com/img/202.jpg",
     price: 412.77,
     retail: 449.0,
-    tiers: [{ qty_range: "1+", qty_min: 1, qty_max: 9604, check_wire: 412.77, bitcoin: 415.79, card: 429.79 }],
+    tiers: [
+      {
+        qty_range: "1+",
+        qty_min: 1,
+        qty_max: 9604,
+        check_wire: 412.77,
+        bitcoin: 415.79,
+        card: 429.79,
+      },
+    ],
     premium: null,
   },
   303: {
@@ -85,7 +108,9 @@ const PRODUCTS = {
     link: "https://mintbuilder.com/products/sold-out-kangaroo",
     price: 61.16,
     retail: 61.16,
-    tiers: [{ qty_range: "1+", qty_min: 1, qty_max: 1, check_wire: 61.16, bitcoin: 61.79, card: 63.79 }],
+    tiers: [
+      { qty_range: "1+", qty_min: 1, qty_max: 1, check_wire: 61.16, bitcoin: 61.79, card: 63.79 },
+    ],
     premium: "Over Spot",
   },
 };
@@ -158,11 +183,19 @@ test("normalizeProductUrl canonicalizes equivalent product URLs", async () => {
 
   // https/http, www, trailing slash, query, fragment, and case all collapse.
   assert.equal(
-    normalizeProductUrl("https://www.MintBuilder.com/Products/1oz-Silver-Buffalo-Round/?aff=reddit#top"),
+    normalizeProductUrl(
+      "https://www.MintBuilder.com/Products/1oz-Silver-Buffalo-Round/?aff=reddit#top"
+    ),
     canonical
   );
-  assert.equal(normalizeProductUrl("http://mintbuilder.com/products/1oz-silver-buffalo-round"), canonical);
-  assert.equal(normalizeProductUrl("https://mintbuilder.com/products/1oz-silver-buffalo-round/"), canonical);
+  assert.equal(
+    normalizeProductUrl("http://mintbuilder.com/products/1oz-silver-buffalo-round"),
+    canonical
+  );
+  assert.equal(
+    normalizeProductUrl("https://mintbuilder.com/products/1oz-silver-buffalo-round/"),
+    canonical
+  );
 
   // Root URLs normalize to the bare host.
   assert.equal(normalizeProductUrl("https://mintbuilder.com/"), "mintbuilder.com");
@@ -682,7 +715,11 @@ test("a cached failure is not sticky once maxAgeMs elapses", async () => {
   // Same key throughout: a key rotation would refetch via the fingerprint, so
   // this proves the TTL alone lets a transient outage recover. Two 500s
   // exhaust the single retry and resolve to a failure state.
-  const fetchImpl = makeFetch(errResponse(500), errResponse(500), okResponse(feedPayload(PRODUCTS)));
+  const fetchImpl = makeFetch(
+    errResponse(500),
+    errResponse(500),
+    okResponse(feedPayload(PRODUCTS))
+  );
 
   const first = await feed.getFeedIndex({
     apiKey: "test-key",

--- a/devops/pollers/shared/price-extract-pipe-table.test.mjs
+++ b/devops/pollers/shared/price-extract-pipe-table.test.mjs
@@ -107,11 +107,11 @@ assert(
   "standard pipe table",
   run(
     `| Qty | (e)Check/Wire | Crypto | Card |\n` +
-    `| --- | --- | --- | --- |\n` +
-    `| 1-9 | $1,950.00 | $1,960.00 | $1,975.00 |\n` +
-    `| 10+ | $1,940.00 | $1,950.00 | $1,965.00 |\n`
+      `| --- | --- | --- | --- |\n` +
+      `| 1-9 | $1,950.00 | $1,960.00 | $1,975.00 |\n` +
+      `| 10+ | $1,940.00 | $1,950.00 | $1,965.00 |\n`
   ),
-  1950.00
+  1950.0
 );
 
 // 2. Reordered columns: wire in col 3 (Qty | Crypto | (e)Check/Wire | Card)
@@ -119,20 +119,16 @@ assert(
   "reordered columns — wire in col 3",
   run(
     `| Qty | Crypto | (e)Check/Wire | Card |\n` +
-    `| --- | --- | --- | --- |\n` +
-    `| 1-9 | $1,960.00 | $1,950.00 | $1,975.00 |\n`
+      `| --- | --- | --- | --- |\n` +
+      `| 1-9 | $1,960.00 | $1,950.00 | $1,975.00 |\n`
   ),
-  1950.00
+  1950.0
 );
 
 // 3. No wire header — expect null
 assert(
   "no wire header → null",
-  run(
-    `| Qty | Crypto | Card |\n` +
-    `| --- | --- | --- |\n` +
-    `| 1-9 | $1,960.00 | $1,975.00 |\n`
-  ),
+  run(`| Qty | Crypto | Card |\n` + `| --- | --- | --- |\n` + `| 1-9 | $1,960.00 | $1,975.00 |\n`),
   null
 );
 
@@ -141,10 +137,10 @@ assert(
   "Check / Wire no-paren variant",
   run(
     `| Qty | Check / Wire | Crypto | Card |\n` +
-    `| --- | --- | --- | --- |\n` +
-    `| 1-9 | $2,050.00 | $2,060.00 | $2,080.00 |\n`
+      `| --- | --- | --- | --- |\n` +
+      `| 1-9 | $2,050.00 | $2,060.00 | $2,080.00 |\n`
   ),
-  2050.00
+  2050.0
 );
 
 // 5. Shipping-price noise before real table — only in-range price should match
@@ -152,11 +148,11 @@ assert(
   "shipping-price noise before real table",
   run(
     `Shipping: $9.95 standard\n\n` +
-    `| Qty | (e)Check/Wire | Crypto | Card |\n` +
-    `| --- | --- | --- | --- |\n` +
-    `| 1-9 | $1,980.00 | $1,990.00 | $2,005.00 |\n`
+      `| Qty | (e)Check/Wire | Crypto | Card |\n` +
+      `| --- | --- | --- | --- |\n` +
+      `| 1-9 | $1,980.00 | $1,990.00 | $2,005.00 |\n`
   ),
-  1980.00
+  1980.0
 );
 
 // ---------------------------------------------------------------------------
@@ -170,10 +166,10 @@ assert(
   "F1: CRLF endings + leading whitespace",
   run(
     "  | Qty | (e)Check/Wire | Crypto | Card |\r\n" +
-    "  | --- | --- | --- | --- |\r\n" +
-    "  | 1-9 | $1,955.00 | $1,965.00 | $1,980.00 |\r\n"
+      "  | --- | --- | --- | --- |\r\n" +
+      "  | 1-9 | $1,955.00 | $1,965.00 | $1,980.00 |\r\n"
   ),
-  1955.00
+  1955.0
 );
 
 // 7. F2 — Single-cell note row containing "(e)Check/Wire" before the real header
@@ -181,14 +177,14 @@ assert(
   "F2: note row false-positive before real header",
   run(
     `| See (e)Check/Wire pricing below |\n` +
-    `\n` +
-    `Some prose about payment methods.\n` +
-    `\n` +
-    `| Qty | (e)Check/Wire | Crypto | Card |\n` +
-    `| --- | --- | --- | --- |\n` +
-    `| 1-9 | $1,945.00 | $1,955.00 | $1,970.00 |\n`
+      `\n` +
+      `Some prose about payment methods.\n` +
+      `\n` +
+      `| Qty | (e)Check/Wire | Crypto | Card |\n` +
+      `| --- | --- | --- | --- |\n` +
+      `| 1-9 | $1,945.00 | $1,955.00 | $1,970.00 |\n`
   ),
-  1945.00
+  1945.0
 );
 
 // 8. F3 — Real table followed by an unrelated trailing table with a wire-column-index
@@ -197,16 +193,16 @@ assert(
   "F3: table boundary — trailing unrelated table ignored",
   run(
     `| Qty | (e)Check/Wire | Crypto | Card |\n` +
-    `| --- | --- | --- | --- |\n` +
-    `| 1-9 | $1,935.00 | $1,945.00 | $1,960.00 |\n` +
-    `\n` +
-    `Some prose separating tables.\n` +
-    `\n` +
-    `| Item | Price | Notes |\n` +
-    `| --- | --- | --- |\n` +
-    `| Bag | $5.00 | free over $500 |\n`
+      `| --- | --- | --- | --- |\n` +
+      `| 1-9 | $1,935.00 | $1,945.00 | $1,960.00 |\n` +
+      `\n` +
+      `Some prose separating tables.\n` +
+      `\n` +
+      `| Item | Price | Notes |\n` +
+      `| --- | --- | --- |\n` +
+      `| Bag | $5.00 | free over $500 |\n`
   ),
-  1935.00
+  1935.0
 );
 
 // ---------------------------------------------------------------------------

--- a/devops/pollers/shared/price-extract-run-full-poller.test.mjs
+++ b/devops/pollers/shared/price-extract-run-full-poller.test.mjs
@@ -108,7 +108,11 @@ test("runFullPoller records a thrown Vendor scrape as one failed target and cont
     ["passing-vendor", "throwing-vendor"],
     "full poller should continue to the passing target after one Vendor throws"
   );
-  assert.equal(summary.exitCode, null, "full poller should not call process.exit when at least one target succeeds");
+  assert.equal(
+    summary.exitCode,
+    null,
+    "full poller should not call process.exit when at least one target succeeds"
+  );
   assert.ok(
     summary.warnings.some((line) => line.includes("synthetic vendor failure")),
     "full poller should warn with the Vendor failure reason"

--- a/devops/pollers/shared/price-extract-summit-oos.test.mjs
+++ b/devops/pollers/shared/price-extract-summit-oos.test.mjs
@@ -333,11 +333,11 @@ test("STRUCTURAL: Summit cutoff + table-first strategy live in the Vendor module
   const regIdx = strategy.indexOf("regularPricePrices()");
   assert.ok(
     tblIdx !== -1 && tierIdx !== -1 && regIdx !== -1,
-    "expected all three extractors in summit extractPrice",
+    "expected all three extractors in summit extractPrice"
   );
   assert.ok(
     tblIdx < regIdx && tierIdx < regIdx,
-    "qty-tier extractors must precede the bulk regularPricePrices fallback",
+    "qty-tier extractors must precede the bulk regularPricePrices fallback"
   );
 });
 
@@ -346,12 +346,12 @@ test("STRUCTURAL: shared.js no longer owns Summit-specific data (isolation guara
   assert.equal(
     sharedSrc.includes("Description Shipping & Returns"),
     false,
-    "summit cutoff anchor must not live in shared.js — it belongs to the Vendor module",
+    "summit cutoff anchor must not live in shared.js — it belongs to the Vendor module"
   );
   assert.equal(
     sharedSrc.includes('providerId === "summitmetals"'),
     false,
-    "summit price branch must not live in shared.js — it belongs to the Vendor module",
+    "summit price branch must not live in shared.js — it belongs to the Vendor module"
   );
 });
 

--- a/devops/pollers/shared/price-extract-tier-anchored.test.mjs
+++ b/devops/pollers/shared/price-extract-tier-anchored.test.mjs
@@ -98,11 +98,7 @@ assert(
 // ---------------------------------------------------------------------------
 
 const sdbSingleTier = "1+ $89.23";
-assert(
-  "2. single-tier '1+' form → wire price ($89.23)",
-  tierSilver(sdbSingleTier),
-  89.23
-);
+assert("2. single-tier '1+' form → wire price ($89.23)", tierSilver(sdbSingleTier), 89.23);
 
 const sdbSingleTierBigger = "Some prose 1+ $4,580.63 more prose";
 assert(
@@ -116,16 +112,8 @@ assert(
 // ---------------------------------------------------------------------------
 
 const onlySpotTicker = "Gold $4,520.00 Silver $75.92 Platinum $1,933.40";
-assert(
-  "4. spot ticker only → null (no qty-tier prefix)",
-  tierSilver(onlySpotTicker),
-  null
-);
-assert(
-  "5. spot ticker only (gold range) → null",
-  tierGold(onlySpotTicker),
-  null
-);
+assert("4. spot ticker only → null (no qty-tier prefix)", tierSilver(onlySpotTicker), null);
+assert("5. spot ticker only (gold range) → null", tierGold(onlySpotTicker), null);
 
 // ---------------------------------------------------------------------------
 // Related-product sidebar ("As low as: $X") MUST be ignored
@@ -134,16 +122,8 @@ assert(
 const sidebarOnly =
   "American Eagle $50 Coin BU (Random Year) As low as: $4,566.00 Buy Now " +
   "1 oz Generic Silver Bar .999 Fine As low as: $76.72 Buy Now";
-assert(
-  "6. related-product sidebar only → null (no qty-tier marker)",
-  tierGold(sidebarOnly),
-  null
-);
-assert(
-  "7. silver sidebar variant → null",
-  tierSilver(sidebarOnly),
-  null
-);
+assert("6. related-product sidebar only → null (no qty-tier marker)", tierGold(sidebarOnly), null);
+assert("7. silver sidebar variant → null", tierSilver(sidebarOnly), null);
 
 // ---------------------------------------------------------------------------
 // Realistic combined: spot ticker survived chrome strip + then real grid
@@ -155,11 +135,7 @@ const combined =
   "1-24 $77.82 $78.61 $80.93 " +
   "500+ $77.22 $78.00 $80.31";
 
-assert(
-  "8. spot ticker + real grid → real grid wins ($77.82)",
-  tierSilver(combined),
-  77.82
-);
+assert("8. spot ticker + real grid → real grid wins ($77.82)", tierSilver(combined), 77.82);
 
 // ---------------------------------------------------------------------------
 // OOS page (sidebar exists but no tier table) — must return null
@@ -170,11 +146,7 @@ const oosPage =
   "Notify Me When Available " +
   "Related: 1 oz Silver Eagle As low as: $92.25 Buy Now";
 
-assert(
-  "9. OOS page with sidebar prices but no tier table → null",
-  tierSilver(oosPage),
-  null
-);
+assert("9. OOS page with sidebar prices but no tier table → null", tierSilver(oosPage), null);
 
 // ---------------------------------------------------------------------------
 // Defensive: qty-tier matches must respect the metal range
@@ -220,11 +192,7 @@ assert(
   null
 );
 
-assert(
-  "14. '$77.82 1-24' → null (price BEFORE tier, not after)",
-  tierSilver("$77.82 1-24"),
-  null
-);
+assert("14. '$77.82 1-24' → null (price BEFORE tier, not after)", tierSilver("$77.82 1-24"), null);
 
 // ---------------------------------------------------------------------------
 // Multi-row table preserves first-row wire (the 1-unit price)

--- a/devops/pollers/shared/webscale-cookies.test.mjs
+++ b/devops/pollers/shared/webscale-cookies.test.mjs
@@ -44,7 +44,10 @@ function tmpEnv() {
 
 console.log("--- webscaleCookieFilePath ---");
 test("honors WEBSCALE_COOKIE_FILE env override", () => {
-  eq(webscaleCookieFilePath({ WEBSCALE_COOKIE_FILE: "/data/webscale-cookies.json" }), "/data/webscale-cookies.json");
+  eq(
+    webscaleCookieFilePath({ WEBSCALE_COOKIE_FILE: "/data/webscale-cookies.json" }),
+    "/data/webscale-cookies.json"
+  );
 });
 test("falls back to a module-local default when unset", () => {
   const p = webscaleCookieFilePath({});
@@ -97,17 +100,29 @@ test("malformed JSON → null (no throw)", () => {
 });
 test("entry missing wspc → null", () => {
   const { env } = tmpEnv();
-  writeFileSync(env.WEBSCALE_COOKIE_FILE, JSON.stringify({ "www.jmbullion.com": { userAgent: "UA" } }), "utf8");
+  writeFileSync(
+    env.WEBSCALE_COOKIE_FILE,
+    JSON.stringify({ "www.jmbullion.com": { userAgent: "UA" } }),
+    "utf8"
+  );
   eq(loadWebscaleCookie("www.jmbullion.com", env), null);
 });
 test("empty wspc string → null", () => {
   const { env } = tmpEnv();
-  writeFileSync(env.WEBSCALE_COOKIE_FILE, JSON.stringify({ "www.jmbullion.com": { wspc: "", userAgent: "UA" } }), "utf8");
+  writeFileSync(
+    env.WEBSCALE_COOKIE_FILE,
+    JSON.stringify({ "www.jmbullion.com": { wspc: "", userAgent: "UA" } }),
+    "utf8"
+  );
   eq(loadWebscaleCookie("www.jmbullion.com", env), null);
 });
 test("missing userAgent → wspc still returned, userAgent null", () => {
   const { env } = tmpEnv();
-  writeFileSync(env.WEBSCALE_COOKIE_FILE, JSON.stringify({ "www.jmbullion.com": { wspc: "X" } }), "utf8");
+  writeFileSync(
+    env.WEBSCALE_COOKIE_FILE,
+    JSON.stringify({ "www.jmbullion.com": { wspc: "X" } }),
+    "utf8"
+  );
   const got = loadWebscaleCookie("www.jmbullion.com", env);
   eq(got.wspc, "X");
   eq(got.userAgent, null);
@@ -120,8 +135,16 @@ test("set writes the cookie file with 0600 perms (credentials)", () => {
 test("set requires hostname and wspc", () => {
   const { env } = tmpEnv();
   let threw = 0;
-  try { setWebscaleCookie("", "x", "UA", env); } catch { threw++; }
-  try { setWebscaleCookie("h", "", "UA", env); } catch { threw++; }
+  try {
+    setWebscaleCookie("", "x", "UA", env);
+  } catch {
+    threw++;
+  }
+  try {
+    setWebscaleCookie("h", "", "UA", env);
+  } catch {
+    threw++;
+  }
   eq(threw, 2);
 });
 
@@ -194,13 +217,21 @@ test("null / empty → false", () => {
   eq(looksLikeWebscaleChallenge(""), false);
 });
 test("'confirm your humanity' innerText → true", () => {
-  eq(looksLikeWebscaleChallenge("Please confirm your humanity. We are temporarily requesting additional verification"), true);
+  eq(
+    looksLikeWebscaleChallenge(
+      "Please confirm your humanity. We are temporarily requesting additional verification"
+    ),
+    true
+  );
 });
 test("/.webscale/i-am-a-human marker → true", () => {
   eq(looksLikeWebscaleChallenge('xhr.open("POST", "/.webscale/i-am-a-human")'), true);
 });
 test("resources.webscale.com errorpage marker → true", () => {
-  eq(looksLikeWebscaleChallenge('<link href="https://resources.webscale.com/css/errorpage.css">'), true);
+  eq(
+    looksLikeWebscaleChallenge('<link href="https://resources.webscale.com/css/errorpage.css">'),
+    true
+  );
 });
 
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Problem

`npm run format:check` fails on `dev` (verified at `6758f93d`) for 10 pre-existing unformatted files under `devops/pollers/shared/`:

```
devops/pollers/shared/price-extract-availability.test.mjs
devops/pollers/shared/price-extract-html-chrome-strip.test.mjs
devops/pollers/shared/price-extract-imports.test.mjs
devops/pollers/shared/price-extract-jsonld.test.mjs
devops/pollers/shared/price-extract-mintbuilder-feed.test.mjs
devops/pollers/shared/price-extract-pipe-table.test.mjs
devops/pollers/shared/price-extract-run-full-poller.test.mjs
devops/pollers/shared/price-extract-summit-oos.test.mjs
devops/pollers/shared/price-extract-tier-anchored.test.mjs
devops/pollers/shared/webscale-cookies.test.mjs
```

A gate that is red *before* any change cannot distinguish "this PR broke formatting" from "the repo was already unformatted" — so every contributor has to manually diff the warning list against their own changed files.

## Change

Ran `npx prettier --write` on exactly those 10 files. Formatting only — no logic, no test assertions, no renames, no other files.

## Verification

| Gate | Before | After |
| --- | --- | --- |
| `npm run format:check` | exit 1 — 10 warnings | **exit 0** — "All matched files use Prettier code style!" |
| `node --test` over the 10 `.mjs` files | exit 0 — 10/10 files pass | exit 0 — 10/10 files pass, **byte-identical output** (timings stripped) |
| `npm run test:unit` | exit 0 — 618/618 | exit 0 — 618/618 |
| `npm run lint` | — | exit 0 |

> [!NOTE]
> These 10 `.mjs` files are **not** covered by `npm run test:unit` — that script globs `tests/unit/*.test.js` only — and no workflow in `.github/workflows/` runs them either (`codeql.yml` is the only workflow). `test:unit` was still run as a repo-wide regression check, but the meaningful behavior check for these files is the direct `node --test` run above, which produced identical output before and after.

### Non-whitespace edits, reviewed individually

`git diff -w` is non-empty, so I checked what actually changed. 6 of 10 files have token-level edits; all are Prettier normalizations with no behavior change:

- **Trailing commas** — added in object/array literals, removed in call arguments, matching the repo's `.prettierrc` `trailingComma: "es5"`.
- **Line rejoin / wrap** at `printWidth: 100`.
- **Grouping parens** around a returned boolean expression in `price-extract-jsonld.test.mjs` — wraps the whole expression, no precedence change.
- **Numeric-literal trailing zeros** in `price-extract-pipe-table.test.mjs`: `1950.00` → `1950.0`, etc. Same IEEE-754 double.

String contents were untouched — the `"$1,960.00"` literals inside the template strings in that same file are unchanged. Call ordering was also verified preserved where the diff alignment made it look reordered (`normalizeProductUrl` in `price-extract-mintbuilder-feed.test.mjs`).

## Scope

Per `CLAUDE.md`, `devops/` config/tooling is **lightweight**: chore PR to `dev`, no Plane issue, no version lock, no spot-bundle rebuild.