### PR TITLE
chore: catch .context docs up to the five-metal spot pipeline (STRK-303)

### DIFF
--- a/.context/architecture.md
+++ b/.context/architecture.md
@@ -516,16 +516,16 @@ Window floor: `Math.floor(minutes / 15) * 15` — e.g. 14:22 → `14:15:00Z`.
 
 One row per metal per 15-min floor.
 
-| Column            | Type       | Description                                             |
-| ----------------- | ---------- | ------------------------------------------------------- |
-| `id`              | INTEGER PK | Auto-increment                                          |
-| `metal`           | TEXT       | `"gold"` \| `"silver"` \| `"platinum"` \| `"palladium"` |
-| `spot`            | REAL       | USD price per troy oz                                   |
-| `source`          | TEXT       | `"metalprice-api"`                                      |
-| `poller_id`       | TEXT       | `"fly-spot"` or `"home-spot"`                           |
-| `timestamp`       | TEXT       | ISO 8601 UTC                                            |
-| `timestamp_floor` | TEXT       | 15-min floor                                            |
-| UNIQUE            |            | `(metal, timestamp_floor)`                              |
+| Column            | Type       | Description                                                                      |
+| ----------------- | ---------- | -------------------------------------------------------------------------------- |
+| `id`              | INTEGER PK | Auto-increment                                                                   |
+| `metal`           | TEXT       | `"gold"` \| `"silver"` \| `"platinum"` \| `"palladium"` \| `"copper"` (STRK-303) |
+| `spot`            | REAL       | USD price per troy oz                                                            |
+| `source`          | TEXT       | `"metalprice-api"`                                                               |
+| `poller_id`       | TEXT       | `"fly-spot"` or `"home-spot"`                                                    |
+| `timestamp`       | TEXT       | ISO 8601 UTC                                                                     |
+| `timestamp_floor` | TEXT       | 15-min floor                                                                     |
+| UNIQUE            |            | `(metal, timestamp_floor)`                                                       |
 
 Indexes: `(metal, timestamp_floor DESC)`, `(timestamp_floor DESC)`.
 

--- a/.context/architecture.md
+++ b/.context/architecture.md
@@ -525,6 +525,7 @@ One row per metal per 15-min floor.
 | `poller_id`       | TEXT       | `"fly-spot"` or `"home-spot"`                                                    |
 | `timestamp`       | TEXT       | ISO 8601 UTC                                                                     |
 | `timestamp_floor` | TEXT       | 15-min floor                                                                     |
+| `scraped_at`      | TEXT       | Ingestion timestamp, `DEFAULT (datetime('now'))`                                 |
 | UNIQUE            |            | `(metal, timestamp_floor)`                                                       |
 
 Indexes: `(metal, timestamp_floor DESC)`, `(timestamp_floor DESC)`.

--- a/.context/deep-dives/api-reference.md
+++ b/.context/deep-dives/api-reference.md
@@ -43,7 +43,7 @@ All v2 endpoints live under `data/v2/`:
 | Endpoint                                 | Description                                                                               | Updated             |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------- |
 | `data/v2/manifest.json`                  | Self-describing index: coin list, endpoint templates, stale thresholds per type           | Every 15 min        |
-| `data/v2/spot/latest.json`               | Current spot prices (4 metals) with OHLCA aggregates                                      | Every 15 min        |
+| `data/v2/spot/latest.json`               | Current spot prices (5 metals) with OHLCA aggregates                                      | Every 15 min        |
 | `data/v2/spot/history-24h.json`          | 24h spot time series (96 windows)                                                         | Every 15 min        |
 | `data/v2/retail/{slug}/latest.json`      | Per-coin vendor prices with carry-forward metadata                                        | Every 15 min        |
 | `data/v2/retail/{slug}/history-7d.json`  | 7-day hourly OHLCA buckets                                                                | Every 15 min        |
@@ -182,7 +182,7 @@ These are writer-side paths (still actively written), not part of the v2 serving
 
 | Endpoint Pattern                  | Description                                                                               | Updated                                   |
 | --------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `data/hourly/YYYY/MM/DD/HH.json`  | Hourly spot prices (4 metals) — overwritten each poll                                     | 4x/hr (remote at `0,30`, home at `15,45`) |
+| `data/hourly/YYYY/MM/DD/HH.json`  | Hourly spot prices (5 metals) — overwritten each poll                                     | 4x/hr (remote at `0,30`, home at `15,45`) |
 | `data/15min/YYYY/MM/DD/HHMM.json` | Immutable 15-min spot snapshots                                                           | Per poll (immutable)                      |
 | `data/spot-history-YYYY.json`     | Annual daily spot history (legacy seed — no longer actively written by `spot-extract.js`) | Legacy                                    |
 
@@ -207,9 +207,9 @@ These are writer-side paths (still actively written), not part of the v2 serving
 ]
 ```
 
-**Metals:** Gold (XAU), Silver (XAG), Platinum (XPT), Palladium (XPD)
+**Metals:** Gold (XAU), Silver (XAG), Platinum (XPT), Palladium (XPD), Copper (XCU) — all quoted USD per troy oz (STRK-303)
 **Data source:** MetalPriceAPI (`metalpriceapi.com`)
-**Rate conversion:** Conditional — `rate >= 1` uses value directly; `rate < 1` inverts (`1 / rate`) to get USD per troy oz
+**Rate conversion:** `derivePrice()` in `devops/pollers/shared/spot-metals.js` prefers the direct `USD{code}` key from the `base=USD` response; only if absent does it invert the bare-symbol reciprocal (`1 / rate`). The old `rate >= 1` magnitude heuristic was removed in STRK-303 — it misread sub-dollar metals like copper (~$0.41/ozt). A per-metal `assertPriceInRange()` sanity check follows.
 
 ---
 


### PR DESCRIPTION
Follow-up to #1454. The wrap notes flagged that `.context/architecture.md` and `.context/deep-dives/api-reference.md` still described a four-metal spot pipeline — only `data-pipelines.md` was corrected in the release PR.

## Changes

- **api-reference.md** — v2 `spot/latest.json` and writer-side hourly files now say **5 metals**; the metals list gains **Copper (XCU)** with a per-troy-oz note; the rate-conversion paragraph now describes `derivePrice()`'s USD-prefixed-key-first logic (verified against `devops/pollers/shared/spot-metals.js`) instead of the `rate >= 1` magnitude heuristic removed in STRK-303.
- **architecture.md** — sqld `spot_prices.metal` enum gains `"copper"`.

## Deliberately unchanged

Frontend-facing four-metal claims (inventory `metal` enum at L380, manual-mode `metalSpotPrices` at L442) — copper is not user-visible until Phase 2 (STRK-305), per the #1454 merge note ("nothing user-visible ships").

Verified against the live feed: `data/v2/spot/latest.json` and today's hourly file both carry `xcu`/Copper ($0.4126 @ 14:00 UTC).