### PR TITLE
chore: ignore .worktree.lock session file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ playwright-report/
 .worktrees/
 .claude/worktrees/
 
+# Per-worktree session lock from the version-lock protocol. Inside a linked worktree
+# the worktree root IS the repo root, so the .worktrees/ rule above never covers it.
+.worktree.lock
+
 # Claude read tracker — session-scoped UUID-named read history, not project history
 claude-read-tracker/
 


### PR DESCRIPTION
## What

Adds `.worktree.lock` to the root `.gitignore`, next to the existing worktree entries.

```gitignore
# Git worktrees for isolated agent work — content dirs are transient, not project history
.worktrees/
.claude/worktrees/

# Per-worktree session lock from the version-lock protocol. Inside a linked worktree
# the worktree root IS the repo root, so the .worktrees/ rule above never covers it.
.worktree.lock
```

## Why

The version-lock protocol has each agent write a `.worktree.lock` session file at the root of its worktree.

From the main checkout this never mattered — the whole `.worktrees/` directory is ignored, so the lock file was covered incidentally. But inside a **linked worktree** the worktree root *is* the repo root, so `.worktree.lock` sits there untracked: it shows up in `git status` and a `git add -A` would commit it.

The workaround in place was appending the string to `.git/info/exclude`, which is local-only and does not travel to other clones or to other developers/agents. The tracked `.gitignore` is the proper fix.

## Verification

Reproduced in worktree `.worktrees/patch-3.36.0` before the change — `git check-ignore -v .worktree.lock` returned nothing and `git status --short` showed `?? .worktree.lock`.

After the change, in this checkout:

```
$ touch .worktree.lock && git check-ignore -v .worktree.lock
.gitignore:66:.worktree.lock	.worktree.lock

$ git status --short
 M .gitignore          # the lock file no longer appears
```

The pattern has no slash, so it matches at any depth — it covers the main checkout and every linked worktree alike.

## Scope

Lightweight config edit per `CLAUDE.md`: one-line `.gitignore` change, no Plane issue and no version lock. No runtime code, tests, or docs touched. `dev` is protected, so this goes in as a PR rather than a direct push.

## Note for the reviewer

`.worktree.lock` is not currently mentioned anywhere in the tracked tree — `devops/version-lock-protocol.md` Step 5 documents `git worktree add` but says nothing about writing a session lock file, and `git grep worktree\.lock` on `dev` returns no hits. The ignore entry is correct and harmless either way, but the protocol doc may be behind the actual agent convention. Flagging it rather than editing the doc, since that's outside this change's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJr8kXaiDYHnmfGgc4MuLC)_